### PR TITLE
Enable Nix-based Development Environment and Caching for OpenCode Agent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,11 @@ jobs:
         extra_nix_config: |
           experimental-features = nix-command flakes
 
-    - name: FlakeHub Cache
-      uses: DeterminateSystems/flakehub-cache-action@v9
+    - name: Cache Nix Store
+      uses: nix-community/cache-nix-action@v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-
 
     - name: Build
       run: nix build -L

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,10 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
           experimental-features = nix-command flakes
-        
+
+    - name: Magic Nix Cache
+      uses: DeterminateSystems/magic-nix-cache-action@v9
+
     - name: Build
       run: nix build -L
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
         extra_nix_config: |
           experimental-features = nix-command flakes
 
-    - name: Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@v9
+    - name: FlakeHub Cache
+      uses: DeterminateSystems/flakehub-cache-action@v9
 
     - name: Build
       run: nix build -L

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -31,6 +31,9 @@ jobs:
 
       - name: Setup Dev Environment
         run: |
+          # Create a profile to prevent GC of the devShell environment
+          nix develop --profile ./dev-profile --command true
+
           nix develop --command bash -c '
             # Add Nix store paths to GITHUB_PATH
             echo "$PATH" | tr ":" "\n" | grep "^/nix/store" >> "$GITHUB_PATH"

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
-      - name: Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v9
+      - name: FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@v9
 
       - name: Setup Dev Environment
         run: |

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -26,8 +26,11 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
-      - name: FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@v9
+      - name: Cache Nix Store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
 
       - name: Setup Dev Environment
         run: |


### PR DESCRIPTION
This PR (re-opening of #55) implements the infrastructure required for the OpenCode agent to build and verify its own code in CI, with optimized caching.

### Changes:
- ****: Added  (Zig Language Server) and ensured all build tools are in the development shell.
- ****: 
    - Integrated Nix installation and .
    - Added a setup step to export Nix environment variables globally.
    - Implemented a profile-based caching strategy to pin dependencies and prevent re-downloads.
- ****: Updated with comprehensive instructions and a note on the pre-configured CI environment.

Fixes #54