### PR TITLE
Implement TreeRegistry for Data-Driven Tree Generation

### DIFF
--- a/src/world/worldgen/tree_registry.zig
+++ b/src/world/worldgen/tree_registry.zig
@@ -11,22 +11,18 @@ pub const TreeDefinition = struct {
 };
 
 pub const TreeRegistry = struct {
-    pub fn getTree(tree_type: TreeType) TreeDefinition {
+    pub fn getTree(tree_type: TreeType) !TreeDefinition {
         return switch (tree_type) {
             .oak => .{ .schematic = schematics.OAK_TREE },
             .birch => .{ .schematic = schematics.BIRCH_TREE },
-            .spruce => .{ .schematic = schematics.SPRUCE_TREE, .place_on = &.{ .grass, .dirt, .snow_block } },
+            .spruce => .{ .schematic = schematics.SPRUCE_TREE, .place_on = &.{ .grass, .dirt, .snow_block }, .spacing_radius = 4 },
             .swamp_oak => .{ .schematic = schematics.SWAMP_OAK, .spacing_radius = 4 },
             .mangrove => .{ .schematic = schematics.MANGROVE_TREE, .place_on = &.{ .mud, .grass } },
             .jungle => .{ .schematic = schematics.JUNGLE_TREE, .spacing_radius = 2 },
             .acacia => .{ .schematic = schematics.ACACIA_TREE, .spacing_radius = 5 },
             .huge_red_mushroom => .{ .schematic = schematics.HUGE_RED_MUSHROOM, .place_on = &.{.mycelium}, .spacing_radius = 4 },
             .huge_brown_mushroom => .{ .schematic = schematics.HUGE_BROWN_MUSHROOM, .place_on = &.{.mycelium}, .spacing_radius = 4 },
-            .none => @panic("Cannot get schematic for TreeType.none"),
+            .none => error.InvalidTreeType,
         };
-    }
-
-    pub fn getSchematic(tree_type: TreeType) Schematic {
-        return getTree(tree_type).schematic;
     }
 };


### PR DESCRIPTION
## Summary
- Implemented `src/world/worldgen/tree_registry.zig` to automatically map `TreeType` enums to schematics.
- Refactored `src/world/worldgen/decoration_registry.zig` to use `TreeRegistry` and `BiomeDefinition` for tree placement instead of hardcoded lists.
- Removes redundant tree definitions and ensures `biome.zig` is the single source of truth for vegetation.

## Changes
- Added `TreeRegistry` struct with `getTree` function.
- Updated `StandardDecorationProvider` to iterate `biome.vegetation.tree_types`.
- Removed manual `OAK_TREE`, `BIRCH_TREE`, etc. entries from `DECORATIONS`.

## Fixes
Fixes #169