### PR TITLE
fix: Remove incorrect static alignment assertion in ShadowPass

### DIFF
--- a/src/engine/graphics/render_graph.zig
+++ b/src/engine/graphics/render_graph.zig
@@ -103,9 +103,6 @@ pub const ShadowPass = struct {
     }
 
     fn execute(ptr: *anyopaque, ctx: SceneContext) void {
-        if (std.debug.runtime_safety) {
-            std.debug.assert(@typeInfo(@TypeOf(ptr)).pointer.alignment >= @alignOf(ShadowPass));
-        }
         const self: *ShadowPass = @ptrCast(@alignCast(ptr));
         // Runtime verification to ensuring pointer safety in debug mode
         std.debug.assert(self.cascade_index < rhi_pkg.SHADOW_CASCADE_COUNT);


### PR DESCRIPTION
## Summary
This PR fixes a runtime assertion failure in `ShadowPass.execute` caused by checking the static alignment of a type-erased `*anyopaque` pointer (alignment 1) against the required alignment of `ShadowPass` (alignment 4).

The assertion `@typeInfo(@TypeOf(ptr)).pointer.alignment >= @alignOf(ShadowPass)` was always false because `ptr` is `*anyopaque`.

The fix removes this incorrect assertion. The subsequent `@ptrCast(@alignCast(ptr))` correctly handles the runtime alignment verification and safety check.