### PR TITLE
Implement missing tree and mushroom schematics

### DIFF
--- a/src/engine/graphics/texture_atlas.zig
+++ b/src/engine/graphics/texture_atlas.zig
@@ -100,6 +100,13 @@ pub const TextureAtlas = struct {
     pub const TILE_FLOWER_RED: u8 = 44;
     pub const TILE_FLOWER_YELLOW: u8 = 45;
     pub const TILE_DEAD_BUSH: u8 = 46;
+    pub const TILE_BIRCH_LOG_SIDE: u8 = 47;
+    pub const TILE_BIRCH_LOG_TOP: u8 = 48;
+    pub const TILE_BIRCH_LEAVES: u8 = 49;
+    pub const TILE_SPRUCE_LOG_SIDE: u8 = 50;
+    pub const TILE_SPRUCE_LOG_TOP: u8 = 51;
+    pub const TILE_SPRUCE_LEAVES: u8 = 52;
+    pub const TILE_VINE: u8 = 53;
 
     /// Block type to tile mapping
     pub fn getTilesForBlock(block_id: u8) BlockTiles {
@@ -144,6 +151,11 @@ pub const TextureAtlas = struct {
             37 => BlockTiles.uniform(TILE_FLOWER_RED),
             38 => BlockTiles.uniform(TILE_FLOWER_YELLOW),
             39 => BlockTiles.uniform(TILE_DEAD_BUSH),
+            40 => .{ .top = TILE_BIRCH_LOG_TOP, .bottom = TILE_BIRCH_LOG_TOP, .side = TILE_BIRCH_LOG_SIDE },
+            41 => BlockTiles.uniform(TILE_BIRCH_LEAVES),
+            42 => .{ .top = TILE_SPRUCE_LOG_TOP, .bottom = TILE_SPRUCE_LOG_TOP, .side = TILE_SPRUCE_LOG_SIDE },
+            43 => BlockTiles.uniform(TILE_SPRUCE_LEAVES),
+            44 => BlockTiles.uniform(TILE_VINE),
             else => BlockTiles.uniform(0),
         };
     }
@@ -242,6 +254,13 @@ pub const TextureAtlas = struct {
         .{ .index = TILE_FLOWER_RED, .name = "flower_red", .block = .flower_red },
         .{ .index = TILE_FLOWER_YELLOW, .name = "flower_yellow", .block = .flower_yellow },
         .{ .index = TILE_DEAD_BUSH, .name = "dead_bush", .block = .dead_bush },
+        .{ .index = TILE_BIRCH_LOG_SIDE, .name = "birch_log_side", .block = .birch_log },
+        .{ .index = TILE_BIRCH_LOG_TOP, .name = "birch_log_top", .block = .birch_log },
+        .{ .index = TILE_BIRCH_LEAVES, .name = "birch_leaves", .block = .birch_leaves },
+        .{ .index = TILE_SPRUCE_LOG_SIDE, .name = "spruce_log_side", .block = .spruce_log },
+        .{ .index = TILE_SPRUCE_LOG_TOP, .name = "spruce_log_top", .block = .spruce_log },
+        .{ .index = TILE_SPRUCE_LEAVES, .name = "spruce_leaves", .block = .spruce_leaves },
+        .{ .index = TILE_VINE, .name = "vine", .block = .vine },
     };
 
     pub fn init(allocator: std.mem.Allocator, rhi_instance: rhi.RHI, pack_manager: ?*resource_pack.ResourcePackManager, max_resolution: u32) !TextureAtlas {

--- a/src/world/block.zig
+++ b/src/world/block.zig
@@ -114,13 +114,18 @@ pub const BlockType = enum(u8) {
     flower_red = 37,
     flower_yellow = 38,
     dead_bush = 39,
+    birch_log = 40,
+    birch_leaves = 41,
+    spruce_log = 42,
+    spruce_leaves = 43,
+    vine = 44,
 
     _,
 
     /// Returns true if block color should be multiplied by biome tint
     pub fn isTintable(self: BlockType) bool {
         return switch (self) {
-            .leaves, .mangrove_leaves, .jungle_leaves, .acacia_leaves, .tall_grass, .water => true,
+            .leaves, .mangrove_leaves, .jungle_leaves, .acacia_leaves, .birch_leaves, .spruce_leaves, .vine, .tall_grass, .water => true,
             else => false,
         };
     }
@@ -138,7 +143,7 @@ pub const BlockType = enum(u8) {
 
     pub fn isTransparent(self: BlockType) bool {
         return switch (self) {
-            .air, .water, .glass, .leaves, .mangrove_leaves, .mangrove_roots, .jungle_leaves, .bamboo, .acacia_leaves, .acacia_sapling, .tall_grass, .flower_red, .flower_yellow, .dead_bush, .cactus, .melon => true,
+            .air, .water, .glass, .leaves, .mangrove_leaves, .mangrove_roots, .jungle_leaves, .bamboo, .acacia_leaves, .acacia_sapling, .birch_leaves, .spruce_leaves, .vine, .tall_grass, .flower_red, .flower_yellow, .dead_bush, .cactus, .melon => true,
             else => false,
         };
     }
@@ -146,7 +151,7 @@ pub const BlockType = enum(u8) {
     /// Returns true if block completely blocks light propagation
     pub fn isOpaque(self: BlockType) bool {
         return switch (self) {
-            .air, .water, .glass, .leaves, .mangrove_leaves, .mangrove_roots, .jungle_leaves, .bamboo, .acacia_leaves, .acacia_sapling, .tall_grass, .flower_red, .flower_yellow, .dead_bush, .cactus, .melon => false,
+            .air, .water, .glass, .leaves, .mangrove_leaves, .mangrove_roots, .jungle_leaves, .bamboo, .acacia_leaves, .acacia_sapling, .birch_leaves, .spruce_leaves, .vine, .tall_grass, .flower_red, .flower_yellow, .dead_bush, .cactus, .melon => false,
             else => true,
         };
     }
@@ -204,6 +209,11 @@ pub const BlockType = enum(u8) {
             .flower_red => .{ 0.9, 0.1, 0.1 },
             .flower_yellow => .{ 0.9, 0.9, 0.1 },
             .dead_bush => .{ 0.4, 0.3, 0.1 },
+            .birch_log => .{ 0.8, 0.8, 0.75 },
+            .birch_leaves => .{ 0.3, 0.7, 0.2 },
+            .spruce_log => .{ 0.35, 0.25, 0.15 },
+            .spruce_leaves => .{ 0.15, 0.4, 0.15 },
+            .vine => .{ 0.2, 0.5, 0.1 },
             _ => .{ 1, 0, 1 }, // Magenta for unknown
         };
     }

--- a/src/world/worldgen/decoration_registry.zig
+++ b/src/world/worldgen/decoration_registry.zig
@@ -75,18 +75,18 @@ pub const DECORATIONS = [_]Decoration{
         },
     },
 
-    // === Trees: Sparse (Plains, Swamp, Mountains) ===
+    // === Trees: Sparse (Plains, Mountains) ===
     .{
         .schematic = .{
             .schematic = schematics.OAK_TREE,
             .place_on = &.{ .grass, .dirt },
-            .biomes = &.{ .plains, .swamp, .mountains },
+            .biomes = &.{ .plains, .mountains },
             .probability = 0.002, // Very sparse
             .spacing_radius = 4,
         },
     },
 
-    // === Trees: Standard Forest (Variant -0.4 to 0.4) ===
+    // === Forest: Oak Trees (Standard) ===
     .{ .schematic = .{
         .schematic = schematics.OAK_TREE,
         .place_on = &.{ .grass, .dirt },
@@ -97,17 +97,101 @@ pub const DECORATIONS = [_]Decoration{
         .variant_max = 0.4,
     } },
 
-    // === Trees: Dense Forest (Variant > 0.4) ===
+    // === Forest: Birch Trees (Standard) ===
+    .{ .schematic = .{
+        .schematic = schematics.BIRCH_TREE,
+        .place_on = &.{ .grass, .dirt },
+        .biomes = &.{.forest},
+        .probability = 0.015,
+        .spacing_radius = 3,
+        .variant_min = 0.0,
+        .variant_max = 0.6,
+    } },
+
+    // === Forest: Dense Oak (Variant > 0.4) ===
     .{
         .schematic = .{
             .schematic = schematics.OAK_TREE,
             .place_on = &.{ .grass, .dirt },
             .biomes = &.{.forest},
-            .probability = 0.15, // Dense!
+            .probability = 0.1,
             .spacing_radius = 2,
             .variant_min = 0.4,
         },
     },
 
-    // Note: Forest with variant < -0.4 has NO trees (Clearing)
+    // === Taiga: Spruce Trees ===
+    .{
+        .schematic = .{
+            .schematic = schematics.SPRUCE_TREE,
+            .place_on = &.{ .grass, .dirt, .snow_block },
+            .biomes = &.{ .taiga, .snow_tundra },
+            .probability = 0.08,
+            .spacing_radius = 3,
+        },
+    },
+
+    // === Swamp: Swamp Oak ===
+    .{
+        .schematic = .{
+            .schematic = schematics.SWAMP_OAK,
+            .place_on = &.{ .grass, .dirt },
+            .biomes = &.{.swamp},
+            .probability = 0.05,
+            .spacing_radius = 4,
+        },
+    },
+
+    // === Mangrove Swamp: Mangrove Trees ===
+    .{
+        .schematic = .{
+            .schematic = schematics.MANGROVE_TREE,
+            .place_on = &.{ .mud, .grass },
+            .biomes = &.{.mangrove_swamp},
+            .probability = 0.12,
+            .spacing_radius = 3,
+        },
+    },
+
+    // === Jungle: Jungle Trees ===
+    .{
+        .schematic = .{
+            .schematic = schematics.JUNGLE_TREE,
+            .place_on = &.{ .grass, .dirt },
+            .biomes = &.{.jungle},
+            .probability = 0.15,
+            .spacing_radius = 2,
+        },
+    },
+
+    // === Savanna: Acacia Trees ===
+    .{
+        .schematic = .{
+            .schematic = schematics.ACACIA_TREE,
+            .place_on = &.{ .grass, .dirt },
+            .biomes = &.{.savanna},
+            .probability = 0.015,
+            .spacing_radius = 5,
+        },
+    },
+
+    // === Mushroom Fields: Huge Mushrooms ===
+    .{
+        .schematic = .{
+            .schematic = schematics.HUGE_RED_MUSHROOM,
+            .place_on = &.{.mycelium},
+            .biomes = &.{.mushroom_fields},
+            .probability = 0.03,
+            .spacing_radius = 4,
+        },
+    },
+    .{
+        .schematic = .{
+            .schematic = schematics.HUGE_BROWN_MUSHROOM,
+            .place_on = &.{.mycelium},
+            .biomes = &.{.mushroom_fields},
+            .probability = 0.03,
+            .spacing_radius = 4,
+        },
+    },
 };

--- a/src/world/worldgen/schematics.zig
+++ b/src/world/worldgen/schematics.zig
@@ -7,39 +7,371 @@ const decoration_types = @import("decoration_types.zig");
 const Schematic = decoration_types.Schematic;
 const SchematicBlock = decoration_types.SchematicBlock;
 
-const LOG = BlockType.wood;
-const LEAVES = BlockType.leaves;
+const OAK_LOG = BlockType.wood;
+const OAK_LEAVES = BlockType.leaves;
+
+const BIRCH_LOG = BlockType.birch_log;
+const BIRCH_LEAVES = BlockType.birch_leaves;
+
+const SPRUCE_LOG = BlockType.spruce_log;
+const SPRUCE_LEAVES = BlockType.spruce_leaves;
+
+const MANGROVE_LOG = BlockType.mangrove_log;
+const MANGROVE_LEAVES = BlockType.mangrove_leaves;
+const MANGROVE_ROOTS = BlockType.mangrove_roots;
+
+const JUNGLE_LOG = BlockType.jungle_log;
+const JUNGLE_LEAVES = BlockType.jungle_leaves;
+
+const ACACIA_LOG = BlockType.acacia_log;
+const ACACIA_LEAVES = BlockType.acacia_leaves;
+
+const VINE = BlockType.vine;
+
+const MUSHROOM_STEM = BlockType.mushroom_stem;
+const RED_MUSHROOM_BLOCK = BlockType.red_mushroom_block;
+const BROWN_MUSHROOM_BLOCK = BlockType.brown_mushroom_block;
 
 pub const OAK_TREE = Schematic{
     .blocks = &[_]SchematicBlock{
         // Trunk
-        .{ .offset = .{ 0, 0, 0 }, .block = LOG },
-        .{ .offset = .{ 0, 1, 0 }, .block = LOG },
-        .{ .offset = .{ 0, 2, 0 }, .block = LOG },
-        .{ .offset = .{ 0, 3, 0 }, .block = LOG },
+        .{ .offset = .{ 0, 0, 0 }, .block = OAK_LOG },
+        .{ .offset = .{ 0, 1, 0 }, .block = OAK_LOG },
+        .{ .offset = .{ 0, 2, 0 }, .block = OAK_LOG },
+        .{ .offset = .{ 0, 3, 0 }, .block = OAK_LOG },
         // Leaves Layer 1
-        .{ .offset = .{ 1, 2, 0 }, .block = LEAVES },
-        .{ .offset = .{ -1, 2, 0 }, .block = LEAVES },
-        .{ .offset = .{ 0, 2, 1 }, .block = LEAVES },
-        .{ .offset = .{ 0, 2, -1 }, .block = LEAVES },
+        .{ .offset = .{ 1, 2, 0 }, .block = OAK_LEAVES },
+        .{ .offset = .{ -1, 2, 0 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 0, 2, 1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 0, 2, -1 }, .block = OAK_LEAVES },
         // Leaves Layer 2
-        .{ .offset = .{ 1, 3, 0 }, .block = LEAVES },
-        .{ .offset = .{ -1, 3, 0 }, .block = LEAVES },
-        .{ .offset = .{ 0, 3, 1 }, .block = LEAVES },
-        .{ .offset = .{ 0, 3, -1 }, .block = LEAVES },
-        .{ .offset = .{ 1, 3, 1 }, .block = LEAVES },
-        .{ .offset = .{ -1, 3, 1 }, .block = LEAVES },
-        .{ .offset = .{ 1, 3, -1 }, .block = LEAVES },
-        .{ .offset = .{ -1, 3, -1 }, .block = LEAVES },
+        .{ .offset = .{ 1, 3, 0 }, .block = OAK_LEAVES },
+        .{ .offset = .{ -1, 3, 0 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 0, 3, 1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 0, 3, -1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 1, 3, 1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ -1, 3, 1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 1, 3, -1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ -1, 3, -1 }, .block = OAK_LEAVES },
         // Top
-        .{ .offset = .{ 0, 4, 0 }, .block = LEAVES },
-        .{ .offset = .{ 0, 4, 1 }, .block = LEAVES },
-        .{ .offset = .{ 0, 4, -1 }, .block = LEAVES },
-        .{ .offset = .{ 1, 4, 0 }, .block = LEAVES },
-        .{ .offset = .{ -1, 4, 0 }, .block = LEAVES },
+        .{ .offset = .{ 0, 4, 0 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 0, 4, 1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 0, 4, -1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 1, 4, 0 }, .block = OAK_LEAVES },
+        .{ .offset = .{ -1, 4, 0 }, .block = OAK_LEAVES },
     },
     .size_x = 5,
     .size_y = 6,
+    .size_z = 5,
+    .center_x = 0,
+    .center_z = 0,
+};
+
+pub const BIRCH_TREE = Schematic{
+    .blocks = &[_]SchematicBlock{
+        // Trunk (5 blocks tall)
+        .{ .offset = .{ 0, 0, 0 }, .block = BIRCH_LOG },
+        .{ .offset = .{ 0, 1, 0 }, .block = BIRCH_LOG },
+        .{ .offset = .{ 0, 2, 0 }, .block = BIRCH_LOG },
+        .{ .offset = .{ 0, 3, 0 }, .block = BIRCH_LOG },
+        .{ .offset = .{ 0, 4, 0 }, .block = BIRCH_LOG },
+        // Leaves Layer 1
+        .{ .offset = .{ 1, 3, 0 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ -1, 3, 0 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ 0, 3, 1 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ 0, 3, -1 }, .block = BIRCH_LEAVES },
+        // Leaves Layer 2
+        .{ .offset = .{ 1, 4, 0 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ -1, 4, 0 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ 0, 4, 1 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ 0, 4, -1 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ 1, 4, 1 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ -1, 4, 1 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ 1, 4, -1 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ -1, 4, -1 }, .block = BIRCH_LEAVES },
+        // Top
+        .{ .offset = .{ 0, 5, 0 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ 0, 5, 1 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ 0, 5, -1 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ 1, 5, 0 }, .block = BIRCH_LEAVES },
+        .{ .offset = .{ -1, 5, 0 }, .block = BIRCH_LEAVES },
+    },
+    .size_x = 5,
+    .size_y = 7,
+    .size_z = 5,
+    .center_x = 0,
+    .center_z = 0,
+};
+
+pub const SPRUCE_TREE = Schematic{
+    .blocks = &[_]SchematicBlock{
+        // Trunk (6 blocks tall)
+        .{ .offset = .{ 0, 0, 0 }, .block = SPRUCE_LOG },
+        .{ .offset = .{ 0, 1, 0 }, .block = SPRUCE_LOG },
+        .{ .offset = .{ 0, 2, 0 }, .block = SPRUCE_LOG },
+        .{ .offset = .{ 0, 3, 0 }, .block = SPRUCE_LOG },
+        .{ .offset = .{ 0, 4, 0 }, .block = SPRUCE_LOG },
+        .{ .offset = .{ 0, 5, 0 }, .block = SPRUCE_LOG },
+        // Bottom Conical Layer (Level 2)
+        .{ .offset = .{ 1, 2, 0 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ -1, 2, 0 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 0, 2, 1 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 0, 2, -1 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 1, 2, 1 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ -1, 2, 1 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 1, 2, -1 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ -1, 2, -1 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 2, 2, 0 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ -2, 2, 0 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 0, 2, 2 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 0, 2, -2 }, .block = SPRUCE_LEAVES },
+        // Middle Conical Layer (Level 4)
+        .{ .offset = .{ 1, 4, 0 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ -1, 4, 0 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 0, 4, 1 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 0, 4, -1 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 1, 4, 1 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ -1, 4, 1 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 1, 4, -1 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ -1, 4, -1 }, .block = SPRUCE_LEAVES },
+        // Top Conical Layer (Level 6)
+        .{ .offset = .{ 0, 6, 0 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 1, 5, 0 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ -1, 5, 0 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 0, 5, 1 }, .block = SPRUCE_LEAVES },
+        .{ .offset = .{ 0, 5, -1 }, .block = SPRUCE_LEAVES },
+    },
+    .size_x = 5,
+    .size_y = 8,
+    .size_z = 5,
+    .center_x = 0,
+    .center_z = 0,
+};
+
+pub const SWAMP_OAK = Schematic{
+    .blocks = &[_]SchematicBlock{
+        // Trunk
+        .{ .offset = .{ 0, 0, 0 }, .block = OAK_LOG },
+        .{ .offset = .{ 0, 1, 0 }, .block = OAK_LOG },
+        .{ .offset = .{ 0, 2, 0 }, .block = OAK_LOG },
+        .{ .offset = .{ 0, 3, 0 }, .block = OAK_LOG },
+        // Leaves Layer 1
+        .{ .offset = .{ 1, 2, 0 }, .block = OAK_LEAVES },
+        .{ .offset = .{ -1, 2, 0 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 0, 2, 1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 0, 2, -1 }, .block = OAK_LEAVES },
+        // Leaves Layer 2
+        .{ .offset = .{ 1, 3, 0 }, .block = OAK_LEAVES },
+        .{ .offset = .{ -1, 3, 0 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 0, 3, 1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 0, 3, -1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 1, 3, 1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ -1, 3, 1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 1, 3, -1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ -1, 3, -1 }, .block = OAK_LEAVES },
+        // Top
+        .{ .offset = .{ 0, 4, 0 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 0, 4, 1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 0, 4, -1 }, .block = OAK_LEAVES },
+        .{ .offset = .{ 1, 4, 0 }, .block = OAK_LEAVES },
+        .{ .offset = .{ -1, 4, 0 }, .block = OAK_LEAVES },
+        // Vines
+        .{ .offset = .{ 1, 1, 0 }, .block = VINE, .probability = 0.5 },
+        .{ .offset = .{ -1, 1, 0 }, .block = VINE, .probability = 0.5 },
+        .{ .offset = .{ 0, 1, 1 }, .block = VINE, .probability = 0.5 },
+        .{ .offset = .{ 0, 1, -1 }, .block = VINE, .probability = 0.5 },
+        .{ .offset = .{ 1, 2, 1 }, .block = VINE, .probability = 0.5 },
+        .{ .offset = .{ -1, 2, 1 }, .block = VINE, .probability = 0.5 },
+    },
+    .size_x = 5,
+    .size_y = 6,
+    .size_z = 5,
+    .center_x = 0,
+    .center_z = 0,
+};
+
+pub const JUNGLE_TREE = Schematic{
+    .blocks = &[_]SchematicBlock{
+        // Trunk (8 blocks tall)
+        .{ .offset = .{ 0, 0, 0 }, .block = JUNGLE_LOG },
+        .{ .offset = .{ 0, 1, 0 }, .block = JUNGLE_LOG },
+        .{ .offset = .{ 0, 2, 0 }, .block = JUNGLE_LOG },
+        .{ .offset = .{ 0, 3, 0 }, .block = JUNGLE_LOG },
+        .{ .offset = .{ 0, 4, 0 }, .block = JUNGLE_LOG },
+        .{ .offset = .{ 0, 5, 0 }, .block = JUNGLE_LOG },
+        .{ .offset = .{ 0, 6, 0 }, .block = JUNGLE_LOG },
+        .{ .offset = .{ 0, 7, 0 }, .block = JUNGLE_LOG },
+        // Large Canopy Level 1 (y=6)
+        .{ .offset = .{ 1, 6, 0 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ -1, 6, 0 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 0, 6, 1 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 0, 6, -1 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 1, 6, 1 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ -1, 6, 1 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 1, 6, -1 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ -1, 6, -1 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 2, 6, 0 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ -2, 6, 0 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 0, 6, 2 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 0, 6, -2 }, .block = JUNGLE_LEAVES },
+        // Large Canopy Level 2 (y=7)
+        .{ .offset = .{ 1, 7, 0 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ -1, 7, 0 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 0, 7, 1 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 0, 7, -1 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 1, 7, 1 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ -1, 7, 1 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 1, 7, -1 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ -1, 7, -1 }, .block = JUNGLE_LEAVES },
+        // Top
+        .{ .offset = .{ 0, 8, 0 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 1, 8, 0 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ -1, 8, 0 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 0, 8, 1 }, .block = JUNGLE_LEAVES },
+        .{ .offset = .{ 0, 8, -1 }, .block = JUNGLE_LEAVES },
+        // Vines
+        .{ .offset = .{ 1, 3, 0 }, .block = VINE, .probability = 0.7 },
+        .{ .offset = .{ -1, 4, 0 }, .block = VINE, .probability = 0.7 },
+        .{ .offset = .{ 0, 2, 1 }, .block = VINE, .probability = 0.7 },
+        .{ .offset = .{ 0, 5, -1 }, .block = VINE, .probability = 0.7 },
+    },
+    .size_x = 5,
+    .size_y = 10,
+    .size_z = 5,
+    .center_x = 0,
+    .center_z = 0,
+};
+
+pub const ACACIA_TREE = Schematic{
+    .blocks = &[_]SchematicBlock{
+        // Trunk
+        .{ .offset = .{ 0, 0, 0 }, .block = ACACIA_LOG },
+        .{ .offset = .{ 0, 1, 0 }, .block = ACACIA_LOG },
+        .{ .offset = .{ 1, 2, 0 }, .block = ACACIA_LOG },
+        .{ .offset = .{ 2, 3, 0 }, .block = ACACIA_LOG },
+        .{ .offset = .{ 2, 4, 0 }, .block = ACACIA_LOG },
+        // Flat Canopy
+        .{ .offset = .{ 2, 4, 0 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 1, 4, 0 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 3, 4, 0 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 2, 4, 1 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 2, 4, -1 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 1, 4, 1 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 1, 4, -1 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 3, 4, 1 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 3, 4, -1 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 0, 4, 0 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 4, 4, 0 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 2, 4, 2 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 2, 4, -2 }, .block = ACACIA_LEAVES },
+        // Top flat layer
+        .{ .offset = .{ 2, 5, 0 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 1, 5, 0 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 3, 5, 0 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 2, 5, 1 }, .block = ACACIA_LEAVES },
+        .{ .offset = .{ 2, 5, -1 }, .block = ACACIA_LEAVES },
+    },
+    .size_x = 5,
+    .size_y = 7,
+    .size_z = 5,
+    .center_x = 0,
+    .center_z = 0,
+};
+
+pub const MANGROVE_TREE = Schematic{
+    .blocks = &[_]SchematicBlock{
+        // Prop Roots (Y starting below surface)
+        .{ .offset = .{ 1, -1, 0 }, .block = MANGROVE_ROOTS },
+        .{ .offset = .{ -1, -1, 0 }, .block = MANGROVE_ROOTS },
+        .{ .offset = .{ 0, -1, 1 }, .block = MANGROVE_ROOTS },
+        .{ .offset = .{ 0, -1, -1 }, .block = MANGROVE_ROOTS },
+        .{ .offset = .{ 1, 0, 0 }, .block = MANGROVE_ROOTS },
+        .{ .offset = .{ -1, 0, 0 }, .block = MANGROVE_ROOTS },
+        .{ .offset = .{ 0, 0, 1 }, .block = MANGROVE_ROOTS },
+        .{ .offset = .{ 0, 0, -1 }, .block = MANGROVE_ROOTS },
+        // Trunk
+        .{ .offset = .{ 0, 1, 0 }, .block = MANGROVE_LOG },
+        .{ .offset = .{ 0, 2, 0 }, .block = MANGROVE_LOG },
+        .{ .offset = .{ 0, 3, 0 }, .block = MANGROVE_LOG },
+        .{ .offset = .{ 0, 4, 0 }, .block = MANGROVE_LOG },
+        // Canopy
+        .{ .offset = .{ 1, 3, 0 }, .block = MANGROVE_LEAVES },
+        .{ .offset = .{ -1, 3, 0 }, .block = MANGROVE_LEAVES },
+        .{ .offset = .{ 0, 3, 1 }, .block = MANGROVE_LEAVES },
+        .{ .offset = .{ 0, 3, -1 }, .block = MANGROVE_LEAVES },
+        .{ .offset = .{ 1, 4, 0 }, .block = MANGROVE_LEAVES },
+        .{ .offset = .{ -1, 4, 0 }, .block = MANGROVE_LEAVES },
+        .{ .offset = .{ 0, 4, 1 }, .block = MANGROVE_LEAVES },
+        .{ .offset = .{ 0, 4, -1 }, .block = MANGROVE_LEAVES },
+        .{ .offset = .{ 0, 5, 0 }, .block = MANGROVE_LEAVES },
+    },
+    .size_x = 5,
+    .size_y = 8,
+    .size_z = 5,
+    .center_x = 0,
+    .center_z = 0,
+};
+
+pub const HUGE_RED_MUSHROOM = Schematic{
+    .blocks = &[_]SchematicBlock{
+        // Stem
+        .{ .offset = .{ 0, 0, 0 }, .block = MUSHROOM_STEM },
+        .{ .offset = .{ 0, 1, 0 }, .block = MUSHROOM_STEM },
+        .{ .offset = .{ 0, 2, 0 }, .block = MUSHROOM_STEM },
+        // Cap
+        .{ .offset = .{ 0, 3, 0 }, .block = RED_MUSHROOM_BLOCK },
+        .{ .offset = .{ 1, 3, 0 }, .block = RED_MUSHROOM_BLOCK },
+        .{ .offset = .{ -1, 3, 0 }, .block = RED_MUSHROOM_BLOCK },
+        .{ .offset = .{ 0, 3, 1 }, .block = RED_MUSHROOM_BLOCK },
+        .{ .offset = .{ 0, 3, -1 }, .block = RED_MUSHROOM_BLOCK },
+        .{ .offset = .{ 1, 3, 1 }, .block = RED_MUSHROOM_BLOCK },
+        .{ .offset = .{ -1, 3, 1 }, .block = RED_MUSHROOM_BLOCK },
+        .{ .offset = .{ 1, 3, -1 }, .block = RED_MUSHROOM_BLOCK },
+        .{ .offset = .{ -1, 3, -1 }, .block = RED_MUSHROOM_BLOCK },
+        // Cap edges (Level 2)
+        .{ .offset = .{ 2, 2, 0 }, .block = RED_MUSHROOM_BLOCK },
+        .{ .offset = .{ -2, 2, 0 }, .block = RED_MUSHROOM_BLOCK },
+        .{ .offset = .{ 0, 2, 2 }, .block = RED_MUSHROOM_BLOCK },
+        .{ .offset = .{ 0, 2, -2 }, .block = RED_MUSHROOM_BLOCK },
+    },
+    .size_x = 5,
+    .size_y = 5,
+    .size_z = 5,
+    .center_x = 0,
+    .center_z = 0,
+};
+
+pub const HUGE_BROWN_MUSHROOM = Schematic{
+    .blocks = &[_]SchematicBlock{
+        // Stem
+        .{ .offset = .{ 0, 0, 0 }, .block = MUSHROOM_STEM },
+        .{ .offset = .{ 0, 1, 0 }, .block = MUSHROOM_STEM },
+        .{ .offset = .{ 0, 2, 0 }, .block = MUSHROOM_STEM },
+        // Flat Cap
+        .{ .offset = .{ 0, 3, 0 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ 1, 3, 0 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ -1, 3, 0 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ 0, 3, 1 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ 0, 3, -1 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ 1, 3, 1 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ -1, 3, 1 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ 1, 3, -1 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ -1, 3, -1 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ 2, 3, 0 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ -2, 3, 0 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ 0, 3, 2 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ 0, 3, -2 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ 2, 3, 1 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ 2, 3, -1 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ -2, 3, 1 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ -2, 3, -1 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ 1, 3, 2 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ -1, 3, 2 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ 1, 3, -2 }, .block = BROWN_MUSHROOM_BLOCK },
+        .{ .offset = .{ -1, 3, -2 }, .block = BROWN_MUSHROOM_BLOCK },
+    },
+    .size_x = 5,
+    .size_y = 5,
     .size_z = 5,
     .center_x = 0,
     .center_z = 0,
@@ -55,9 +387,70 @@ test "OAK_TREE properties" {
     var log_count: usize = 0;
     var leaf_count: usize = 0;
     for (OAK_TREE.blocks) |b| {
-        if (b.block == LOG) log_count += 1;
-        if (b.block == LEAVES) leaf_count += 1;
+        if (b.block == OAK_LOG) log_count += 1;
+        if (b.block == OAK_LEAVES) leaf_count += 1;
     }
     try std.testing.expectEqual(@as(usize, 4), log_count);
     try std.testing.expectEqual(@as(usize, 17), leaf_count);
+}
+
+test "BIRCH_TREE properties" {
+    const std = @import("std");
+    try std.testing.expectEqual(@as(i32, 5), BIRCH_TREE.size_x);
+    try std.testing.expectEqual(@as(i32, 7), BIRCH_TREE.size_y);
+    try std.testing.expectEqual(@as(i32, 5), BIRCH_TREE.size_z);
+
+    var log_count: usize = 0;
+    var leaf_count: usize = 0;
+    for (BIRCH_TREE.blocks) |b| {
+        if (b.block == BIRCH_LOG) log_count += 1;
+        if (b.block == BIRCH_LEAVES) leaf_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 5), log_count);
+    try std.testing.expect(leaf_count > 10);
+}
+
+test "SPRUCE_TREE properties" {
+    const std = @import("std");
+    try std.testing.expectEqual(@as(i32, 8), SPRUCE_TREE.size_y);
+
+    var log_count: usize = 0;
+    var leaf_count: usize = 0;
+    for (SPRUCE_TREE.blocks) |b| {
+        if (b.block == SPRUCE_LOG) log_count += 1;
+        if (b.block == SPRUCE_LEAVES) leaf_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 6), log_count);
+    try std.testing.expect(leaf_count > 15);
+}
+
+test "JUNGLE_TREE properties" {
+    const std = @import("std");
+    try std.testing.expectEqual(@as(i32, 10), JUNGLE_TREE.size_y);
+
+    var log_count: usize = 0;
+    var leaf_count: usize = 0;
+    for (JUNGLE_TREE.blocks) |b| {
+        if (b.block == JUNGLE_LOG) log_count += 1;
+        if (b.block == JUNGLE_LEAVES) leaf_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 8), log_count);
+}
+
+test "HUGE_MUSHROOM properties" {
+    const std = @import("std");
+    try std.testing.expectEqual(@as(i32, 5), HUGE_RED_MUSHROOM.size_y);
+    try std.testing.expectEqual(@as(i32, 5), HUGE_BROWN_MUSHROOM.size_y);
+
+    var red_cap_count: usize = 0;
+    for (HUGE_RED_MUSHROOM.blocks) |b| {
+        if (b.block == RED_MUSHROOM_BLOCK) red_cap_count += 1;
+    }
+    try std.testing.expect(red_cap_count > 10);
+
+    var brown_cap_count: usize = 0;
+    for (HUGE_BROWN_MUSHROOM.blocks) |b| {
+        if (b.block == BROWN_MUSHROOM_BLOCK) brown_cap_count += 1;
+    }
+    try std.testing.expect(brown_cap_count > 10);
 }


### PR DESCRIPTION
## Summary
This PR implements 8 new multi-block schematics and 5 new block types to provide biome-specific vegetation, resolving issue #170.

### Changes:
- **New Block Types**: Added `birch_log`, `birch_leaves`, `spruce_log`, `spruce_leaves`, and `vine` to `BlockType`.
- **Texture Atlas Updates**: Added tile mappings for the new blocks.
- **New Schematics**:
  - `BIRCH_TREE`: White trunk, slightly taller than oak.
  - `SPRUCE_TREE`: Conical shape with dark foliage.
  - `JUNGLE_TREE`: Tall (8 blocks) with canopy and vines.
  - `ACACIA_TREE`: Diagonal trunk and flat canopy.
  - `MANGROVE_TREE`: Featuring prop roots.
  - `SWAMP_OAK`: Oak variant with hanging vines.
  - `HUGE_RED_MUSHROOM` & `HUGE_BROWN_MUSHROOM`: For mushroom fields.
- **Decoration Registry**: Updated to map these schematics to their respective biomes (Forest, Taiga, Jungle, Savanna, Swamp, Mushroom Fields).

### Verification:
- Added unit tests for new schematics in `src/world/worldgen/schematics.zig`.
- Ran `nix develop --command zig build test` (all 153 tests passed).

Fixes #170