### PR TITLE
feat: implement layered noise worldgen with multi-noise biomes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,19 @@
-# AGENTS.md - Zig OpenGL Project
+# AGENTS.md - Zig OpenGL Voxel Engine
 
 ## Build Commands
 ```bash
-nix develop              # Enter dev shell with zig, SDL3, GLEW, OpenGL
-zig build                # Build the project
-zig build run            # Build and run
-nix build                # Production build (patched binary in ./result/bin/)
+nix develop        # Enter dev shell (provides zig, SDL3, GLEW, OpenGL)
+zig build          # Build the project
+zig build run      # Build and run
+nix build          # Production build (outputs to ./result/bin/)
 ```
+No tests - this is a graphics/game project. Verify changes by running `zig build run`.
 
-## Code Style Guidelines
-- **Language**: Zig 0.14 (master/nightly)
-- **Imports**: Use `@import("std")` first, then `@cImport` for C headers
-- **Naming**: snake_case for variables/functions, PascalCase for types/structs
-- **Error Handling**: Return error unions (`!void`), use `try` for propagation
-- **Defer**: Use `defer` for cleanup (SDL_Quit, glDeleteProgram, etc.)
-- **C Interop**: Access via `c.` prefix after `@cImport`, handle optional fn pointers with `.?()`
-- **Constants**: Use `const` by default, multiline strings with `\\` prefix
-- **Types**: Explicit types for C interop (c.GLuint, c.GLenum), infer Zig types
-- **Comments**: Use `//` for single-line, document sections with numbered steps
-- **Architecture**: Follow SOLID principles per ROADMAP.md for extensibility
+## Code Style
+- **Zig 0.14** (master/nightly), uses SDL3 + GLEW + OpenGL 3.3
+- **Imports**: `@import("std")` first, then local modules, then `c.zig` for C bindings
+- **Naming**: `snake_case` for vars/functions, `PascalCase` for types/structs
+- **Errors**: Return error unions (`!void`), propagate with `try`, use `defer` for cleanup
+- **C Interop**: Access C via `c.` prefix (see `src/c.zig`), explicit C types (c.GLuint)
+- **Constants**: Prefer `const`, use `\\` for multiline GLSL shader strings
+- **Structure**: Engine code in `src/engine/`, world/voxel code in `src/world/`

--- a/src/world/block.zig
+++ b/src/world/block.zig
@@ -2,6 +2,55 @@
 
 const std = @import("std");
 
