### PR TITLE
Refactor: Decompose App and Fix Vulkan Parity/SOLID issues

### DIFF
--- a/src/engine/core/window.zig
+++ b/src/engine/core/window.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const c = @import("../../c.zig").c;
+const log = @import("log.zig");
+
+pub const WindowManager = struct {
+    window: *c.SDL_Window,
+    gl_context: ?c.SDL_GLContext,
+    is_vulkan: bool,
+
+    pub fn init(allocator: std.mem.Allocator, use_vulkan: bool) !WindowManager {
+        _ = allocator;
+        if (c.SDL_Init(c.SDL_INIT_VIDEO) == false) {
+            std.debug.print("SDL Init Failed: {s}\n", .{c.SDL_GetError()});
+            return error.SDLInitializationFailed;
+        }
+
+        if (!use_vulkan) {
+            _ = c.SDL_GL_SetAttribute(c.SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+            _ = c.SDL_GL_SetAttribute(c.SDL_GL_CONTEXT_MINOR_VERSION, 3);
+            _ = c.SDL_GL_SetAttribute(c.SDL_GL_CONTEXT_PROFILE_MASK, c.SDL_GL_CONTEXT_PROFILE_CORE);
+            _ = c.SDL_GL_SetAttribute(c.SDL_GL_DEPTH_SIZE, 24);
+        }
+
+        var window_flags: u32 = c.SDL_WINDOW_RESIZABLE;
+        if (use_vulkan) {
+            window_flags |= c.SDL_WINDOW_VULKAN;
+        } else {
+            window_flags |= c.SDL_WINDOW_OPENGL;
+        }
+
+        const window = c.SDL_CreateWindow(
+            "Zig Voxel Engine",
+            1280,
+            720,
+            @intCast(window_flags),
+        );
+        if (window == null) {
+            log.log.err("Window Creation Failed: {s}", .{c.SDL_GetError()});
+            return error.WindowCreationFailed;
+        }
+        log.log.info("Window created successfully", .{});
+
+        var gl_context: ?c.SDL_GLContext = null;
+        if (!use_vulkan) {
+            gl_context = c.SDL_GL_CreateContext(window);
+            if (gl_context == null) return error.GLContextCreationFailed;
+            _ = c.SDL_GL_MakeCurrent(window, gl_context.?);
+            c.glewExperimental = c.GL_TRUE;
+        }
+
+        return WindowManager{
+            .window = window.?,
+            .gl_context = gl_context,
+            .is_vulkan = use_vulkan,
+        };
+    }
+
+    pub fn deinit(self: *WindowManager) void {
+        if (self.gl_context) |ctx| {
+            _ = c.SDL_GL_DestroyContext(ctx);
+        }
+        c.SDL_DestroyWindow(self.window);
+        c.SDL_Quit();
+    }
+};

--- a/src/engine/graphics/csm.zig
+++ b/src/engine/graphics/csm.zig
@@ -1,0 +1,110 @@
+const std = @import("std");
+const Mat4 = @import("../math/mat4.zig").Mat4;
+const Vec3 = @import("../math/vec3.zig").Vec3;
+const rhi = @import("rhi.zig");
+
+pub const CASCADE_COUNT = rhi.SHADOW_CASCADE_COUNT;
+
+pub const ShadowCascades = struct {
+    light_space_matrices: [CASCADE_COUNT]Mat4,
+    cascade_splits: [CASCADE_COUNT]f32,
+    texel_sizes: [CASCADE_COUNT]f32,
+};
+
+pub fn computeCascades(resolution: u32, camera_fov: f32, aspect: f32, near: f32, far: f32, sun_dir: Vec3, cam_view: Mat4, z_range_01: bool) ShadowCascades {
+    const lambda = 0.8;
+    const shadow_dist = far;
+
+    var cascades: ShadowCascades = .{
+        .light_space_matrices = undefined,
+        .cascade_splits = undefined,
+        .texel_sizes = undefined,
+    };
+
+    // Calculate split distances (linear/log blend)
+    for (0..CASCADE_COUNT) |i| {
+        const p = @as(f32, @floatFromInt(i + 1)) / @as(f32, @floatFromInt(CASCADE_COUNT));
+        const log_split = near * std.math.pow(f32, shadow_dist / near, p);
+        const lin_split = near + (shadow_dist - near) * p;
+        cascades.cascade_splits[i] = std.math.lerp(lin_split, log_split, lambda);
+    }
+
+    // Calculate matrices for each cascade
+    var last_split = near;
+    for (0..CASCADE_COUNT) |i| {
+        const split = cascades.cascade_splits[i];
+
+        // 1. Compute bounding sphere of frustum slice (STABLE CSM approach)
+        const tan_fov_half = std.math.tan(camera_fov / 2.0);
+        const tan_fov_h_half = tan_fov_half * aspect;
+
+        const near_v = last_split;
+        const far_v = split;
+        const center_z = (near_v + far_v) / 2.0;
+        const center_view = Vec3.init(0, 0, -center_z);
+
+        const xf = far_v * tan_fov_h_half;
+        const yf = far_v * tan_fov_half;
+        const zf = -far_v;
+        const far_corner = Vec3.init(xf, yf, zf);
+        var radius = far_corner.sub(center_view).length();
+        radius = @ceil(radius * 16.0) / 16.0;
+
+        // 2. Transform center to World Space
+        const inv_cam_view = cam_view.inverse();
+        const center_world = inv_cam_view.transformPoint(center_view);
+
+        // 3. Build Light Rotation Matrix (Looking in -sun direction)
+        var up = Vec3.init(0, 1, 0);
+        if (@abs(sun_dir.y) > 0.99) up = Vec3.init(0, 0, 1);
+        const light_rot = Mat4.lookAt(Vec3.zero, sun_dir.scale(-1.0), up);
+
+        // 4. Transform center to Light Space
+        const center_ls = light_rot.transformPoint(center_world);
+
+        // 5. Snap center to texel grid in LIGHT SPACE
+        const texel_size = (2.0 * radius) / @as(f32, @floatFromInt(resolution));
+        cascades.texel_sizes[i] = texel_size;
+
+        const center_snapped = Vec3.init(
+            @floor(center_ls.x / texel_size) * texel_size,
+            @floor(center_ls.y / texel_size) * texel_size,
+            center_ls.z,
+        );
+
+        // 6. Build Ortho Projection (Centered around snapped center)
+        const minX = center_snapped.x - radius;
+        const maxX = center_snapped.x + radius;
+        const minY = center_snapped.y - radius;
+        const maxY = center_snapped.y + radius;
+
+        const maxZ = center_snapped.z + radius + 300.0;
+        const minZ = center_snapped.z - radius - 100.0;
+
+        var light_ortho = Mat4.identity;
+        light_ortho.data[0][0] = 2.0 / (maxX - minX);
+        light_ortho.data[3][0] = -(maxX + minX) / (maxX - minX);
+
+        light_ortho.data[1][1] = 2.0 / (maxY - minY);
+        light_ortho.data[3][1] = -(maxY + minY) / (maxY - minY);
+
+        if (z_range_01) {
+            const A = 1.0 / (maxZ - minZ);
+            const B = -A * minZ;
+            light_ortho.data[2][2] = A;
+            light_ortho.data[3][2] = B;
+        } else {
+            // Standard OpenGL: map closer to -1, further to 1
+            // maxZ is closer (less negative), minZ is further (more negative)
+            const A = -2.0 / (maxZ - minZ);
+            const B = (maxZ + minZ) / (maxZ - minZ);
+            light_ortho.data[2][2] = A;
+            light_ortho.data[3][2] = B;
+        }
+
+        cascades.light_space_matrices[i] = light_ortho.multiply(light_rot);
+        last_split = split;
+    }
+
+    return cascades;
+}

--- a/src/engine/graphics/shadows.zig
+++ b/src/engine/graphics/shadows.zig
@@ -10,8 +10,10 @@ const Shader = @import("shader.zig").Shader;
 
 const rhi = @import("rhi.zig");
 
+const CSM = @import("csm.zig");
+
 pub const ShadowMap = struct {
-    pub const CASCADE_COUNT = rhi.SHADOW_CASCADE_COUNT;
+    pub const CASCADE_COUNT = CSM.CASCADE_COUNT;
     depth_maps: [CASCADE_COUNT]Texture,
     fbos: [CASCADE_COUNT]c.GLuint,
     resolution: u32,
@@ -74,109 +76,8 @@ pub const ShadowMap = struct {
         sh.deinit();
     }
 
-    pub const ShadowCascades = struct {
-        light_space_matrices: [CASCADE_COUNT]Mat4,
-        cascade_splits: [CASCADE_COUNT]f32,
-        texel_sizes: [CASCADE_COUNT]f32,
-    };
-
-    pub fn computeCascades(resolution: u32, camera_fov: f32, aspect: f32, near: f32, far: f32, sun_dir: Vec3, cam_view: Mat4, z_range_01: bool) ShadowCascades {
-        const lambda = 0.8;
-        const shadow_dist = far;
-
-        var cascades: ShadowCascades = .{
-            .light_space_matrices = undefined,
-            .cascade_splits = undefined,
-            .texel_sizes = undefined,
-        };
-
-        // Calculate split distances (linear/log blend)
-        for (0..CASCADE_COUNT) |i| {
-            const p = @as(f32, @floatFromInt(i + 1)) / @as(f32, @floatFromInt(CASCADE_COUNT));
-            const log_split = near * std.math.pow(f32, shadow_dist / near, p);
-            const lin_split = near + (shadow_dist - near) * p;
-            cascades.cascade_splits[i] = std.math.lerp(lin_split, log_split, lambda);
-        }
-
-        // Calculate matrices for each cascade
-        var last_split = near;
-        for (0..CASCADE_COUNT) |i| {
-            const split = cascades.cascade_splits[i];
-
-            // 1. Compute bounding sphere of frustum slice (STABLE CSM approach)
-            const tan_fov_half = std.math.tan(camera_fov / 2.0);
-            const tan_fov_h_half = tan_fov_half * aspect;
-
-            const near_v = last_split;
-            const far_v = split;
-            const center_z = (near_v + far_v) / 2.0;
-            const center_view = Vec3.init(0, 0, -center_z);
-
-            const xf = far_v * tan_fov_h_half;
-            const yf = far_v * tan_fov_half;
-            const zf = -far_v;
-            const far_corner = Vec3.init(xf, yf, zf);
-            var radius = far_corner.sub(center_view).length();
-            radius = @ceil(radius * 16.0) / 16.0;
-
-            // 2. Transform center to World Space
-            const inv_cam_view = cam_view.inverse();
-            const center_world = inv_cam_view.transformPoint(center_view);
-
-            // 3. Build Light Rotation Matrix (Looking in -sun direction)
-            var up = Vec3.init(0, 1, 0);
-            if (@abs(sun_dir.y) > 0.99) up = Vec3.init(0, 0, 1);
-            const light_rot = Mat4.lookAt(Vec3.zero, sun_dir.scale(-1.0), up);
-
-            // 4. Transform center to Light Space
-            const center_ls = light_rot.transformPoint(center_world);
-
-            // 5. Snap center to texel grid in LIGHT SPACE
-            const texel_size = (2.0 * radius) / @as(f32, @floatFromInt(resolution));
-            cascades.texel_sizes[i] = texel_size;
-
-            const center_snapped = Vec3.init(
-                @floor(center_ls.x / texel_size) * texel_size,
-                @floor(center_ls.y / texel_size) * texel_size,
-                center_ls.z,
-            );
-
-            // 6. Build Ortho Projection (Centered around snapped center)
-            const minX = center_snapped.x - radius;
-            const maxX = center_snapped.x + radius;
-            const minY = center_snapped.y - radius;
-            const maxY = center_snapped.y + radius;
-
-            const maxZ = center_snapped.z + radius + 300.0;
-            const minZ = center_snapped.z - radius - 100.0;
-
-            var light_ortho = Mat4.identity;
-            light_ortho.data[0][0] = 2.0 / (maxX - minX);
-            light_ortho.data[3][0] = -(maxX + minX) / (maxX - minX);
-
-            light_ortho.data[1][1] = 2.0 / (maxY - minY);
-            light_ortho.data[3][1] = -(maxY + minY) / (maxY - minY);
-
-            if (z_range_01) {
-                const A = 1.0 / (maxZ - minZ);
-                const B = -A * minZ;
-                light_ortho.data[2][2] = A;
-                light_ortho.data[3][2] = B;
-            } else {
-                // Standard OpenGL: map closer to -1, further to 1
-                // maxZ is closer (less negative), minZ is further (more negative)
-                const A = -2.0 / (maxZ - minZ);
-                const B = (maxZ + minZ) / (maxZ - minZ);
-                light_ortho.data[2][2] = A;
-                light_ortho.data[3][2] = B;
-            }
-
-            cascades.light_space_matrices[i] = light_ortho.multiply(light_rot);
-            last_split = split;
-        }
-
-        return cascades;
-    }
+    pub const ShadowCascades = CSM.ShadowCascades;
+    pub const computeCascades = CSM.computeCascades;
 
     /// Calculate cascade splits and matrices
     pub fn update(self: *ShadowMap, camera_fov: f32, aspect: f32, near: f32, far: f32, sun_dir: Vec3, cam_pos: Vec3, cam_view: Mat4) void {

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -363,7 +363,7 @@ pub const App = struct {
                                 var buf: [64]u8 = undefined;
                                 s.setInt(std.fmt.bufPrintZ(&buf, "uShadowMap{}", .{i}) catch "uShadowMap0", @intCast(1 + i));
                             }
-                            const cascades = ShadowMap.computeCascades(self.settings.shadow_resolution, self.camera.fov, aspect, 0.1, self.settings.shadow_distance, if (self.render_system.atmosphere) |a| a.sun_dir else Vec3.init(0, 1, 0), self.camera.getViewMatrixOriginCentered(), true);
+                            const cascades = ShadowMap.computeCascades(self.settings.shadow_resolution, self.camera.fov, aspect, 0.1, self.settings.shadow_distance, if (self.render_system.atmosphere) |a| a.sun_dir else Vec3.init(0, 1, 0), self.camera.getViewMatrixOriginCentered(), false);
                             self.render_system.rhi.updateShadowUniforms(.{
                                 .light_space_matrices = cascades.light_space_matrices,
                                 .cascade_splits = cascades.cascade_splits,

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -5,20 +5,15 @@ const c = @import("../c.zig").c;
 const Vec3 = @import("../engine/math/vec3.zig").Vec3;
 const Mat4 = @import("../engine/math/mat4.zig").Mat4;
 const Camera = @import("../engine/graphics/camera.zig").Camera;
-const Shader = @import("../engine/graphics/shader.zig").Shader;
-const setVSync = @import("../engine/graphics/renderer.zig").setVSync;
 const Input = @import("../engine/input/input.zig").Input;
 const Time = @import("../engine/core/time.zig").Time;
 const UISystem = @import("../engine/ui/ui_system.zig").UISystem;
 const Color = @import("../engine/ui/ui_system.zig").Color;
-const Rect = @import("../engine/ui/ui_system.zig").Rect;
 const log = @import("../engine/core/log.zig");
-const TextureAtlas = @import("../engine/graphics/texture_atlas.zig").TextureAtlas;
-const Atmosphere = @import("../engine/graphics/atmosphere.zig").Atmosphere;
 const ShadowMap = @import("../engine/graphics/shadows.zig").ShadowMap;
-const Clouds = @import("../engine/graphics/clouds.zig").Clouds;
 const Font = @import("../engine/ui/font.zig");
 const Widgets = @import("../engine/ui/widgets.zig");
+const WindowManager = @import("../engine/core/window.zig").WindowManager;
 
 // World imports
 const World = @import("../world/world.zig").World;
@@ -26,37 +21,24 @@ const worldToChunk = @import("../world/chunk.zig").worldToChunk;
 const WorldMap = @import("../world/worldgen/world_map.zig").WorldMap;
 
 const rhi_pkg = @import("../engine/graphics/rhi.zig");
-const RHI = rhi_pkg.RHI;
-const rhi_opengl = @import("../engine/graphics/rhi_opengl.zig");
-const rhi_vulkan = @import("../engine/graphics/rhi_vulkan.zig");
 
 // Game imports
 const AppState = @import("state.zig").AppState;
 const Settings = @import("state.zig").Settings;
 const Menus = @import("menus.zig");
+const RenderSystem = @import("render_system.zig").RenderSystem;
 
 pub const App = struct {
     allocator: std.mem.Allocator,
-    window: *c.SDL_Window,
-    gl_context: ?c.SDL_GLContext,
-    rhi: RHI,
-    is_vulkan: bool,
+    window_manager: WindowManager,
+    render_system: RenderSystem,
 
     settings: Settings,
     input: Input,
     time: Time,
     camera: Camera,
 
-    shader: ?Shader,
-    debug_shader: ?Shader,
-    debug_quad_vao: c.GLuint,
-    debug_quad_vbo: c.GLuint,
-
-    atlas: TextureAtlas,
     ui: ?UISystem,
-    atmosphere: ?Atmosphere,
-    clouds: ?Clouds,
-    shadow_map: ?ShadowMap,
 
     app_state: AppState,
     last_state: AppState,
@@ -92,73 +74,7 @@ pub const App = struct {
             }
         }
 
-        if (c.SDL_Init(c.SDL_INIT_VIDEO) == false) {
-            std.debug.print("SDL Init Failed: {s}\n", .{c.SDL_GetError()});
-            return error.SDLInitializationFailed;
-        }
-
-        if (!use_vulkan) {
-            _ = c.SDL_GL_SetAttribute(c.SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-            _ = c.SDL_GL_SetAttribute(c.SDL_GL_CONTEXT_MINOR_VERSION, 3);
-            _ = c.SDL_GL_SetAttribute(c.SDL_GL_CONTEXT_PROFILE_MASK, c.SDL_GL_CONTEXT_PROFILE_CORE);
-            _ = c.SDL_GL_SetAttribute(c.SDL_GL_DEPTH_SIZE, 24);
-        }
-
-        var window_flags: u32 = c.SDL_WINDOW_RESIZABLE;
-        if (use_vulkan) {
-            window_flags |= c.SDL_WINDOW_VULKAN;
-        } else {
-            window_flags |= c.SDL_WINDOW_OPENGL;
-        }
-
-        const window = c.SDL_CreateWindow(
-            "Zig Voxel Engine",
-            1280,
-            720,
-            @intCast(window_flags),
-        );
-        if (window == null) {
-            log.log.err("Window Creation Failed: {s}", .{c.SDL_GetError()});
-            return error.WindowCreationFailed;
-        }
-        log.log.info("Window created successfully", .{});
-
-        var gl_context: ?c.SDL_GLContext = null;
-        if (!use_vulkan) {
-            gl_context = c.SDL_GL_CreateContext(window);
-            if (gl_context == null) return error.GLContextCreationFailed;
-            _ = c.SDL_GL_MakeCurrent(window, gl_context.?);
-            c.glewExperimental = c.GL_TRUE;
-        }
-
-        const RhiResult = struct {
-            rhi: RHI,
-            is_vulkan: bool,
-        };
-
-        const rhi_and_type = if (use_vulkan) blk: {
-            log.log.info("Attempting to initialize Vulkan backend...", .{});
-            const res = rhi_vulkan.createRHI(allocator, window.?);
-            if (res) |v| {
-                break :blk RhiResult{ .rhi = v, .is_vulkan = true };
-            } else |err| {
-                log.log.err("Failed to initialize Vulkan: {}. Falling back to OpenGL.", .{err});
-                if (c.glewInit() != c.GLEW_OK) return error.GLEWInitFailed;
-                break :blk RhiResult{ .rhi = try rhi_opengl.createRHI(allocator), .is_vulkan = false };
-            }
-        } else blk: {
-            log.log.info("Initializing OpenGL backend...", .{});
-            if (c.glewInit() != c.GLEW_OK) {
-                return error.GLEWInitFailed;
-            }
-            break :blk RhiResult{ .rhi = try rhi_opengl.createRHI(allocator), .is_vulkan = false };
-        };
-
-        const rhi = rhi_and_type.rhi;
-        const is_vulkan = rhi_and_type.is_vulkan;
-
-        // Initialize RHI resources (UI shaders, etc.)
-        try rhi.init(allocator);
+        const wm = try WindowManager.init(allocator, use_vulkan);
 
         log.log.info("Initializing engine systems...", .{});
         const settings = Settings{};
@@ -166,7 +82,9 @@ pub const App = struct {
         input.window_width = 1280;
         input.window_height = 720;
         const time = Time.init();
-        if (!is_vulkan) setVSync(settings.vsync);
+
+        const rs = try RenderSystem.init(allocator, wm.window, wm.is_vulkan, &settings);
+        if (!rs.is_vulkan) rs.rhi.setVSync(settings.vsync);
 
         const camera = Camera.init(.{
             .position = Vec3.init(8, 100, 8),
@@ -174,54 +92,18 @@ pub const App = struct {
             .move_speed = 50.0,
         });
 
-        const shader: ?Shader = if (!is_vulkan) try Shader.initFromFile(allocator, "assets/shaders/terrain.vert", "assets/shaders/terrain.frag") else null;
-
-        var debug_shader: ?Shader = null;
-        var debug_quad_vao: c.GLuint = 0;
-        var debug_quad_vbo: c.GLuint = 0;
-
-        if (!is_vulkan) {
-            const debug_vs = "#version 330 core\nlayout (location = 0) in vec2 aPos;layout (location = 1) in vec2 aTexCoord;out vec2 vTexCoord;void main() {gl_Position = vec4(aPos, 0.0, 1.0);vTexCoord = aTexCoord;}";
-            const debug_fs = "#version 330 core\nout vec4 FragColor;in vec2 vTexCoord;uniform sampler2D uDepthMap;void main() {float depth = texture(uDepthMap, vTexCoord).r;FragColor = vec4(vec3(depth), 1.0);}";
-            debug_shader = try Shader.initSimple(debug_vs, debug_fs);
-            const quad_vertices = [_]f32{ -1.0, 1.0, 0.0, 1.0, -1.0, -1.0, 0.0, 0.0, 1.0, -1.0, 1.0, 0.0, -1.0, 1.0, 0.0, 1.0, 1.0, -1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0 };
-            c.glGenVertexArrays().?(1, &debug_quad_vao);
-            c.glGenBuffers().?(1, &debug_quad_vbo);
-            c.glBindVertexArray().?(debug_quad_vao);
-            c.glBindBuffer().?(c.GL_ARRAY_BUFFER, debug_quad_vbo);
-            c.glBufferData().?(c.GL_ARRAY_BUFFER, quad_vertices.len * @sizeOf(f32), &quad_vertices, c.GL_STATIC_DRAW);
-            c.glEnableVertexAttribArray().?(0);
-            c.glVertexAttribPointer().?(0, 2, c.GL_FLOAT, c.GL_FALSE, 4 * @sizeOf(f32), null);
-            c.glEnableVertexAttribArray().?(1);
-            c.glVertexAttribPointer().?(1, 2, c.GL_FLOAT, c.GL_FALSE, 4 * @sizeOf(f32), @ptrFromInt(2 * @sizeOf(f32)));
-        }
-
-        const atlas = TextureAtlas.init(allocator, rhi);
-        const ui = try UISystem.init(rhi, 1280, 720);
-        const atmosphere = if (is_vulkan) Atmosphere.initNoGL() else Atmosphere.init();
-        const clouds = if (is_vulkan) Clouds.initNoGL() else try Clouds.init();
-        const shadow_map = if (!is_vulkan) ShadowMap.init(rhi, settings.shadow_resolution) catch null else null;
+        const ui = try UISystem.init(rs.rhi, 1280, 720);
 
         const app = try allocator.create(App);
         app.* = .{
             .allocator = allocator,
-            .window = window.?,
-            .gl_context = gl_context,
-            .rhi = rhi,
-            .is_vulkan = is_vulkan,
+            .window_manager = wm,
+            .render_system = rs,
             .settings = settings,
             .input = input,
             .time = time,
             .camera = camera,
-            .shader = shader,
-            .debug_shader = debug_shader,
-            .debug_quad_vao = debug_quad_vao,
-            .debug_quad_vbo = debug_quad_vbo,
-            .atlas = atlas,
             .ui = ui,
-            .atmosphere = atmosphere,
-            .clouds = clouds,
-            .shadow_map = shadow_map,
             .app_state = .home,
             .last_state = .home,
             .pending_world_cleanup = false,
@@ -249,37 +131,23 @@ pub const App = struct {
         if (self.world_map) |*m| m.deinit();
         if (self.world) |w| w.deinit();
         self.seed_input.deinit(self.allocator);
-        if (self.shadow_map) |*sm| sm.deinit();
-        if (self.clouds) |*cl| cl.deinit();
-        if (self.atmosphere) |*a| a.deinit();
-        if (self.ui) |*u| u.deinit();
-        self.atlas.deinit();
-        if (self.debug_shader) |*s| s.deinit();
-        if (!self.is_vulkan) {
-            if (self.debug_quad_vao != 0) c.glDeleteVertexArrays().?(1, &self.debug_quad_vao);
-            if (self.debug_quad_vbo != 0) c.glDeleteBuffers().?(1, &self.debug_quad_vbo);
-        }
-        if (self.shader) |*s| s.deinit();
-        self.input.deinit();
-        self.rhi.deinit();
 
-        if (self.gl_context) |ctx| {
-            _ = c.SDL_GL_DestroyContext(ctx);
-        }
-        c.SDL_DestroyWindow(self.window);
-        c.SDL_Quit();
+        if (self.ui) |*u| u.deinit();
+        self.render_system.deinit();
+        self.input.deinit();
+        self.window_manager.deinit();
 
         self.allocator.destroy(self);
     }
 
     pub fn run(self: *App) !void {
-        self.rhi.setViewport(1280, 720);
+        self.render_system.rhi.setViewport(1280, 720);
         log.log.info("=== Zig Voxel Engine ===", .{});
 
         while (!self.input.should_quit) {
             // Safe deferred world management OUTSIDE the frame window
             if (self.pending_world_cleanup or self.pending_new_world_seed != null) {
-                self.rhi.waitIdle();
+                self.render_system.rhi.waitIdle();
                 if (self.world) |w| {
                     w.deinit();
                     self.world = null;
@@ -288,20 +156,24 @@ pub const App = struct {
             }
 
             if (self.pending_new_world_seed) |seed| {
-                self.world = try World.init(self.allocator, self.settings.render_distance, seed, self.rhi);
-                if (self.world_map == null) self.world_map = WorldMap.init(self.rhi, 256, 256);
+                self.pending_new_world_seed = null;
+                self.world = World.init(self.allocator, self.settings.render_distance, seed, self.render_system.rhi) catch |err| {
+                    log.log.err("Failed to create world: {}", .{err});
+                    self.app_state = .home;
+                    continue;
+                };
+                if (self.world_map == null) self.world_map = WorldMap.init(self.render_system.rhi, 256, 256);
                 self.show_map = false;
                 self.map_needs_update = true;
                 self.camera = Camera.init(.{ .position = Vec3.init(8, 100, 8), .pitch = -0.3, .move_speed = 50.0 });
-                self.pending_new_world_seed = null;
             }
 
             self.time.update();
-            if (self.atmosphere) |*a| a.update(self.time.delta_time);
-            if (self.clouds) |*cl| cl.update(self.time.delta_time);
+            if (self.render_system.atmosphere) |*a| a.update(self.time.delta_time);
+            if (self.render_system.clouds) |*cl| cl.update(self.time.delta_time);
             self.input.beginFrame();
             self.input.pollEvents();
-            self.rhi.setViewport(self.input.window_width, self.input.window_height);
+            self.render_system.rhi.setViewport(self.input.window_width, self.input.window_height);
             if (self.ui) |*u| u.resize(self.input.window_width, self.input.window_height);
             const screen_w: f32 = @floatFromInt(self.input.window_width);
             const screen_h: f32 = @floatFromInt(self.input.window_height);
@@ -313,7 +185,7 @@ pub const App = struct {
             if (self.input.isKeyPressed(.escape)) {
                 if (self.show_map) {
                     self.show_map = false;
-                    if (self.app_state == .world) self.input.setMouseCapture(self.window, true);
+                    if (self.app_state == .world) self.input.setMouseCapture(self.window_manager.window, true);
                 } else {
                     switch (self.app_state) {
                         .home => self.input.should_quit = true,
@@ -324,11 +196,11 @@ pub const App = struct {
                         .settings => self.app_state = self.last_state,
                         .world => {
                             self.app_state = .paused;
-                            self.input.setMouseCapture(self.window, false);
+                            self.input.setMouseCapture(self.window_manager.window, false);
                         },
                         .paused => {
                             self.app_state = .world;
-                            self.input.setMouseCapture(self.window, true);
+                            self.input.setMouseCapture(self.window_manager.window, true);
                         },
                     }
                 }
@@ -338,21 +210,21 @@ pub const App = struct {
             const in_pause = self.app_state == .paused;
 
             if (in_world or in_pause) {
-                if (in_world and self.input.isKeyPressed(.tab)) self.input.setMouseCapture(self.window, !self.input.mouse_captured);
-                if (self.input.isKeyPressed(.c)) if (self.clouds) |*cl| {
+                if (in_world and self.input.isKeyPressed(.tab)) self.input.setMouseCapture(self.window_manager.window, !self.input.mouse_captured);
+                if (self.input.isKeyPressed(.c)) if (self.render_system.clouds) |*cl| {
                     cl.enabled = !cl.enabled;
                 };
                 if (self.input.isKeyPressed(.f)) {
                     self.settings.wireframe_enabled = !self.settings.wireframe_enabled;
-                    self.rhi.setWireframe(self.settings.wireframe_enabled);
+                    self.render_system.rhi.setWireframe(self.settings.wireframe_enabled);
                 }
                 if (self.input.isKeyPressed(.t)) {
                     self.settings.textures_enabled = !self.settings.textures_enabled;
-                    self.rhi.setTexturesEnabled(self.settings.textures_enabled);
+                    self.render_system.rhi.setTexturesEnabled(self.settings.textures_enabled);
                 }
                 if (self.input.isKeyPressed(.v)) {
                     self.settings.vsync = !self.settings.vsync;
-                    self.rhi.setVSync(self.settings.vsync);
+                    self.render_system.rhi.setVSync(self.settings.vsync);
                 }
                 if (self.input.isKeyPressed(.u)) self.debug_shadows = !self.debug_shadows;
                 if (self.input.isKeyPressed(.m)) {
@@ -363,12 +235,15 @@ pub const App = struct {
                         self.map_pos_z = self.camera.position.z;
                         self.map_target_zoom = self.map_zoom;
                         self.map_needs_update = true;
-                        self.input.setMouseCapture(self.window, false);
-                    } else if (self.app_state == .world) self.input.setMouseCapture(self.window, true);
+                        self.input.setMouseCapture(self.window_manager.window, false);
+                    } else if (self.app_state == .world) self.input.setMouseCapture(self.window_manager.window, true);
                 }
 
                 if (self.show_map) {
                     const dt = @min(self.time.delta_time, 0.033);
+                    // ... map input logic (omitted for brevity, same as before) ...
+                    // Wait, I need to keep this logic or extract it.
+                    // For now, I'll copy-paste the map input logic as it's coupled to App state.
                     if (self.input.isKeyDown(.plus) or self.input.isKeyDown(.kp_plus)) {
                         self.map_target_zoom /= @exp(1.2 * dt);
                         self.map_needs_update = true;
@@ -423,11 +298,11 @@ pub const App = struct {
                 }
 
                 if (self.debug_shadows and self.input.isKeyPressed(.k)) self.debug_cascade_idx = (self.debug_cascade_idx + 1) % 3;
-                if (self.input.isKeyPressed(.@"1")) if (self.atmosphere) |*a| a.setTimeOfDay(0.0);
-                if (self.input.isKeyPressed(.@"2")) if (self.atmosphere) |*a| a.setTimeOfDay(0.25);
-                if (self.input.isKeyPressed(.@"3")) if (self.atmosphere) |*a| a.setTimeOfDay(0.5);
-                if (self.input.isKeyPressed(.@"4")) if (self.atmosphere) |*a| a.setTimeOfDay(0.75);
-                if (self.input.isKeyPressed(.n)) if (self.atmosphere) |*a| {
+                if (self.input.isKeyPressed(.@"1")) if (self.render_system.atmosphere) |*a| a.setTimeOfDay(0.0);
+                if (self.input.isKeyPressed(.@"2")) if (self.render_system.atmosphere) |*a| a.setTimeOfDay(0.25);
+                if (self.input.isKeyPressed(.@"3")) if (self.render_system.atmosphere) |*a| a.setTimeOfDay(0.5);
+                if (self.input.isKeyPressed(.@"4")) if (self.render_system.atmosphere) |*a| a.setTimeOfDay(0.75);
+                if (self.input.isKeyPressed(.n)) if (self.render_system.atmosphere) |*a| {
                     a.time_scale = if (a.time_scale > 0) @as(f32, 0.0) else @as(f32, 1.0);
                 };
 
@@ -445,22 +320,22 @@ pub const App = struct {
                         try active_world.update(self.camera.position);
                     } else self.app_state = .home;
                 }
-            } else if (self.input.mouse_captured) self.input.setMouseCapture(self.window, false);
+            } else if (self.input.mouse_captured) self.input.setMouseCapture(self.window_manager.window, false);
 
-            const clear_color = if (in_world or in_pause) (if (self.atmosphere) |a| a.fog_color else Vec3.init(0.5, 0.7, 1.0)) else Vec3.init(0.07, 0.08, 0.1);
-            self.rhi.setClearColor(clear_color);
-            self.rhi.beginFrame();
+            const clear_color = if (in_world or in_pause) (if (self.render_system.atmosphere) |a| a.fog_color else Vec3.init(0.5, 0.7, 1.0)) else Vec3.init(0.07, 0.08, 0.1);
+            self.render_system.rhi.setClearColor(clear_color);
+            self.render_system.rhi.beginFrame();
 
             if (in_world or in_pause) {
                 if (self.world) |active_world| {
                     const aspect = screen_w / screen_h;
                     const view_proj_cull = self.camera.getViewProjectionMatrixOriginCentered(aspect);
-                    const view_proj_render = if (self.is_vulkan)
+                    const view_proj_render = if (self.render_system.is_vulkan)
                         Mat4.perspectiveReverseZ(self.camera.fov, aspect, self.camera.near, self.camera.far).multiply(self.camera.getViewMatrixOriginCentered())
                     else
                         view_proj_cull;
-                    if (self.shadow_map) |*sm| {
-                        if (self.atmosphere) |atmo| {
+                    if (self.render_system.shadow_map) |*sm| {
+                        if (self.render_system.atmosphere) |atmo| {
                             var light_dir = atmo.sun_dir;
                             if (atmo.sun_intensity < 0.05 and atmo.moon_intensity > 0.05) light_dir = atmo.moon_dir;
                             if (atmo.sun_intensity > 0.05 or atmo.moon_intensity > 0.05) {
@@ -473,30 +348,30 @@ pub const App = struct {
                             }
                         }
                     }
-                    if (!self.is_vulkan) {
-                        self.rhi.beginMainPass();
-                        if (self.atmosphere) |*a| a.renderSky(self.camera.forward, self.camera.right, self.camera.up, aspect, self.camera.fov);
+                    if (!self.render_system.is_vulkan) {
+                        self.render_system.rhi.beginMainPass();
+                        if (self.render_system.atmosphere) |*a| a.renderSky(self.camera.forward, self.camera.right, self.camera.up, aspect, self.camera.fov);
                     }
-                    if (self.shader) |*s| {
+                    if (self.render_system.shader) |*s| {
                         s.use();
-                        self.atlas.bind(0);
+                        self.render_system.atlas.bind(0);
                         s.setInt("uTexture", 0);
                         s.setBool("uUseTexture", self.settings.textures_enabled);
-                        if (self.shadow_map) |*sm| {
+                        if (self.render_system.shadow_map) |*sm| {
                             for (0..3) |i| {
                                 sm.depth_maps[i].bind(@intCast(1 + i));
                                 var buf: [64]u8 = undefined;
                                 s.setInt(std.fmt.bufPrintZ(&buf, "uShadowMap{}", .{i}) catch "uShadowMap0", @intCast(1 + i));
                             }
-                            const cascades = ShadowMap.computeCascades(self.settings.shadow_resolution, self.camera.fov, aspect, 0.1, self.settings.shadow_distance, if (self.atmosphere) |a| a.sun_dir else Vec3.init(0, 1, 0), self.camera.getViewMatrixOriginCentered(), true);
-                            self.rhi.updateShadowUniforms(.{
+                            const cascades = ShadowMap.computeCascades(self.settings.shadow_resolution, self.camera.fov, aspect, 0.1, self.settings.shadow_distance, if (self.render_system.atmosphere) |a| a.sun_dir else Vec3.init(0, 1, 0), self.camera.getViewMatrixOriginCentered(), true);
+                            self.render_system.rhi.updateShadowUniforms(.{
                                 .light_space_matrices = cascades.light_space_matrices,
                                 .cascade_splits = cascades.cascade_splits,
                                 .shadow_texel_sizes = cascades.texel_sizes,
                             });
                         }
-                        if (self.atmosphere) |atmo| {
-                            const cp: rhi_pkg.CloudParams = if (self.clouds) |*cl| blk: {
+                        if (self.render_system.atmosphere) |atmo| {
+                            const cp: rhi_pkg.CloudParams = if (self.render_system.clouds) |*cl| blk: {
                                 const p = cl.getCloudShadowParams();
                                 break :blk .{
                                     .wind_offset_x = p.wind_offset_x,
@@ -507,28 +382,28 @@ pub const App = struct {
                                 };
                             } else .{};
 
-                            self.rhi.updateGlobalUniforms(view_proj_cull, self.camera.position, atmo.sun_dir, atmo.time_of_day, atmo.fog_color, atmo.fog_density, atmo.fog_enabled, atmo.sun_intensity, atmo.ambient_intensity, cp);
+                            self.render_system.rhi.updateGlobalUniforms(view_proj_cull, self.camera.position, atmo.sun_dir, atmo.time_of_day, atmo.fog_color, atmo.fog_density, atmo.fog_enabled, atmo.sun_intensity, atmo.ambient_intensity, cp);
                         }
                         active_world.render(view_proj_cull, self.camera.position);
-                    } else if (self.is_vulkan) {
+                    } else if (self.render_system.is_vulkan) {
                         const fallback_sun_dir = Vec3.init(0.5, 0.8, 0.2);
                         const fallback_sky_color = Vec3.init(0.5, 0.7, 1.0);
                         const fallback_horizon_color = Vec3.init(0.8, 0.85, 0.95);
 
-                        const sun_dir = if (self.atmosphere) |a| a.sun_dir else fallback_sun_dir;
-                        const time_val = if (self.atmosphere) |a| a.time_of_day else 0.25;
-                        const fog_color = if (self.atmosphere) |a| a.fog_color else Vec3.init(0.7, 0.8, 0.9);
-                        const fog_density = if (self.atmosphere) |a| a.fog_density else 0.0;
-                        const fog_enabled = if (self.atmosphere) |a| a.fog_enabled else false;
-                        const sun_intensity_val = if (self.atmosphere) |a| a.sun_intensity else 1.0;
-                        const moon_intensity_val = if (self.atmosphere) |a| a.moon_intensity else 0.0;
-                        const ambient_val = if (self.atmosphere) |a| a.ambient_intensity else 0.2;
-                        const sky_color = if (self.atmosphere) |a| a.sky_color else fallback_sky_color;
-                        const horizon_color = if (self.atmosphere) |a| a.horizon_color else fallback_horizon_color;
+                        const sun_dir = if (self.render_system.atmosphere) |a| a.sun_dir else fallback_sun_dir;
+                        const time_val = if (self.render_system.atmosphere) |a| a.time_of_day else 0.25;
+                        const fog_color = if (self.render_system.atmosphere) |a| a.fog_color else Vec3.init(0.7, 0.8, 0.9);
+                        const fog_density = if (self.render_system.atmosphere) |a| a.fog_density else 0.0;
+                        const fog_enabled = if (self.render_system.atmosphere) |a| a.fog_enabled else false;
+                        const sun_intensity_val = if (self.render_system.atmosphere) |a| a.sun_intensity else 1.0;
+                        const moon_intensity_val = if (self.render_system.atmosphere) |a| a.moon_intensity else 0.0;
+                        const ambient_val = if (self.render_system.atmosphere) |a| a.ambient_intensity else 0.2;
+                        const sky_color = if (self.render_system.atmosphere) |a| a.sky_color else fallback_sky_color;
+                        const horizon_color = if (self.render_system.atmosphere) |a| a.horizon_color else fallback_horizon_color;
 
                         var light_dir = sun_dir;
                         var light_active = true;
-                        if (self.atmosphere) |atmo| {
+                        if (self.render_system.atmosphere) |atmo| {
                             if (atmo.sun_intensity < 0.05 and atmo.moon_intensity > 0.05) {
                                 light_dir = atmo.moon_dir;
                             }
@@ -537,20 +412,20 @@ pub const App = struct {
 
                         if (light_active) {
                             const cascades = ShadowMap.computeCascades(self.settings.shadow_resolution, self.camera.fov, aspect, 0.1, self.settings.shadow_distance, light_dir, self.camera.getViewMatrixOriginCentered(), true);
-                            self.rhi.updateShadowUniforms(.{
+                            self.render_system.rhi.updateShadowUniforms(.{
                                 .light_space_matrices = cascades.light_space_matrices,
                                 .cascade_splits = cascades.cascade_splits,
                                 .shadow_texel_sizes = cascades.texel_sizes,
                             });
                             for (0..ShadowMap.CASCADE_COUNT) |i| {
-                                self.rhi.beginShadowPass(@intCast(i));
-                                self.rhi.updateGlobalUniforms(cascades.light_space_matrices[i], self.camera.position, light_dir, time_val, fog_color, fog_density, false, 0.0, 0.0, .{});
+                                self.render_system.rhi.beginShadowPass(@intCast(i));
+                                self.render_system.rhi.updateGlobalUniforms(cascades.light_space_matrices[i], self.camera.position, light_dir, time_val, fog_color, fog_density, false, 0.0, 0.0, .{});
                                 active_world.renderShadowPass(cascades.light_space_matrices[i], self.camera.position);
-                                self.rhi.endShadowPass();
+                                self.render_system.rhi.endShadowPass();
                             }
                         }
 
-                        self.rhi.drawSky(.{
+                        self.render_system.rhi.drawSky(.{
                             .cam_pos = self.camera.position,
                             .cam_forward = self.camera.forward,
                             .cam_right = self.camera.right,
@@ -565,8 +440,8 @@ pub const App = struct {
                             .time = time_val,
                         });
 
-                        self.atlas.bind(0);
-                        const cp: rhi_pkg.CloudParams = if (self.clouds) |*cl| blk: {
+                        self.render_system.atlas.bind(0);
+                        const cp: rhi_pkg.CloudParams = if (self.render_system.clouds) |*cl| blk: {
                             const p = cl.getCloudShadowParams();
                             break :blk .{
                                 .wind_offset_x = p.wind_offset_x,
@@ -576,16 +451,16 @@ pub const App = struct {
                                 .cloud_height = p.cloud_height,
                             };
                         } else .{};
-                        self.rhi.updateGlobalUniforms(view_proj_render, self.camera.position, sun_dir, time_val, fog_color, fog_density, fog_enabled, sun_intensity_val, ambient_val, cp);
+                        self.render_system.rhi.updateGlobalUniforms(view_proj_render, self.camera.position, sun_dir, time_val, fog_color, fog_density, fog_enabled, sun_intensity_val, ambient_val, cp);
                         active_world.render(view_proj_cull, self.camera.position);
                     }
-                    if (self.clouds) |*cl| if (self.atmosphere) |atmo| if (!self.is_vulkan) cl.render(self.camera.position, &view_proj_cull.data, atmo.sun_dir, atmo.sun_intensity, atmo.fog_color, atmo.fog_density);
-                    if (self.debug_shadows and self.debug_shader != null and self.shadow_map != null) {
-                        self.debug_shader.?.use();
+                    if (self.render_system.clouds) |*cl| if (self.render_system.atmosphere) |atmo| if (!self.render_system.is_vulkan) cl.render(self.camera.position, &view_proj_cull.data, atmo.sun_dir, atmo.sun_intensity, atmo.fog_color, atmo.fog_density);
+                    if (self.debug_shadows and self.render_system.debug_shader != null and self.render_system.shadow_map != null) {
+                        self.render_system.debug_shader.?.use();
                         c.glActiveTexture().?(c.GL_TEXTURE0);
-                        c.glBindTexture(c.GL_TEXTURE_2D, @intCast(self.shadow_map.?.depth_maps[self.debug_cascade_idx].handle));
-                        self.debug_shader.?.setInt("uDepthMap", 0);
-                        c.glBindVertexArray().?(self.debug_quad_vao);
+                        c.glBindTexture(c.GL_TEXTURE_2D, @intCast(self.render_system.shadow_map.?.depth_maps[self.debug_cascade_idx].handle));
+                        self.render_system.debug_shader.?.setInt("uDepthMap", 0);
+                        c.glBindVertexArray().?(self.render_system.debug_quad_vao);
                         c.glDrawArrays(c.GL_TRIANGLES, 0, 6);
                         c.glBindVertexArray().?(0);
                     }
@@ -635,7 +510,7 @@ pub const App = struct {
                         var hr: i32 = 0;
                         var mn: i32 = 0;
                         var si: f32 = 1.0;
-                        if (self.atmosphere) |atmo| {
+                        if (self.render_system.atmosphere) |atmo| {
                             const h = atmo.getHours();
                             hr = @intFromFloat(h);
                             mn = @intFromFloat((h - @as(f32, @floatFromInt(hr))) * 60.0);
@@ -656,7 +531,7 @@ pub const App = struct {
                             Font.drawTextCentered(u, "PAUSED", screen_w * 0.5, py - 60.0, 3.0, Color.white);
                             if (Widgets.drawButton(u, .{ .x = px, .y = py, .width = pw, .height = ph }, "RESUME", 2.0, mouse_x, mouse_y, mouse_clicked)) {
                                 self.app_state = .world;
-                                self.input.setMouseCapture(self.window, true);
+                                self.input.setMouseCapture(self.window_manager.window, true);
                             }
                             py += ph + 16.0;
                             if (Widgets.drawButton(u, .{ .x = px, .y = py, .width = pw, .height = ph }, "SETTINGS", 2.0, mouse_x, mouse_y, mouse_clicked)) {
@@ -674,20 +549,28 @@ pub const App = struct {
                 }
             } else if (self.ui) |*u| {
                 u.begin();
+                const ctx = Menus.MenuContext{
+                    .ui = u,
+                    .input = &self.input,
+                    .screen_w = screen_w,
+                    .screen_h = screen_h,
+                    .time = &self.time,
+                    .allocator = self.allocator,
+                };
                 switch (self.app_state) {
                     .home => {
-                        const action = Menus.drawHome(u, screen_w, screen_h, &self.app_state, &self.input, &self.last_state, &self.seed_focused);
+                        const action = Menus.drawHome(ctx, &self.app_state, &self.last_state, &self.seed_focused);
                         if (action == .quit) self.input.should_quit = true;
                     },
-                    .settings => Menus.drawSettings(u, screen_w, screen_h, &self.app_state, &self.settings, &self.input, self.last_state, self.rhi),
-                    .singleplayer => try Menus.drawSingleplayer(u, screen_w, screen_h, &self.app_state, &self.input, &self.seed_input, &self.seed_focused, self.allocator, &self.time, &self.pending_new_world_seed),
+                    .settings => Menus.drawSettings(ctx, &self.app_state, &self.settings, self.last_state, self.render_system.rhi),
+                    .singleplayer => try Menus.drawSingleplayer(ctx, &self.app_state, &self.seed_input, &self.seed_focused, &self.pending_new_world_seed),
                     .world, .paused => unreachable,
                 }
                 u.end();
             }
 
-            self.rhi.endFrame();
-            if (!self.is_vulkan) _ = c.SDL_GL_SwapWindow(self.window);
+            self.render_system.rhi.endFrame();
+            if (!self.render_system.is_vulkan) _ = c.SDL_GL_SwapWindow(self.window_manager.window);
             if (in_world) {
                 if (self.world) |active_world| {
                     if (self.time.frame_count % 120 == 0) {

--- a/src/game/menus.zig
+++ b/src/game/menus.zig
@@ -18,108 +18,117 @@ pub const MenuAction = enum {
     quit,
 };
 
-pub fn drawHome(u: *UISystem, screen_w: f32, screen_h: f32, app_state: *AppState, input: *const Input, last_state: *AppState, seed_focused: *bool) MenuAction {
-    const mouse_pos = input.getMousePosition();
+pub const MenuContext = struct {
+    ui: *UISystem,
+    input: *const Input,
+    screen_w: f32,
+    screen_h: f32,
+    time: *const Time,
+    allocator: std.mem.Allocator,
+};
+
+pub fn drawHome(ctx: MenuContext, app_state: *AppState, last_state: *AppState, seed_focused: *bool) MenuAction {
+    const mouse_pos = ctx.input.getMousePosition();
     const mouse_x: f32 = @floatFromInt(mouse_pos.x);
     const mouse_y: f32 = @floatFromInt(mouse_pos.y);
-    const mouse_clicked = input.isMouseButtonPressed(.left);
+    const mouse_clicked = ctx.input.isMouseButtonPressed(.left);
 
-    Font.drawTextCentered(u, "ZIG VOXEL ENGINE", screen_w * 0.5, screen_h * 0.16, 4.0, Color.rgba(0.95, 0.96, 0.98, 1.0));
-    const bw: f32 = @min(screen_w * 0.5, 360.0);
+    Font.drawTextCentered(ctx.ui, "ZIG VOXEL ENGINE", ctx.screen_w * 0.5, ctx.screen_h * 0.16, 4.0, Color.rgba(0.95, 0.96, 0.98, 1.0));
+    const bw: f32 = @min(ctx.screen_w * 0.5, 360.0);
     const bh: f32 = 48.0;
-    const bx: f32 = (screen_w - bw) * 0.5;
-    var by: f32 = screen_h * 0.4;
-    if (Widgets.drawButton(u, .{ .x = bx, .y = by, .width = bw, .height = bh }, "SINGLEPLAYER", 2.2, mouse_x, mouse_y, mouse_clicked)) {
+    const bx: f32 = (ctx.screen_w - bw) * 0.5;
+    var by: f32 = ctx.screen_h * 0.4;
+    if (Widgets.drawButton(ctx.ui, .{ .x = bx, .y = by, .width = bw, .height = bh }, "SINGLEPLAYER", 2.2, mouse_x, mouse_y, mouse_clicked)) {
         app_state.* = .singleplayer;
         seed_focused.* = true;
     }
     by += bh + 14.0;
-    if (Widgets.drawButton(u, .{ .x = bx, .y = by, .width = bw, .height = bh }, "SETTINGS", 2.2, mouse_x, mouse_y, mouse_clicked)) {
+    if (Widgets.drawButton(ctx.ui, .{ .x = bx, .y = by, .width = bw, .height = bh }, "SETTINGS", 2.2, mouse_x, mouse_y, mouse_clicked)) {
         last_state.* = .home;
         app_state.* = .settings;
     }
     by += bh + 14.0;
-    if (Widgets.drawButton(u, .{ .x = bx, .y = by, .width = bw, .height = bh }, "QUIT", 2.2, mouse_x, mouse_y, mouse_clicked)) {
+    if (Widgets.drawButton(ctx.ui, .{ .x = bx, .y = by, .width = bw, .height = bh }, "QUIT", 2.2, mouse_x, mouse_y, mouse_clicked)) {
         return .quit;
     }
     return .none;
 }
 
-pub fn drawSettings(u: *UISystem, screen_w: f32, screen_h: f32, app_state: *AppState, settings: *Settings, input: *const Input, last_state: AppState, rhi: RHI) void {
-    const mouse_pos = input.getMousePosition();
+pub fn drawSettings(ctx: MenuContext, app_state: *AppState, settings: *Settings, last_state: AppState, rhi: RHI) void {
+    const mouse_pos = ctx.input.getMousePosition();
     const mouse_x: f32 = @floatFromInt(mouse_pos.x);
     const mouse_y: f32 = @floatFromInt(mouse_pos.y);
-    const mouse_clicked = input.isMouseButtonPressed(.left);
+    const mouse_clicked = ctx.input.isMouseButtonPressed(.left);
 
-    const pw: f32 = @min(screen_w * 0.7, 600.0);
+    const pw: f32 = @min(ctx.screen_w * 0.7, 600.0);
     const ph: f32 = 400.0;
-    const px: f32 = (screen_w - pw) * 0.5;
-    const py: f32 = (screen_h - ph) * 0.5;
-    u.drawRect(.{ .x = px, .y = py, .width = pw, .height = ph }, Color.rgba(0.12, 0.14, 0.18, 0.95));
-    u.drawRectOutline(.{ .x = px, .y = py, .width = pw, .height = ph }, Color.rgba(0.28, 0.33, 0.42, 1.0), 2.0);
-    Font.drawTextCentered(u, "SETTINGS", screen_w * 0.5, py + 20.0, 2.8, Color.white);
+    const px: f32 = (ctx.screen_w - pw) * 0.5;
+    const py: f32 = (ctx.screen_h - ph) * 0.5;
+    ctx.ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = ph }, Color.rgba(0.12, 0.14, 0.18, 0.95));
+    ctx.ui.drawRectOutline(.{ .x = px, .y = py, .width = pw, .height = ph }, Color.rgba(0.28, 0.33, 0.42, 1.0), 2.0);
+    Font.drawTextCentered(ctx.ui, "SETTINGS", ctx.screen_w * 0.5, py + 20.0, 2.8, Color.white);
     var sy: f32 = py + 80.0;
     const lx: f32 = px + 40.0;
     const vx: f32 = px + pw - 200.0;
-    Font.drawText(u, "RENDER DISTANCE", lx, sy, 2.0, Color.white);
-    Font.drawNumber(u, @intCast(settings.render_distance), vx + 60.0, sy, Color.white);
-    if (Widgets.drawButton(u, .{ .x = vx, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "-", 1.5, mouse_x, mouse_y, mouse_clicked)) {
+    Font.drawText(ctx.ui, "RENDER DISTANCE", lx, sy, 2.0, Color.white);
+    Font.drawNumber(ctx.ui, @intCast(settings.render_distance), vx + 60.0, sy, Color.white);
+    if (Widgets.drawButton(ctx.ui, .{ .x = vx, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "-", 1.5, mouse_x, mouse_y, mouse_clicked)) {
         if (settings.render_distance > 1) settings.render_distance -= 1;
     }
-    if (Widgets.drawButton(u, .{ .x = vx + 100.0, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "+", 1.5, mouse_x, mouse_y, mouse_clicked)) {
+    if (Widgets.drawButton(ctx.ui, .{ .x = vx + 100.0, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "+", 1.5, mouse_x, mouse_y, mouse_clicked)) {
         settings.render_distance += 1;
     }
     sy += 50.0;
-    Font.drawText(u, "SENSITIVITY", lx, sy, 2.0, Color.white);
-    Font.drawNumber(u, @intFromFloat(settings.mouse_sensitivity), vx + 60.0, sy, Color.white);
-    if (Widgets.drawButton(u, .{ .x = vx, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "-", 1.5, mouse_x, mouse_y, mouse_clicked)) {
+    Font.drawText(ctx.ui, "SENSITIVITY", lx, sy, 2.0, Color.white);
+    Font.drawNumber(ctx.ui, @intFromFloat(settings.mouse_sensitivity), vx + 60.0, sy, Color.white);
+    if (Widgets.drawButton(ctx.ui, .{ .x = vx, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "-", 1.5, mouse_x, mouse_y, mouse_clicked)) {
         if (settings.mouse_sensitivity > 10.0) settings.mouse_sensitivity -= 5.0;
     }
-    if (Widgets.drawButton(u, .{ .x = vx + 100.0, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "+", 1.5, mouse_x, mouse_y, mouse_clicked)) {
+    if (Widgets.drawButton(ctx.ui, .{ .x = vx + 100.0, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "+", 1.5, mouse_x, mouse_y, mouse_clicked)) {
         if (settings.mouse_sensitivity < 200.0) settings.mouse_sensitivity += 5.0;
     }
     sy += 50.0;
-    Font.drawText(u, "FOV", lx, sy, 2.0, Color.white);
-    Font.drawNumber(u, @intFromFloat(settings.fov), vx + 60.0, sy, Color.white);
-    if (Widgets.drawButton(u, .{ .x = vx, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "-", 1.5, mouse_x, mouse_y, mouse_clicked)) {
+    Font.drawText(ctx.ui, "FOV", lx, sy, 2.0, Color.white);
+    Font.drawNumber(ctx.ui, @intFromFloat(settings.fov), vx + 60.0, sy, Color.white);
+    if (Widgets.drawButton(ctx.ui, .{ .x = vx, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "-", 1.5, mouse_x, mouse_y, mouse_clicked)) {
         if (settings.fov > 30.0) settings.fov -= 5.0;
     }
-    if (Widgets.drawButton(u, .{ .x = vx + 100.0, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "+", 1.5, mouse_x, mouse_y, mouse_clicked)) {
+    if (Widgets.drawButton(ctx.ui, .{ .x = vx + 100.0, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "+", 1.5, mouse_x, mouse_y, mouse_clicked)) {
         if (settings.fov < 120.0) settings.fov += 5.0;
     }
     sy += 50.0;
-    Font.drawText(u, "VSYNC", lx, sy, 2.0, Color.white);
-    if (Widgets.drawButton(u, .{ .x = vx, .y = sy - 5.0, .width = 130.0, .height = 30.0 }, if (settings.vsync) "ENABLED" else "DISABLED", 1.5, mouse_x, mouse_y, mouse_clicked)) {
+    Font.drawText(ctx.ui, "VSYNC", lx, sy, 2.0, Color.white);
+    if (Widgets.drawButton(ctx.ui, .{ .x = vx, .y = sy - 5.0, .width = 130.0, .height = 30.0 }, if (settings.vsync) "ENABLED" else "DISABLED", 1.5, mouse_x, mouse_y, mouse_clicked)) {
         settings.vsync = !settings.vsync;
         rhi.setVSync(settings.vsync);
     }
     sy += 50.0;
-    Font.drawText(u, "SHADOW DISTANCE", lx, sy, 2.0, Color.white);
-    Font.drawNumber(u, @intFromFloat(settings.shadow_distance), vx + 60.0, sy, Color.white);
-    if (Widgets.drawButton(u, .{ .x = vx, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "-", 1.5, mouse_x, mouse_y, mouse_clicked)) {
+    Font.drawText(ctx.ui, "SHADOW DISTANCE", lx, sy, 2.0, Color.white);
+    Font.drawNumber(ctx.ui, @intFromFloat(settings.shadow_distance), vx + 60.0, sy, Color.white);
+    if (Widgets.drawButton(ctx.ui, .{ .x = vx, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "-", 1.5, mouse_x, mouse_y, mouse_clicked)) {
         if (settings.shadow_distance > 50.0) settings.shadow_distance -= 50.0;
     }
-    if (Widgets.drawButton(u, .{ .x = vx + 100.0, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "+", 1.5, mouse_x, mouse_y, mouse_clicked)) {
+    if (Widgets.drawButton(ctx.ui, .{ .x = vx + 100.0, .y = sy - 5.0, .width = 30.0, .height = 30.0 }, "+", 1.5, mouse_x, mouse_y, mouse_clicked)) {
         if (settings.shadow_distance < 1000.0) settings.shadow_distance += 50.0;
     }
-    if (Widgets.drawButton(u, .{ .x = px + (pw - 120.0) * 0.5, .y = py + ph - 60.0, .width = 120.0, .height = 40.0 }, "BACK", 2.0, mouse_x, mouse_y, mouse_clicked)) app_state.* = last_state;
+    if (Widgets.drawButton(ctx.ui, .{ .x = px + (pw - 120.0) * 0.5, .y = py + ph - 60.0, .width = 120.0, .height = 40.0 }, "BACK", 2.0, mouse_x, mouse_y, mouse_clicked)) app_state.* = last_state;
 }
 
-pub fn drawSingleplayer(u: *UISystem, screen_w: f32, screen_h: f32, app_state: *AppState, input: *const Input, seed_input: *std.ArrayListUnmanaged(u8), seed_focused: *bool, allocator: std.mem.Allocator, time: *const Time, pending_new_world_seed: *?u64) !void {
-    const mouse_pos = input.getMousePosition();
+pub fn drawSingleplayer(ctx: MenuContext, app_state: *AppState, seed_input: *std.ArrayListUnmanaged(u8), seed_focused: *bool, pending_new_world_seed: *?u64) !void {
+    const mouse_pos = ctx.input.getMousePosition();
     const mouse_x: f32 = @floatFromInt(mouse_pos.x);
     const mouse_y: f32 = @floatFromInt(mouse_pos.y);
-    const mouse_clicked = input.isMouseButtonPressed(.left);
+    const mouse_clicked = ctx.input.isMouseButtonPressed(.left);
 
-    const pw: f32 = @min(screen_w * 0.7, 520.0);
+    const pw: f32 = @min(ctx.screen_w * 0.7, 520.0);
     const ph: f32 = 260.0;
-    const px: f32 = (screen_w - pw) * 0.5;
-    const py: f32 = screen_h * 0.24;
-    u.drawRect(.{ .x = px, .y = py, .width = pw, .height = ph }, Color.rgba(0.12, 0.14, 0.18, 0.92));
-    u.drawRectOutline(.{ .x = px, .y = py, .width = pw, .height = ph }, Color.rgba(0.28, 0.33, 0.42, 1.0), 2.0);
-    Font.drawTextCentered(u, "CREATE WORLD", screen_w * 0.5, py + 18.0, 2.8, Color.rgba(0.92, 0.94, 0.97, 1.0));
+    const px: f32 = (ctx.screen_w - pw) * 0.5;
+    const py: f32 = ctx.screen_h * 0.24;
+    ctx.ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = ph }, Color.rgba(0.12, 0.14, 0.18, 0.92));
+    ctx.ui.drawRectOutline(.{ .x = px, .y = py, .width = pw, .height = ph }, Color.rgba(0.28, 0.33, 0.42, 1.0), 2.0);
+    Font.drawTextCentered(ctx.ui, "CREATE WORLD", ctx.screen_w * 0.5, py + 18.0, 2.8, Color.rgba(0.92, 0.94, 0.97, 1.0));
     const ly: f32 = py + 78.0;
-    Font.drawText(u, "SEED", px + 24.0, ly, 2.0, Color.rgba(0.72, 0.78, 0.86, 1.0));
+    Font.drawText(ctx.ui, "SEED", px + 24.0, ly, 2.0, Color.rgba(0.72, 0.78, 0.86, 1.0));
     const ih: f32 = 42.0;
     const iy: f32 = ly + 22.0;
     const rw: f32 = 120.0;
@@ -129,21 +138,21 @@ pub fn drawSingleplayer(u: *UISystem, screen_w: f32, screen_h: f32, app_state: *
     const seed_rect = Rect{ .x = ix, .y = iy, .width = iw, .height = ih };
     const random_rect = Rect{ .x = rx, .y = iy, .width = rw, .height = ih };
     if (mouse_clicked) seed_focused.* = seed_rect.contains(mouse_x, mouse_y);
-    Widgets.drawTextInput(u, seed_rect, seed_input.items, "LEAVE BLANK FOR RANDOM", 2.0, seed_focused.*, @as(u32, @intFromFloat(time.elapsed * 2.0)) % 2 == 0);
-    if (Widgets.drawButton(u, random_rect, "RANDOM", 1.8, mouse_x, mouse_y, mouse_clicked)) {
+    Widgets.drawTextInput(ctx.ui, seed_rect, seed_input.items, "LEAVE BLANK FOR RANDOM", 2.0, seed_focused.*, @as(u32, @intFromFloat(ctx.time.elapsed * 2.0)) % 2 == 0);
+    if (Widgets.drawButton(ctx.ui, random_rect, "RANDOM", 1.8, mouse_x, mouse_y, mouse_clicked)) {
         const gen = seed_gen.randomSeedValue();
-        try seed_gen.setSeedInput(seed_input, allocator, gen);
+        try seed_gen.setSeedInput(seed_input, ctx.allocator, gen);
         seed_focused.* = true;
     }
-    if (seed_focused.*) try handleSeedTyping(seed_input, allocator, input, 32);
+    if (seed_focused.*) try handleSeedTyping(seed_input, ctx.allocator, ctx.input, 32);
     const byy: f32 = py + ph - 64.0;
     const hw: f32 = (pw - 24.0 - 12.0 - 24.0) / 2.0;
-    if (Widgets.drawButton(u, .{ .x = px + 24.0, .y = byy, .width = hw, .height = 40.0 }, "BACK", 1.9, mouse_x, mouse_y, mouse_clicked)) {
+    if (Widgets.drawButton(ctx.ui, .{ .x = px + 24.0, .y = byy, .width = hw, .height = 40.0 }, "BACK", 1.9, mouse_x, mouse_y, mouse_clicked)) {
         app_state.* = .home;
         seed_focused.* = false;
     }
-    if (Widgets.drawButton(u, .{ .x = px + 24.0 + hw + 12.0, .y = byy, .width = hw, .height = 40.0 }, "CREATE", 1.9, mouse_x, mouse_y, mouse_clicked) or input.isKeyPressed(.enter)) {
-        const seed = try seed_gen.resolveSeed(seed_input, allocator);
+    if (Widgets.drawButton(ctx.ui, .{ .x = px + 24.0 + hw + 12.0, .y = byy, .width = hw, .height = 40.0 }, "CREATE", 1.9, mouse_x, mouse_y, mouse_clicked) or ctx.input.isKeyPressed(.enter)) {
+        const seed = try seed_gen.resolveSeed(seed_input, ctx.allocator);
         pending_new_world_seed.* = seed;
         app_state.* = .world;
         seed_focused.* = false;

--- a/src/game/render_system.zig
+++ b/src/game/render_system.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+const c = @import("../c.zig").c;
+const log = @import("../engine/core/log.zig");
+const rhi_pkg = @import("../engine/graphics/rhi.zig");
+const RHI = rhi_pkg.RHI;
+const rhi_opengl = @import("../engine/graphics/rhi_opengl.zig");
+const rhi_vulkan = @import("../engine/graphics/rhi_vulkan.zig");
+const Shader = @import("../engine/graphics/shader.zig").Shader;
+const TextureAtlas = @import("../engine/graphics/texture_atlas.zig").TextureAtlas;
+const Atmosphere = @import("../engine/graphics/atmosphere.zig").Atmosphere;
+const ShadowMap = @import("../engine/graphics/shadows.zig").ShadowMap;
+const Clouds = @import("../engine/graphics/clouds.zig").Clouds;
+const Settings = @import("state.zig").Settings;
+
+pub const RenderSystem = struct {
+    allocator: std.mem.Allocator,
+    rhi: RHI,
+    is_vulkan: bool,
+    shader: ?Shader,
+    debug_shader: ?Shader,
+    debug_quad_vao: c.GLuint,
+    debug_quad_vbo: c.GLuint,
+    atlas: TextureAtlas,
+    atmosphere: ?Atmosphere,
+    clouds: ?Clouds,
+    shadow_map: ?ShadowMap,
+
+    pub fn init(allocator: std.mem.Allocator, window: *c.SDL_Window, is_vulkan: bool, settings: *const Settings) !RenderSystem {
+        const RhiResult = struct {
+            rhi: RHI,
+            is_vulkan: bool,
+        };
+
+        const rhi_and_type = if (is_vulkan) blk: {
+            log.log.info("Attempting to initialize Vulkan backend...", .{});
+            const res = rhi_vulkan.createRHI(allocator, window);
+            if (res) |v| {
+                break :blk RhiResult{ .rhi = v, .is_vulkan = true };
+            } else |err| {
+                log.log.err("Failed to initialize Vulkan: {}. Falling back to OpenGL.", .{err});
+                if (c.glewInit() != c.GLEW_OK) return error.GLEWInitFailed;
+                break :blk RhiResult{ .rhi = try rhi_opengl.createRHI(allocator), .is_vulkan = false };
+            }
+        } else blk: {
+            log.log.info("Initializing OpenGL backend...", .{});
+            if (c.glewInit() != c.GLEW_OK) {
+                return error.GLEWInitFailed;
+            }
+            break :blk RhiResult{ .rhi = try rhi_opengl.createRHI(allocator), .is_vulkan = false };
+        };
+
+        const rhi = rhi_and_type.rhi;
+        const actual_is_vulkan = rhi_and_type.is_vulkan;
+
+        try rhi.init(allocator);
+
+        const shader: ?Shader = if (!actual_is_vulkan) try Shader.initFromFile(allocator, "assets/shaders/terrain.vert", "assets/shaders/terrain.frag") else null;
+
+        var debug_shader: ?Shader = null;
+        var debug_quad_vao: c.GLuint = 0;
+        var debug_quad_vbo: c.GLuint = 0;
+
+        if (!actual_is_vulkan) {
+            const debug_vs = "#version 330 core\nlayout (location = 0) in vec2 aPos;layout (location = 1) in vec2 aTexCoord;out vec2 vTexCoord;void main() {gl_Position = vec4(aPos, 0.0, 1.0);vTexCoord = aTexCoord;}";
+            const debug_fs = "#version 330 core\nout vec4 FragColor;in vec2 vTexCoord;uniform sampler2D uDepthMap;void main() {float depth = texture(uDepthMap, vTexCoord).r;FragColor = vec4(vec3(depth), 1.0);}";
+            debug_shader = try Shader.initSimple(debug_vs, debug_fs);
+            const quad_vertices = [_]f32{ -1.0, 1.0, 0.0, 1.0, -1.0, -1.0, 0.0, 0.0, 1.0, -1.0, 1.0, 0.0, -1.0, 1.0, 0.0, 1.0, 1.0, -1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0 };
+            c.glGenVertexArrays().?(1, &debug_quad_vao);
+            c.glGenBuffers().?(1, &debug_quad_vbo);
+            c.glBindVertexArray().?(debug_quad_vao);
+            c.glBindBuffer().?(c.GL_ARRAY_BUFFER, debug_quad_vbo);
+            c.glBufferData().?(c.GL_ARRAY_BUFFER, quad_vertices.len * @sizeOf(f32), &quad_vertices, c.GL_STATIC_DRAW);
+            c.glEnableVertexAttribArray().?(0);
+            c.glVertexAttribPointer().?(0, 2, c.GL_FLOAT, c.GL_FALSE, 4 * @sizeOf(f32), null);
+            c.glEnableVertexAttribArray().?(1);
+            c.glVertexAttribPointer().?(1, 2, c.GL_FLOAT, c.GL_FALSE, 4 * @sizeOf(f32), @ptrFromInt(2 * @sizeOf(f32)));
+        }
+
+        const atlas = TextureAtlas.init(allocator, rhi);
+        const atmosphere = if (actual_is_vulkan) Atmosphere.initNoGL() else Atmosphere.init();
+        const clouds = if (actual_is_vulkan) Clouds.initNoGL() else try Clouds.init();
+        const shadow_map = if (!actual_is_vulkan) ShadowMap.init(rhi, settings.shadow_resolution) catch null else null;
+
+        return RenderSystem{
+            .allocator = allocator,
+            .rhi = rhi,
+            .is_vulkan = actual_is_vulkan,
+            .shader = shader,
+            .debug_shader = debug_shader,
+            .debug_quad_vao = debug_quad_vao,
+            .debug_quad_vbo = debug_quad_vbo,
+            .atlas = atlas,
+            .atmosphere = atmosphere,
+            .clouds = clouds,
+            .shadow_map = shadow_map,
+        };
+    }
+
+    pub fn deinit(self: *RenderSystem) void {
+        if (self.shadow_map) |*sm| sm.deinit();
+        if (self.clouds) |*cl| cl.deinit();
+        if (self.atmosphere) |*a| a.deinit();
+        self.atlas.deinit();
+        if (self.debug_shader) |*s| s.deinit();
+        if (!self.is_vulkan) {
+            if (self.debug_quad_vao != 0) c.glDeleteVertexArrays().?(1, &self.debug_quad_vao);
+            if (self.debug_quad_vbo != 0) c.glDeleteBuffers().?(1, &self.debug_quad_vbo);
+        }
+        if (self.shader) |*s| s.deinit();
+        self.rhi.deinit();
+    }
+};


### PR DESCRIPTION
## Summary
This PR completes the SOLID refactoring and addresses Vulkan parity concerns identified in code review.

## Changes
- **App Decomposition**: Split the monolithic `App` struct into focused subsystems:
  - `WindowManager` (`src/engine/core/window.zig`): Handles SDL window and context creation.
  - `RenderSystem` (`src/game/render_system.zig`): Manages RHI, shaders, and rendering resources.
  - `App` (`src/game/app.zig`): Orchestrates the game loop and state.

- **Vulkan/OpenGL Parity**:
  - Extracted shared CSM (Cascaded Shadow Map) math to `src/engine/graphics/csm.zig`. This clarifies that while OpenGL uses the `ShadowMap` struct for resource management, Vulkan uses the same math logic but manages resources internally in `VulkanContext`.
  - Addressed memory risks by properly clearing `pending_new_world_seed` on initialization failure.

- **Interface Segregation**:
  - Refactored `menus.zig` to use a `MenuContext` struct, significantly reducing parameter list size and coupling.

## Verification
- Validated build with `zig build`.
- Validated runtime with `zig build run -- --backend vulkan`.