### PR TITLE
feat: add shader compilation validation tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,17 @@ jobs:
 
     - name: Build
       run: nix build -L
+
+    - name: Validate OpenGL shaders
+      run: |
+        nix develop --command sh -c '
+          echo "Validating OpenGL shaders..."
+          for shader in assets/shaders/*.vert assets/shaders/*.frag; do
+            echo "  Checking $shader"
+            glslangValidator "$shader"
+          done
+          echo "All OpenGL shaders valid!"
+        '
       
     - name: Prepare Artifact
       run: |

--- a/assets/shaders/cloud.frag
+++ b/assets/shaders/cloud.frag
@@ -1,0 +1,63 @@
+#version 330 core
+in vec3 vWorldPos;
+in float vDistance;
+out vec4 FragColor;
+uniform vec3 uCameraPos;
+uniform float uCloudHeight;
+uniform float uCloudCoverage;
+uniform float uCloudScale;
+uniform float uWindOffsetX;
+uniform float uWindOffsetZ;
+uniform vec3 uSunDir;
+uniform float uSunIntensity;
+uniform vec3 uBaseColor;
+uniform vec3 uFogColor;
+uniform float uFogDensity;
+float hash(vec2 p) {
+    p = fract(p * vec2(234.34, 435.345));
+    p += dot(p, p + 34.23);
+    return fract(p.x * p.y);
+}
+float noise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    float a = hash(i);
+    float b = hash(i + vec2(1.0, 0.0));
+    float c = hash(i + vec2(0.0, 1.0));
+    float d = hash(i + vec2(1.0, 1.0));
+    vec2 u = f * f * (3.0 - 2.0 * f);
+    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+float fbm(vec2 p, int octaves) {
+    float value = 0.0;
+    float amplitude = 0.5;
+    float frequency = 1.0;
+    for (int i = 0; i < octaves; i++) {
+        value += amplitude * noise(p * frequency);
+        amplitude *= 0.5;
+        frequency *= 2.0;
+    }
+    return value;
+}
+void main() {
+    float cloudBlockSize = 12.0;
+    vec2 worldXZ = vWorldPos.xz + vec2(uWindOffsetX, uWindOffsetZ);
+    vec2 pixelPos = floor(worldXZ / cloudBlockSize) * cloudBlockSize;
+    vec2 samplePos = pixelPos * uCloudScale;
+    float cloudValue = fbm(samplePos, 3);
+    float threshold = 1.0 - uCloudCoverage;
+    if (cloudValue < threshold) discard;
+    vec3 nightTint = vec3(0.1, 0.12, 0.2);
+    vec3 dayColor = uBaseColor;
+    vec3 cloudColor = mix(nightTint, dayColor, uSunIntensity);
+    float lightFactor = clamp(uSunDir.y, 0.0, 1.0);
+    cloudColor *= (0.7 + 0.3 * lightFactor);
+    float fogFactor = 1.0 - exp(-vDistance * uFogDensity * 0.4);
+    cloudColor = mix(cloudColor, uFogColor, fogFactor);
+    float alpha = 1.0 * (1.0 - fogFactor * 0.8);
+    float altitudeDiff = uCameraPos.y - uCloudHeight;
+    if (altitudeDiff > 0.0) {
+        alpha *= 1.0 - smoothstep(10.0, 400.0, altitudeDiff);
+    }
+    FragColor = vec4(cloudColor, alpha);
+}

--- a/assets/shaders/cloud.vert
+++ b/assets/shaders/cloud.vert
@@ -1,0 +1,17 @@
+#version 330 core
+layout (location = 0) in vec2 aPos;
+out vec3 vWorldPos;
+out float vDistance;
+uniform vec3 uCameraPos;
+uniform float uCloudHeight;
+uniform mat4 uViewProj;
+void main() {
+    vec3 relPos = vec3(
+        aPos.x,
+        uCloudHeight - uCameraPos.y,
+        aPos.y
+    );
+    vWorldPos = vec3(aPos.x + uCameraPos.x, uCloudHeight, aPos.y + uCameraPos.z);
+    vDistance = length(relPos);
+    gl_Position = uViewProj * vec4(relPos, 1.0);
+}

--- a/assets/shaders/debug_shadow.frag
+++ b/assets/shaders/debug_shadow.frag
@@ -1,0 +1,8 @@
+#version 330 core
+out vec4 FragColor;
+in vec2 vTexCoord;
+uniform sampler2D uDepthMap;
+void main() {
+    float depth = texture(uDepthMap, vTexCoord).r;
+    FragColor = vec4(vec3(depth), 1.0);
+}

--- a/assets/shaders/debug_shadow.vert
+++ b/assets/shaders/debug_shadow.vert
@@ -1,0 +1,8 @@
+#version 330 core
+layout (location = 0) in vec2 aPos;
+layout (location = 1) in vec2 aTexCoord;
+out vec2 vTexCoord;
+void main() {
+    gl_Position = vec4(aPos, 0.0, 1.0);
+    vTexCoord = aTexCoord;
+}

--- a/assets/shaders/sky.frag
+++ b/assets/shaders/sky.frag
@@ -1,0 +1,89 @@
+#version 330 core
+in vec3 vWorldDir;
+out vec4 FragColor;
+
+uniform vec3 uSunDir;
+uniform vec3 uSkyColor;
+uniform vec3 uHorizonColor;
+uniform float uSunIntensity;
+uniform float uMoonIntensity;
+uniform float uTime;
+
+float hash21(vec2 p) {
+    p = fract(p * vec2(234.34, 435.345));
+    p += dot(p, p + 34.23);
+    return fract(p.x * p.y);
+}
+
+vec2 hash22(vec2 p) {
+    float n = hash21(p);
+    return vec2(n, hash21(p + n));
+}
+
+float stars(vec3 dir) {
+    float theta = atan(dir.z, dir.x);
+    float phi = asin(clamp(dir.y, -1.0, 1.0));
+
+    vec2 gridCoord = vec2(theta * 15.0, phi * 30.0);
+    vec2 cell = floor(gridCoord);
+    vec2 cellFrac = fract(gridCoord);
+
+    float brightness = 0.0;
+
+    for (int dy = -1; dy <= 1; dy++) {
+        for (int dx = -1; dx <= 1; dx++) {
+            vec2 neighbor = cell + vec2(float(dx), float(dy));
+
+            float starChance = hash21(neighbor);
+            if (starChance > 0.92) {
+                vec2 starPos = hash22(neighbor * 1.7);
+                vec2 offset = vec2(float(dx), float(dy)) + starPos - cellFrac;
+                float dist = length(offset);
+
+                float starBright = smoothstep(0.08, 0.0, dist);
+
+                starBright *= 0.5 + 0.5 * hash21(neighbor * 3.14);
+
+                float twinkle = 0.7 + 0.3 * sin(hash21(neighbor) * 50.0 + uTime * 8.0);
+                starBright *= twinkle;
+
+                brightness = max(brightness, starBright);
+            }
+        }
+    }
+
+    return brightness;
+}
+
+void main() {
+    vec3 dir = normalize(vWorldDir);
+
+    float horizon = 1.0 - abs(dir.y);
+    horizon = pow(horizon, 1.5);
+    vec3 sky = mix(uSkyColor, uHorizonColor, horizon);
+
+    float sunDot = dot(dir, uSunDir);
+    float sunDisc = smoothstep(0.9995, 0.9999, sunDot);
+    vec3 sunColor = vec3(1.0, 0.95, 0.8);
+
+    float sunGlow = pow(max(sunDot, 0.0), 8.0) * 0.5;
+    sunGlow += pow(max(sunDot, 0.0), 64.0) * 0.3;
+
+    float moonDot = dot(dir, -uSunDir);
+    float moonDisc = smoothstep(0.9990, 0.9995, moonDot);
+    vec3 moonColor = vec3(0.9, 0.9, 1.0);
+
+    float starIntensity = 0.0;
+    if (uSunIntensity < 0.3 && dir.y > 0.0) {
+        float nightFactor = 1.0 - uSunIntensity * 3.33;
+        starIntensity = stars(dir) * nightFactor * 1.5;
+    }
+
+    vec3 finalColor = sky;
+    finalColor += sunGlow * uSunIntensity * vec3(1.0, 0.8, 0.4);
+    finalColor += sunDisc * sunColor * uSunIntensity;
+    finalColor += moonDisc * moonColor * uMoonIntensity * 3.0;
+    finalColor += vec3(starIntensity);
+
+    FragColor = vec4(finalColor, 1.0);
+}

--- a/assets/shaders/sky.vert
+++ b/assets/shaders/sky.vert
@@ -1,0 +1,15 @@
+#version 330 core
+layout (location = 0) in vec2 aPos;
+out vec3 vWorldDir;
+uniform vec3 uCamForward;
+uniform vec3 uCamRight;
+uniform vec3 uCamUp;
+uniform float uAspect;
+uniform float uTanHalfFov;
+void main() {
+    gl_Position = vec4(aPos, 0.9999, 1.0);
+    vec3 rayDir = uCamForward
+                + uCamRight * aPos.x * uAspect * uTanHalfFov
+                + uCamUp * aPos.y * uTanHalfFov;
+    vWorldDir = rayDir;
+}

--- a/assets/shaders/ui.frag
+++ b/assets/shaders/ui.frag
@@ -1,0 +1,6 @@
+#version 330 core
+in vec4 vColor;
+out vec4 FragColor;
+void main() {
+    FragColor = vColor;
+}

--- a/assets/shaders/ui.vert
+++ b/assets/shaders/ui.vert
@@ -1,0 +1,9 @@
+#version 330 core
+layout (location = 0) in vec2 aPos;
+layout (location = 1) in vec4 aColor;
+out vec4 vColor;
+uniform mat4 projection;
+void main() {
+    gl_Position = projection * vec4(aPos, 0.0, 1.0);
+    vColor = aColor;
+}

--- a/assets/shaders/ui_tex.frag
+++ b/assets/shaders/ui_tex.frag
@@ -1,0 +1,7 @@
+#version 330 core
+in vec2 vTexCoord;
+out vec4 FragColor;
+uniform sampler2D uTexture;
+void main() {
+    FragColor = texture(uTexture, vTexCoord);
+}

--- a/assets/shaders/ui_tex.vert
+++ b/assets/shaders/ui_tex.vert
@@ -1,0 +1,9 @@
+#version 330 core
+layout (location = 0) in vec2 aPos;
+layout (location = 1) in vec2 aTexCoord;
+out vec2 vTexCoord;
+uniform mat4 projection;
+void main() {
+    gl_Position = projection * vec4(aPos, 0.0, 1.0);
+    vTexCoord = aTexCoord;
+}

--- a/build.zig
+++ b/build.zig
@@ -80,6 +80,7 @@ pub fn build(b: *std.Build) void {
     });
     integration_root_module.addImport("zig-math", zig_math);
     integration_root_module.addImport("zig-noise", zig_noise);
+    integration_root_module.addImport("shader_sources", shader_sources);
 
     const exe_integration_tests = b.addTest(.{
         .root_module = integration_root_module,

--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,12 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    const shader_sources = b.createModule(.{
+        .root_source_file = b.path("shader_sources.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const root_module = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
@@ -23,6 +29,7 @@ pub fn build(b: *std.Build) void {
     });
     root_module.addImport("zig-math", zig_math);
     root_module.addImport("zig-noise", zig_noise);
+    root_module.addImport("shader_sources", shader_sources);
 
     const exe = b.addExecutable(.{
         .name = "zig-triangle",
@@ -55,6 +62,7 @@ pub fn build(b: *std.Build) void {
     });
     test_root_module.addImport("zig-math", zig_math);
     test_root_module.addImport("zig-noise", zig_noise);
+    test_root_module.addImport("shader_sources", shader_sources);
 
     const exe_tests = b.addTest(.{
         .root_module = test_root_module,
@@ -86,20 +94,20 @@ pub fn build(b: *std.Build) void {
     const run_integration_tests = b.addRunArtifact(exe_integration_tests);
     test_integration_step.dependOn(&run_integration_tests.step);
 
-    const validate_vulkan_terrain_vert = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/terrain.vert"});
-    const validate_vulkan_terrain_frag = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/terrain.frag"});
-    const validate_vulkan_shadow_vert = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/shadow.vert"});
-    const validate_vulkan_shadow_frag = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/shadow.frag"});
-    const validate_vulkan_sky_vert = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/sky.vert"});
-    const validate_vulkan_sky_frag = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/sky.frag"});
-    const validate_vulkan_ui_vert = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/ui.vert"});
-    const validate_vulkan_ui_frag = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/ui.frag"});
-    const validate_vulkan_ui_tex_vert = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/ui_tex.vert"});
-    const validate_vulkan_ui_tex_frag = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/ui_tex.frag"});
-    const validate_vulkan_cloud_vert = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/cloud.vert"});
-    const validate_vulkan_cloud_frag = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/cloud.frag"});
-    const validate_vulkan_debug_shadow_vert = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/debug_shadow.vert"});
-    const validate_vulkan_debug_shadow_frag = b.addSystemCommand(&.{"glslangValidator", "-V", "assets/shaders/vulkan/debug_shadow.frag"});
+    const validate_vulkan_terrain_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/terrain.vert" });
+    const validate_vulkan_terrain_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/terrain.frag" });
+    const validate_vulkan_shadow_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/shadow.vert" });
+    const validate_vulkan_shadow_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/shadow.frag" });
+    const validate_vulkan_sky_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/sky.vert" });
+    const validate_vulkan_sky_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/sky.frag" });
+    const validate_vulkan_ui_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/ui.vert" });
+    const validate_vulkan_ui_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/ui.frag" });
+    const validate_vulkan_ui_tex_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/ui_tex.vert" });
+    const validate_vulkan_ui_tex_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/ui_tex.frag" });
+    const validate_vulkan_cloud_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/cloud.vert" });
+    const validate_vulkan_cloud_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/cloud.frag" });
+    const validate_vulkan_debug_shadow_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/debug_shadow.vert" });
+    const validate_vulkan_debug_shadow_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/debug_shadow.frag" });
 
     test_step.dependOn(&validate_vulkan_terrain_vert.step);
     test_step.dependOn(&validate_vulkan_terrain_frag.step);
@@ -115,5 +123,4 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&validate_vulkan_cloud_frag.step);
     test_step.dependOn(&validate_vulkan_debug_shadow_vert.step);
     test_step.dependOn(&validate_vulkan_debug_shadow_frag.step);
-
 }

--- a/shader_sources.zig
+++ b/shader_sources.zig
@@ -1,0 +1,32 @@
+//! OpenGL shader sources for testing and runtime embedding.
+//!
+//! This module provides compile-time access to all OpenGL shader files
+//! for validation tests and runtime use via @embedFile.
+
+pub const terrain_vert = @embedFile("assets/shaders/terrain.vert");
+pub const terrain_frag = @embedFile("assets/shaders/terrain.frag");
+pub const ui_vert = @embedFile("assets/shaders/ui.vert");
+pub const ui_frag = @embedFile("assets/shaders/ui.frag");
+pub const ui_tex_vert = @embedFile("assets/shaders/ui_tex.vert");
+pub const ui_tex_frag = @embedFile("assets/shaders/ui_tex.frag");
+pub const sky_vert = @embedFile("assets/shaders/sky.vert");
+pub const sky_frag = @embedFile("assets/shaders/sky.frag");
+pub const cloud_vert = @embedFile("assets/shaders/cloud.vert");
+pub const cloud_frag = @embedFile("assets/shaders/cloud.frag");
+pub const debug_shadow_vert = @embedFile("assets/shaders/debug_shadow.vert");
+pub const debug_shadow_frag = @embedFile("assets/shaders/debug_shadow.frag");
+
+pub const all = [_][]const u8{
+    terrain_vert,
+    terrain_frag,
+    ui_vert,
+    ui_frag,
+    ui_tex_vert,
+    ui_tex_frag,
+    sky_vert,
+    sky_frag,
+    cloud_vert,
+    cloud_frag,
+    debug_shadow_vert,
+    debug_shadow_frag,
+};

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -762,3 +762,71 @@ test "adjacent transparent blocks share face" {
     }
     try testing.expect(total_verts < 72);
 }
+
+// ============================================================================
+// GLSL Shader Validation Tests
+// ============================================================================
+
+// All OpenGL shader sources (12 files: 6 pairs)
+const shader_sources = @import("shader_sources");
+
+test "GLSL shader version directives" {
+    const version_directive = "#version 330 core";
+
+    for (shader_sources.all) |src| {
+        // Find end of first line
+        var first_line_end: usize = 0;
+        for (src, 0..) |ch, i| {
+            if (ch == '\n' or ch == '\r') {
+                first_line_end = i;
+                break;
+            }
+        }
+        const first_line = src[0..first_line_end];
+
+        // Verify version directive is present at start
+        try testing.expect(std.mem.startsWith(u8, first_line, version_directive));
+    }
+}
+
+test "GLSL shader in/out consistency - terrain" {
+    const vert_src = shader_sources.terrain_vert;
+    const frag_src = shader_sources.terrain_frag;
+
+    // Verify required uniforms exist
+    try testing.expect(std.mem.indexOf(u8, vert_src, "uniform mat4 transform") != null);
+    try testing.expect(std.mem.indexOf(u8, frag_src, "uniform sampler2D uTexture") != null);
+    try testing.expect(std.mem.indexOf(u8, frag_src, "uniform sampler2D uShadowMap0") != null);
+
+    // Verify varyings match between vertex output and fragment input
+    const varyings = [_][]const u8{
+        "vColor",
+        "vNormal",
+        "vTexCoord",
+        "vTileID",
+        "vDistance",
+        "vSkyLight",
+        "vBlockLight",
+        "vFragPosWorld",
+        "vViewDepth",
+    };
+
+    for (varyings) |varying| {
+        // Vertex shader should have the varying
+        try testing.expect(std.mem.indexOf(u8, vert_src, varying) != null);
+        // Fragment shader should have the varying
+        try testing.expect(std.mem.indexOf(u8, frag_src, varying) != null);
+    }
+}
+
+test "GLSL shader brace matching" {
+    for (shader_sources.all) |src| {
+        var open: usize = 0;
+        var close: usize = 0;
+        for (src) |ch| {
+            if (ch == '{') open += 1;
+            if (ch == '}') close += 1;
+        }
+        try testing.expectEqual(open, close);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract embedded GLSL shaders from `rhi_opengl.zig` to external files for validation
- Add `shader_sources.zig` module to centralize shader embedding via `@embedFile`
- Add 3 consolidated shader validation tests to `tests.zig`
- Add CI step to validate OpenGL shaders with `glslangValidator`

## Changes

### New Files (10 OpenGL shaders)
- `assets/shaders/ui.vert`, `ui.frag` - UI rendering
- `assets/shaders/ui_tex.vert`, `ui_tex.frag` - Textured UI
- `assets/shaders/sky.vert`, `sky.frag` - Sky/atmosphere with stars
- `assets/shaders/cloud.vert`, `cloud.frag` - Clouds with FBM noise
- `assets/shaders/debug_shadow.vert`, `debug_shadow.frag` - Shadow map debug
- `shader_sources.zig` - Central shader embedding module

### New Tests
1. `GLSL shader version directives` - All shaders start with `#version 330 core`
2. `GLSL shader in/out consistency - terrain` - Validates uniforms/varyings match
3. `GLSL shader brace matching` - Balanced `{` and `}` in all shaders

### CI
- Added OpenGL shader validation step using `glslangValidator`

Closes #83