### PR TITLE
Fix Vulkan performance: Async buffer/texture uploads

### DIFF
--- a/src/engine/graphics/rhi_vulkan.zig
+++ b/src/engine/graphics/rhi_vulkan.zig
@@ -3867,6 +3867,7 @@ pub fn createRHI(allocator: std.mem.Allocator, window: *c.SDL_Window, render_dev
         ctx.shadow_ubos[i] = .{ .buffer = null, .memory = null, .size = 0, .is_host_visible = false };
         ctx.ui_vbos[i] = .{ .buffer = null, .memory = null, .size = 0, .is_host_visible = false };
         ctx.descriptor_sets[i] = null;
+        ctx.buffer_deletion_queue[i] = .empty;
     }
     ctx.model_ubo = .{ .buffer = null, .memory = null, .size = 0, .is_host_visible = false };
 


### PR DESCRIPTION
## Summary
This PR resolves issue #87 by implementing asynchronous buffer and texture uploads for the Vulkan backend, eliminating severe CPU stalls caused by `vkQueueWaitIdle`.

## Changes
- **Staging Buffer Ring**: Implemented a per-frame, persistent staging buffer ring (8MB per frame) to avoid expensive per-upload buffer allocation/destruction.
- **Async Transfer Queue**: Added a dedicated per-frame transfer command buffer.
- **Async Uploads**: Refactored `uploadBuffer`, `createTexture`, and `updateTexture` to record copy commands to the transfer queue instead of blocking.
- **Frame Synchronization**: Implemented `ensureFrameReady` to robustly handle on-demand frame resource resetting and fence waiting, supporting uploads both inside and outside the main render loop.
- **Synchronization**: Updated `endFrame` to batch submit transfer and graphics command buffers, ensuring correct execution order.

## Performance
- Eliminated `vkQueueWaitIdle` from the hot path (chunk meshing and uploads).
- Maintains high FPS during world generation and chunk loading.
- Fallback to synchronous path included if the staging ring fills up, ensuring stability.

## Verification
- `zig build test` passes (consistent with baseline).
- Manual verification via `zig build run -- --backend vulkan` confirms the engine runs smoothly without crashes (after fixing an initialization bug).