### PR TITLE
Refactor: Decouple World and App architecture (Issue #146)

### DIFF
--- a/src/engine/core/job_system.zig
+++ b/src/engine/core/job_system.zig
@@ -66,6 +66,8 @@ pub const Job = struct {
     }
 };
 
+pub const REPRIORITIZE_THRESHOLD = 16;
+
 pub const JobQueue = struct {
     mutex: Mutex,
     cond: Condition,
@@ -80,7 +82,7 @@ pub const JobQueue = struct {
     // Lazy re-prioritization: mark dirty instead of immediate rebuild
     needs_reprioritize: bool = false,
     // Threshold: only reprioritize if queue has this many items
-    reprioritize_threshold: usize = 16,
+    reprioritize_threshold: usize = REPRIORITIZE_THRESHOLD,
 
     fn compareJobs(context: void, a: Job, b: Job) std.math.Order {
         _ = context;
@@ -97,7 +99,7 @@ pub const JobQueue = struct {
             .abort_worker = false,
             .allocator = allocator,
             .needs_reprioritize = false,
-            .reprioritize_threshold = 16,
+            .reprioritize_threshold = REPRIORITIZE_THRESHOLD,
         };
     }
 

--- a/src/engine/core/job_system.zig
+++ b/src/engine/core/job_system.zig
@@ -1,4 +1,4 @@
-//! Job system for asynchronous chunk operations.
+//! Job system for asynchronous operations.
 
 const std = @import("std");
 const Thread = std.Thread;
@@ -8,20 +8,61 @@ const Chunk = @import("../../world/chunk.zig").Chunk;
 const log = @import("log.zig");
 
 pub const JobType = enum {
-    generation,
-    meshing,
+    chunk_generation,
+    chunk_meshing,
+    generic,
 };
 
 pub const Job = struct {
     type: JobType,
-    chunk_x: i32,
-    chunk_z: i32,
-    job_token: u32,
-    dist_sq: i32, // Priority: closer is smaller
 
-    // Comparison for min-heap (lower dist = higher priority)
+    // Priority value for generic jobs (lower = higher priority)
+    priority: i32 = 0,
+
+    // Distance-based priority for spatial jobs (lower = closer to player)
+    dist_sq: i32 = 0,
+
+    // Payload union - holds job-specific data
+    data: union {
+        chunk: ChunkJobData,
+        generic: GenericJobData,
+    },
+
+    pub const ChunkJobData = struct {
+        x: i32,
+        z: i32,
+        job_token: u32,
+    };
+
+    pub const GenericJobData = struct {
+        context: *anyopaque,
+        process_fn: *const fn (*anyopaque) void,
+    };
+
+    // Comparison for min-heap (lower priority/dist = higher priority)
     pub fn compare(a: Job, b: Job) std.math.Order {
-        return std.math.order(a.dist_sq, b.dist_sq);
+        return std.math.order(a.getPriorityValue(), b.getPriorityValue());
+    }
+
+    fn getPriorityValue(self: Job) i32 {
+        return switch (self.type) {
+            .chunk_generation, .chunk_meshing => self.dist_sq,
+            .generic => self.priority,
+        };
+    }
+
+    pub fn getChunkCoords(self: Job) ?struct { x: i32, z: i32 } {
+        return switch (self.type) {
+            .chunk_generation, .chunk_meshing => .{ .x = self.data.chunk.x, .z = self.data.chunk.z },
+            else => null,
+        };
+    }
+
+    pub fn getJobToken(self: Job) ?u32 {
+        return switch (self.type) {
+            .chunk_generation, .chunk_meshing => self.data.chunk.job_token,
+            else => null,
+        };
     }
 };
 
@@ -101,11 +142,15 @@ pub const JobQueue = struct {
 
         // Extract all jobs
         while (self.jobs.removeOrNull()) |job| {
-            // Recalculate distance from current player position
-            const dx = job.chunk_x - self.player_cx;
-            const dz = job.chunk_z - self.player_cz;
             var updated_job = job;
-            updated_job.dist_sq = dx * dx + dz * dz;
+
+            // Only update distance for chunk-based jobs
+            if (job.getChunkCoords()) |coords| {
+                const dx = coords.x - self.player_cx;
+                const dz = coords.z - self.player_cz;
+                updated_job.dist_sq = dx * dx + dz * dz;
+            }
+
             temp.append(self.allocator, updated_job) catch {
                 log.log.warn("Job queue: dropped job during priority update (allocation failed)", .{});
                 continue;
@@ -210,7 +255,14 @@ pub const WorkerPool = struct {
     fn workerThread(queue: *JobQueue, pool: *WorkerPool) void {
         while (true) {
             const job = queue.pop() orelse break;
-            pool.process_job_fn(pool.context, job);
+            switch (job.type) {
+                .chunk_generation, .chunk_meshing => {
+                    pool.process_job_fn(pool.context, job);
+                },
+                .generic => {
+                    job.data.generic.process_fn(job.data.generic.context);
+                },
+            }
         }
     }
 };

--- a/src/engine/graphics/rhi_vulkan.zig
+++ b/src/engine/graphics/rhi_vulkan.zig
@@ -2642,6 +2642,12 @@ fn deinit(ctx_ptr: *anyopaque) void {
         if (ctx.model_ubo.memory != null) c.vkFreeMemory(ctx.vulkan_device.vk_device, ctx.model_ubo.memory, null);
         if (ctx.dummy_instance_buffer.buffer != null) c.vkDestroyBuffer(ctx.vulkan_device.vk_device, ctx.dummy_instance_buffer.buffer, null);
         if (ctx.dummy_instance_buffer.memory != null) c.vkFreeMemory(ctx.vulkan_device.vk_device, ctx.dummy_instance_buffer.memory, null);
+        if (ctx.debug_shadow_vbo.buffer != null) c.vkDestroyBuffer(ctx.vulkan_device.vk_device, ctx.debug_shadow_vbo.buffer, null);
+        if (ctx.debug_shadow_vbo.memory != null) c.vkFreeMemory(ctx.vulkan_device.vk_device, ctx.debug_shadow_vbo.memory, null);
+        if (ctx.cloud_vbo.buffer != null) c.vkDestroyBuffer(ctx.vulkan_device.vk_device, ctx.cloud_vbo.buffer, null);
+        if (ctx.cloud_vbo.memory != null) c.vkFreeMemory(ctx.vulkan_device.vk_device, ctx.cloud_vbo.memory, null);
+        if (ctx.cloud_ebo.buffer != null) c.vkDestroyBuffer(ctx.vulkan_device.vk_device, ctx.cloud_ebo.buffer, null);
+        if (ctx.cloud_ebo.memory != null) c.vkFreeMemory(ctx.vulkan_device.vk_device, ctx.cloud_ebo.memory, null);
 
         ctx.vulkan_swapchain.deinit();
 

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -21,6 +21,10 @@ const LODConfig = @import("../world/lod_chunk.zig").LODConfig;
 const CSM = @import("../engine/graphics/csm.zig");
 
 const World = @import("../world/world.zig").World;
+const GameSession = @import("session.zig").GameSession;
+const AtmosphereState = @import("session.zig").AtmosphereState;
+const CloudState = @import("session.zig").CloudState;
+const InputMapper = @import("input_mapper.zig").InputMapper;
 const rhi_pkg = @import("../engine/graphics/rhi.zig");
 const RHI = rhi_pkg.RHI;
 const rhi_vulkan = @import("../engine/graphics/rhi_vulkan.zig");
@@ -46,211 +50,6 @@ const HandRenderer = @import("hand_renderer.zig").HandRenderer;
 
 const debug_build = builtin.mode == .Debug;
 
-const AtmosphereState = struct {
-    world_ticks: u64 = 0,
-    tick_accumulator: f32 = 0.0,
-    time_scale: f32 = 1.0,
-    time_of_day: f32 = 0.25,
-    sun_intensity: f32 = 1.0,
-    moon_intensity: f32 = 0.0,
-    sun_dir: Vec3 = Vec3.init(0, 1, 0),
-    moon_dir: Vec3 = Vec3.init(0, -1, 0),
-    sky_color: Vec3 = Vec3.init(0.5, 0.7, 1.0),
-    horizon_color: Vec3 = Vec3.init(0.8, 0.85, 0.95),
-    sun_color: Vec3 = Vec3.init(1.0, 1.0, 1.0),
-    fog_color: Vec3 = Vec3.init(0.6, 0.75, 0.95),
-    ambient_intensity: f32 = 0.3,
-    fog_density: f32 = 0.0015,
-    fog_enabled: bool = true,
-    orbit_tilt: f32 = 0.35,
-
-    fn smoothstep(edge0: f32, edge1: f32, x: f32) f32 {
-        const t = std.math.clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
-        return t * t * (3.0 - 2.0 * t);
-    }
-
-    fn lerpVec3(a: Vec3, b: Vec3, t: f32) Vec3 {
-        return Vec3.init(
-            std.math.lerp(a.x, b.x, t),
-            std.math.lerp(a.y, b.y, t),
-            std.math.lerp(a.z, b.z, t),
-        );
-    }
-
-    pub fn update(self: *AtmosphereState, delta_time: f32) void {
-        self.tick_accumulator += delta_time * 20.0 * self.time_scale;
-        if (self.tick_accumulator >= 1.0) {
-            const ticks_delta: u64 = @intFromFloat(self.tick_accumulator);
-            self.world_ticks +%= ticks_delta;
-            self.tick_accumulator -= @floatFromInt(ticks_delta);
-        }
-
-        const day_ticks = self.world_ticks % 24000;
-        self.time_of_day = @as(f32, @floatFromInt(day_ticks)) / 24000.0;
-
-        self.updateCelestialBodies();
-        self.updateIntensities();
-        self.updateColors();
-    }
-
-    fn updateCelestialBodies(self: *AtmosphereState) void {
-        const sun_angle = self.time_of_day * std.math.tau;
-        const cos_angle = @cos(sun_angle);
-        const sin_angle = @sin(sun_angle);
-        const cos_tilt = @cos(self.orbit_tilt);
-        const sin_tilt = @sin(self.orbit_tilt);
-
-        self.sun_dir = Vec3.init(
-            sin_angle,
-            -cos_angle * cos_tilt,
-            -cos_angle * sin_tilt,
-        ).normalize();
-        self.moon_dir = self.sun_dir.scale(-1);
-    }
-
-    fn updateIntensities(self: *AtmosphereState) void {
-        const t = self.time_of_day;
-        const DAWN_START: f32 = 0.20;
-        const DAWN_END: f32 = 0.30;
-        const DUSK_START: f32 = 0.70;
-        const DUSK_END: f32 = 0.80;
-
-        if (t < DAWN_START) {
-            self.sun_intensity = 0;
-        } else if (t < DAWN_END) {
-            self.sun_intensity = smoothstep(DAWN_START, DAWN_END, t);
-        } else if (t < DUSK_START) {
-            self.sun_intensity = 1.0;
-        } else if (t < DUSK_END) {
-            self.sun_intensity = 1.0 - smoothstep(DUSK_START, DUSK_END, t);
-        } else {
-            self.sun_intensity = 0;
-        }
-
-        self.moon_intensity = (1.0 - self.sun_intensity) * 0.15;
-        const day_ambient: f32 = 0.45;
-        const night_ambient: f32 = 0.15;
-        self.ambient_intensity = std.math.lerp(night_ambient, day_ambient, self.sun_intensity);
-    }
-
-    fn updateColors(self: *AtmosphereState) void {
-        const t = self.time_of_day;
-        const DAWN_START: f32 = 0.20;
-        const DAWN_END: f32 = 0.30;
-        const DUSK_START: f32 = 0.70;
-        const DUSK_END: f32 = 0.80;
-
-        const day_sky = Vec3.init(0.4, 0.65, 1.0).toLinear();
-        const day_horizon = Vec3.init(0.7, 0.8, 0.95).toLinear();
-        const night_sky = Vec3.init(0.02, 0.02, 0.08).toLinear();
-        const night_horizon = Vec3.init(0.05, 0.05, 0.12).toLinear();
-        const dawn_sky = Vec3.init(0.25, 0.3, 0.5).toLinear();
-        const dawn_horizon = Vec3.init(0.95, 0.55, 0.2).toLinear();
-        const dusk_sky = Vec3.init(0.25, 0.3, 0.5).toLinear();
-        const dusk_horizon = Vec3.init(0.95, 0.55, 0.2).toLinear();
-
-        const day_sun = Vec3.init(1.0, 0.95, 0.9).toLinear();
-        const dawn_sun = Vec3.init(1.0, 0.85, 0.6).toLinear();
-        const dusk_sun = Vec3.init(1.0, 0.85, 0.6).toLinear();
-        const night_sun = Vec3.init(0.04, 0.04, 0.1).toLinear();
-
-        if (t < DAWN_START) {
-            self.sky_color = night_sky;
-            self.horizon_color = night_horizon;
-            self.sun_color = night_sun;
-        } else if (t < DAWN_END) {
-            const blend = smoothstep(DAWN_START, DAWN_END, t);
-            self.sky_color = lerpVec3(night_sky, dawn_sky, blend);
-            self.horizon_color = lerpVec3(night_horizon, dawn_horizon, blend);
-            self.sun_color = lerpVec3(night_sun, dawn_sun, blend);
-        } else if (t < 0.35) {
-            const blend = smoothstep(DAWN_END, 0.35, t);
-            self.sky_color = lerpVec3(dawn_sky, day_sky, blend);
-            self.horizon_color = lerpVec3(dawn_horizon, day_horizon, blend);
-            self.sun_color = lerpVec3(dawn_sun, day_sun, blend);
-        } else if (t < DUSK_START) {
-            self.sky_color = day_sky;
-            self.horizon_color = day_horizon;
-            self.sun_color = day_sun;
-        } else if (t < 0.75) {
-            const blend = smoothstep(DUSK_START, 0.75, t);
-            self.sky_color = lerpVec3(day_sky, dusk_sky, blend);
-            self.horizon_color = lerpVec3(day_horizon, dusk_horizon, blend);
-            self.sun_color = lerpVec3(day_sun, dusk_sun, blend);
-        } else if (t < DUSK_END) {
-            const blend = smoothstep(0.75, DUSK_END, t);
-            self.sky_color = lerpVec3(dusk_sky, night_sky, blend);
-            self.horizon_color = lerpVec3(dusk_horizon, night_horizon, blend);
-            self.sun_color = lerpVec3(dusk_sun, night_sun, blend);
-        } else {
-            self.sky_color = night_sky;
-            self.horizon_color = night_horizon;
-            self.sun_color = night_sun;
-        }
-
-        self.fog_color = self.horizon_color;
-        self.fog_density = std.math.lerp(0.0015, 0.0008, self.sun_intensity);
-    }
-
-    pub fn setTimeOfDay(self: *AtmosphereState, time: f32) void {
-        self.world_ticks = @intFromFloat(time * 24000.0);
-        self.time_of_day = time;
-        self.tick_accumulator = 0;
-        self.updateCelestialBodies();
-        self.updateIntensities();
-        self.updateColors();
-    }
-
-    pub fn getHours(self: *const AtmosphereState) f32 {
-        return self.time_of_day * 24.0;
-    }
-
-    pub fn getSkyLightFactor(self: *const AtmosphereState) f32 {
-        return @max(self.sun_intensity, self.moon_intensity);
-    }
-};
-
-const CloudState = struct {
-    wind_offset_x: f32 = 0.0,
-    wind_offset_z: f32 = 0.0,
-    cloud_scale: f32 = 1.0 / 64.0,
-    cloud_coverage: f32 = 0.5,
-    cloud_height: f32 = 160.0,
-    cloud_thickness: f32 = 12.0,
-    base_color: Vec3 = Vec3.init(1.0, 1.0, 1.0),
-
-    pub fn update(self: *CloudState, delta_time: f32) void {
-        const wind_dir_x: f32 = 1.0;
-        const wind_dir_z: f32 = 0.2;
-        const wind_speed: f32 = 2.0;
-        self.wind_offset_x += wind_dir_x * wind_speed * delta_time;
-        self.wind_offset_z += wind_dir_z * wind_speed * delta_time;
-    }
-
-    pub fn getShadowParams(self: *const CloudState) struct {
-        wind_offset_x: f32,
-        wind_offset_z: f32,
-        cloud_scale: f32,
-        cloud_coverage: f32,
-        cloud_height: f32,
-    } {
-        return .{
-            .wind_offset_x = self.wind_offset_x,
-            .wind_offset_z = self.wind_offset_z,
-            .cloud_scale = self.cloud_scale,
-            .cloud_coverage = self.cloud_coverage,
-            .cloud_height = self.cloud_height,
-        };
-    }
-};
-
-const DebugState = struct {
-    shadows: bool = false,
-    cascade_idx: usize = 0,
-    show_fps: bool = false,
-    show_block_info: bool = false,
-};
-
 pub const App = struct {
     allocator: std.mem.Allocator,
     window_manager: WindowManager,
@@ -269,8 +68,6 @@ pub const App = struct {
     sky_pass: render_graph_pkg.SkyPass,
     opaque_pass: render_graph_pkg.OpaquePass,
     cloud_pass: render_graph_pkg.CloudPass,
-    atmosphere: AtmosphereState,
-    clouds: CloudState,
 
     settings: Settings,
     input: Input,
@@ -286,19 +83,7 @@ pub const App = struct {
     seed_input: std.ArrayListUnmanaged(u8),
     seed_focused: bool,
 
-    world: ?*World,
-    world_map: ?WorldMap,
-    map_controller: MapController,
-
-    // Player and inventory system
-    player: ?Player,
-    inventory: Inventory,
-    inventory_ui_state: inventory_ui.InventoryUI,
-    creative_mode: bool,
-    block_outline: BlockOutline,
-    hand_renderer: HandRenderer,
-
-    debug_state: DebugState,
+    game_session: ?*GameSession,
 
     pub fn init(allocator: std.mem.Allocator) !*App {
         // Load settings first to get window resolution
@@ -354,10 +139,6 @@ pub const App = struct {
             env_map.?.bind(9);
         }
 
-        var atmosphere = AtmosphereState{};
-        atmosphere.setTimeOfDay(0.25);
-        const clouds = CloudState{};
-
         const atmosphere_system = try AtmosphereSystem.init(allocator, rhi);
 
         const camera = Camera.init(.{
@@ -390,8 +171,6 @@ pub const App = struct {
             .sky_pass = .{},
             .opaque_pass = .{},
             .cloud_pass = .{},
-            .atmosphere = atmosphere,
-            .clouds = clouds,
             .settings = settings,
             .input = input,
             .time = time,
@@ -403,16 +182,7 @@ pub const App = struct {
             .pending_new_world_seed = null,
             .seed_input = std.ArrayListUnmanaged(u8).empty,
             .seed_focused = false,
-            .world = null,
-            .world_map = null,
-            .map_controller = .{},
-            .player = null,
-            .inventory = Inventory.init(),
-            .inventory_ui_state = .{},
-            .creative_mode = true, // Default to creative mode
-            .block_outline = BlockOutline.init(rhi),
-            .hand_renderer = HandRenderer.init(rhi),
-            .debug_state = .{},
+            .game_session = null,
         };
 
         app.material_system = try MaterialSystem.init(allocator, rhi, &app.atlas);
@@ -431,8 +201,7 @@ pub const App = struct {
     }
 
     pub fn deinit(self: *App) void {
-        if (self.world_map) |*m| m.deinit();
-        if (self.world) |w| w.deinit();
+        if (self.game_session) |session| session.deinit();
         self.seed_input.deinit(self.allocator);
 
         if (self.ui) |*u| u.deinit();
@@ -440,8 +209,6 @@ pub const App = struct {
         self.render_graph.deinit();
         self.atmosphere_system.deinit();
         self.material_system.deinit();
-        self.block_outline.deinit();
-        self.hand_renderer.deinit();
         self.atlas.deinit();
         if (self.env_map) |*t| t.deinit();
         self.resource_pack_manager.deinit();
@@ -460,47 +227,28 @@ pub const App = struct {
 
         if (self.pending_world_cleanup or self.pending_new_world_seed != null) {
             self.rhi.waitIdle();
-            if (self.world) |w| {
-                w.deinit();
-                self.world = null;
+            if (self.game_session) |session| {
+                session.deinit();
+                self.game_session = null;
             }
             self.pending_world_cleanup = false;
         }
 
         if (self.pending_new_world_seed) |seed| {
             self.pending_new_world_seed = null;
-            const lod_config = LODConfig{
-                .lod0_radius = @min(self.settings.render_distance, 16), // Cap high-detail chunks to 16 radius (256 blocks)
-                .lod1_radius = 40,
-                .lod2_radius = 80,
-                .lod3_radius = 160,
+            self.game_session = GameSession.init(self.allocator, self.rhi, seed, self.settings.render_distance, self.settings.lod_enabled) catch |err| {
+                log.log.err("Failed to create game session: {}", .{err});
+                self.app_state = .home;
+                return;
             };
-            if (self.settings.lod_enabled) {
-                // Determine max render distance based on config
-                // If render distance is huge (e.g. 50), effective distance for World is clamped by lod0_radius due to my prev fix
-                // But World itself needs the full render distance to pass to fog/sky rendering if used there
-                self.world = World.initWithLOD(self.allocator, self.settings.render_distance, seed, self.rhi, lod_config) catch |err| {
-                    log.log.err("Failed to create world with LOD: {}", .{err});
-                    self.app_state = .home;
-                    return;
-                };
-            } else {
-                self.world = World.init(self.allocator, self.settings.render_distance, seed, self.rhi) catch |err| {
-                    log.log.err("Failed to create world: {}", .{err});
-                    self.app_state = .home;
-                    return;
-                };
-            }
-            if (self.world_map == null) self.world_map = WorldMap.init(self.rhi, 256, 256);
-            self.map_controller.show_map = false;
-            self.map_controller.map_needs_update = true;
-            self.player = Player.init(Vec3.init(8, 100, 8), self.creative_mode);
-            self.camera = self.player.?.camera;
+            self.camera = self.game_session.?.camera;
         }
 
         self.time.update();
-        self.atmosphere.update(self.time.delta_time);
-        self.clouds.update(self.time.delta_time);
+
+        const in_world = self.app_state == .world;
+        const in_pause = self.app_state == .paused;
+
         self.input.beginFrame();
         self.input.pollEvents();
         self.rhi.setViewport(self.input.window_width, self.input.window_height);
@@ -513,10 +261,16 @@ pub const App = struct {
         const mouse_clicked = self.input.isMouseButtonPressed(.left);
 
         if (self.input.isKeyPressed(.escape)) {
-            if (self.map_controller.show_map) {
-                self.map_controller.show_map = false;
-                if (self.app_state == .world) self.input.setMouseCapture(self.window_manager.window, true);
-            } else {
+            var handled = false;
+            if (self.game_session) |session| {
+                if (session.map_controller.show_map) {
+                    session.map_controller.show_map = false;
+                    if (self.app_state == .world) self.input.setMouseCapture(self.window_manager.window, true);
+                    handled = true;
+                }
+            }
+
+            if (!handled) {
                 switch (self.app_state) {
                     .home => self.input.should_quit = true,
                     .singleplayer => {
@@ -545,111 +299,38 @@ pub const App = struct {
             }
         }
 
-        const in_world = self.app_state == .world;
-        const in_pause = self.app_state == .paused;
-
         if (in_world or in_pause) {
-            if (in_world and self.input.isKeyPressed(.tab)) self.input.setMouseCapture(self.window_manager.window, !self.input.mouse_captured);
-            if (self.input.isKeyPressed(.f)) {
-                self.settings.wireframe_enabled = !self.settings.wireframe_enabled;
-                self.rhi.setWireframe(self.settings.wireframe_enabled);
-            }
-            if (self.input.isKeyPressed(.t)) {
-                self.settings.textures_enabled = !self.settings.textures_enabled;
-                self.rhi.setTexturesEnabled(self.settings.textures_enabled);
-            }
-            if (self.input.isKeyPressed(.v)) {
-                self.settings.vsync = !self.settings.vsync;
-                self.rhi.setVSync(self.settings.vsync);
-            }
-            if (self.input.isKeyPressed(.f2)) {
-                self.debug_state.show_fps = !self.debug_state.show_fps;
-            }
-            if (self.input.isKeyPressed(.f5)) {
-                self.debug_state.show_block_info = !self.debug_state.show_block_info;
-            }
-            if (debug_build and self.input.isKeyPressed(.u)) self.debug_state.shadows = !self.debug_state.shadows;
-
-            self.map_controller.update(&self.input, &self.camera, self.time.delta_time, self.window_manager.window, screen_w, screen_h, if (self.world_map) |m| m.width else 256);
-
-            if (debug_build and self.debug_state.shadows and self.input.isKeyPressed(.k)) self.debug_state.cascade_idx = (self.debug_state.cascade_idx + 1) % 3;
-
-            if (self.input.isKeyPressed(.n)) {
-                self.atmosphere.time_scale = if (self.atmosphere.time_scale > 0) @as(f32, 0.0) else @as(f32, 1.0);
-            }
-
-            if (self.input.isKeyPressed(.i)) {
-                self.inventory_ui_state.toggle();
-                self.input.setMouseCapture(self.window_manager.window, !self.inventory_ui_state.visible);
-            }
-
-            if (self.input.isKeyPressed(.f3)) {
-                self.creative_mode = !self.creative_mode;
-                if (self.player) |*p| {
-                    p.setCreativeMode(self.creative_mode);
+            if (self.game_session) |session| {
+                if (in_world and InputMapper.isActionPressed(&self.input, .tab_menu)) self.input.setMouseCapture(self.window_manager.window, !self.input.mouse_captured);
+                if (InputMapper.isActionPressed(&self.input, .toggle_wireframe)) {
+                    self.settings.wireframe_enabled = !self.settings.wireframe_enabled;
+                    self.rhi.setWireframe(self.settings.wireframe_enabled);
                 }
-            }
-
-            if (!self.inventory_ui_state.visible) {
-                if (self.input.isKeyPressed(.@"1")) self.inventory.selectSlot(0);
-                if (self.input.isKeyPressed(.@"2")) self.inventory.selectSlot(1);
-                if (self.input.isKeyPressed(.@"3")) self.inventory.selectSlot(2);
-                if (self.input.isKeyPressed(.@"4")) self.inventory.selectSlot(3);
-                if (self.input.isKeyPressed(.@"5")) self.inventory.selectSlot(4);
-                if (self.input.isKeyPressed(.@"6")) self.inventory.selectSlot(5);
-                if (self.input.isKeyPressed(.@"7")) self.inventory.selectSlot(6);
-                if (self.input.isKeyPressed(.@"8")) self.inventory.selectSlot(7);
-                if (self.input.isKeyPressed(.@"9")) self.inventory.selectSlot(8);
-                if (self.input.scroll_y != 0) {
-                    self.inventory.scrollSelection(@intFromFloat(self.input.scroll_y));
+                if (InputMapper.isActionPressed(&self.input, .toggle_textures)) {
+                    self.settings.textures_enabled = !self.settings.textures_enabled;
+                    self.rhi.setTexturesEnabled(self.settings.textures_enabled);
                 }
-            }
-
-            if (in_world) {
-                if (!self.map_controller.show_map and !in_pause and !self.inventory_ui_state.visible) {
-                    if (self.player) |*p| {
-                        if (self.world) |active_world| {
-                            p.update(&self.input, active_world, self.time.delta_time, self.time.elapsed);
-                            self.camera = p.camera;
-                            if (self.input.isMouseButtonPressed(.left)) {
-                                p.breakTargetBlock(active_world);
-                                self.hand_renderer.swing();
-                            }
-                            if (self.input.isMouseButtonPressed(.right)) {
-                                if (self.inventory.getSelectedBlock()) |block_type| {
-                                    p.placeBlock(active_world, block_type);
-                                    self.hand_renderer.swing();
-                                }
-                            }
-                        }
-                    } else {
-                        self.camera.update(&self.input, self.time.delta_time);
-                    }
-                    self.hand_renderer.update(self.time.delta_time);
-                    self.hand_renderer.updateMesh(self.inventory, &self.atlas);
+                if (InputMapper.isActionPressed(&self.input, .toggle_vsync)) {
+                    self.settings.vsync = !self.settings.vsync;
+                    self.rhi.setVSync(self.settings.vsync);
                 }
 
-                if (self.world) |active_world| {
-                    if (active_world.render_distance != self.settings.render_distance) {
-                        active_world.setRenderDistance(self.settings.render_distance);
-                    }
-                    try active_world.update(self.camera.position, self.time.delta_time);
-                } else self.app_state = .home;
-            } else if (in_pause) {
-                if (self.world) |active_world| {
-                    if (active_world.render_distance != self.settings.render_distance) {
-                        active_world.setRenderDistance(self.settings.render_distance);
-                    }
+                // Update session (handles internal input, physics, etc.)
+                try session.update(self.time.delta_time, self.time.elapsed, &self.input, &self.atlas, self.window_manager.window, in_pause);
+                self.camera = session.player.camera;
+
+                if (session.world.render_distance != self.settings.render_distance) {
+                    session.world.setRenderDistance(self.settings.render_distance);
                 }
-            }
+            } else self.app_state = .home;
         } else if (self.input.mouse_captured) self.input.setMouseCapture(self.window_manager.window, false);
 
-        const clear_color = if (in_world or in_pause) self.atmosphere.fog_color else Vec3.init(0.07, 0.08, 0.1).toLinear();
+        const clear_color = if ((in_world or in_pause) and self.game_session != null) self.game_session.?.atmosphere.fog_color else Vec3.init(0.07, 0.08, 0.1).toLinear();
         self.rhi.setClearColor(clear_color);
         self.rhi.beginFrame();
 
         if (in_world or in_pause) {
-            if (self.world) |active_world| {
+            if (self.game_session) |session| {
                 const aspect = screen_w / screen_h;
                 const view_proj_render = Mat4.perspectiveReverseZ(self.camera.fov, aspect, self.camera.near, self.camera.far).multiply(self.camera.getViewMatrixOriginCentered());
                 const sky_params = rhi_pkg.SkyParams{
@@ -659,28 +340,28 @@ pub const App = struct {
                     .cam_up = self.camera.up,
                     .aspect = aspect,
                     .tan_half_fov = @tan(self.camera.fov / 2.0),
-                    .sun_dir = self.atmosphere.sun_dir,
-                    .sky_color = self.atmosphere.sky_color,
-                    .horizon_color = self.atmosphere.horizon_color,
-                    .sun_intensity = self.atmosphere.sun_intensity,
-                    .moon_intensity = self.atmosphere.moon_intensity,
-                    .time = self.atmosphere.time_of_day,
+                    .sun_dir = session.atmosphere.sun_dir,
+                    .sky_color = session.atmosphere.sky_color,
+                    .horizon_color = session.atmosphere.horizon_color,
+                    .sun_intensity = session.atmosphere.sun_intensity,
+                    .moon_intensity = session.atmosphere.moon_intensity,
+                    .time = session.atmosphere.time_of_day,
                 };
                 const cloud_params: rhi_pkg.CloudParams = blk: {
-                    const p = self.clouds.getShadowParams();
+                    const p = session.clouds.getShadowParams();
                     break :blk .{
                         .cam_pos = self.camera.position,
                         .view_proj = view_proj_render,
-                        .sun_dir = self.atmosphere.sun_dir,
-                        .sun_intensity = self.atmosphere.sun_intensity,
-                        .fog_color = self.atmosphere.fog_color,
-                        .fog_density = self.atmosphere.fog_density,
+                        .sun_dir = session.atmosphere.sun_dir,
+                        .sun_intensity = session.atmosphere.sun_intensity,
+                        .fog_color = session.atmosphere.fog_color,
+                        .fog_density = session.atmosphere.fog_density,
                         .wind_offset_x = p.wind_offset_x,
                         .wind_offset_z = p.wind_offset_z,
                         .cloud_scale = p.cloud_scale,
                         .cloud_coverage = p.cloud_coverage,
                         .cloud_height = p.cloud_height,
-                        .base_color = self.clouds.base_color,
+                        .base_color = session.clouds.base_color,
                         .pbr_enabled = self.settings.pbr_enabled and self.atlas.has_pbr,
                         .shadow_samples = self.settings.shadow_pcf_samples,
                         .shadow_blend = self.settings.shadow_cascade_blend,
@@ -696,11 +377,11 @@ pub const App = struct {
                     };
                 };
 
-                self.rhi.updateGlobalUniforms(view_proj_render, self.camera.position, self.atmosphere.sun_dir, self.atmosphere.sun_color, self.atmosphere.time_of_day, self.atmosphere.fog_color, self.atmosphere.fog_density, self.atmosphere.fog_enabled, self.atmosphere.sun_intensity, self.atmosphere.ambient_intensity, self.settings.textures_enabled, cloud_params);
+                self.rhi.updateGlobalUniforms(view_proj_render, self.camera.position, session.atmosphere.sun_dir, session.atmosphere.sun_color, session.atmosphere.time_of_day, session.atmosphere.fog_color, session.atmosphere.fog_density, session.atmosphere.fog_enabled, session.atmosphere.sun_intensity, session.atmosphere.ambient_intensity, self.settings.textures_enabled, cloud_params);
 
                 const render_ctx = render_graph_pkg.SceneContext{
                     .rhi = self.rhi,
-                    .world = active_world,
+                    .world = session.world,
                     .camera = &self.camera,
                     .atmosphere_system = self.atmosphere_system,
                     .material_system = self.material_system,
@@ -715,88 +396,11 @@ pub const App = struct {
                 };
                 self.render_graph.execute(render_ctx);
 
-                if (self.player) |p| {
-                    if (p.target_block) |target| self.block_outline.draw(target.x, target.y, target.z, self.camera.position);
-                }
-                self.hand_renderer.draw(self.camera.position, self.camera.yaw, self.camera.pitch);
+                if (session.player.target_block) |target| session.block_outline.draw(target.x, target.y, target.z, self.camera.position);
+                session.hand_renderer.draw(self.camera.position, self.camera.yaw, self.camera.pitch);
 
                 if (self.ui) |*u| {
                     u.begin();
-                    if (self.world_map) |*m| {
-                        try self.map_controller.draw(u, screen_w, screen_h, m, &active_world.generator, self.camera.position);
-                    }
-                    if (self.debug_state.show_fps) {
-                        u.drawRect(.{ .x = 10, .y = 10, .width = 80, .height = 30 }, Color.rgba(0, 0, 0, 0.7));
-                        Font.drawNumber(u, @intFromFloat(self.time.fps), 15, 15, Color.white);
-                    }
-                    if (debug_build) {
-                        if (!self.debug_state.show_fps) {
-                            u.drawRect(.{ .x = 10, .y = 10, .width = 80, .height = 30 }, Color.rgba(0, 0, 0, 0.7));
-                            Font.drawNumber(u, @intFromFloat(self.time.fps), 15, 15, Color.white);
-                        }
-                        const stats = active_world.getStats();
-                        const rs = active_world.getRenderStats();
-                        const pc = worldToChunk(@intFromFloat(self.camera.position.x), @intFromFloat(self.camera.position.z));
-                        const hy: f32 = 50.0;
-                        u.drawRect(.{ .x = 10, .y = hy, .width = 220, .height = 170 }, Color.rgba(0, 0, 0, 0.6));
-                        Font.drawText(u, "POS:", 15, hy + 5, 1.5, Color.white);
-                        Font.drawNumber(u, pc.chunk_x, 120, hy + 5, Color.white);
-                        Font.drawNumber(u, pc.chunk_z, 170, hy + 5, Color.white);
-                        Font.drawText(u, "CHUNKS:", 15, hy + 25, 1.5, Color.white);
-                        Font.drawNumber(u, @intCast(stats.chunks_loaded), 140, hy + 25, Color.white);
-                        Font.drawText(u, "VISIBLE:", 15, hy + 45, 1.5, Color.white);
-                        Font.drawNumber(u, @intCast(rs.chunks_rendered), 140, hy + 45, Color.white);
-                        Font.drawText(u, "QUEUED GEN:", 15, hy + 65, 1.5, Color.white);
-                        Font.drawNumber(u, @intCast(stats.gen_queue), 140, hy + 65, Color.white);
-                        Font.drawText(u, "QUEUED MESH:", 15, hy + 85, 1.5, Color.white);
-                        Font.drawNumber(u, @intCast(stats.mesh_queue), 140, hy + 85, Color.white);
-                        Font.drawText(u, "PENDING UP:", 15, hy + 105, 1.5, Color.white);
-                        Font.drawNumber(u, @intCast(stats.upload_queue), 140, hy + 105, Color.white);
-                        const h = self.atmosphere.getHours();
-                        const hr = @as(i32, @intFromFloat(h));
-                        const mn = @as(i32, @intFromFloat((h - @as(f32, @floatFromInt(hr))) * 60.0));
-                        Font.drawText(u, "TIME:", 15, hy + 125, 1.5, Color.white);
-                        Font.drawNumber(u, hr, 100, hy + 125, Color.white);
-                        Font.drawText(u, ":", 125, hy + 125, 1.5, Color.white);
-                        Font.drawNumber(u, mn, 140, hy + 125, Color.white);
-                        Font.drawText(u, "SUN:", 15, hy + 145, 1.5, Color.white);
-                        Font.drawNumber(u, @intFromFloat(self.atmosphere.sun_intensity * 100.0), 100, hy + 145, Color.white);
-
-                        if (self.world) |world| {
-                            const px_i: i32 = @intFromFloat(self.camera.position.x);
-                            const pz_i: i32 = @intFromFloat(self.camera.position.z);
-                            const region = world.generator.getRegionInfo(px_i, pz_i);
-                            const c3 = region_pkg.getRoleColor(region.role);
-                            Font.drawText(u, "ROLE:", 15, hy + 165, 1.5, Color.rgba(c3[0], c3[1], c3[2], 1.0));
-                            var buf: [32]u8 = undefined;
-                            const label = std.fmt.bufPrint(&buf, "{s}", .{@tagName(region.role)}) catch "???";
-                            Font.drawText(u, label, 100, hy + 165, 1.5, Color.white);
-                        }
-                    }
-
-                    if (self.debug_state.show_block_info) {
-                        if (self.player) |p| {
-                            if (p.target_block) |target| {
-                                if (self.world) |world| {
-                                    const block = world.getBlock(target.x, target.y, target.z);
-                                    const tiles = TextureAtlas.getTilesForBlock(@intFromEnum(block));
-                                    const ux = screen_w - 350;
-                                    var uy: f32 = 10;
-                                    u.drawRect(.{ .x = ux - 10, .y = uy, .width = 350, .height = 80 }, Color.rgba(0, 0, 0, 0.7));
-                                    var buf: [128]u8 = undefined;
-                                    const pos_text = std.fmt.bufPrint(&buf, "BLOCK: {s} ({}, {}, {})", .{ @tagName(block), target.x, target.y, target.z }) catch "BLOCK: ???";
-                                    Font.drawText(u, pos_text, ux, uy + 5, 1.5, Color.white);
-                                    uy += 25;
-                                    const tiles_text = std.fmt.bufPrint(&buf, "TILES: T:{} B:{} S:{}", .{ tiles.top, tiles.bottom, tiles.side }) catch "TILES: ???";
-                                    Font.drawText(u, tiles_text, ux, uy + 5, 1.5, Color.white);
-                                    uy += 25;
-                                    const pack_name = if (self.resource_pack_manager.active_pack) |ap| ap else "Default";
-                                    const pack_text = std.fmt.bufPrint(&buf, "PACK: {s}", .{pack_name}) catch "PACK: ???";
-                                    Font.drawText(u, pack_text, ux, uy + 5, 1.5, Color.white);
-                                }
-                            }
-                        }
-                    }
 
                     if (in_pause) {
                         u.drawRect(.{ .x = 0, .y = 0, .width = screen_w, .height = screen_h }, Color.rgba(0, 0, 0, 0.5));
@@ -818,28 +422,11 @@ pub const App = struct {
                         if (Widgets.drawButton(u, .{ .x = px, .y = py, .width = pw, .height = ph }, "QUIT TO TITLE", 2.0, mouse_x, mouse_y, mouse_clicked)) {
                             self.app_state = .home;
                             self.pending_world_cleanup = true;
-                            self.player = null;
                         }
+                    } else {
+                        try session.drawHUD(u, self.resource_pack_manager.active_pack, self.time.fps, screen_w, screen_h, mouse_x, mouse_y, mouse_clicked);
                     }
 
-                    if (!in_pause and !self.inventory_ui_state.visible) {
-                        const cx = screen_w / 2.0;
-                        const cy = screen_h / 2.0;
-                        u.drawRect(.{ .x = cx - 10, .y = cy - 1, .width = 20, .height = 2 }, Color.white);
-                        u.drawRect(.{ .x = cx - 1, .y = cy - 10, .width = 2, .height = 20 }, Color.white);
-                    }
-                    if (!self.inventory_ui_state.visible) hotbar.drawDefault(u, &self.inventory, screen_w, screen_h);
-                    if (self.inventory_ui_state.visible) {
-                        const time_action = self.inventory_ui_state.draw(u, &self.inventory, mouse_x, mouse_y, mouse_clicked, screen_w, screen_h);
-                        if (time_action) |time_idx| {
-                            const times = [_]f32{ 0.0, 0.25, 0.5, 0.75 };
-                            if (time_idx < 4) self.atmosphere.setTimeOfDay(times[time_idx]);
-                        }
-                    }
-                    if (self.creative_mode) {
-                        Font.drawText(u, "CREATIVE", screen_w - 100, 10, 1.5, Color.rgba(100, 200, 255, 200));
-                        if (self.player) |p| if (p.fly_mode) Font.drawText(u, "FLYING", screen_w - 80, 25, 1.5, Color.rgba(150, 255, 150, 200));
-                    }
                     u.end();
                 }
             }
@@ -907,36 +494,6 @@ pub const App = struct {
         self.rhi.setViewport(self.input.window_width, self.input.window_height);
         log.log.info("=== ZigCraft ===", .{});
         while (!self.input.should_quit) {
-            if (self.pending_world_cleanup or self.pending_new_world_seed != null) {
-                self.rhi.waitIdle();
-                if (self.world) |w| {
-                    w.deinit();
-                    self.world = null;
-                }
-                self.pending_world_cleanup = false;
-            }
-            if (self.pending_new_world_seed) |seed| {
-                self.pending_new_world_seed = null;
-                const lod_config = LODConfig{ .lod0_radius = self.settings.render_distance, .lod1_radius = 40, .lod2_radius = 80, .lod3_radius = 160 };
-                if (self.settings.lod_enabled) {
-                    self.world = World.initWithLOD(self.allocator, self.settings.render_distance, seed, self.rhi, lod_config) catch |err| {
-                        log.log.err("Failed to create world with LOD: {}", .{err});
-                        self.app_state = .home;
-                        continue;
-                    };
-                } else {
-                    self.world = World.init(self.allocator, self.settings.render_distance, seed, self.rhi) catch |err| {
-                        log.log.err("Failed to create world: {}", .{err});
-                        self.app_state = .home;
-                        continue;
-                    };
-                }
-                if (self.world_map == null) self.world_map = WorldMap.init(self.rhi, 256, 256);
-                self.map_controller.show_map = false;
-                self.map_controller.map_needs_update = true;
-                self.player = Player.init(Vec3.init(8, 100, 8), self.creative_mode);
-                self.camera = self.player.?.camera;
-            }
             try self.runSingleFrame();
         }
     }

--- a/src/game/input_mapper.zig
+++ b/src/game/input_mapper.zig
@@ -1,0 +1,112 @@
+//! Input mapper - abstracts raw input into game actions.
+
+const std = @import("std");
+const interfaces = @import("../engine/core/interfaces.zig");
+const Key = interfaces.Key;
+const MouseButton = interfaces.MouseButton;
+const Input = @import("../engine/input/input.zig").Input;
+
+pub const GameAction = enum {
+    move_forward,
+    move_backward,
+    move_left,
+    move_right,
+    jump,
+    crouch,
+    sprint,
+    fly,
+
+    interact_primary, // Left click
+    interact_secondary, // Right click
+
+    inventory,
+    tab_menu,
+    pause,
+
+    slot_1,
+    slot_2,
+    slot_3,
+    slot_4,
+    slot_5,
+    slot_6,
+    slot_7,
+    slot_8,
+    slot_9,
+
+    toggle_wireframe,
+    toggle_textures,
+    toggle_vsync,
+    toggle_fps,
+    toggle_block_info,
+    toggle_shadows,
+    cycle_cascade,
+    toggle_time_scale,
+    toggle_creative,
+};
+
+pub const InputMapper = struct {
+    pub fn isActionActive(input: *const Input, action: GameAction) bool {
+        return switch (action) {
+            .move_forward => input.isKeyDown(.w),
+            .move_backward => input.isKeyDown(.s),
+            .move_left => input.isKeyDown(.a),
+            .move_right => input.isKeyDown(.d),
+            .jump => input.isKeyDown(.space),
+            .crouch => input.isKeyDown(.left_shift),
+            .sprint => input.isKeyDown(.left_ctrl),
+            else => false,
+        };
+    }
+
+    pub fn isActionPressed(input: *const Input, action: GameAction) bool {
+        return switch (action) {
+            .inventory => input.isKeyPressed(.i),
+            .tab_menu => input.isKeyPressed(.tab),
+            .pause => input.isKeyPressed(.escape),
+
+            .slot_1 => input.isKeyPressed(.@"1"),
+            .slot_2 => input.isKeyPressed(.@"2"),
+            .slot_3 => input.isKeyPressed(.@"3"),
+            .slot_4 => input.isKeyPressed(.@"4"),
+            .slot_5 => input.isKeyPressed(.@"5"),
+            .slot_6 => input.isKeyPressed(.@"6"),
+            .slot_7 => input.isKeyPressed(.@"7"),
+            .slot_8 => input.isKeyPressed(.@"8"),
+            .slot_9 => input.isKeyPressed(.@"9"),
+
+            .toggle_wireframe => input.isKeyPressed(.f),
+            .toggle_textures => input.isKeyPressed(.t),
+            .toggle_vsync => input.isKeyPressed(.v),
+            .toggle_fps => input.isKeyPressed(.f2),
+            .toggle_block_info => input.isKeyPressed(.f5),
+            .toggle_shadows => input.isKeyPressed(.u),
+            .cycle_cascade => input.isKeyPressed(.k),
+            .toggle_time_scale => input.isKeyPressed(.n),
+            .toggle_creative => input.isKeyPressed(.f3),
+
+            .interact_primary => input.isMouseButtonPressed(.left),
+            .interact_secondary => input.isMouseButtonPressed(.right),
+
+            .jump => input.isKeyPressed(.space),
+
+            else => false,
+        };
+    }
+
+    pub fn isActionReleased(input: *const Input, action: GameAction) bool {
+        return switch (action) {
+            .jump => input.isKeyReleased(.space),
+            else => false,
+        };
+    }
+
+    pub fn getMovementVector(input: *const Input) struct { x: f32, z: f32 } {
+        var x: f32 = 0;
+        var z: f32 = 0;
+        if (input.isKeyDown(.w)) z += 1;
+        if (input.isKeyDown(.s)) z -= 1;
+        if (input.isKeyDown(.a)) x -= 1;
+        if (input.isKeyDown(.d)) x += 1;
+        return .{ .x = x, .z = z };
+    }
+};

--- a/src/game/session.zig
+++ b/src/game/session.zig
@@ -1,0 +1,466 @@
+//! Game session - handles active gameplay state.
+
+const std = @import("std");
+const Vec3 = @import("../engine/math/vec3.zig").Vec3;
+const World = @import("../world/world.zig").World;
+const WorldMap = @import("../world/worldgen/world_map.zig").WorldMap;
+const MapController = @import("map_controller.zig").MapController;
+const Player = @import("player.zig").Player;
+const Inventory = @import("inventory.zig").Inventory;
+const inventory_ui = @import("ui/inventory_ui.zig");
+const BlockOutline = @import("block_outline.zig").BlockOutline;
+const HandRenderer = @import("hand_renderer.zig").HandRenderer;
+const Camera = @import("../engine/graphics/camera.zig").Camera;
+const RHI = @import("../engine/graphics/rhi.zig").RHI;
+const TextureAtlas = @import("../engine/graphics/texture_atlas.zig").TextureAtlas;
+const Input = @import("../engine/input/input.zig").Input;
+const LODConfig = @import("../world/lod_chunk.zig").LODConfig;
+const log = @import("../engine/core/log.zig");
+const input_mapper = @import("input_mapper.zig");
+const InputMapper = input_mapper.InputMapper;
+const GameAction = input_mapper.GameAction;
+
+const CSM = @import("../engine/graphics/csm.zig");
+const UISystem = @import("../engine/ui/ui_system.zig").UISystem;
+const Color = @import("../engine/ui/ui_system.zig").Color;
+const Font = @import("../engine/ui/font.zig");
+const Widgets = @import("../engine/ui/widgets.zig");
+const region_pkg = @import("../world/worldgen/region.zig");
+const hotbar = @import("ui/hotbar.zig");
+const worldToChunk = @import("../world/chunk.zig").worldToChunk;
+const TerrainGenerator = @import("../world/worldgen/generator.zig").TerrainGenerator;
+
+pub const AtmosphereState = struct {
+    world_ticks: u64 = 0,
+    tick_accumulator: f32 = 0.0,
+    time_scale: f32 = 1.0,
+    time_of_day: f32 = 0.25,
+    sun_intensity: f32 = 1.0,
+    moon_intensity: f32 = 0.0,
+    sun_dir: Vec3 = Vec3.init(0, 1, 0),
+    moon_dir: Vec3 = Vec3.init(0, -1, 0),
+    sky_color: Vec3 = Vec3.init(0.5, 0.7, 1.0),
+    horizon_color: Vec3 = Vec3.init(0.8, 0.85, 0.95),
+    sun_color: Vec3 = Vec3.init(1.0, 1.0, 1.0),
+    fog_color: Vec3 = Vec3.init(0.6, 0.75, 0.95),
+    ambient_intensity: f32 = 0.3,
+    fog_density: f32 = 0.0015,
+    fog_enabled: bool = true,
+    orbit_tilt: f32 = 0.35,
+
+    fn smoothstep(edge0: f32, edge1: f32, x: f32) f32 {
+        const t = std.math.clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+        return t * t * (3.0 - 2.0 * t);
+    }
+
+    fn lerpVec3(a: Vec3, b: Vec3, t: f32) Vec3 {
+        return Vec3.init(
+            std.math.lerp(a.x, b.x, t),
+            std.math.lerp(a.y, b.y, t),
+            std.math.lerp(a.z, b.z, t),
+        );
+    }
+
+    pub fn update(self: *AtmosphereState, delta_time: f32) void {
+        self.tick_accumulator += delta_time * 20.0 * self.time_scale;
+        if (self.tick_accumulator >= 1.0) {
+            const ticks_delta: u64 = @intFromFloat(self.tick_accumulator);
+            self.world_ticks +%= ticks_delta;
+            self.tick_accumulator -= @floatFromInt(ticks_delta);
+        }
+
+        const day_ticks = self.world_ticks % 24000;
+        self.time_of_day = @as(f32, @floatFromInt(day_ticks)) / 24000.0;
+
+        self.updateCelestialBodies();
+        self.updateIntensities();
+        self.updateColors();
+    }
+
+    fn updateCelestialBodies(self: *AtmosphereState) void {
+        const sun_angle = self.time_of_day * std.math.tau;
+        const cos_angle = @cos(sun_angle);
+        const sin_angle = @sin(sun_angle);
+        const cos_tilt = @cos(self.orbit_tilt);
+        const sin_tilt = @sin(self.orbit_tilt);
+
+        self.sun_dir = Vec3.init(
+            sin_angle,
+            -cos_angle * cos_tilt,
+            -cos_angle * sin_tilt,
+        ).normalize();
+        self.moon_dir = self.sun_dir.scale(-1);
+    }
+
+    fn updateIntensities(self: *AtmosphereState) void {
+        const t = self.time_of_day;
+        const DAWN_START: f32 = 0.20;
+        const DAWN_END: f32 = 0.30;
+        const DUSK_START: f32 = 0.70;
+        const DUSK_END: f32 = 0.80;
+
+        if (t < DAWN_START) {
+            self.sun_intensity = 0;
+        } else if (t < DAWN_END) {
+            self.sun_intensity = smoothstep(DAWN_START, DAWN_END, t);
+        } else if (t < DUSK_START) {
+            self.sun_intensity = 1.0;
+        } else if (t < DUSK_END) {
+            self.sun_intensity = 1.0 - smoothstep(DUSK_START, DUSK_END, t);
+        } else {
+            self.sun_intensity = 0;
+        }
+
+        self.moon_intensity = (1.0 - self.sun_intensity) * 0.15;
+        const day_ambient: f32 = 0.45;
+        const night_ambient: f32 = 0.15;
+        self.ambient_intensity = std.math.lerp(night_ambient, day_ambient, self.sun_intensity);
+    }
+
+    fn updateColors(self: *AtmosphereState) void {
+        const t = self.time_of_day;
+        const DAWN_START: f32 = 0.20;
+        const DAWN_END: f32 = 0.30;
+        const DUSK_START: f32 = 0.70;
+        const DUSK_END: f32 = 0.80;
+
+        const day_sky = Vec3.init(0.4, 0.65, 1.0).toLinear();
+        const day_horizon = Vec3.init(0.7, 0.8, 0.95).toLinear();
+        const night_sky = Vec3.init(0.02, 0.02, 0.08).toLinear();
+        const night_horizon = Vec3.init(0.05, 0.05, 0.12).toLinear();
+        const dawn_sky = Vec3.init(0.25, 0.3, 0.5).toLinear();
+        const dawn_horizon = Vec3.init(0.95, 0.55, 0.2).toLinear();
+        const dusk_sky = Vec3.init(0.25, 0.3, 0.5).toLinear();
+        const dusk_horizon = Vec3.init(0.95, 0.55, 0.2).toLinear();
+
+        const day_sun = Vec3.init(1.0, 0.95, 0.9).toLinear();
+        const dawn_sun = Vec3.init(1.0, 0.85, 0.6).toLinear();
+        const dusk_sun = Vec3.init(1.0, 0.85, 0.6).toLinear();
+        const night_sun = Vec3.init(0.04, 0.04, 0.1).toLinear();
+
+        if (t < DAWN_START) {
+            self.sky_color = night_sky;
+            self.horizon_color = night_horizon;
+            self.sun_color = night_sun;
+        } else if (t < DAWN_END) {
+            const blend = smoothstep(DAWN_START, DAWN_END, t);
+            self.sky_color = lerpVec3(night_sky, dawn_sky, blend);
+            self.horizon_color = lerpVec3(night_horizon, dawn_horizon, blend);
+            self.sun_color = lerpVec3(night_sun, dawn_sun, blend);
+        } else if (t < 0.35) {
+            const blend = smoothstep(DAWN_END, 0.35, t);
+            self.sky_color = lerpVec3(dawn_sky, day_sky, blend);
+            self.horizon_color = lerpVec3(dawn_horizon, day_horizon, blend);
+            self.sun_color = lerpVec3(dawn_sun, day_sun, blend);
+        } else if (t < DUSK_START) {
+            self.sky_color = day_sky;
+            self.horizon_color = day_horizon;
+            self.sun_color = day_sun;
+        } else if (t < 0.75) {
+            const blend = smoothstep(DUSK_START, 0.75, t);
+            self.sky_color = lerpVec3(day_sky, dusk_sky, blend);
+            self.horizon_color = lerpVec3(day_horizon, dusk_horizon, blend);
+            self.sun_color = lerpVec3(day_sun, dusk_sun, blend);
+        } else if (t < DUSK_END) {
+            const blend = smoothstep(0.75, DUSK_END, t);
+            self.sky_color = lerpVec3(dusk_sky, night_sky, blend);
+            self.horizon_color = lerpVec3(dusk_horizon, night_horizon, blend);
+            self.sun_color = lerpVec3(dusk_sun, night_sun, blend);
+        } else {
+            self.sky_color = night_sky;
+            self.horizon_color = night_horizon;
+            self.sun_color = night_sun;
+        }
+
+        self.fog_color = self.horizon_color;
+        self.fog_density = std.math.lerp(0.0015, 0.0008, self.sun_intensity);
+    }
+
+    pub fn setTimeOfDay(self: *AtmosphereState, time: f32) void {
+        self.world_ticks = @intFromFloat(time * 24000.0);
+        self.time_of_day = time;
+        self.tick_accumulator = 0;
+        self.updateCelestialBodies();
+        self.updateIntensities();
+        self.updateColors();
+    }
+
+    pub fn getHours(self: *const AtmosphereState) f32 {
+        return self.time_of_day * 24.0;
+    }
+
+    pub fn getSkyLightFactor(self: *const AtmosphereState) f32 {
+        return @max(self.sun_intensity, self.moon_intensity);
+    }
+};
+
+pub const CloudState = struct {
+    wind_offset_x: f32 = 0.0,
+    wind_offset_z: f32 = 0.0,
+    cloud_scale: f32 = 1.0 / 64.0,
+    cloud_coverage: f32 = 0.5,
+    cloud_height: f32 = 160.0,
+    cloud_thickness: f32 = 12.0,
+    base_color: Vec3 = Vec3.init(1.0, 1.0, 1.0),
+
+    pub fn update(self: *CloudState, delta_time: f32) void {
+        const wind_dir_x: f32 = 1.0;
+        const wind_dir_z: f32 = 0.2;
+        const wind_speed: f32 = 2.0;
+        self.wind_offset_x += wind_dir_x * wind_speed * delta_time;
+        self.wind_offset_z += wind_dir_z * wind_speed * delta_time;
+    }
+
+    pub fn getShadowParams(self: *const CloudState) struct {
+        wind_offset_x: f32,
+        wind_offset_z: f32,
+        cloud_scale: f32,
+        cloud_coverage: f32,
+        cloud_height: f32,
+    } {
+        return .{
+            .wind_offset_x = self.wind_offset_x,
+            .wind_offset_z = self.wind_offset_z,
+            .cloud_scale = self.cloud_scale,
+            .cloud_coverage = self.cloud_coverage,
+            .cloud_height = self.cloud_height,
+        };
+    }
+};
+
+pub const GameSession = struct {
+    allocator: std.mem.Allocator,
+    world: *World,
+    world_map: WorldMap,
+    map_controller: MapController,
+
+    player: Player,
+    inventory: Inventory,
+    inventory_ui_state: inventory_ui.InventoryUI,
+    block_outline: BlockOutline,
+    hand_renderer: HandRenderer,
+    camera: Camera, // References player camera, but we might want a decoupled camera if player is null (e.g. spectator) - for now keep it simple and match App
+
+    atmosphere: AtmosphereState,
+    clouds: CloudState,
+
+    creative_mode: bool,
+
+    debug_show_fps: bool = false,
+    debug_show_block_info: bool = false,
+    debug_shadows: bool = false,
+    debug_cascade_idx: usize = 0,
+
+    pub fn init(allocator: std.mem.Allocator, rhi: RHI, seed: u64, render_distance: i32, lod_enabled: bool) !*GameSession {
+        const session = try allocator.create(GameSession);
+
+        const lod_config = LODConfig{
+            .lod0_radius = @min(render_distance, 16),
+            .lod1_radius = 40,
+            .lod2_radius = 80,
+            .lod3_radius = 160,
+        };
+
+        const world = if (lod_enabled)
+            try World.initWithLOD(allocator, render_distance, seed, rhi, lod_config)
+        else
+            try World.init(allocator, render_distance, seed, rhi);
+
+        const world_map = WorldMap.init(rhi, 256, 256);
+
+        const player = Player.init(Vec3.init(8, 100, 8), true); // Default creative for now
+
+        var atmosphere = AtmosphereState{};
+        atmosphere.setTimeOfDay(0.25);
+
+        session.* = .{
+            .allocator = allocator,
+            .world = world,
+            .world_map = world_map,
+            .map_controller = .{},
+            .player = player,
+            .inventory = Inventory.init(),
+            .inventory_ui_state = .{},
+            .block_outline = BlockOutline.init(rhi),
+            .hand_renderer = HandRenderer.init(rhi),
+            .camera = player.camera,
+            .atmosphere = atmosphere,
+            .clouds = CloudState{},
+            .creative_mode = true,
+        };
+
+        // Force map update initially
+        session.map_controller.map_needs_update = true;
+
+        return session;
+    }
+
+    pub fn deinit(self: *GameSession) void {
+        self.world.deinit();
+        self.world_map.deinit();
+        self.block_outline.deinit();
+        self.hand_renderer.deinit();
+        self.allocator.destroy(self);
+    }
+
+    pub fn update(self: *GameSession, dt: f32, total_time: f32, input: *Input, atlas: *TextureAtlas, window: anytype, paused: bool) !void {
+        self.atmosphere.update(dt);
+        self.clouds.update(dt);
+
+        // Update Camera from Player
+        self.camera = self.player.camera;
+
+        const screen_w: f32 = @floatFromInt(input.window_width);
+        const screen_h: f32 = @floatFromInt(input.window_height);
+
+        if (!paused) {
+            if (InputMapper.isActionPressed(input, .toggle_fps)) self.debug_show_fps = !self.debug_show_fps;
+            if (InputMapper.isActionPressed(input, .toggle_block_info)) self.debug_show_block_info = !self.debug_show_block_info;
+            if (InputMapper.isActionPressed(input, .toggle_shadows)) self.debug_shadows = !self.debug_shadows;
+            if (self.debug_shadows and InputMapper.isActionPressed(input, .cycle_cascade)) self.debug_cascade_idx = (self.debug_cascade_idx + 1) % 3;
+            if (InputMapper.isActionPressed(input, .toggle_time_scale)) {
+                self.atmosphere.time_scale = if (self.atmosphere.time_scale > 0) @as(f32, 0.0) else @as(f32, 1.0);
+            }
+            if (InputMapper.isActionPressed(input, .toggle_creative)) {
+                self.creative_mode = !self.creative_mode;
+                self.player.setCreativeMode(self.creative_mode);
+            }
+
+            if (InputMapper.isActionPressed(input, .inventory)) {
+                self.inventory_ui_state.toggle();
+                input.setMouseCapture(window, !self.inventory_ui_state.visible);
+            }
+
+            if (!self.inventory_ui_state.visible) {
+                if (InputMapper.isActionPressed(input, .slot_1)) self.inventory.selectSlot(0);
+                if (InputMapper.isActionPressed(input, .slot_2)) self.inventory.selectSlot(1);
+                if (InputMapper.isActionPressed(input, .slot_3)) self.inventory.selectSlot(2);
+                if (InputMapper.isActionPressed(input, .slot_4)) self.inventory.selectSlot(3);
+                if (InputMapper.isActionPressed(input, .slot_5)) self.inventory.selectSlot(4);
+                if (InputMapper.isActionPressed(input, .slot_6)) self.inventory.selectSlot(5);
+                if (InputMapper.isActionPressed(input, .slot_7)) self.inventory.selectSlot(6);
+                if (InputMapper.isActionPressed(input, .slot_8)) self.inventory.selectSlot(7);
+                if (InputMapper.isActionPressed(input, .slot_9)) self.inventory.selectSlot(8);
+                if (input.scroll_y != 0) {
+                    self.inventory.scrollSelection(@intFromFloat(input.scroll_y));
+                }
+            }
+
+            if (self.map_controller.show_map) {
+                self.map_controller.update(input, &self.camera, dt, window, screen_w, screen_h, self.world_map.width);
+            } else {
+                if (!self.inventory_ui_state.visible) {
+                    self.player.update(input, self.world, dt, total_time);
+
+                    // Handle interaction
+                    if (InputMapper.isActionPressed(input, .interact_primary)) {
+                        self.player.breakTargetBlock(self.world);
+                        self.hand_renderer.swing();
+                    }
+                    if (InputMapper.isActionPressed(input, .interact_secondary)) {
+                        if (self.inventory.getSelectedBlock()) |block_type| {
+                            self.player.placeBlock(self.world, block_type);
+                            self.hand_renderer.swing();
+                        }
+                    }
+                }
+
+                self.hand_renderer.update(dt);
+                self.hand_renderer.updateMesh(self.inventory, atlas);
+            }
+
+            try self.world.update(self.player.camera.position, dt);
+        }
+    }
+
+    pub fn drawHUD(self: *GameSession, ui: *UISystem, active_pack: ?[]const u8, fps: f32, screen_w: f32, screen_h: f32, mouse_x: f32, mouse_y: f32, mouse_clicked: bool) !void {
+        if (self.map_controller.show_map) {
+            try self.map_controller.draw(ui, screen_w, screen_h, &self.world_map, &self.world.generator, self.camera.position);
+            return;
+        }
+
+        if (self.debug_show_fps) {
+            ui.drawRect(.{ .x = 10, .y = 10, .width = 80, .height = 30 }, Color.rgba(0, 0, 0, 0.7));
+            Font.drawNumber(ui, @intFromFloat(fps), 15, 15, Color.white);
+        }
+
+        const stats = self.world.getStats();
+        const rs = self.world.getRenderStats();
+        const pc = worldToChunk(@intFromFloat(self.camera.position.x), @intFromFloat(self.camera.position.z));
+        const hy: f32 = 50.0;
+        ui.drawRect(.{ .x = 10, .y = hy, .width = 220, .height = 170 }, Color.rgba(0, 0, 0, 0.6));
+        Font.drawText(ui, "POS:", 15, hy + 5, 1.5, Color.white);
+        Font.drawNumber(ui, pc.chunk_x, 120, hy + 5, Color.white);
+        Font.drawNumber(ui, pc.chunk_z, 170, hy + 5, Color.white);
+        Font.drawText(ui, "CHUNKS:", 15, hy + 25, 1.5, Color.white);
+        Font.drawNumber(ui, @intCast(stats.chunks_loaded), 140, hy + 25, Color.white);
+        Font.drawText(ui, "VISIBLE:", 15, hy + 45, 1.5, Color.white);
+        Font.drawNumber(ui, @intCast(rs.chunks_rendered), 140, hy + 45, Color.white);
+        Font.drawText(ui, "QUEUED GEN:", 15, hy + 65, 1.5, Color.white);
+        Font.drawNumber(ui, @intCast(stats.gen_queue), 140, hy + 65, Color.white);
+        Font.drawText(ui, "QUEUED MESH:", 15, hy + 85, 1.5, Color.white);
+        Font.drawNumber(ui, @intCast(stats.mesh_queue), 140, hy + 85, Color.white);
+        Font.drawText(ui, "PENDING UP:", 15, hy + 105, 1.5, Color.white);
+        Font.drawNumber(ui, @intCast(stats.upload_queue), 140, hy + 105, Color.white);
+        const h = self.atmosphere.getHours();
+        const hr = @as(i32, @intFromFloat(h));
+        const mn = @as(i32, @intFromFloat((h - @as(f32, @floatFromInt(hr))) * 60.0));
+        Font.drawText(ui, "TIME:", 15, hy + 125, 1.5, Color.white);
+        Font.drawNumber(ui, hr, 100, hy + 125, Color.white);
+        Font.drawText(ui, ":", 125, hy + 125, 1.5, Color.white);
+        Font.drawNumber(ui, mn, 140, hy + 125, Color.white);
+        Font.drawText(ui, "SUN:", 15, hy + 145, 1.5, Color.white);
+        Font.drawNumber(ui, @intFromFloat(self.atmosphere.sun_intensity * 100.0), 100, hy + 145, Color.white);
+
+        const px_i: i32 = @intFromFloat(self.camera.position.x);
+        const pz_i: i32 = @intFromFloat(self.camera.position.z);
+        const region = self.world.generator.getRegionInfo(px_i, pz_i);
+        const c3 = region_pkg.getRoleColor(region.role);
+        Font.drawText(ui, "ROLE:", 15, hy + 165, 1.5, Color.rgba(c3[0], c3[1], c3[2], 1.0));
+        var buf: [32]u8 = undefined;
+        const label = std.fmt.bufPrint(&buf, "{s}", .{@tagName(region.role)}) catch "???";
+        Font.drawText(ui, label, 100, hy + 165, 1.5, Color.white);
+
+        if (self.debug_show_block_info) {
+            if (self.player.target_block) |target| {
+                const block_type = self.world.getBlock(target.x, target.y, target.z);
+                const tiles = TextureAtlas.getTilesForBlock(@intFromEnum(block_type));
+                const ux = screen_w - 350;
+                var uy: f32 = 10;
+                ui.drawRect(.{ .x = ux - 10, .y = uy, .width = 350, .height = 80 }, Color.rgba(0, 0, 0, 0.7));
+                var buf2: [128]u8 = undefined;
+                const pos_text = std.fmt.bufPrint(&buf2, "BLOCK: {s} ({}, {}, {})", .{ @tagName(block_type), target.x, target.y, target.z }) catch "BLOCK: ???";
+                Font.drawText(ui, pos_text, ux, uy + 5, 1.5, Color.white);
+                uy += 25;
+                const tiles_text = std.fmt.bufPrint(&buf2, "TILES: T:{} B:{} S:{}", .{ tiles.top, tiles.bottom, tiles.side }) catch "TILES: ???";
+                Font.drawText(ui, tiles_text, ux, uy + 5, 1.5, Color.white);
+                uy += 25;
+                const pack_name = if (active_pack) |ap| ap else "Default";
+                const pack_text = std.fmt.bufPrint(&buf2, "PACK: {s}", .{pack_name}) catch "PACK: ???";
+                Font.drawText(ui, pack_text, ux, uy + 5, 1.5, Color.white);
+            }
+        }
+
+        if (!self.inventory_ui_state.visible) {
+            const cx = screen_w / 2.0;
+            const cy = screen_h / 2.0;
+            ui.drawRect(.{ .x = cx - 10, .y = cy - 1, .width = 20, .height = 2 }, Color.white);
+            ui.drawRect(.{ .x = cx - 1, .y = cy - 10, .width = 2, .height = 20 }, Color.white);
+        }
+
+        if (!self.inventory_ui_state.visible) hotbar.drawDefault(ui, &self.inventory, screen_w, screen_h);
+
+        if (self.inventory_ui_state.visible) {
+            const time_action = self.inventory_ui_state.draw(ui, &self.inventory, mouse_x, mouse_y, mouse_clicked, screen_w, screen_h);
+            if (time_action) |time_idx| {
+                const times = [_]f32{ 0.0, 0.25, 0.5, 0.75 };
+                if (time_idx < 4) self.atmosphere.setTimeOfDay(times[time_idx]);
+            }
+        }
+
+        if (self.creative_mode) {
+            Font.drawText(ui, "CREATIVE", screen_w - 100, 10, 1.5, Color.rgba(100, 200, 255, 200));
+            if (self.player.fly_mode) Font.drawText(ui, "FLYING", screen_w - 80, 25, 1.5, Color.rgba(150, 255, 150, 200));
+        }
+    }
+};

--- a/src/integration_test.zig
+++ b/src/integration_test.zig
@@ -28,7 +28,8 @@ test "smoke test: launch, generate, render, exit" {
 
     try app.runSingleFrame();
 
-    try testing.expect(app.world != null);
-    const stats = app.world.?.getStats();
+    try testing.expect(app.game_session != null);
+    const session = app.game_session.?;
+    const stats = session.world.getStats();
     try testing.expect(stats.chunks_loaded > 0);
 }

--- a/src/world/chunk.zig
+++ b/src/world/chunk.zig
@@ -9,6 +9,10 @@ pub const CHUNK_SIZE_Y = 256;
 pub const CHUNK_SIZE_Z = 16;
 pub const CHUNK_VOLUME = CHUNK_SIZE_X * CHUNK_SIZE_Y * CHUNK_SIZE_Z;
 
+/// Buffer distance beyond render_distance for chunk unloading.
+/// Prevents thrashing when player moves near chunk boundaries.
+pub const CHUNK_UNLOAD_BUFFER: i32 = 1;
+
 /// Maximum light level (0-15)
 pub const MAX_LIGHT: u4 = 15;
 

--- a/src/world/chunk_storage.zig
+++ b/src/world/chunk_storage.zig
@@ -112,23 +112,9 @@ pub const ChunkStorage = struct {
         return false;
     }
 
-    pub fn iterator(self: *ChunkStorage) struct {
-        storage: *ChunkStorage,
-        inner: std.HashMap(ChunkKey, *ChunkData, ChunkKeyContext, 80).Iterator,
-
-        pub fn next(it: *@This()) ?struct { ChunkKey, *ChunkData } {
-            it.storage.chunks_mutex.lockShared();
-            defer it.storage.chunks_mutex.unlockShared();
-            return it.inner.next();
-        }
-    } {
-        return .{
-            .storage = self,
-            .inner = self.chunks.iterator(),
-        };
-    }
-
-    pub fn iteratorExcludingLock(self: *ChunkStorage) std.HashMap(ChunkKey, *ChunkData, ChunkKeyContext, 80).Iterator {
+    /// Unsafe iterator - caller must hold chunks_mutex!
+    /// Using next() on the returned iterator is not thread-safe without external locking.
+    pub fn iteratorUnsafe(self: *ChunkStorage) std.HashMap(ChunkKey, *ChunkData, ChunkKeyContext, 80).Iterator {
         return self.chunks.iterator();
     }
 };

--- a/src/world/chunk_storage.zig
+++ b/src/world/chunk_storage.zig
@@ -1,0 +1,134 @@
+//! Thread-safe chunk storage for World.
+
+const std = @import("std");
+const Chunk = @import("chunk.zig").Chunk;
+const ChunkMesh = @import("chunk_mesh.zig").ChunkMesh;
+
+pub const ChunkKey = struct {
+    x: i32,
+    z: i32,
+
+    pub fn hash(self: ChunkKey) u64 {
+        const ux: u64 = @bitCast(@as(i64, self.x));
+        const uz: u64 = @bitCast(@as(i64, self.z));
+        return ux ^ (uz *% 0x9e3779b97f4a7c15);
+    }
+
+    pub fn eql(a: ChunkKey, b: ChunkKey) bool {
+        return a.x == b.x and a.z == b.z;
+    }
+};
+
+const ChunkKeyContext = struct {
+    pub fn hash(self: @This(), key: ChunkKey) u64 {
+        _ = self;
+        return key.hash();
+    }
+
+    pub fn eql(self: @This(), a: ChunkKey, b: ChunkKey) bool {
+        _ = self;
+        return a.eql(b);
+    }
+};
+
+pub const ChunkData = struct {
+    chunk: Chunk,
+    mesh: ChunkMesh,
+};
+
+pub const ChunkStorage = struct {
+    chunks: std.HashMap(ChunkKey, *ChunkData, ChunkKeyContext, 80),
+    chunks_mutex: std.Thread.RwLock,
+    allocator: std.mem.Allocator,
+    next_job_token: u32,
+
+    pub fn init(allocator: std.mem.Allocator) ChunkStorage {
+        return .{
+            .chunks = std.HashMap(ChunkKey, *ChunkData, ChunkKeyContext, 80).init(allocator),
+            .chunks_mutex = .{},
+            .allocator = allocator,
+            .next_job_token = 1,
+        };
+    }
+
+    pub fn deinit(self: *ChunkStorage, vertex_allocator: anytype) void {
+        var iter = self.chunks.iterator();
+        while (iter.next()) |entry| {
+            entry.value_ptr.*.mesh.deinit(vertex_allocator);
+            self.allocator.destroy(entry.value_ptr.*);
+        }
+        self.chunks.deinit();
+    }
+
+    pub fn deinitWithoutRHI(self: *ChunkStorage) void {
+        var iter = self.chunks.iterator();
+        while (iter.next()) |entry| {
+            entry.value_ptr.*.mesh.deinitWithoutRHI();
+            self.allocator.destroy(entry.value_ptr.*);
+        }
+        self.chunks.deinit();
+    }
+
+    pub fn count(self: *const ChunkStorage) usize {
+        self.chunks_mutex.lockShared();
+        defer self.chunks_mutex.unlockShared();
+        return self.chunks.count();
+    }
+
+    pub fn get(self: *ChunkStorage, cx: i32, cz: i32) ?*ChunkData {
+        self.chunks_mutex.lockShared();
+        defer self.chunks_mutex.unlockShared();
+        return self.chunks.get(ChunkKey{ .x = cx, .z = cz });
+    }
+
+    pub fn getOrCreate(self: *ChunkStorage, cx: i32, cz: i32) !*ChunkData {
+        self.chunks_mutex.lock();
+        defer self.chunks_mutex.unlock();
+
+        const key = ChunkKey{ .x = cx, .z = cz };
+        if (self.chunks.get(key)) |data| return data;
+
+        const data = try self.allocator.create(ChunkData);
+        data.* = .{
+            .chunk = Chunk.init(cx, cz),
+            .mesh = ChunkMesh.init(self.allocator),
+        };
+        data.chunk.job_token = self.next_job_token;
+        self.next_job_token += 1;
+        try self.chunks.put(key, data);
+        return data;
+    }
+
+    pub fn remove(self: *ChunkStorage, cx: i32, cz: i32, vertex_allocator: anytype) bool {
+        self.chunks_mutex.lock();
+        defer self.chunks_mutex.unlock();
+
+        const key = ChunkKey{ .x = cx, .z = cz };
+        if (self.chunks.fetchRemove(key)) |entry| {
+            entry.value.*.mesh.deinit(vertex_allocator);
+            self.allocator.destroy(entry.value);
+            return true;
+        }
+        return false;
+    }
+
+    pub fn iterator(self: *ChunkStorage) struct {
+        storage: *ChunkStorage,
+        inner: std.HashMap(ChunkKey, *ChunkData, ChunkKeyContext, 80).Iterator,
+
+        pub fn next(it: *@This()) ?struct { ChunkKey, *ChunkData } {
+            it.storage.chunks_mutex.lockShared();
+            defer it.storage.chunks_mutex.unlockShared();
+            return it.inner.next();
+        }
+    } {
+        return .{
+            .storage = self,
+            .inner = self.chunks.iterator(),
+        };
+    }
+
+    pub fn iteratorExcludingLock(self: *ChunkStorage) std.HashMap(ChunkKey, *ChunkData, ChunkKeyContext, 80).Iterator {
+        return self.chunks.iterator();
+    }
+};

--- a/src/world/world.zig
+++ b/src/world/world.zig
@@ -188,6 +188,10 @@ pub const World = struct {
         }
     }
 
+    /// Get chunk data at chunk coordinates.
+    /// WARNING: Returned pointer is only guaranteed valid if called from the main thread
+    /// and used before the next call to World.update (which may unload chunks).
+    /// If accessing from a background thread, the chunk must be pinned first.
     pub fn getChunk(self: *World, cx: i32, cz: i32) ?*ChunkData {
         self.storage.chunks_mutex.lockShared();
         defer self.storage.chunks_mutex.unlockShared();

--- a/src/world/world.zig
+++ b/src/world/world.zig
@@ -30,10 +30,11 @@ const RingBuffer = @import("../engine/core/ring_buffer.zig").RingBuffer;
 const log = @import("../engine/core/log.zig");
 
 const LODConfig = @import("lod_chunk.zig").LODConfig;
+const CHUNK_UNLOAD_BUFFER = @import("chunk.zig").CHUNK_UNLOAD_BUFFER;
 
 /// Buffer distance beyond render_distance for chunk unloading.
 /// Prevents thrashing when player moves near chunk boundaries.
-const CHUNK_UNLOAD_BUFFER: i32 = 1;
+// const CHUNK_UNLOAD_BUFFER: i32 = 1;
 
 pub const ChunkPos = struct { x: i32, z: i32 };
 
@@ -221,7 +222,7 @@ pub const World = struct {
         self.storage.chunks_mutex.lockShared();
         defer self.storage.chunks_mutex.unlockShared();
         var total_verts: u64 = 0;
-        var iter = self.storage.chunks.iterator();
+        var iter = self.storage.iteratorUnsafe();
         while (iter.next()) |entry| {
             if (entry.value_ptr.*.mesh.solid_allocation) |alloc| total_verts += alloc.count;
             if (entry.value_ptr.*.mesh.fluid_allocation) |alloc| total_verts += alloc.count;

--- a/src/world/world.zig
+++ b/src/world/world.zig
@@ -5,6 +5,9 @@ const Chunk = @import("chunk.zig").Chunk;
 const ChunkMesh = @import("chunk_mesh.zig").ChunkMesh;
 const NeighborChunks = @import("chunk_mesh.zig").NeighborChunks;
 const BlockType = @import("block.zig").BlockType;
+const ChunkStorage = @import("chunk_storage.zig").ChunkStorage;
+const ChunkData = @import("chunk_storage.zig").ChunkData;
+const ChunkKey = @import("chunk_storage.zig").ChunkKey;
 const worldToChunk = @import("chunk.zig").worldToChunk;
 const worldToLocal = @import("chunk.zig").worldToLocal;
 const CHUNK_SIZE_X = @import("chunk.zig").CHUNK_SIZE_X;
@@ -17,6 +20,9 @@ const Mat4 = @import("../engine/math/mat4.zig").Mat4;
 const Frustum = @import("../engine/math/frustum.zig").Frustum;
 const rhi_mod = @import("../engine/graphics/rhi.zig");
 const RHI = rhi_mod.RHI;
+const WorldStreamer = @import("world_streamer.zig").WorldStreamer;
+const WorldRenderer = @import("world_renderer.zig").WorldRenderer;
+const RenderStats = @import("world_renderer.zig").RenderStats;
 const JobQueue = @import("../engine/core/job_system.zig").JobQueue;
 const WorkerPool = @import("../engine/core/job_system.zig").WorkerPool;
 const Job = @import("../engine/core/job_system.zig").Job;
@@ -29,197 +35,42 @@ const LODConfig = @import("lod_chunk.zig").LODConfig;
 /// Prevents thrashing when player moves near chunk boundaries.
 const CHUNK_UNLOAD_BUFFER: i32 = 1;
 
-pub const ChunkKey = struct {
-    x: i32,
-    z: i32,
-
-    pub fn hash(self: ChunkKey) u64 {
-        const ux: u64 = @bitCast(@as(i64, self.x));
-        const uz: u64 = @bitCast(@as(i64, self.z));
-        return ux ^ (uz *% 0x9e3779b97f4a7c15);
-    }
-
-    pub fn eql(a: ChunkKey, b: ChunkKey) bool {
-        return a.x == b.x and a.z == b.z;
-    }
-};
-
-const ChunkKeyContext = struct {
-    pub fn hash(self: @This(), key: ChunkKey) u64 {
-        _ = self;
-        return key.hash();
-    }
-
-    pub fn eql(self: @This(), a: ChunkKey, b: ChunkKey) bool {
-        _ = self;
-        return a.eql(b);
-    }
-};
-
-pub const ChunkData = struct {
-    chunk: Chunk,
-    mesh: ChunkMesh,
-};
-
 pub const ChunkPos = struct { x: i32, z: i32 };
 
-/// Player movement tracking for predictive chunk loading
-pub const PlayerMovement = struct {
-    /// Normalized movement direction (0,0 if stationary)
-    dir_x: f32 = 0,
-    dir_z: f32 = 0,
-    /// Speed in blocks/second
-    speed: f32 = 0,
-    /// Last position for velocity calculation
-    last_pos: Vec3 = Vec3.init(0, 0, 0),
-    /// Whether we have valid velocity data
-    has_velocity: bool = false,
-
-    /// Update with new position, returns true if direction changed significantly
-    pub fn update(self: *PlayerMovement, pos: Vec3, dt: f32) bool {
-        if (dt <= 0.001) return false;
-
-        const dx = pos.x - self.last_pos.x;
-        const dz = pos.z - self.last_pos.z;
-        self.last_pos = pos;
-
-        const dist = @sqrt(dx * dx + dz * dz);
-        self.speed = dist / dt;
-
-        // Only track direction if moving fast enough (> 2 blocks/sec)
-        if (self.speed < 2.0) {
-            self.has_velocity = false;
-            return false;
-        }
-
-        const old_dx = self.dir_x;
-        const old_dz = self.dir_z;
-
-        self.dir_x = dx / dist;
-        self.dir_z = dz / dist;
-        self.has_velocity = true;
-
-        // Check if direction changed significantly (> 45 degrees)
-        const dot = old_dx * self.dir_x + old_dz * self.dir_z;
-        return dot < 0.707; // cos(45°)
-    }
-
-    /// Calculate priority weight for a chunk based on movement direction.
-    /// Returns a multiplier: < 1.0 for chunks ahead, > 1.0 for chunks behind.
-    pub fn priorityWeight(self: *const PlayerMovement, chunk_dx: i32, chunk_dz: i32) f32 {
-        if (!self.has_velocity) return 1.0;
-
-        const cdx: f32 = @floatFromInt(chunk_dx);
-        const cdz: f32 = @floatFromInt(chunk_dz);
-        const dist = @sqrt(cdx * cdx + cdz * cdz);
-        if (dist < 0.001) return 0.5; // Player's chunk gets high priority
-
-        // Dot product with movement direction: 1.0 = ahead, -1.0 = behind
-        const dot = (cdx * self.dir_x + cdz * self.dir_z) / dist;
-
-        // Map [-1, 1] to [0.5, 1.5] - chunks ahead get 0.5x distance weight
-        return 1.0 - dot * 0.5;
-    }
-};
-
-pub const RenderStats = struct {
-    chunks_total: u32 = 0,
-    chunks_rendered: u32 = 0,
-    chunks_culled: u32 = 0,
-    vertices_rendered: u64 = 0,
-};
-
 pub const World = struct {
-    chunks: std.HashMap(ChunkKey, *ChunkData, ChunkKeyContext, 80),
-    chunks_mutex: std.Thread.RwLock,
+    storage: ChunkStorage,
+    streamer: *WorldStreamer,
+    renderer: *WorldRenderer,
     allocator: std.mem.Allocator,
     generator: TerrainGenerator,
     render_distance: i32,
-    last_render_stats: RenderStats,
-    gen_queue: *JobQueue,
-    mesh_queue: *JobQueue,
-    gen_pool: *WorkerPool,
-    mesh_pool: *WorkerPool,
-    upload_queue: RingBuffer(ChunkKey),
-    visible_chunks: std.ArrayListUnmanaged(*ChunkData),
-    next_job_token: u32,
-    last_pc: ChunkPos,
-    player_movement: PlayerMovement,
     rhi: RHI,
     paused: bool = false,
 
     // LOD System (Issue #114)
     lod_manager: ?*LODManager,
     lod_enabled: bool,
-    vertex_allocator: GlobalVertexAllocator,
-
-    // MDI Resources
-    instance_data: std.ArrayListUnmanaged(rhi_mod.InstanceData),
-    solid_commands: std.ArrayListUnmanaged(rhi_mod.DrawIndirectCommand),
-    fluid_commands: std.ArrayListUnmanaged(rhi_mod.DrawIndirectCommand),
-    instance_buffers: [rhi_mod.MAX_FRAMES_IN_FLIGHT]rhi_mod.BufferHandle,
-    indirect_buffers: [rhi_mod.MAX_FRAMES_IN_FLIGHT]rhi_mod.BufferHandle,
-    frame_index: usize,
-    mdi_instance_offset: usize,
-    mdi_command_offset: usize,
 
     pub fn init(allocator: std.mem.Allocator, render_distance: i32, seed: u64, rhi: RHI) !*World {
         const world = try allocator.create(World);
 
-        const gen_queue = try allocator.create(JobQueue);
-        gen_queue.* = JobQueue.init(allocator);
-
-        const mesh_queue = try allocator.create(JobQueue);
-        mesh_queue.* = JobQueue.init(allocator);
-
-        const generator = TerrainGenerator.init(seed, allocator);
-
-        // Increasing to 6GB (6144MB) to prevent OOM on high render distances (e.g. Ultra with 32+ chunks)
-        // With complex terrain, 4GB can be exceeded.
-        const vertex_allocator = try GlobalVertexAllocator.init(allocator, rhi, 6144);
-
-        // Init MDI buffers (capacity for ~16384 chunks to be safe for high render distances + shadows)
-        const max_chunks = 16384;
-        var instance_buffers: [rhi_mod.MAX_FRAMES_IN_FLIGHT]rhi_mod.BufferHandle = undefined;
-        var indirect_buffers: [rhi_mod.MAX_FRAMES_IN_FLIGHT]rhi_mod.BufferHandle = undefined;
-        for (0..rhi_mod.MAX_FRAMES_IN_FLIGHT) |i| {
-            instance_buffers[i] = rhi.createBuffer(max_chunks * @sizeOf(rhi_mod.InstanceData), .storage);
-            indirect_buffers[i] = rhi.createBuffer(max_chunks * @sizeOf(rhi_mod.DrawIndirectCommand) * 2, .indirect); // *2 for solid+fluid
-        }
+        const storage = ChunkStorage.init(allocator);
 
         world.* = .{
-            .chunks = std.HashMap(ChunkKey, *ChunkData, ChunkKeyContext, 80).init(allocator),
-            .chunks_mutex = .{},
+            .storage = storage,
+            .streamer = undefined,
+            .renderer = undefined,
             .allocator = allocator,
             .render_distance = render_distance,
-            .generator = generator,
-            .last_render_stats = .{},
-            .gen_queue = gen_queue,
-            .mesh_queue = mesh_queue,
-            .gen_pool = undefined,
-            .mesh_pool = undefined,
-            .upload_queue = try RingBuffer(ChunkKey).init(allocator, 256),
-            .visible_chunks = .empty,
-            .next_job_token = 1,
-            .last_pc = .{ .x = 9999, .z = 9999 },
-            .player_movement = .{},
+            .generator = TerrainGenerator.init(seed, allocator),
             .rhi = rhi,
             .paused = false,
             .lod_manager = null,
             .lod_enabled = false,
-            .vertex_allocator = vertex_allocator,
-            .instance_data = .empty,
-            .solid_commands = .empty,
-            .fluid_commands = .empty,
-            .instance_buffers = instance_buffers,
-            .indirect_buffers = indirect_buffers,
-            .frame_index = 0,
-            .mdi_instance_offset = 0,
-            .mdi_command_offset = 0,
         };
 
-        world.gen_pool = try WorkerPool.init(allocator, 4, gen_queue, world, processGenJob);
-        world.mesh_pool = try WorkerPool.init(allocator, 3, mesh_queue, world, processMeshJob);
+        world.streamer = try WorldStreamer.init(allocator, &world.storage, &world.generator, render_distance);
+        world.renderer = try WorldRenderer.init(allocator, rhi, &world.storage);
 
         return world;
     }
@@ -239,81 +90,40 @@ pub const World = struct {
 
     pub fn deinit(self: *World) void {
         self.rhi.waitIdle();
-        self.gen_queue.stop();
-        self.mesh_queue.stop();
+        self.streamer.deinit();
 
-        self.gen_pool.deinit();
-        self.mesh_pool.deinit();
-
-        self.gen_queue.deinit();
-        self.mesh_queue.deinit();
-        self.allocator.destroy(self.gen_queue);
-        self.allocator.destroy(self.mesh_queue);
-
-        self.upload_queue.deinit();
-        self.visible_chunks.deinit(self.allocator);
-
-        var iter = self.chunks.iterator();
-        while (iter.next()) |entry| {
-            entry.value_ptr.*.mesh.deinit(&self.vertex_allocator);
-            self.allocator.destroy(entry.value_ptr.*);
-        }
-        self.chunks.deinit();
+        // Storage must be deinitialized before renderer because it uses the renderer's vertex_allocator
+        // to free mesh buffers.
+        // On shutdown we can skip per-chunk GPU frees since the allocator is destroyed next.
+        self.storage.deinitWithoutRHI();
+        self.renderer.deinit();
 
         // Cleanup LOD manager if enabled
         if (self.lod_manager) |lod_mgr| {
             lod_mgr.deinit();
         }
 
-        for (0..rhi_mod.MAX_FRAMES_IN_FLIGHT) |i| {
-            if (self.instance_buffers[i] != 0) self.rhi.destroyBuffer(self.instance_buffers[i]);
-            if (self.indirect_buffers[i] != 0) self.rhi.destroyBuffer(self.indirect_buffers[i]);
-        }
-        self.instance_data.deinit(self.allocator);
-        self.solid_commands.deinit(self.allocator);
-        self.fluid_commands.deinit(self.allocator);
-
-        self.vertex_allocator.deinit();
         self.allocator.destroy(self);
     }
 
     pub fn pauseGeneration(self: *World) void {
         self.paused = true;
-        self.gen_queue.setPaused(true);
-        self.mesh_queue.setPaused(true);
+        self.streamer.setPaused(true);
 
         // Pause LOD manager if enabled
         if (self.lod_manager) |lod_mgr| {
             lod_mgr.pause();
         }
-
-        // Reset chunks that were waiting for generation or meshing
-        self.chunks_mutex.lock();
-        defer self.chunks_mutex.unlock();
-        var iter = self.chunks.iterator();
-        while (iter.next()) |entry| {
-            const chunk = &entry.value_ptr.*.chunk;
-            if (chunk.state == .generating) {
-                chunk.state = .missing;
-            } else if (chunk.state == .meshing) {
-                chunk.state = .generated;
-            }
-        }
     }
 
     pub fn resumeGeneration(self: *World) void {
         self.paused = false;
-        self.gen_queue.setPaused(false);
-        self.mesh_queue.setPaused(false);
+        self.streamer.setPaused(false);
 
         // Resume LOD manager if enabled
         if (self.lod_manager) |lod_mgr| {
             lod_mgr.unpause();
         }
-
-        // Chunks will be re-queued in the next update() cycle
-        // Force an update of player position to trigger re-scanning
-        self.last_pc = .{ .x = 9999, .z = 9999 };
     }
 
     /// Set render distance and trigger chunk loading/unloading update
@@ -321,149 +131,18 @@ pub const World = struct {
         if (self.render_distance != distance) {
             std.log.info("Render distance changed: {} -> {}", .{ self.render_distance, distance });
             self.render_distance = distance;
+            self.streamer.setRenderDistance(distance);
+
             // Only update LOD0 radius - LOD1/2/3 are fixed for "infinite" terrain view
             if (self.lod_manager) |lod_mgr| {
                 lod_mgr.config.lod0_radius = distance;
                 std.log.info("LOD0 radius updated to match render distance: {}", .{distance});
             }
-            // Force chunk rescan on next update
-            self.last_pc = .{ .x = 9999, .z = 9999 };
-        }
-    }
-
-    fn processGenJob(ctx: *anyopaque, job: Job) void {
-        const self: *World = @ptrCast(@alignCast(ctx));
-
-        self.chunks_mutex.lockShared();
-        const chunk_data = self.chunks.get(ChunkKey{ .x = job.chunk_x, .z = job.chunk_z }) orelse {
-            self.chunks_mutex.unlockShared();
-            return;
-        };
-
-        // Skip if chunk is now too far from player (stale job)
-        const dx = job.chunk_x - self.last_pc.x;
-        const dz = job.chunk_z - self.last_pc.z;
-        const max_dist = self.render_distance + CHUNK_UNLOAD_BUFFER;
-        if (dx * dx + dz * dz > max_dist * max_dist) {
-            // Reset state so it can be re-queued if player returns
-            if (chunk_data.chunk.state == .generating) {
-                chunk_data.chunk.state = .missing;
-            }
-            self.chunks_mutex.unlockShared();
-            return;
-        }
-
-        // Pin chunk to prevent unloading during generation.
-        chunk_data.chunk.pin();
-        self.chunks_mutex.unlockShared();
-
-        defer chunk_data.chunk.unpin();
-
-        if (chunk_data.chunk.state == .generating and chunk_data.chunk.job_token == job.job_token) {
-            self.generator.generate(&chunk_data.chunk, &self.gen_queue.abort_worker);
-            if (self.gen_queue.abort_worker) {
-                chunk_data.chunk.state = .missing;
-                return;
-            }
-            chunk_data.chunk.state = .generated;
-            self.markNeighborsForRemesh(job.chunk_x, job.chunk_z);
-        }
-    }
-
-    fn processMeshJob(ctx: *anyopaque, job: Job) void {
-        const self: *World = @ptrCast(@alignCast(ctx));
-
-        self.chunks_mutex.lockShared();
-        const chunk_data = self.chunks.get(ChunkKey{ .x = job.chunk_x, .z = job.chunk_z }) orelse {
-            self.chunks_mutex.unlockShared();
-            return;
-        };
-
-        // Skip if chunk is now too far from player (stale job)
-        const dx = job.chunk_x - self.last_pc.x;
-        const dz = job.chunk_z - self.last_pc.z;
-        const max_dist = self.render_distance + CHUNK_UNLOAD_BUFFER;
-        if (dx * dx + dz * dz > max_dist * max_dist) {
-            if (chunk_data.chunk.state == .meshing) {
-                chunk_data.chunk.state = .generated;
-            }
-            self.chunks_mutex.unlockShared();
-            return;
-        }
-
-        // Pin chunk and neighbors to prevent unloading during mesh building.
-        chunk_data.chunk.pin();
-        const neighbors = NeighborChunks{
-            .north = if (self.chunks.get(ChunkKey{ .x = job.chunk_x, .z = job.chunk_z - 1 })) |d| d: {
-                d.chunk.pin();
-                break :d &d.chunk;
-            } else null,
-            .south = if (self.chunks.get(ChunkKey{ .x = job.chunk_x, .z = job.chunk_z + 1 })) |d| d: {
-                d.chunk.pin();
-                break :d &d.chunk;
-            } else null,
-            .east = if (self.chunks.get(ChunkKey{ .x = job.chunk_x + 1, .z = job.chunk_z })) |d| d: {
-                d.chunk.pin();
-                break :d &d.chunk;
-            } else null,
-            .west = if (self.chunks.get(ChunkKey{ .x = job.chunk_x - 1, .z = job.chunk_z })) |d| d: {
-                d.chunk.pin();
-                break :d &d.chunk;
-            } else null,
-        };
-        self.chunks_mutex.unlockShared();
-
-        defer {
-            chunk_data.chunk.unpin();
-            if (neighbors.north) |n| @as(*Chunk, @constCast(n)).unpin();
-            if (neighbors.south) |s| @as(*Chunk, @constCast(s)).unpin();
-            if (neighbors.east) |e| @as(*Chunk, @constCast(e)).unpin();
-            if (neighbors.west) |w| @as(*Chunk, @constCast(w)).unpin();
-        }
-
-        if (chunk_data.chunk.state == .meshing and chunk_data.chunk.job_token == job.job_token) {
-            chunk_data.mesh.buildWithNeighbors(&chunk_data.chunk, neighbors) catch |err| {
-                log.log.err("Mesh build failed for chunk ({}, {}): {}", .{ job.chunk_x, job.chunk_z, err });
-            };
-            if (self.mesh_queue.abort_worker) {
-                chunk_data.chunk.state = .generated;
-                return;
-            }
-            chunk_data.chunk.state = .mesh_ready;
         }
     }
 
     pub fn getOrCreateChunk(self: *World, chunk_x: i32, chunk_z: i32) !*ChunkData {
-        self.chunks_mutex.lock();
-        defer self.chunks_mutex.unlock();
-
-        const key = ChunkKey{ .x = chunk_x, .z = chunk_z };
-        if (self.chunks.get(key)) |data| return data;
-
-        const data = try self.allocator.create(ChunkData);
-        data.* = .{
-            .chunk = Chunk.init(chunk_x, chunk_z),
-            .mesh = ChunkMesh.init(self.allocator),
-        };
-        data.chunk.job_token = self.next_job_token;
-        self.next_job_token += 1;
-        try self.chunks.put(key, data);
-        return data;
-    }
-
-    fn markNeighborsForRemesh(self: *World, cx: i32, cz: i32) void {
-        const offsets = [_][2]i32{ .{ 0, 1 }, .{ 0, -1 }, .{ 1, 0 }, .{ -1, 0 } };
-        self.chunks_mutex.lockShared();
-        defer self.chunks_mutex.unlockShared();
-        for (offsets) |off| {
-            if (self.chunks.get(ChunkKey{ .x = cx + off[0], .z = cz + off[1] })) |data| {
-                if (data.chunk.state == .renderable) {
-                    data.chunk.state = .generated;
-                } else if (data.chunk.state == .mesh_ready or data.chunk.state == .uploading or data.chunk.state == .meshing) {
-                    data.chunk.dirty = true;
-                }
-            }
-        }
+        return self.storage.getOrCreate(chunk_x, chunk_z);
     }
 
     pub fn getBlock(self: *World, world_x: i32, world_y: i32, world_z: i32) BlockType {
@@ -509,296 +188,53 @@ pub const World = struct {
     }
 
     pub fn getChunk(self: *World, cx: i32, cz: i32) ?*ChunkData {
-        self.chunks_mutex.lockShared();
-        defer self.chunks_mutex.unlockShared();
-        return self.chunks.get(ChunkKey{ .x = cx, .z = cz });
+        self.storage.chunks_mutex.lockShared();
+        defer self.storage.chunks_mutex.unlockShared();
+        return self.storage.chunks.get(ChunkKey{ .x = cx, .z = cz });
     }
 
     pub fn update(self: *World, player_pos: Vec3, dt: f32) !void {
-        if (self.paused) return;
+        try self.streamer.update(player_pos, dt, self.lod_manager);
 
-        // Update velocity tracking for predictive loading
-        _ = self.player_movement.update(player_pos, dt);
+        // Process a few uploads per frame
+        self.streamer.processUploads(self.renderer.vertex_allocator, 32);
 
-        const pc = worldToChunk(@intFromFloat(player_pos.x), @intFromFloat(player_pos.z));
-        const moved = pc.chunk_x != self.last_pc.x or pc.chunk_z != self.last_pc.z;
+        // Process unloads
+        try self.streamer.processUnloads(player_pos, self.renderer.vertex_allocator, self.lod_manager);
 
-        if (moved) {
-            self.last_pc = .{ .x = pc.chunk_x, .z = pc.chunk_z };
-
-            try self.gen_queue.updatePlayerPos(pc.chunk_x, pc.chunk_z);
-            try self.mesh_queue.updatePlayerPos(pc.chunk_x, pc.chunk_z);
-
-            // Clamp generation distance to LOD0 radius if LOD is active - prevent generating chunks we won't mesh
-            const render_dist = if (self.lod_manager) |mgr| @min(self.render_distance, mgr.config.lod0_radius) else self.render_distance;
-
-            var cz = pc.chunk_z - render_dist;
-            while (cz <= pc.chunk_z + render_dist) : (cz += 1) {
-                var cx = pc.chunk_x - render_dist;
-                while (cx <= pc.chunk_x + render_dist) : (cx += 1) {
-                    const dx = cx - pc.chunk_x;
-                    const dz = cz - pc.chunk_z;
-                    const dist_sq = dx * dx + dz * dz;
-
-                    if (dist_sq > render_dist * render_dist) continue;
-
-                    const data = try self.getOrCreateChunk(cx, cz);
-
-                    switch (data.chunk.state) {
-                        .missing => {
-                            // Apply velocity-based priority weighting
-                            const weight = self.player_movement.priorityWeight(dx, dz);
-                            const weighted_dist: i32 = @intFromFloat(@as(f32, @floatFromInt(dist_sq)) * weight);
-
-                            try self.gen_queue.push(.{
-                                .type = .generation,
-                                .chunk_x = cx,
-                                .chunk_z = cz,
-                                .job_token = data.chunk.job_token,
-                                .dist_sq = weighted_dist,
-                            });
-                            data.chunk.state = .generating;
-                        },
-                        else => {},
-                    }
-                }
-            }
-        }
-
-        self.chunks_mutex.lockShared();
-        var mesh_iter = self.chunks.iterator();
-
-        const render_dist = if (self.lod_manager) |mgr| @min(self.render_distance, mgr.config.lod0_radius) else self.render_distance;
-
-        while (mesh_iter.next()) |entry| {
-            const key = entry.key_ptr.*;
-            const data = entry.value_ptr.*;
-            if (data.chunk.state == .generated) {
-                const dx = data.chunk.chunk_x - pc.chunk_x;
-                const dz = data.chunk.chunk_z - pc.chunk_z;
-                if (dx * dx + dz * dz <= render_dist * render_dist) {
-                    // Apply velocity-based priority weighting
-                    const weight = self.player_movement.priorityWeight(dx, dz);
-                    const weighted_dist: i32 = @intFromFloat(@as(f32, @floatFromInt(dx * dx + dz * dz)) * weight);
-
-                    try self.mesh_queue.push(.{
-                        .type = .meshing,
-                        .chunk_x = data.chunk.chunk_x,
-                        .chunk_z = data.chunk.chunk_z,
-                        .job_token = data.chunk.job_token,
-                        .dist_sq = weighted_dist,
-                    });
-                    data.chunk.state = .meshing;
-                }
-            } else if (data.chunk.state == .mesh_ready) {
-                data.chunk.state = .uploading;
-                try self.upload_queue.push(key);
-            } else if (data.chunk.state == .renderable and data.chunk.dirty) {
-                data.chunk.dirty = false;
-                data.chunk.state = .generated;
-            }
-        }
-        self.chunks_mutex.unlockShared();
-
-        const max_uploads: usize = 32;
-        var uploads: usize = 0;
-        while (!self.upload_queue.isEmpty() and uploads < max_uploads) {
-            const key = self.upload_queue.pop() orelse break;
-            if (self.chunks.get(key)) |data| {
-                if (data.chunk.state != .uploading) continue;
-
-                data.mesh.upload(&self.vertex_allocator);
-                if (data.mesh.ready) {
-                    data.chunk.state = .renderable;
-                } else {
-                    // Allocation failed (OOM), reset state so it can be retried or unloaded
-                    data.chunk.state = .mesh_ready;
-                }
-                uploads += 1;
-            }
-        }
-
-        const render_dist_unload = if (self.lod_manager) |mgr| @min(self.render_distance, mgr.config.lod0_radius) else self.render_distance;
-        const unload_dist_sq = (render_dist_unload + CHUNK_UNLOAD_BUFFER) * (render_dist_unload + CHUNK_UNLOAD_BUFFER);
-        self.chunks_mutex.lock();
-        var to_remove = std.ArrayListUnmanaged(ChunkKey).empty;
-        defer to_remove.deinit(self.allocator);
-
-        var unload_iter = self.chunks.iterator();
-        while (unload_iter.next()) |entry| {
-            const key = entry.key_ptr.*;
-            const data = entry.value_ptr.*;
-            const dx = key.x - pc.chunk_x;
-            const dz = key.z - pc.chunk_z;
-            if (dx * dx + dz * dz > unload_dist_sq) {
-                if (data.chunk.state != .generating and data.chunk.state != .meshing and
-                    !data.chunk.isPinned())
-                {
-                    try to_remove.append(self.allocator, key);
-                }
-            }
-        }
-
-        for (to_remove.items) |key| {
-            if (self.chunks.get(key)) |data| {
-                data.mesh.deinit(&self.vertex_allocator);
-                self.allocator.destroy(data);
-                _ = self.chunks.remove(key);
-            }
-        }
-        self.chunks_mutex.unlock();
-
-        // Update LOD manager if enabled
-        if (self.lod_manager) |lod_mgr| {
-            const velocity = Vec3.init(
-                self.player_movement.dir_x * self.player_movement.speed,
-                0,
-                self.player_movement.dir_z * self.player_movement.speed,
-            );
-            try lod_mgr.update(player_pos, velocity);
-        }
+        // NOTE: LOD Manager update is handled inside streamer.update() now
     }
 
     pub fn render(self: *World, view_proj: Mat4, camera_pos: Vec3) void {
-        self.last_render_stats = .{};
-
-        // Lock chunks for the chunk checker callback
-        self.chunks_mutex.lockShared();
-        defer self.chunks_mutex.unlockShared();
-
-        // Render LOD meshes first (background, distant)
-        // Pass a chunk checker so LOD regions only hide when chunks are actually loaded
-        if (self.lod_manager) |lod_mgr| {
-            lod_mgr.render(view_proj, camera_pos, isChunkRenderable, @ptrCast(self));
-        }
-
-        // IMPORTANT: Reset mask radius to 0 for LOD0 chunks
-        if (self.lod_manager) |lod_mgr| {
-            _ = lod_mgr;
-        }
-
-        self.visible_chunks.clearRetainingCapacity();
-
-        const frustum = Frustum.fromViewProj(view_proj);
-
-        const pc = worldToChunk(@intFromFloat(camera_pos.x), @intFromFloat(camera_pos.z));
-
-        const render_dist = if (self.lod_manager) |mgr| @min(self.render_distance, mgr.config.lod0_radius) else self.render_distance;
-
-        var cz = pc.chunk_z - render_dist;
-        while (cz <= pc.chunk_z + render_dist) : (cz += 1) {
-            var cx = pc.chunk_x - render_dist;
-            while (cx <= pc.chunk_x + render_dist) : (cx += 1) {
-                if (self.chunks.get(.{ .x = cx, .z = cz })) |data| {
-                    if (data.chunk.state == .renderable or data.mesh.solid_allocation != null or data.mesh.fluid_allocation != null) {
-                        if (frustum.intersectsChunkRelative(cx, cz, camera_pos.x, camera_pos.y, camera_pos.z)) {
-                            self.visible_chunks.append(self.allocator, data) catch {};
-                        } else {
-                            self.last_render_stats.chunks_culled += 1;
-                        }
-                    }
-                }
-            }
-        }
-
-        self.last_render_stats.chunks_total = @intCast(self.chunks.count());
-
-        for (self.visible_chunks.items) |data| {
-            self.last_render_stats.chunks_rendered += 1;
-            const chunk_world_x: f32 = @floatFromInt(data.chunk.chunk_x * CHUNK_SIZE_X);
-            const chunk_world_z: f32 = @floatFromInt(data.chunk.chunk_z * CHUNK_SIZE_Z);
-            const rel_x = chunk_world_x - camera_pos.x;
-            const rel_z = chunk_world_z - camera_pos.z;
-            const rel_y = -camera_pos.y;
-            const model = Mat4.translate(Vec3.init(rel_x, rel_y, rel_z));
-
-            self.rhi.setModelMatrix(model, 0);
-
-            if (data.mesh.solid_allocation) |alloc| {
-                self.last_render_stats.vertices_rendered += alloc.count;
-                self.rhi.drawOffset(self.vertex_allocator.buffer, alloc.count, .triangles, alloc.offset);
-            }
-            if (data.mesh.fluid_allocation) |alloc| {
-                self.last_render_stats.vertices_rendered += alloc.count;
-                self.rhi.drawOffset(self.vertex_allocator.buffer, alloc.count, .triangles, alloc.offset);
-            }
-        }
-
-        self.mdi_instance_offset = 0;
-        self.mdi_command_offset = 0;
+        self.renderer.render(view_proj, camera_pos, self.render_distance, self.lod_manager);
     }
 
     pub fn renderShadowPass(self: *World, light_space_matrix: Mat4, camera_pos: Vec3) void {
-        // Build frustum from the light's orthographic projection matrix
-        const shadow_frustum = Frustum.fromViewProj(light_space_matrix);
-
-        self.chunks_mutex.lockShared();
-        defer self.chunks_mutex.unlockShared();
-
-        const frustum = shadow_frustum;
-        const pc = worldToChunk(@intFromFloat(camera_pos.x), @intFromFloat(camera_pos.z));
-
-        const render_dist = if (self.lod_manager) |mgr| @min(self.render_distance, mgr.config.lod0_radius) else self.render_distance;
-
-        var cz = pc.chunk_z - render_dist;
-        while (cz <= pc.chunk_z + render_dist) : (cz += 1) {
-            var cx = pc.chunk_x - render_dist;
-            while (cx <= pc.chunk_x + render_dist) : (cx += 1) {
-                if (self.chunks.get(.{ .x = cx, .z = cz })) |data| {
-                    if (data.chunk.state == .renderable or data.mesh.solid_allocation != null or data.mesh.fluid_allocation != null) {
-                        const chunk_world_x: f32 = @floatFromInt(data.chunk.chunk_x * CHUNK_SIZE_X);
-                        const chunk_world_z: f32 = @floatFromInt(data.chunk.chunk_z * CHUNK_SIZE_Z);
-
-                        if (!frustum.intersectsChunkRelative(cx, cz, camera_pos.x, camera_pos.y, camera_pos.z)) {
-                            continue;
-                        }
-
-                        const rel_x = chunk_world_x - camera_pos.x;
-                        const rel_z = chunk_world_z - camera_pos.z;
-                        const rel_y = -camera_pos.y;
-                        const model = Mat4.translate(Vec3.init(rel_x, rel_y, rel_z));
-
-                        if (data.mesh.solid_allocation) |alloc| {
-                            self.rhi.setModelMatrix(model, 0);
-                            self.rhi.drawOffset(self.vertex_allocator.buffer, alloc.count, .triangles, alloc.offset);
-                        }
-                    }
-                }
-            }
-        }
-
-        self.mdi_instance_offset = 0;
-        self.mdi_command_offset = 0;
+        self.renderer.renderShadowPass(light_space_matrix, camera_pos, self.render_distance, self.lod_manager);
     }
 
     pub fn getRenderStats(self: *const World) RenderStats {
-        return self.last_render_stats;
+        return self.renderer.last_render_stats;
     }
 
     pub fn getStats(self: *World) struct { chunks_loaded: usize, total_vertices: u64, gen_queue: usize, mesh_queue: usize, upload_queue: usize } {
-        self.chunks_mutex.lockShared();
-        defer self.chunks_mutex.unlockShared();
+        self.storage.chunks_mutex.lockShared();
+        defer self.storage.chunks_mutex.unlockShared();
         var total_verts: u64 = 0;
-        var iter = self.chunks.iterator();
+        var iter = self.storage.chunks.iterator();
         while (iter.next()) |entry| {
             if (entry.value_ptr.*.mesh.solid_allocation) |alloc| total_verts += alloc.count;
             if (entry.value_ptr.*.mesh.fluid_allocation) |alloc| total_verts += alloc.count;
         }
 
-        self.gen_queue.mutex.lock();
-        const gen_count = self.gen_queue.jobs.count();
-        self.gen_queue.mutex.unlock();
-
-        self.mesh_queue.mutex.lock();
-        const mesh_count = self.mesh_queue.jobs.count();
-        self.mesh_queue.mutex.unlock();
+        const streamer_stats = self.streamer.getStats();
 
         return .{
-            .chunks_loaded = self.chunks.count(),
+            .chunks_loaded = self.storage.chunks.count(),
             .total_vertices = total_verts,
-            .gen_queue = gen_count,
-            .mesh_queue = mesh_count,
-            .upload_queue = self.upload_queue.count(),
+            .gen_queue = streamer_stats.gen_queue,
+            .mesh_queue = streamer_stats.mesh_queue,
+            .upload_queue = streamer_stats.upload_queue,
         };
     }
 
@@ -813,15 +249,5 @@ pub const World = struct {
     /// Check if LOD system is enabled
     pub fn isLODEnabled(self: *const World) bool {
         return self.lod_enabled;
-    }
-
-    /// Callback for LODManager to check if a chunk is loaded and renderable.
-    /// Must be called while chunks_mutex is held.
-    fn isChunkRenderable(chunk_x: i32, chunk_z: i32, ctx: *anyopaque) bool {
-        const self: *World = @ptrCast(@alignCast(ctx));
-        if (self.chunks.get(.{ .x = chunk_x, .z = chunk_z })) |data| {
-            return data.chunk.state == .renderable;
-        }
-        return false;
     }
 };

--- a/src/world/world_renderer.zig
+++ b/src/world/world_renderer.zig
@@ -1,0 +1,202 @@
+//! World renderer - handles chunk rendering, culling, and MDI.
+
+const std = @import("std");
+const ChunkData = @import("chunk_storage.zig").ChunkData;
+const ChunkStorage = @import("chunk_storage.zig").ChunkStorage;
+const worldToChunk = @import("chunk.zig").worldToChunk;
+const CHUNK_SIZE_X = @import("chunk.zig").CHUNK_SIZE_X;
+const CHUNK_SIZE_Z = @import("chunk.zig").CHUNK_SIZE_Z;
+const GlobalVertexAllocator = @import("chunk_allocator.zig").GlobalVertexAllocator;
+const LODManager = @import("lod_manager.zig").LODManager;
+const Vec3 = @import("../engine/math/vec3.zig").Vec3;
+const Mat4 = @import("../engine/math/mat4.zig").Mat4;
+const Frustum = @import("../engine/math/frustum.zig").Frustum;
+const rhi_mod = @import("../engine/graphics/rhi.zig");
+const RHI = rhi_mod.RHI;
+const World = @import("world.zig").World; // Circular dependency if not careful, better avoid. But isChunkRenderable callback needs it?
+// Actually isChunkRenderable uses World* but only needs access to storage/chunk state.
+
+pub const RenderStats = struct {
+    chunks_total: u32 = 0,
+    chunks_rendered: u32 = 0,
+    chunks_culled: u32 = 0,
+    vertices_rendered: u64 = 0,
+};
+
+pub const WorldRenderer = struct {
+    allocator: std.mem.Allocator,
+    storage: *ChunkStorage,
+    rhi: RHI,
+
+    vertex_allocator: *GlobalVertexAllocator,
+    visible_chunks: std.ArrayListUnmanaged(*ChunkData),
+    last_render_stats: RenderStats,
+
+    // MDI Resources
+    instance_data: std.ArrayListUnmanaged(rhi_mod.InstanceData),
+    solid_commands: std.ArrayListUnmanaged(rhi_mod.DrawIndirectCommand),
+    fluid_commands: std.ArrayListUnmanaged(rhi_mod.DrawIndirectCommand),
+    instance_buffers: [rhi_mod.MAX_FRAMES_IN_FLIGHT]rhi_mod.BufferHandle,
+    indirect_buffers: [rhi_mod.MAX_FRAMES_IN_FLIGHT]rhi_mod.BufferHandle,
+    frame_index: usize,
+    mdi_instance_offset: usize,
+    mdi_command_offset: usize,
+
+    pub fn init(allocator: std.mem.Allocator, rhi: RHI, storage: *ChunkStorage) !*WorldRenderer {
+        const renderer = try allocator.create(WorldRenderer);
+
+        const vertex_allocator = try allocator.create(GlobalVertexAllocator);
+        vertex_allocator.* = try GlobalVertexAllocator.init(allocator, rhi, 6144);
+
+        const max_chunks = 16384;
+        var instance_buffers: [rhi_mod.MAX_FRAMES_IN_FLIGHT]rhi_mod.BufferHandle = undefined;
+        var indirect_buffers: [rhi_mod.MAX_FRAMES_IN_FLIGHT]rhi_mod.BufferHandle = undefined;
+        for (0..rhi_mod.MAX_FRAMES_IN_FLIGHT) |i| {
+            instance_buffers[i] = rhi.createBuffer(max_chunks * @sizeOf(rhi_mod.InstanceData), .storage);
+            indirect_buffers[i] = rhi.createBuffer(max_chunks * @sizeOf(rhi_mod.DrawIndirectCommand) * 2, .indirect);
+        }
+
+        renderer.* = .{
+            .allocator = allocator,
+            .storage = storage,
+            .rhi = rhi,
+            .vertex_allocator = vertex_allocator,
+            .visible_chunks = .empty,
+            .last_render_stats = .{},
+            .instance_data = .empty,
+            .solid_commands = .empty,
+            .fluid_commands = .empty,
+            .instance_buffers = instance_buffers,
+            .indirect_buffers = indirect_buffers,
+            .frame_index = 0,
+            .mdi_instance_offset = 0,
+            .mdi_command_offset = 0,
+        };
+
+        return renderer;
+    }
+
+    pub fn deinit(self: *WorldRenderer) void {
+        self.visible_chunks.deinit(self.allocator);
+
+        for (0..rhi_mod.MAX_FRAMES_IN_FLIGHT) |i| {
+            if (self.instance_buffers[i] != 0) self.rhi.destroyBuffer(self.instance_buffers[i]);
+            if (self.indirect_buffers[i] != 0) self.rhi.destroyBuffer(self.indirect_buffers[i]);
+        }
+        self.instance_data.deinit(self.allocator);
+        self.solid_commands.deinit(self.allocator);
+        self.fluid_commands.deinit(self.allocator);
+
+        self.vertex_allocator.deinit();
+        self.allocator.destroy(self.vertex_allocator);
+        self.allocator.destroy(self);
+    }
+
+    pub fn render(self: *WorldRenderer, view_proj: Mat4, camera_pos: Vec3, render_distance: i32, lod_manager: ?*LODManager) void {
+        self.last_render_stats = .{};
+
+        self.storage.chunks_mutex.lockShared();
+        defer self.storage.chunks_mutex.unlockShared();
+
+        if (lod_manager) |lod_mgr| {
+            lod_mgr.render(view_proj, camera_pos, isChunkRenderable, @ptrCast(self.storage));
+        }
+
+        self.visible_chunks.clearRetainingCapacity();
+
+        const frustum = Frustum.fromViewProj(view_proj);
+        const pc = worldToChunk(@intFromFloat(camera_pos.x), @intFromFloat(camera_pos.z));
+        const render_dist = if (lod_manager) |mgr| @min(render_distance, mgr.config.lod0_radius) else render_distance;
+
+        var cz = pc.chunk_z - render_dist;
+        while (cz <= pc.chunk_z + render_dist) : (cz += 1) {
+            var cx = pc.chunk_x - render_dist;
+            while (cx <= pc.chunk_x + render_dist) : (cx += 1) {
+                if (self.storage.chunks.get(.{ .x = cx, .z = cz })) |data| {
+                    if (data.chunk.state == .renderable or data.mesh.solid_allocation != null or data.mesh.fluid_allocation != null) {
+                        if (frustum.intersectsChunkRelative(cx, cz, camera_pos.x, camera_pos.y, camera_pos.z)) {
+                            self.visible_chunks.append(self.allocator, data) catch {};
+                        } else {
+                            self.last_render_stats.chunks_culled += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        self.last_render_stats.chunks_total = @intCast(self.storage.chunks.count());
+
+        for (self.visible_chunks.items) |data| {
+            self.last_render_stats.chunks_rendered += 1;
+            const chunk_world_x: f32 = @floatFromInt(data.chunk.chunk_x * CHUNK_SIZE_X);
+            const chunk_world_z: f32 = @floatFromInt(data.chunk.chunk_z * CHUNK_SIZE_Z);
+            const rel_x = chunk_world_x - camera_pos.x;
+            const rel_z = chunk_world_z - camera_pos.z;
+            const rel_y = -camera_pos.y;
+            const model = Mat4.translate(Vec3.init(rel_x, rel_y, rel_z));
+
+            self.rhi.setModelMatrix(model, 0);
+
+            if (data.mesh.solid_allocation) |alloc| {
+                self.last_render_stats.vertices_rendered += alloc.count;
+                self.rhi.drawOffset(self.vertex_allocator.buffer, alloc.count, .triangles, alloc.offset);
+            }
+            if (data.mesh.fluid_allocation) |alloc| {
+                self.last_render_stats.vertices_rendered += alloc.count;
+                self.rhi.drawOffset(self.vertex_allocator.buffer, alloc.count, .triangles, alloc.offset);
+            }
+        }
+
+        self.mdi_instance_offset = 0;
+        self.mdi_command_offset = 0;
+    }
+
+    pub fn renderShadowPass(self: *WorldRenderer, light_space_matrix: Mat4, camera_pos: Vec3, render_distance: i32, lod_manager: ?*LODManager) void {
+        const shadow_frustum = Frustum.fromViewProj(light_space_matrix);
+
+        self.storage.chunks_mutex.lockShared();
+        defer self.storage.chunks_mutex.unlockShared();
+
+        const frustum = shadow_frustum;
+        const pc = worldToChunk(@intFromFloat(camera_pos.x), @intFromFloat(camera_pos.z));
+        const render_dist = if (lod_manager) |mgr| @min(render_distance, mgr.config.lod0_radius) else render_distance;
+
+        var cz = pc.chunk_z - render_dist;
+        while (cz <= pc.chunk_z + render_dist) : (cz += 1) {
+            var cx = pc.chunk_x - render_dist;
+            while (cx <= pc.chunk_x + render_dist) : (cx += 1) {
+                if (self.storage.chunks.get(.{ .x = cx, .z = cz })) |data| {
+                    if (data.chunk.state == .renderable or data.mesh.solid_allocation != null or data.mesh.fluid_allocation != null) {
+                        const chunk_world_x: f32 = @floatFromInt(data.chunk.chunk_x * CHUNK_SIZE_X);
+                        const chunk_world_z: f32 = @floatFromInt(data.chunk.chunk_z * CHUNK_SIZE_Z);
+
+                        if (!frustum.intersectsChunkRelative(cx, cz, camera_pos.x, camera_pos.y, camera_pos.z)) {
+                            continue;
+                        }
+
+                        const rel_x = chunk_world_x - camera_pos.x;
+                        const rel_z = chunk_world_z - camera_pos.z;
+                        const rel_y = -camera_pos.y;
+                        const model = Mat4.translate(Vec3.init(rel_x, rel_y, rel_z));
+
+                        if (data.mesh.solid_allocation) |alloc| {
+                            self.rhi.setModelMatrix(model, 0);
+                            self.rhi.drawOffset(self.vertex_allocator.buffer, alloc.count, .triangles, alloc.offset);
+                        }
+                    }
+                }
+            }
+        }
+
+        self.mdi_instance_offset = 0;
+        self.mdi_command_offset = 0;
+    }
+
+    fn isChunkRenderable(chunk_x: i32, chunk_z: i32, ctx: *anyopaque) bool {
+        const storage: *ChunkStorage = @ptrCast(@alignCast(ctx));
+        if (storage.chunks.get(.{ .x = chunk_x, .z = chunk_z })) |data| {
+            return data.chunk.state == .renderable;
+        }
+        return false;
+    }
+};

--- a/src/world/world_streamer.zig
+++ b/src/world/world_streamer.zig
@@ -225,6 +225,8 @@ pub const WorldStreamer = struct {
                             });
                             data.chunk.state = .generating;
                         },
+                        // .queued_for_generation is handled implicitly by the job queue.
+                        // .generating state persists until the job completes.
                         else => {},
                     }
                 }

--- a/src/world/world_streamer.zig
+++ b/src/world/world_streamer.zig
@@ -1,0 +1,458 @@
+//! World streamer - handles asynchronous chunk loading and unloading.
+
+const std = @import("std");
+const Vec3 = @import("../engine/math/vec3.zig").Vec3;
+const Chunk = @import("chunk.zig").Chunk;
+const ChunkKey = @import("chunk_storage.zig").ChunkKey;
+const ChunkStorage = @import("chunk_storage.zig").ChunkStorage;
+const NeighborChunks = @import("chunk_mesh.zig").NeighborChunks;
+const JobQueue = @import("../engine/core/job_system.zig").JobQueue;
+const WorkerPool = @import("../engine/core/job_system.zig").WorkerPool;
+const Job = @import("../engine/core/job_system.zig").Job;
+const RingBuffer = @import("../engine/core/ring_buffer.zig").RingBuffer;
+const TerrainGenerator = @import("worldgen/generator.zig").TerrainGenerator;
+const LODManager = @import("lod_manager.zig").LODManager;
+const worldToChunk = @import("chunk.zig").worldToChunk;
+const GlobalVertexAllocator = @import("chunk_allocator.zig").GlobalVertexAllocator;
+const log = @import("../engine/core/log.zig");
+
+/// Buffer distance beyond render_distance for chunk unloading.
+/// Prevents thrashing when player moves near chunk boundaries.
+const CHUNK_UNLOAD_BUFFER: i32 = 1;
+
+/// Player movement tracking for predictive chunk loading
+pub const PlayerMovement = struct {
+    /// Normalized movement direction (0,0 if stationary)
+    dir_x: f32 = 0,
+    dir_z: f32 = 0,
+    /// Speed in blocks/second
+    speed: f32 = 0,
+    /// Last position for velocity calculation
+    last_pos: Vec3 = Vec3.init(0, 0, 0),
+    /// Whether we have valid velocity data
+    has_velocity: bool = false,
+
+    /// Update with new position, returns true if direction changed significantly
+    pub fn update(self: *PlayerMovement, pos: Vec3, dt: f32) bool {
+        if (dt <= 0.001) return false;
+
+        const dx = pos.x - self.last_pos.x;
+        const dz = pos.z - self.last_pos.z;
+        self.last_pos = pos;
+
+        const dist = @sqrt(dx * dx + dz * dz);
+        self.speed = dist / dt;
+
+        // Only track direction if moving fast enough (> 2 blocks/sec)
+        if (self.speed < 2.0) {
+            self.has_velocity = false;
+            return false;
+        }
+
+        const old_dx = self.dir_x;
+        const old_dz = self.dir_z;
+
+        self.dir_x = dx / dist;
+        self.dir_z = dz / dist;
+        self.has_velocity = true;
+
+        // Check if direction changed significantly (> 45 degrees)
+        const dot = old_dx * self.dir_x + old_dz * self.dir_z;
+        return dot < 0.707; // cos(45°)
+    }
+
+    /// Calculate priority weight for a chunk based on movement direction.
+    /// Returns a multiplier: < 1.0 for chunks ahead, > 1.0 for chunks behind.
+    pub fn priorityWeight(self: *const PlayerMovement, chunk_dx: i32, chunk_dz: i32) f32 {
+        if (!self.has_velocity) return 1.0;
+
+        const cdx: f32 = @floatFromInt(chunk_dx);
+        const cdz: f32 = @floatFromInt(chunk_dz);
+        const dist = @sqrt(cdx * cdx + cdz * cdz);
+        if (dist < 0.001) return 0.5; // Player's chunk gets high priority
+
+        // Dot product with movement direction: 1.0 = ahead, -1.0 = behind
+        const dot = (cdx * self.dir_x + cdz * self.dir_z) / dist;
+
+        // Map [-1, 1] to [0.5, 1.5] - chunks ahead get 0.5x distance weight
+        return 1.0 - dot * 0.5;
+    }
+};
+
+pub const WorldStreamer = struct {
+    allocator: std.mem.Allocator,
+    storage: *ChunkStorage,
+    generator: *TerrainGenerator,
+
+    gen_queue: *JobQueue,
+    mesh_queue: *JobQueue,
+    gen_pool: *WorkerPool,
+    mesh_pool: *WorkerPool,
+    upload_queue: RingBuffer(ChunkKey),
+
+    player_movement: PlayerMovement,
+    last_pc: struct { x: i32, z: i32 },
+    render_distance: i32,
+
+    paused: bool = false,
+
+    pub fn init(allocator: std.mem.Allocator, storage: *ChunkStorage, generator: *TerrainGenerator, render_distance: i32) !*WorldStreamer {
+        const streamer = try allocator.create(WorldStreamer);
+
+        const gen_queue = try allocator.create(JobQueue);
+        gen_queue.* = JobQueue.init(allocator);
+
+        const mesh_queue = try allocator.create(JobQueue);
+        mesh_queue.* = JobQueue.init(allocator);
+
+        streamer.* = .{
+            .allocator = allocator,
+            .storage = storage,
+            .generator = generator,
+            .gen_queue = gen_queue,
+            .mesh_queue = mesh_queue,
+            .gen_pool = undefined,
+            .mesh_pool = undefined,
+            .upload_queue = try RingBuffer(ChunkKey).init(allocator, 256),
+            .player_movement = .{},
+            .last_pc = .{ .x = 9999, .z = 9999 },
+            .render_distance = render_distance,
+        };
+
+        streamer.gen_pool = try WorkerPool.init(allocator, 4, gen_queue, streamer, processGenJob);
+        streamer.mesh_pool = try WorkerPool.init(allocator, 3, mesh_queue, streamer, processMeshJob);
+
+        return streamer;
+    }
+
+    pub fn deinit(self: *WorldStreamer) void {
+        self.gen_queue.stop();
+        self.mesh_queue.stop();
+
+        self.gen_pool.deinit();
+        self.mesh_pool.deinit();
+
+        self.gen_queue.deinit();
+        self.mesh_queue.deinit();
+        self.allocator.destroy(self.gen_queue);
+        self.allocator.destroy(self.mesh_queue);
+
+        self.upload_queue.deinit();
+        self.allocator.destroy(self);
+    }
+
+    pub fn setPaused(self: *WorldStreamer, paused: bool) void {
+        self.paused = paused;
+        self.gen_queue.setPaused(paused);
+        self.mesh_queue.setPaused(paused);
+
+        if (paused) {
+            // Reset chunks that were waiting for generation or meshing
+            self.storage.chunks_mutex.lock();
+            defer self.storage.chunks_mutex.unlock();
+            var iter = self.storage.iteratorExcludingLock();
+            while (iter.next()) |entry| {
+                const chunk = &entry.value_ptr.*.chunk;
+                if (chunk.state == .generating) {
+                    chunk.state = .missing;
+                } else if (chunk.state == .meshing) {
+                    chunk.state = .generated;
+                }
+            }
+        } else {
+            // Force chunk rescan on next update
+            self.last_pc = .{ .x = 9999, .z = 9999 };
+        }
+    }
+
+    pub fn setRenderDistance(self: *WorldStreamer, distance: i32) void {
+        if (self.render_distance != distance) {
+            self.render_distance = distance;
+            // Force chunk rescan on next update
+            self.last_pc = .{ .x = 9999, .z = 9999 };
+        }
+    }
+
+    pub fn update(self: *WorldStreamer, player_pos: Vec3, dt: f32, lod_manager: ?*LODManager) !void {
+        if (self.paused) return;
+
+        // Update velocity tracking for predictive loading
+        _ = self.player_movement.update(player_pos, dt);
+
+        const pc = worldToChunk(@intFromFloat(player_pos.x), @intFromFloat(player_pos.z));
+        const moved = pc.chunk_x != self.last_pc.x or pc.chunk_z != self.last_pc.z;
+
+        if (moved) {
+            self.last_pc = .{ .x = pc.chunk_x, .z = pc.chunk_z };
+
+            try self.gen_queue.updatePlayerPos(pc.chunk_x, pc.chunk_z);
+            try self.mesh_queue.updatePlayerPos(pc.chunk_x, pc.chunk_z);
+
+            // Clamp generation distance to LOD0 radius if LOD is active
+            const render_dist = if (lod_manager) |mgr| @min(self.render_distance, mgr.config.lod0_radius) else self.render_distance;
+
+            var cz = pc.chunk_z - render_dist;
+            while (cz <= pc.chunk_z + render_dist) : (cz += 1) {
+                var cx = pc.chunk_x - render_dist;
+                while (cx <= pc.chunk_x + render_dist) : (cx += 1) {
+                    const dx = cx - pc.chunk_x;
+                    const dz = cz - pc.chunk_z;
+                    const dist_sq = dx * dx + dz * dz;
+
+                    if (dist_sq > render_dist * render_dist) continue;
+
+                    const data = try self.storage.getOrCreate(cx, cz);
+
+                    switch (data.chunk.state) {
+                        .missing => {
+                            const weight = self.player_movement.priorityWeight(dx, dz);
+                            const weighted_dist: i32 = @intFromFloat(@as(f32, @floatFromInt(dist_sq)) * weight);
+
+                            try self.gen_queue.push(.{
+                                .type = .chunk_generation,
+                                .dist_sq = weighted_dist,
+                                .data = .{
+                                    .chunk = .{
+                                        .x = cx,
+                                        .z = cz,
+                                        .job_token = data.chunk.job_token,
+                                    },
+                                },
+                            });
+                            data.chunk.state = .generating;
+                        },
+                        else => {},
+                    }
+                }
+            }
+        }
+
+        self.storage.chunks_mutex.lockShared();
+        var mesh_iter = self.storage.iteratorExcludingLock();
+
+        const render_dist = if (lod_manager) |mgr| @min(self.render_distance, mgr.config.lod0_radius) else self.render_distance;
+
+        while (mesh_iter.next()) |entry| {
+            const key = entry.key_ptr.*;
+            const data = entry.value_ptr.*;
+            if (data.chunk.state == .generated) {
+                const dx = data.chunk.chunk_x - pc.chunk_x;
+                const dz = data.chunk.chunk_z - pc.chunk_z;
+                if (dx * dx + dz * dz <= render_dist * render_dist) {
+                    const weight = self.player_movement.priorityWeight(dx, dz);
+                    const weighted_dist: i32 = @intFromFloat(@as(f32, @floatFromInt(dx * dx + dz * dz)) * weight);
+
+                    try self.mesh_queue.push(.{
+                        .type = .chunk_meshing,
+                        .dist_sq = weighted_dist,
+                        .data = .{
+                            .chunk = .{
+                                .x = data.chunk.chunk_x,
+                                .z = data.chunk.chunk_z,
+                                .job_token = data.chunk.job_token,
+                            },
+                        },
+                    });
+                    data.chunk.state = .meshing;
+                }
+            } else if (data.chunk.state == .mesh_ready) {
+                data.chunk.state = .uploading;
+                try self.upload_queue.push(key);
+            } else if (data.chunk.state == .renderable and data.chunk.dirty) {
+                data.chunk.dirty = false;
+                data.chunk.state = .generated;
+            }
+        }
+        self.storage.chunks_mutex.unlockShared();
+
+        // Update LOD manager if enabled
+        if (lod_manager) |lod_mgr| {
+            const velocity = Vec3.init(
+                self.player_movement.dir_x * self.player_movement.speed,
+                0,
+                self.player_movement.dir_z * self.player_movement.speed,
+            );
+            try lod_mgr.update(player_pos, velocity);
+        }
+    }
+
+    pub fn processUploads(self: *WorldStreamer, vertex_allocator: *GlobalVertexAllocator, max_uploads: usize) void {
+        var uploads: usize = 0;
+        while (!self.upload_queue.isEmpty() and uploads < max_uploads) {
+            const key = self.upload_queue.pop() orelse break;
+            if (self.storage.get(key.x, key.z)) |data| {
+                if (data.chunk.state != .uploading) continue;
+
+                data.mesh.upload(vertex_allocator);
+                if (data.mesh.ready) {
+                    data.chunk.state = .renderable;
+                } else {
+                    data.chunk.state = .mesh_ready;
+                }
+                uploads += 1;
+            }
+        }
+    }
+
+    pub fn processUnloads(self: *WorldStreamer, player_pos: Vec3, vertex_allocator: *GlobalVertexAllocator, lod_manager: ?*LODManager) !void {
+        const pc = worldToChunk(@intFromFloat(player_pos.x), @intFromFloat(player_pos.z));
+        const render_dist_unload = if (lod_manager) |mgr| @min(self.render_distance, mgr.config.lod0_radius) else self.render_distance;
+        const unload_dist_sq = (render_dist_unload + CHUNK_UNLOAD_BUFFER) * (render_dist_unload + CHUNK_UNLOAD_BUFFER);
+
+        self.storage.chunks_mutex.lock();
+        var to_remove = std.ArrayListUnmanaged(ChunkKey).empty;
+        defer to_remove.deinit(self.allocator);
+
+        var unload_iter = self.storage.iteratorExcludingLock();
+        while (unload_iter.next()) |entry| {
+            const key = entry.key_ptr.*;
+            const data = entry.value_ptr.*;
+            const dx = key.x - pc.chunk_x;
+            const dz = key.z - pc.chunk_z;
+            if (dx * dx + dz * dz > unload_dist_sq) {
+                if (data.chunk.state != .generating and data.chunk.state != .meshing and
+                    !data.chunk.isPinned())
+                {
+                    try to_remove.append(self.allocator, key);
+                }
+            }
+        }
+
+        for (to_remove.items) |key| {
+            _ = self.storage.remove(key.x, key.z, vertex_allocator);
+        }
+        self.storage.chunks_mutex.unlock();
+    }
+
+    fn processGenJob(ctx: *anyopaque, job: Job) void {
+        const self: *WorldStreamer = @ptrCast(@alignCast(ctx));
+        const cx = job.data.chunk.x;
+        const cz = job.data.chunk.z;
+
+        self.storage.chunks_mutex.lockShared();
+        const chunk_data = self.storage.chunks.get(ChunkKey{ .x = cx, .z = cz }) orelse {
+            self.storage.chunks_mutex.unlockShared();
+            return;
+        };
+
+        const dx = cx - self.last_pc.x;
+        const dz = cz - self.last_pc.z;
+        const max_dist = self.render_distance + CHUNK_UNLOAD_BUFFER;
+        if (dx * dx + dz * dz > max_dist * max_dist) {
+            if (chunk_data.chunk.state == .generating) {
+                chunk_data.chunk.state = .missing;
+            }
+            self.storage.chunks_mutex.unlockShared();
+            return;
+        }
+
+        chunk_data.chunk.pin();
+        self.storage.chunks_mutex.unlockShared();
+
+        defer chunk_data.chunk.unpin();
+
+        if (chunk_data.chunk.state == .generating and chunk_data.chunk.job_token == job.data.chunk.job_token) {
+            self.generator.generate(&chunk_data.chunk, &self.gen_queue.abort_worker);
+            if (self.gen_queue.abort_worker) {
+                chunk_data.chunk.state = .missing;
+                return;
+            }
+            chunk_data.chunk.state = .generated;
+            self.markNeighborsForRemesh(cx, cz);
+        }
+    }
+
+    fn processMeshJob(ctx: *anyopaque, job: Job) void {
+        const self: *WorldStreamer = @ptrCast(@alignCast(ctx));
+        const cx = job.data.chunk.x;
+        const cz = job.data.chunk.z;
+
+        self.storage.chunks_mutex.lockShared();
+        const chunk_data = self.storage.chunks.get(ChunkKey{ .x = cx, .z = cz }) orelse {
+            self.storage.chunks_mutex.unlockShared();
+            return;
+        };
+
+        const dx = cx - self.last_pc.x;
+        const dz = cz - self.last_pc.z;
+        const max_dist = self.render_distance + CHUNK_UNLOAD_BUFFER;
+        if (dx * dx + dz * dz > max_dist * max_dist) {
+            if (chunk_data.chunk.state == .meshing) {
+                chunk_data.chunk.state = .generated;
+            }
+            self.storage.chunks_mutex.unlockShared();
+            return;
+        }
+
+        chunk_data.chunk.pin();
+        const neighbors = NeighborChunks{
+            .north = if (self.storage.chunks.get(ChunkKey{ .x = cx, .z = cz - 1 })) |d| d: {
+                d.chunk.pin();
+                break :d &d.chunk;
+            } else null,
+            .south = if (self.storage.chunks.get(ChunkKey{ .x = cx, .z = cz + 1 })) |d| d: {
+                d.chunk.pin();
+                break :d &d.chunk;
+            } else null,
+            .east = if (self.storage.chunks.get(ChunkKey{ .x = cx + 1, .z = cz })) |d| d: {
+                d.chunk.pin();
+                break :d &d.chunk;
+            } else null,
+            .west = if (self.storage.chunks.get(ChunkKey{ .x = cx - 1, .z = cz })) |d| d: {
+                d.chunk.pin();
+                break :d &d.chunk;
+            } else null,
+        };
+        self.storage.chunks_mutex.unlockShared();
+
+        defer {
+            chunk_data.chunk.unpin();
+            if (neighbors.north) |n| @as(*Chunk, @constCast(n)).unpin();
+            if (neighbors.south) |s| @as(*Chunk, @constCast(s)).unpin();
+            if (neighbors.east) |e| @as(*Chunk, @constCast(e)).unpin();
+            if (neighbors.west) |w| @as(*Chunk, @constCast(w)).unpin();
+        }
+
+        if (chunk_data.chunk.state == .meshing and chunk_data.chunk.job_token == job.data.chunk.job_token) {
+            chunk_data.mesh.buildWithNeighbors(&chunk_data.chunk, neighbors) catch |err| {
+                log.log.err("Mesh build failed for chunk ({}, {}): {}", .{ cx, cz, err });
+            };
+            if (self.mesh_queue.abort_worker) {
+                chunk_data.chunk.state = .generated;
+                return;
+            }
+            chunk_data.chunk.state = .mesh_ready;
+        }
+    }
+
+    fn markNeighborsForRemesh(self: *WorldStreamer, cx: i32, cz: i32) void {
+        const offsets = [_][2]i32{ .{ 0, 1 }, .{ 0, -1 }, .{ 1, 0 }, .{ -1, 0 } };
+        self.storage.chunks_mutex.lockShared();
+        defer self.storage.chunks_mutex.unlockShared();
+        for (offsets) |off| {
+            if (self.storage.chunks.get(ChunkKey{ .x = cx + off[0], .z = cz + off[1] })) |data| {
+                if (data.chunk.state == .renderable) {
+                    data.chunk.state = .generated;
+                } else if (data.chunk.state == .mesh_ready or data.chunk.state == .uploading or data.chunk.state == .meshing) {
+                    data.chunk.dirty = true;
+                }
+            }
+        }
+    }
+
+    pub fn getStats(self: *WorldStreamer) struct { gen_queue: usize, mesh_queue: usize, upload_queue: usize } {
+        self.gen_queue.mutex.lock();
+        const gen_count = self.gen_queue.jobs.count();
+        self.gen_queue.mutex.unlock();
+
+        self.mesh_queue.mutex.lock();
+        const mesh_count = self.mesh_queue.jobs.count();
+        self.mesh_queue.mutex.unlock();
+
+        return .{
+            .gen_queue = gen_count,
+            .mesh_queue = mesh_count,
+            .upload_queue = self.upload_queue.count(),
+        };
+    }
+};


### PR DESCRIPTION
This PR resolves Issue #146 by refactoring the `World` and `App` "God Objects" into smaller, single-responsibility components.

## Changes
- **World Decomposition**:
    - Extracted `ChunkStorage` for thread-safe chunk management.
    - Extracted `WorldStreamer` for async chunk loading/unloading and job management.
    - Extracted `WorldRenderer` for rendering logic and MDI buffer management.
    - `World` is now a lightweight coordinator.
- **App Decomposition**:
    - Created `GameSession` to encapsulate gameplay state (`World`, `Player`, `Inventory`).
    - Created `InputMapper` to abstract raw inputs into `GameAction`s.
    - `App` now manages high-level application state and menus.
- **JobSystem Generalization**:
    - Refactored `Job` to use a tagged union, supporting generic background tasks.
- **Stability Fixes**:
    - Fixed a shutdown crash caused by incorrect deinitialization order (`ChunkStorage` vs `GlobalVertexAllocator`).
    - Added proper cleanup for Vulkan debug buffers.

## Verification
- `zig build` passes.
- The game runs and shuts down without crashing.
- Render distance and LOD systems continue to function as expected.