### PR TITLE
feat: voxel engine with worldgen, async streaming, and render stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,99 @@
-# Zig 0.14 + SDL3 + OpenGL Pyramid
+# Zig Voxel Engine
 
-A simple 3D spinning pyramid implemented in [Zig](https://ziglang.org/) (0.14/master), using [SDL3](https://wiki.libsdl.org/SDL3/FrontPage) for windowing and [OpenGL 3.3](https://www.opengl.org/) for rendering.
-
-This project uses **Nix** to provide a reproducible development and build environment, ensuring all dependencies (Zig compiler, SDL3, GLEW, OpenGL drivers) are correctly linked and patched.
+A Minecraft-style voxel engine built with [Zig](https://ziglang.org/) (0.14/master), [SDL3](https://wiki.libsdl.org/SDL3/FrontPage), and [OpenGL 3.3](https://www.opengl.org/).
 
 ## Features
-- **Modern OpenGL (3.3 Core):** Uses Shaders, VAOs, and VBOs.
-- **3D Math:** Custom matrix math struct for perspective projection, translation, and rotation.
-- **Nix Flake:** Fully hermetic build and development shell.
-- **Auto-Patching:** The Nix build process automatically fixes ELF interpreters and RPATHs (including `libstdc++` for audio backends).
+
+### Rendering
+- **Modern OpenGL 3.3 Core** - Shaders, VAOs, VBOs
+- **Floating Origin** - Camera-relative rendering prevents precision loss at large coordinates
+- **Reverse-Z Depth Buffer** - Better depth precision at far distances
+- **Greedy Meshing** - Optimized chunk mesh generation
+- **Frustum Culling** - Camera-relative chunk culling
+- **Texture Atlas** - 16x16 tile atlas for block textures
+- **Flat Shading** - Per-face normals for clean voxel look
+
+### World Generation
+- **Multi-noise Biome System** - 11 biome types based on temperature/humidity
+- **Domain Warping** - Natural-looking terrain variation
+- **Layered Noise** - Continental, erosion, and detail noise layers
+- **Cave Generation** - 3D noise-based cave systems
+- **Water Bodies** - Lakes and oceans at sea level
+
+### Engine
+- **Multithreaded Chunk Loading** - 4 generation + 3 meshing worker threads
+- **Job Prioritization** - Chunks closest to player load first
+- **Dynamic Re-prioritization** - Jobs update when player moves
+- **Subchunk Rendering** - 16 vertical subchunks per chunk column
+- **Solid/Fluid Render Passes** - Proper water transparency
+
+### Controls
+| Key | Action |
+|-----|--------|
+| WASD | Move |
+| Space | Fly up |
+| Shift | Fly down |
+| Mouse | Look around |
+| Tab | Toggle mouse capture |
+| F | Toggle wireframe |
+| T | Toggle textures |
+| V | Toggle VSync |
+| Esc | Pause/Menu |
 
 ## Prerequisites
-- [Nix](https://nixos.org/download.html) with `flakes` enabled.
+
+- [Nix](https://nixos.org/download.html) with `flakes` enabled
 
 ## Build & Run
 
-### 1. Build with Nix
-This produces a patched binary in `./result/bin/`:
-
-```bash
-nix build
-```
-
-### 2. Run
-```bash
-./result/bin/zig-triangle
-```
-
-### Development Shell
-To work on the code with `zls` and the `zig` compiler available in your path:
-
+### Development
 ```bash
 nix develop
 zig build run
 ```
-*(Note: `zig build run` inside `nix develop` uses the local cache and might require `LD_LIBRARY_PATH` setup if not fully patched, but the flake handles the production build perfectly)*
+
+### Production Build
+```bash
+nix build
+./result/bin/zig-triangle
+```
 
 ## Project Structure
-- `src/main.zig`: Application entry point, render loop, and shader logic.
-- `build.zig`: Zig build configuration.
-- `flake.nix`: Nix dependencies, package definition, and wrapper logic.
+
+```
+src/
+  engine/
+    core/       # Job system, logging, time
+    graphics/   # Camera, renderer, shaders, textures
+    input/      # Input handling
+    math/       # Vec3, Mat4, AABB, Frustum
+    ui/         # UI system for menus
+  world/
+    worldgen/   # Terrain generator, noise functions
+    block.zig   # Block types and properties
+    chunk.zig   # Chunk data structure
+    chunk_mesh.zig  # Greedy meshing
+    world.zig   # World manager, chunk loading
+  main.zig      # Entry point, game loop
+  c.zig         # C bindings (SDL3, GLEW, OpenGL)
+```
+
+## Technical Details
+
+### Render Stability
+The engine implements industry-standard techniques to prevent terrain shimmering at high altitude and large render distances:
+
+1. **Floating Origin** - Chunk vertices use local coordinates (0-16), world offset applied via model matrix relative to camera position
+2. **Reverse-Z Depth** - Near plane maps to z=1, far plane to z=0, with `glDepthFunc(GL_GEQUAL)`
+3. **Near Plane** - Set to 0.5 (not 0.1) for better depth precision
+4. **Flat Shading** - `flat` interpolation qualifier on normals prevents lighting shimmer
+
+### Chunk System
+- Chunk size: 16x256x16 blocks
+- 16 subchunks per column (16x16x16 each)
+- Render distance configurable in settings
+- Chunks unload when player moves away
+
+## License
+
+MIT

--- a/src/engine/graphics/renderer.zig
+++ b/src/engine/graphics/renderer.zig
@@ -51,9 +51,14 @@ pub const Renderer = struct {
         log.log.info("OpenGL Version: {s}", .{version});
         log.log.info("GLSL Version: {s}", .{glsl_version});
 
-        // Enable depth testing
+        // Enable depth testing with reverse-Z for better precision at distance
         c.glEnable(c.GL_DEPTH_TEST);
-        c.glDepthFunc(c.GL_LESS);
+        c.glDepthFunc(c.GL_GEQUAL); // Reverse-Z: greater values are closer
+        c.glClearDepth(0.0); // Clear to 0 (far plane in reverse-Z)
+        // glClipControl for [0,1] depth range - use function pointer from GLEW
+        if (c.glClipControl()) |clip_fn| {
+            clip_fn(c.GL_LOWER_LEFT, c.GL_ZERO_TO_ONE);
+        }
 
         // Enable backface culling
         c.glEnable(c.GL_CULL_FACE);

--- a/src/engine/math/frustum.zig
+++ b/src/engine/math/frustum.zig
@@ -132,17 +132,25 @@ pub const Frustum = struct {
 
     /// Check if a chunk (given by chunk coordinates) intersects the frustum
     /// Chunks are 16x256x16 blocks
+    /// For floating origin rendering, pass camera position to compute relative coordinates
     pub fn intersectsChunk(self: Frustum, chunk_x: i32, chunk_z: i32) bool {
+        return self.intersectsChunkRelative(chunk_x, chunk_z, 0, 0, 0);
+    }
+
+    /// Check if a chunk intersects the frustum using camera-relative coordinates
+    pub fn intersectsChunkRelative(self: Frustum, chunk_x: i32, chunk_z: i32, cam_x: f32, cam_y: f32, cam_z: f32) bool {
         const CHUNK_SIZE_X: f32 = 16.0;
         const CHUNK_SIZE_Y: f32 = 256.0;
         const CHUNK_SIZE_Z: f32 = 16.0;
 
-        const world_x: f32 = @floatFromInt(chunk_x * 16);
-        const world_z: f32 = @floatFromInt(chunk_z * 16);
+        // Chunk world position relative to camera
+        const world_x: f32 = @as(f32, @floatFromInt(chunk_x * 16)) - cam_x;
+        const world_z: f32 = @as(f32, @floatFromInt(chunk_z * 16)) - cam_z;
+        const world_y: f32 = -cam_y; // Y=0 in chunk space
 
         const aabb = AABB.init(
-            Vec3.init(world_x, 0, world_z),
-            Vec3.init(world_x + CHUNK_SIZE_X, CHUNK_SIZE_Y, world_z + CHUNK_SIZE_Z),
+            Vec3.init(world_x, world_y, world_z),
+            Vec3.init(world_x + CHUNK_SIZE_X, world_y + CHUNK_SIZE_Y, world_z + CHUNK_SIZE_Z),
         );
 
         return self.intersectsAABB(aabb);

--- a/src/engine/math/mat4.zig
+++ b/src/engine/math/mat4.zig
@@ -51,6 +51,23 @@ pub const Mat4 = struct {
         return result;
     }
 
+    /// Perspective projection with reverse-Z for better depth precision at distance
+    /// Maps near plane to z=1 and far plane to z=0 (reversed from standard)
+    /// Use with glDepthFunc(GL_GEQUAL) and glClearDepth(0.0)
+    pub fn perspectiveReverseZ(fov_radians: f32, aspect: f32, near: f32, far: f32) Mat4 {
+        const tan_half_fov = std.math.tan(fov_radians / 2.0);
+        var result = Mat4.zero;
+
+        result.data[0][0] = 1.0 / (aspect * tan_half_fov);
+        result.data[1][1] = 1.0 / tan_half_fov;
+        // Reverse-Z: swap near and far in depth calculation
+        result.data[2][2] = near / (far - near);
+        result.data[2][3] = -1.0;
+        result.data[3][2] = (far * near) / (far - near);
+
+        return result;
+    }
+
     pub fn orthographic(left: f32, right_val: f32, bottom: f32, top: f32, near: f32, far: f32) Mat4 {
         var result = Mat4.zero;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -408,7 +408,7 @@ pub fn main() !void {
                         if (settings.render_distance > 1) settings.render_distance -= 1;
                     }
                     if (drawButton(&ui, .{ .x = value_x + 100.0, .y = setting_y - 5.0, .width = 30.0, .height = 30.0 }, "+", 1.5, mouse_x, mouse_y, mouse_clicked)) {
-                        if (settings.render_distance < 32) settings.render_distance += 1;
+                        settings.render_distance += 1; // No upper limit for experiments
                     }
                     setting_y += 50.0;
 


### PR DESCRIPTION
## Summary

Major engine overhaul transforming the basic voxel demo into a full Minecraft-style engine:

- **World Generation**: Multi-noise biome system (11 types), domain warping, layered terrain noise, cave generation, water bodies
- **Chunk Streaming**: Multithreaded async loading (4 gen + 3 mesh workers), job prioritization by distance, dynamic re-prioritization
- **Render Stability**: Floating origin rendering, reverse-Z depth buffer, flat shading - eliminates terrain shimmer at high altitude/distance
- **UI/UX**: Full menu system with home, singleplayer, settings, and pause screens
- **Performance**: Greedy meshing, subchunk rendering, frustum culling, cross-chunk face culling

### Technical Highlights
- Camera-relative chunk positions prevent floating-point precision loss
- Reverse-Z depth with `glDepthFunc(GL_GEQUAL)` for better far-plane precision
- Configurable render distance with no upper cap