+/// Biome types for terrain generation
+pub const Biome = enum(u8) {
+    deep_ocean = 0,
+    ocean = 1,
+    beach = 2,
+    plains = 3,
+    forest = 4,
+    taiga = 5, // cold forest
+    desert = 6,
+    snow_tundra = 7,
+    mountains = 8,
+    snowy_mountains = 9,
+    river = 10,
+
+    /// Get surface block for this biome
+    pub fn getSurfaceBlock(self: Biome) BlockType {
+        return switch (self) {
+            .deep_ocean, .ocean => .gravel,
+            .beach => .sand,
+            .plains, .forest => .grass,
+            .taiga => .grass, // Could use podzol if we add it
+            .desert => .sand,
+            .snow_tundra, .snowy_mountains => .snow_block,
+            .mountains => .stone,
+            .river => .sand,
+        };
+    }
+
+    /// Get filler block (subsurface) for this biome
+    pub fn getFillerBlock(self: Biome) BlockType {
+        return switch (self) {
+            .deep_ocean => .gravel,
+            .ocean => .sand,
+            .beach, .desert, .river => .sand,
+            .plains, .forest, .taiga => .dirt,
+            .snow_tundra => .dirt,
+            .mountains, .snowy_mountains => .stone,
+        };
+    }
+
+    /// Get ocean floor block for this biome
+    pub fn getOceanFloorBlock(self: Biome, depth: f32) BlockType {
+        _ = self;
+        if (depth > 30) return .gravel; // Deep ocean floor
+        if (depth > 15) return .clay; // Mid-depth
+        return .sand; // Shallow
+    }
+};
+
 pub const BlockType = enum(u8) {
     air = 0,
     stone = 1,
@@ -20,6 +69,7 @@ pub const BlockType = enum(u8) {
     coal_ore = 14,
     iron_ore = 15,
     gold_ore = 16,
+    clay = 17,
 
     _,
 
@@ -71,6 +121,7 @@ pub const BlockType = enum(u8) {
             .coal_ore => .{ 0.1, 0.1, 0.1 },
             .iron_ore => .{ 0.6, 0.5, 0.4 },
             .gold_ore => .{ 0.9, 0.8, 0.2 },
+            .clay => .{ 0.6, 0.6, 0.7 },
             _ => .{ 1, 0, 1 }, // Magenta for unknown
         };
     }

--- a/src/world/chunk_mesh.zig
+++ b/src/world/chunk_mesh.zig
@@ -154,9 +154,13 @@ pub const ChunkMesh = struct {
                 const y_min: i32 = @intCast(si * SUBCHUNK_SIZE);
                 const y_max: i32 = y_min + SUBCHUNK_SIZE;
 
-                if (isEmittingSubchunk(axis, s - 1, u, v, y_min, y_max) and b1.isSolid() and !b2.occludes(b1, axis)) {
+                // Check if b1 should emit a face (solid blocks OR water facing non-water)
+                const b1_emits = b1.isSolid() or (b1 == .water and b2 != .water);
+                const b2_emits = b2.isSolid() or (b2 == .water and b1 != .water);
+
+                if (isEmittingSubchunk(axis, s - 1, u, v, y_min, y_max) and b1_emits and !b2.occludes(b1, axis)) {
                     mask[u + v * du] = .{ .block = b1, .side = true };
-                } else if (isEmittingSubchunk(axis, s, u, v, y_min, y_max) and b2.isSolid() and !b1.occludes(b2, axis)) {
+                } else if (isEmittingSubchunk(axis, s, u, v, y_min, y_max) and b2_emits and !b1.occludes(b2, axis)) {
                     mask[u + v * du] = .{ .block = b2, .side = false };
                 }
             }

--- a/src/world/worldgen/generator.zig
+++ b/src/world/worldgen/generator.zig
@@ -1,25 +1,93 @@
-//! Terrain generator using noise functions.
+//! Terrain generator using layered noise stack per worldgen-spec2.md
+//! Implements: domain warping, multi-noise biomes, controlled caves,
+//! ocean shaping, river carving, and varied mountain/cliff generation.
 
 const std = @import("std");
-const Noise = @import("noise.zig").Noise;
+const noise_mod = @import("noise.zig");
+const Noise = noise_mod.Noise;
+const smoothstep = noise_mod.smoothstep;
+const clamp01 = noise_mod.clamp01;
 const Chunk = @import("../chunk.zig").Chunk;
 const CHUNK_SIZE_X = @import("../chunk.zig").CHUNK_SIZE_X;
 const CHUNK_SIZE_Y = @import("../chunk.zig").CHUNK_SIZE_Y;
 const CHUNK_SIZE_Z = @import("../chunk.zig").CHUNK_SIZE_Z;
 const BlockType = @import("../block.zig").BlockType;
+const Biome = @import("../block.zig").Biome;
+
+/// Terrain generation parameters
+const Params = struct {
+    // Section 4.1: Domain Warping
+    warp_scale: f32 = 1.0 / 1100.0,
+    warp_amplitude: f32 = 50.0,
+
+    // Section 4.2: Continentalness (large scale landmass)
+    continental_scale: f32 = 1.0 / 2600.0,
+    deep_ocean_threshold: f32 = 0.35,
+    coast_threshold: f32 = 0.46,
+
+    // Section 4.3: Erosion (sharp vs smooth terrain)
+    erosion_scale: f32 = 1.0 / 1100.0,
+
+    // Section 4.4: Peaks/Valleys (mountain rhythm)
+    peaks_scale: f32 = 1.0 / 900.0,
+
+    // Section 4.5: Climate
+    temperature_scale: f32 = 1.0 / 5000.0,
+    humidity_scale: f32 = 1.0 / 4000.0,
+    temp_lapse: f32 = 0.25, // Temperature reduction per altitude
+
+    // Section 5: Height function
+    sea_level: i32 = 64,
+    mount_amp: f32 = 120.0,
+    detail_scale: f32 = 1.0 / 220.0,
+    detail_amp: f32 = 12.0,
+
+    // Section 6: Ocean shaping
+    coast_jitter_scale: f32 = 1.0 / 650.0,
+    seabed_scale: f32 = 1.0 / 280.0,
+    seabed_amp: f32 = 6.0,
+
+    // Section 7: Rivers
+    river_scale: f32 = 1.0 / 1200.0,
+    river_min: f32 = 0.74,
+    river_max: f32 = 0.84,
+    river_depth_max: f32 = 12.0,
+
+    // Section 10: Caves
+    cave_mask_scale: f32 = 1.0 / 1200.0,
+    cave_3d_scale: f32 = 0.025,
+    cave_y_scale: f32 = 0.035, // Vertically stretched caves
+    cave_threshold: f32 = 0.55,
+    cave_surface_protection: i32 = 8, // No caves within N blocks of surface
+};
 
 pub const TerrainGenerator = struct {
     // Noise generators for different layers
+    // Domain warp (2 noise fields for x/z offset)
+    warp_noise_x: Noise,
+    warp_noise_z: Noise,
+
+    // Core 2D fields
     continentalness_noise: Noise,
     erosion_noise: Noise,
-    peaks_valleys_noise: Noise,
+    peaks_noise: Noise,
     temperature_noise: Noise,
     humidity_noise: Noise,
-    river_noise: Noise,
-    cave_noise: Noise,
 
-    // Terrain parameters
-    sea_level: i32 = 64,
+    // Detail and feature noise
+    detail_noise: Noise,
+    coast_jitter_noise: Noise,
+    seabed_noise: Noise,
+    river_noise: Noise,
+
+    // Cave noise (2D mask + 3D carving)
+    cave_mask_noise: Noise,
+    cave_3d_noise: Noise,
+
+    // Filler depth variation
+    filler_depth_noise: Noise,
+
+    params: Params,
 
     pub fn init(seed: u64) TerrainGenerator {
         // Derive seeds for different layers to ensure they are independent
@@ -27,13 +95,21 @@ pub const TerrainGenerator = struct {
         const random = prng.random();
 
         return .{
+            .warp_noise_x = Noise.init(random.int(u64)),
+            .warp_noise_z = Noise.init(random.int(u64)),
             .continentalness_noise = Noise.init(random.int(u64)),
             .erosion_noise = Noise.init(random.int(u64)),
-            .peaks_valleys_noise = Noise.init(random.int(u64)),
+            .peaks_noise = Noise.init(random.int(u64)),
             .temperature_noise = Noise.init(random.int(u64)),
             .humidity_noise = Noise.init(random.int(u64)),
+            .detail_noise = Noise.init(random.int(u64)),
+            .coast_jitter_noise = Noise.init(random.int(u64)),
+            .seabed_noise = Noise.init(random.int(u64)),
             .river_noise = Noise.init(random.int(u64)),
-            .cave_noise = Noise.init(random.int(u64)),
+            .cave_mask_noise = Noise.init(random.int(u64)),
+            .cave_3d_noise = Noise.init(random.int(u64)),
+            .filler_depth_noise = Noise.init(random.int(u64)),
+            .params = .{},
         };
     }
 
@@ -41,6 +117,8 @@ pub const TerrainGenerator = struct {
     pub fn generate(self: *const TerrainGenerator, chunk: *Chunk) void {
         const world_x = chunk.getWorldX();
         const world_z = chunk.getWorldZ();
+        const p = self.params;
+        const sea: f32 = @floatFromInt(p.sea_level);
 
         var local_z: u32 = 0;
         while (local_z < CHUNK_SIZE_Z) : (local_z += 1) {
@@ -49,42 +127,68 @@ pub const TerrainGenerator = struct {
                 const wx: f32 = @floatFromInt(world_x + @as(i32, @intCast(local_x)));
                 const wz: f32 = @floatFromInt(world_z + @as(i32, @intCast(local_z)));
 
-                // 1. Compute Global Maps
-                const continentalness = self.getContinentalness(wx, wz);
-                const erosion = self.getErosion(wx, wz);
-                const peaks_valleys = self.getPeaksValleys(wx, wz);
-                const river_val = self.getRiverValue(wx, wz);
+                // === Section 4.1: Domain Warping ===
+                const warp = self.computeWarp(wx, wz);
+                const xw = wx + warp.x;
+                const zw = wz + warp.z;
 
-                // 2. Compute Base Height
-                var height_val = self.computeHeight(continentalness, erosion, peaks_valleys);
+                // === Section 4.2-4.5: Sample core 2D fields ===
+                const c = self.getContinentalness(xw, zw); // [0,1]
+                const e = self.getErosion(xw, zw); // [0,1]
+                const pv = self.getPeaksValleys(xw, zw); // [0,1] ridged
 
-                // River Carving
-                if (river_val < 0.05) { // River threshold
-                    // Carve down to slightly below sea level or smooth it out
-                    // Normalize river value 0..0.05 to 0..1 for depth blending
-                    const t = river_val / 0.05;
-                    const river_bed = @as(f32, @floatFromInt(self.sea_level - 2));
-                    height_val = std.math.lerp(river_bed, height_val, t * t); // Quadratic ease-out for banks
+                // === Section 6.1: Coastline jitter ===
+                const coast_jitter = self.coast_jitter_noise.fbm2D(xw, zw, 3, 2.0, 0.5, p.coast_jitter_scale) * 0.05;
+                const c_jittered = clamp01(c + coast_jitter);
+
+                // === Section 5: Height function ===
+                var terrain_height = self.computeHeight(c_jittered, e, pv, xw, zw);
+
+                // === Section 7: River carving ===
+                const river_mask = self.getRiverMask(xw, zw);
+                if (river_mask > 0 and terrain_height > sea - 5) {
+                    const river_depth = river_mask * p.river_depth_max;
+                    terrain_height = @min(terrain_height, terrain_height - river_depth);
                 }
 
-                const terrain_height: i32 = @intFromFloat(height_val);
+                // === Section 6.2: Seabed variation for ocean columns ===
+                var is_ocean = false;
+                if (terrain_height < sea) {
+                    is_ocean = true;
+                    // Apply seabed variation
+                    const deep_factor = 1.0 - smoothstep(p.deep_ocean_threshold, 0.5, c_jittered);
+                    const seabed_detail = self.seabed_noise.fbm2D(xw, zw, 5, 2.0, 0.5, p.seabed_scale) * p.seabed_amp;
+                    const base_seabed = sea - 18.0 - deep_factor * 35.0;
+                    terrain_height = @min(terrain_height, base_seabed + seabed_detail);
+                }
 
-                // 3. Biome info (for surface blocks)
-                const temperature = self.temperature_noise.fbm2D(wx, wz, 2, 2.0, 0.5, 0.002);
-                const humidity = self.humidity_noise.fbm2D(wx, wz, 2, 2.0, 0.5, 0.002);
+                const terrain_height_i: i32 = @intFromFloat(terrain_height);
+
+                // === Section 4.5: Climate with altitude adjustment ===
+                const altitude_offset: f32 = @max(0, terrain_height - sea);
+                var temperature = self.getTemperature(xw, zw);
+                temperature = clamp01(temperature - (altitude_offset / 512.0) * p.temp_lapse);
+                const humidity = self.getHumidity(xw, zw);
+
+                // === Section 8: Biome selection ===
+                const mountain_mask = self.getMountainMask(pv, e);
+                const biome = self.selectBiome(c_jittered, e, mountain_mask, terrain_height_i, temperature, humidity, river_mask);
+
+                // === Section 9: Surface layers ===
+                const filler_depth = self.getFillerDepth(xw, zw, e, biome);
+
+                // === Section 10: Cave mask ===
+                const cave_allowed = self.getCaveAllowed(xw, zw);
 
                 // Fill column
                 var y: i32 = 0;
                 while (y < CHUNK_SIZE_Y) : (y += 1) {
-                    var block = self.getBlockAt(y, terrain_height, continentalness, temperature, humidity);
+                    var block = self.getBlockAt(y, terrain_height_i, biome, filler_depth, is_ocean, sea);
 
-                    // Cave carving
+                    // Cave carving (Section 10)
                     if (block != .air and block != .water and block != .bedrock) {
-                        const wy: f32 = @floatFromInt(y);
-                        // 3D noise for caves. Scale 0.04 seems reasonable for "cheese" caves
-                        const cave_val = self.cave_noise.perlin3D(wx * 0.04, wy * 0.04, wz * 0.04);
-                        if (cave_val > 0.4) {
-                            block = .air;
+                        if (self.shouldCarve(wx, @floatFromInt(y), wz, terrain_height_i, cave_allowed)) {
+                            block = if (y < p.sea_level) .water else .air;
                         }
                     }
 
@@ -95,18 +199,272 @@ pub const TerrainGenerator = struct {
 
         chunk.generated = true;
 
-        // 4. Ores
+        // Ores
         self.generateOres(chunk);
 
-        // 5. Decorate (Trees, Cacti, etc.)
+        // Features (trees, cacti, etc.)
         self.generateFeatures(chunk);
 
         chunk.dirty = true;
     }
 
+    // ========== Section 4.1: Domain Warping ==========
+
+    fn computeWarp(self: *const TerrainGenerator, x: f32, z: f32) struct { x: f32, z: f32 } {
+        const p = self.params;
+        const offset_x = self.warp_noise_x.fbm2D(x, z, 3, 2.0, 0.5, p.warp_scale) * p.warp_amplitude;
+        const offset_z = self.warp_noise_z.fbm2D(x, z, 3, 2.0, 0.5, p.warp_scale) * p.warp_amplitude;
+        return .{ .x = offset_x, .z = offset_z };
+    }
+
+    // ========== Section 4.2-4.5: Core 2D Fields ==========
+
+    fn getContinentalness(self: *const TerrainGenerator, x: f32, z: f32) f32 {
+        const val = self.continentalness_noise.fbm2D(x, z, 4, 2.0, 0.5, self.params.continental_scale);
+        return (val + 1.0) * 0.5; // Normalize to [0, 1]
+    }
+
+    fn getErosion(self: *const TerrainGenerator, x: f32, z: f32) f32 {
+        const val = self.erosion_noise.fbm2D(x, z, 4, 2.0, 0.5, self.params.erosion_scale);
+        return (val + 1.0) * 0.5;
+    }
+
+    fn getPeaksValleys(self: *const TerrainGenerator, x: f32, z: f32) f32 {
+        return self.peaks_noise.ridged2D(x, z, 5, 2.0, 0.5, self.params.peaks_scale);
+    }
+
+    fn getTemperature(self: *const TerrainGenerator, x: f32, z: f32) f32 {
+        const val = self.temperature_noise.fbm2D(x, z, 3, 2.0, 0.5, self.params.temperature_scale);
+        return (val + 1.0) * 0.5;
+    }
+
+    fn getHumidity(self: *const TerrainGenerator, x: f32, z: f32) f32 {
+        const val = self.humidity_noise.fbm2D(x, z, 3, 2.0, 0.5, self.params.humidity_scale);
+        return (val + 1.0) * 0.5;
+    }
+
+    // ========== Section 5: Height Function ==========
+
+    fn getMountainMask(self: *const TerrainGenerator, pv: f32, e: f32) f32 {
+        _ = self;
+        // Mountains where peaks are high AND erosion is low (rugged)
+        const peak_factor = smoothstep(0.55, 0.85, pv);
+        const rugged_factor = 1.0 - smoothstep(0.45, 0.80, e);
+        return peak_factor * rugged_factor;
+    }
+
+    fn computeHeight(self: *const TerrainGenerator, c: f32, e: f32, pv: f32, x: f32, z: f32) f32 {
+        const p = self.params;
+        const sea: f32 = @floatFromInt(p.sea_level);
+
+        // Section 5.1: Base height from continentalness
+        const land_factor = smoothstep(0.35, 0.75, c);
+        var base_height = std.math.lerp(sea - 55.0, sea + 70.0, land_factor);
+
+        // Section 5.2: Mountain lift
+        const m_mask = self.getMountainMask(pv, e);
+        const mount = std.math.pow(f32, m_mask, 1.7) * p.mount_amp;
+        base_height += mount;
+
+        // Section 5.3: Local detail (hills)
+        const detail = self.detail_noise.fbm2D(x, z, 5, 2.0, 0.5, p.detail_scale) * p.detail_amp;
+        base_height += detail;
+
+        // Section 5.5: Cliff/terrace shaping - reduce smoothness in rugged areas
+        // Higher erosion = smoother terrain, lower = more cliffs
+        // We can add subtle terracing in low-erosion mountain areas
+        if (m_mask > 0.3 and e < 0.4) {
+            const terrace_step: f32 = 4.0;
+            const terrace_strength: f32 = 0.25 * (1.0 - e);
+            const terraced = @round(base_height / terrace_step) * terrace_step;
+            base_height = std.math.lerp(base_height, terraced, terrace_strength);
+        }
+
+        return base_height;
+    }
+
+    // ========== Section 7: Rivers ==========
+
+    fn getRiverMask(self: *const TerrainGenerator, x: f32, z: f32) f32 {
+        const p = self.params;
+        // Use ridged noise inverted (valleys are rivers)
+        const r = self.river_noise.ridged2D(x, z, 4, 2.0, 0.5, p.river_scale);
+        const river_val = 1.0 - r;
+        return smoothstep(p.river_min, p.river_max, river_val);
+    }
+
+    // ========== Section 8: Biome Selection ==========
+
+    fn selectBiome(
+        self: *const TerrainGenerator,
+        c: f32,
+        e: f32,
+        mountain_mask: f32,
+        height: i32,
+        temp: f32,
+        humidity: f32,
+        river_mask: f32,
+    ) Biome {
+        _ = self;
+        _ = e;
+        const sea = 64;
+
+        // River biome
+        if (river_mask > 0.5 and height <= sea) {
+            return .river;
+        }
+
+        // Deep ocean
+        if (c < 0.35) {
+            return .deep_ocean;
+        }
+
+        // Ocean
+        if (c < 0.46 and height < sea - 2) {
+            return .ocean;
+        }
+
+        // Beach (near sea level, coastal)
+        if (c < 0.52 and @abs(height - sea) < 4) {
+            return .beach;
+        }
+
+        // Land biomes
+        // Mountains (high elevation or rugged)
+        if (height > sea + 95 or mountain_mask > 0.6) {
+            if (temp < 0.35) {
+                return .snowy_mountains;
+            }
+            return .mountains;
+        }
+
+        // Climate-based biomes
+        if (temp < 0.25) {
+            return .snow_tundra;
+        }
+
+        if (temp < 0.40) {
+            return .taiga;
+        }
+
+        if (temp > 0.65 and humidity < 0.35) {
+            return .desert;
+        }
+
+        if (humidity > 0.55) {
+            return .forest;
+        }
+
+        return .plains;
+    }
+
+    // ========== Section 9: Surface Layers ==========
+
+    fn getFillerDepth(self: *const TerrainGenerator, x: f32, z: f32, erosion: f32, biome: Biome) i32 {
+        _ = biome;
+        // Base filler depth with variation
+        const base: f32 = 3.0;
+        const variation = self.filler_depth_noise.fbm2D(x, z, 2, 2.0, 0.5, 0.01) * 2.0;
+        var depth = base + variation;
+
+        // Reduce on cliffs (low erosion = more exposed rock)
+        if (erosion < 0.35) {
+            depth *= erosion / 0.35;
+        }
+
+        return @intFromFloat(@max(1, depth));
+    }
+
+    fn getBlockAt(
+        self: *const TerrainGenerator,
+        y: i32,
+        terrain_height: i32,
+        biome: Biome,
+        filler_depth: i32,
+        is_ocean: bool,
+        sea: f32,
+    ) BlockType {
+        _ = self;
+        const sea_level: i32 = @intFromFloat(sea);
+
+        if (y == 0) return .bedrock;
+
+        // Above terrain
+        if (y > terrain_height) {
+            if (y <= sea_level) return .water;
+            return .air;
+        }
+
+        // Ocean floor
+        if (is_ocean and y == terrain_height) {
+            const depth: f32 = sea - @as(f32, @floatFromInt(terrain_height));
+            return biome.getOceanFloorBlock(depth);
+        }
+
+        // Surface block
+        if (y == terrain_height) {
+            // Snow on top of cold biomes
+            if (biome == .snowy_mountains or biome == .snow_tundra) {
+                return .snow_block;
+            }
+            return biome.getSurfaceBlock();
+        }
+
+        // Filler layers (dirt/sand under surface)
+        if (y > terrain_height - filler_depth) {
+            return biome.getFillerBlock();
+        }
+
+        // Stone below
+        return .stone;
+    }
+
+    // ========== Section 10: Caves ==========
+
+    fn getCaveAllowed(self: *const TerrainGenerator, x: f32, z: f32) f32 {
+        const p = self.params;
+        const mask_val = self.cave_mask_noise.fbm2DNormalized(x, z, 3, 2.0, 0.5, p.cave_mask_scale);
+        return smoothstep(0.58, 0.80, mask_val);
+    }
+
+    fn shouldCarve(self: *const TerrainGenerator, x: f32, y: f32, z: f32, terrain_height: i32, cave_allowed: f32) bool {
+        const p = self.params;
+
+        // No caves if region doesn't allow
+        if (cave_allowed < 0.1) return false;
+
+        // Surface protection
+        const yi: i32 = @intFromFloat(y);
+        if (yi > terrain_height - p.cave_surface_protection) return false;
+
+        // Depth band preference (caves prefer mid-depths)
+        const band = smoothstep(12, 60, y) * (1.0 - smoothstep(120, 180, y));
+        if (band < 0.1) return false;
+
+        // 3D carving noise
+        const n = self.cave_3d_noise.fbm3D(
+            x * p.cave_3d_scale,
+            y * p.cave_y_scale,
+            z * p.cave_3d_scale,
+            4,
+            2.0,
+            0.5,
+            1.0,
+        );
+
+        // Threshold with cave_allowed influence
+        const threshold = p.cave_threshold + (1.0 - cave_allowed) * 0.2;
+        return n > threshold;
+    }
+
+    // ========== Ores ==========
+
     fn generateOres(self: *const TerrainGenerator, chunk: *Chunk) void {
-        // Seed based on chunk and salt
-        var prng = std.Random.DefaultPrng.init(self.erosion_noise.seed +% @as(u64, @bitCast(@as(i64, chunk.chunk_x))) *% 59381 +% @as(u64, @bitCast(@as(i64, chunk.chunk_z))) *% 28411);
+        var prng = std.Random.DefaultPrng.init(
+            self.erosion_noise.seed +%
+                @as(u64, @bitCast(@as(i64, chunk.chunk_x))) *% 59381 +%
+                @as(u64, @bitCast(@as(i64, chunk.chunk_z))) *% 28411,
+        );
         const random = prng.random();
 
         self.placeOreVeins(chunk, .coal_ore, 20, 6, 10, 128, random);
@@ -114,7 +472,16 @@ pub const TerrainGenerator = struct {
         self.placeOreVeins(chunk, .gold_ore, 3, 3, 2, 32, random);
     }
 
-    fn placeOreVeins(self: *const TerrainGenerator, chunk: *Chunk, block: BlockType, count: u32, size: u32, min_y: i32, max_y: i32, random: std.Random) void {
+    fn placeOreVeins(
+        self: *const TerrainGenerator,
+        chunk: *Chunk,
+        block: BlockType,
+        count: u32,
+        size: u32,
+        min_y: i32,
+        max_y: i32,
+        random: std.Random,
+    ) void {
         _ = self;
         for (0..count) |_| {
             const cx = random.uintLessThan(u32, CHUNK_SIZE_X);
@@ -123,7 +490,6 @@ pub const TerrainGenerator = struct {
             if (range <= 0) continue;
             const cy = min_y + @as(i32, @intCast(random.uintLessThan(u32, @intCast(range))));
 
-            // Simple blob vein
             const vein_size = random.uintLessThan(u32, size) + 2;
 
             var i: u32 = 0;
@@ -137,32 +503,29 @@ pub const TerrainGenerator = struct {
                 const tz = @as(i32, @intCast(cz)) + oz;
 
                 if (chunk.getBlockSafe(tx, ty, tz) == .stone) {
-                    chunk.setBlock(@intCast(tx), @intCast(ty), @intCast(tz), block);
+                    if (tx >= 0 and tx < CHUNK_SIZE_X and
+                        ty >= 0 and ty < CHUNK_SIZE_Y and
+                        tz >= 0 and tz < CHUNK_SIZE_Z)
+                    {
+                        chunk.setBlock(@intCast(tx), @intCast(ty), @intCast(tz), block);
+                    }
                 }
             }
         }
     }
 
+    // ========== Features (Trees, Cacti, etc.) ==========
+
     fn generateFeatures(self: *const TerrainGenerator, chunk: *Chunk) void {
-        var prng = std.Random.DefaultPrng.init(self.continentalness_noise.seed ^ @as(u64, @bitCast(@as(i64, chunk.chunk_x))) ^ (@as(u64, @bitCast(@as(i64, chunk.chunk_z))) << 32));
+        var prng = std.Random.DefaultPrng.init(
+            self.continentalness_noise.seed ^
+                @as(u64, @bitCast(@as(i64, chunk.chunk_x))) ^
+                (@as(u64, @bitCast(@as(i64, chunk.chunk_z))) << 32),
+        );
         const random = prng.random();
 
         // Attempt to place features
-
-        // Oases (Rare, Desert only)
-        if (random.float(f32) < 0.02) {
-            const wx = @as(f32, @floatFromInt(chunk.getWorldX() + 8));
-            const wz = @as(f32, @floatFromInt(chunk.getWorldZ() + 8));
-            const temp = self.temperature_noise.fbm2D(wx, wz, 2, 2.0, 0.5, 0.002);
-            const humidity = self.humidity_noise.fbm2D(wx, wz, 2, 2.0, 0.5, 0.002);
-
-            if (temp > 0.5 and humidity < -0.2) {
-                self.placeOasis(chunk, 8, 8);
-            }
-        }
-
-        // Simple approach: try N times
-        const attempts = 10;
+        const attempts = 12;
         for (0..attempts) |_| {
             const lx = random.uintLessThan(u32, CHUNK_SIZE_X);
             const lz = random.uintLessThan(u32, CHUNK_SIZE_Z);
@@ -177,52 +540,14 @@ pub const TerrainGenerator = struct {
 
             // Tree placement (on grass)
             if (surface_block == .grass) {
-                if (random.float(f32) < 0.05) { // 5% chance per attempt on grass
+                if (random.float(f32) < 0.06) {
                     self.placeTree(chunk, lx, @intCast(y + 1), lz, random);
                 }
             }
-            // Cactus placement (on sand)
-            else if (surface_block == .sand) {
-                if (random.float(f32) < 0.02) { // 2% chance on sand
+            // Cactus placement (on sand, not underwater)
+            else if (surface_block == .sand and y > self.params.sea_level) {
+                if (random.float(f32) < 0.015) {
                     self.placeCactus(chunk, lx, @intCast(y + 1), lz, random);
-                }
-            }
-        }
-    }
-
-    fn placeOasis(self: *const TerrainGenerator, chunk: *Chunk, cx: u32, cz: u32) void {
-        _ = self;
-        var cy: i32 = CHUNK_SIZE_Y - 1;
-        while (cy > 0) : (cy -= 1) {
-            if (chunk.getBlock(cx, @intCast(cy), cz) != .air) break;
-        }
-
-        const radius = 6;
-        var z: i32 = -radius;
-        while (z <= radius) : (z += 1) {
-            var x: i32 = -radius;
-            while (x <= radius) : (x += 1) {
-                const dist = x * x + z * z;
-                if (dist < radius * radius) {
-                    const tx = @as(i32, @intCast(cx)) + x;
-                    const tz = @as(i32, @intCast(cz)) + z;
-
-                    if (tx >= 0 and tx < CHUNK_SIZE_X and tz >= 0 and tz < CHUNK_SIZE_Z) {
-                        // Water pool
-                        chunk.setBlock(@intCast(tx), @intCast(cy), @intCast(tz), .water);
-                        if (cy > 0) chunk.setBlock(@intCast(tx), @intCast(cy - 1), @intCast(tz), .water);
-                        if (cy > 1) chunk.setBlock(@intCast(tx), @intCast(cy - 2), @intCast(tz), .sand);
-
-                        // Palm trees around edge
-                        if (dist > (radius - 3) * (radius - 3) and @mod(x + z, 4) == 0) {
-                            if (cy + 4 < CHUNK_SIZE_Y) {
-                                chunk.setBlock(@intCast(tx), @intCast(cy + 1), @intCast(tz), .wood);
-                                chunk.setBlock(@intCast(tx), @intCast(cy + 2), @intCast(tz), .wood);
-                                chunk.setBlock(@intCast(tx), @intCast(cy + 3), @intCast(tz), .wood);
-                                chunk.setBlock(@intCast(tx), @intCast(cy + 4), @intCast(tz), .leaves);
-                            }
-                        }
-                    }
                 }
             }
         }
@@ -240,7 +565,7 @@ pub const TerrainGenerator = struct {
             }
         }
 
-        // Leaves (very simple blob)
+        // Leaves
         const leaf_start = y + height - 2;
         const leaf_end = y + height + 1;
 
@@ -251,15 +576,12 @@ pub const TerrainGenerator = struct {
             while (lz <= range) : (lz += 1) {
                 var lx: i32 = -range;
                 while (lx <= range) : (lx += 1) {
-                    // Don't replace trunk
                     if (lx == 0 and lz == 0 and ly < y + height) continue;
 
-                    // Simple distance check for roundness
                     if (lx * lx + lz * lz <= range * range + 1) {
                         const target_x = @as(i32, @intCast(x)) + lx;
                         const target_z = @as(i32, @intCast(z)) + lz;
 
-                        // Check bounds (simple v1: only place if inside chunk)
                         if (target_x >= 0 and target_x < CHUNK_SIZE_X and
                             target_z >= 0 and target_z < CHUNK_SIZE_Z and
                             ly < CHUNK_SIZE_Y)
@@ -283,83 +605,5 @@ pub const TerrainGenerator = struct {
                 chunk.setBlock(x, cy, z, .cactus);
             }
         }
-    }
-
-    fn getContinentalness(self: *const TerrainGenerator, x: f32, z: f32) f32 {
-        // Large scale features: 0.002 frequency
-        return self.continentalness_noise.fbm2D(x, z, 3, 2.0, 0.5, 0.002);
-    }
-
-    fn getErosion(self: *const TerrainGenerator, x: f32, z: f32) f32 {
-        return self.erosion_noise.fbm2D(x, z, 3, 2.0, 0.5, 0.003);
-    }
-
-    fn getPeaksValleys(self: *const TerrainGenerator, x: f32, z: f32) f32 {
-        return self.peaks_valleys_noise.fbm2D(x, z, 4, 2.0, 0.5, 0.008);
-    }
-
-    fn getRiverValue(self: *const TerrainGenerator, x: f32, z: f32) f32 {
-        // Rivers are low frequency, winding. We use abs(noise) close to 0.
-        // Frequency: 0.001 (very large scale)
-        const val = self.river_noise.fbm2D(x, z, 4, 2.0, 0.5, 0.0015);
-        return @abs(val);
-    }
-
-    fn computeHeight(self: *const TerrainGenerator, c: f32, e: f32, pv: f32) f32 {
-        _ = e; // Erosion could smooth things out later
-
-        // Base height from continentalness
-        // c in [-1, 1]
-        // -1.0 .. -0.2 => Deep Ocean / Ocean
-        // -0.2 .. 0.0  => Coast
-        // 0.0 .. 1.0   => Land / Mountains
-
-        var base_height: f32 = @floatFromInt(self.sea_level);
-
-        if (c < -0.3) {
-            // Deep Ocean
-            base_height += c * 30.0;
-        } else if (c < 0.1) {
-            // Ocean/Beach transition
-            base_height += c * 10.0;
-        } else {
-            // Land
-            base_height += c * 50.0;
-
-            // Add peaks and valleys on land
-            base_height += pv * 20.0;
-        }
-
-        return base_height;
-    }
-
-    fn getBlockAt(self: *const TerrainGenerator, y: i32, terrain_height: i32, continentalness: f32, temp: f32, humidity: f32) BlockType {
-        if (y == 0) return .bedrock;
-
-        if (y > terrain_height) {
-            if (y <= self.sea_level) return .water;
-            return .air;
-        }
-
-        // Surface blocks
-        if (y == terrain_height) {
-            if (y <= self.sea_level + 1 and continentalness < 0.15) {
-                return .sand; // Beach
-            }
-            if (temp < -0.3) return .snow_block; // Cold biome
-            if (temp > 0.5 and humidity < -0.2) return .sand; // Desert
-            return .grass;
-        }
-
-        // Subsurface
-        if (y > terrain_height - 4) {
-            if (y <= self.sea_level + 1 and continentalness < 0.15) {
-                return .sand;
-            }
-            if (temp > 0.5 and humidity < -0.2) return .sand; // Desert sand depth
-            return .dirt;
-        }
-
-        return .stone;
     }
 };


### PR DESCRIPTION
Implements worldgen-spec2.md with Minecraft-style terrain generation:
- Domain warping to break repetitive noise patterns
- Layered 2D fields: continentalness, erosion, peaks/valleys, climate
- Height function with base terrain, mountains, detail, cliff terracing
- Ocean shaping: coastline jitter, varied seabed by depth
- River carving using inverted ridged noise
- Multi-noise biome selection (11 biomes based on climate/elevation)
- Controlled caves with 2D mask, depth bands, surface protection
- Fix water rendering by emitting faces for water-to-non-water boundaries