### PR TITLE
Segregate IRenderContext Interface

### DIFF
--- a/src/engine/graphics/atmosphere_system.zig
+++ b/src/engine/graphics/atmosphere_system.zig
@@ -1,8 +1,10 @@
 const std = @import("std");
 const rhi = @import("rhi.zig");
 const RHI = rhi.RHI;
+const c = @import("../../c.zig").c;
 const Vec3 = @import("../math/vec3.zig").Vec3;
 const Mat4 = @import("../math/mat4.zig").Mat4;
+const log = @import("../core/log.zig");
 
 pub const AtmosphereSystem = struct {
     allocator: std.mem.Allocator,
@@ -43,21 +45,81 @@ pub const AtmosphereSystem = struct {
         self.allocator.destroy(self);
     }
 
-    pub fn renderClouds(self: *AtmosphereSystem, params: rhi.CloudParams, view_proj: Mat4) void {
-        // Phase 5 Refactor: Use RHI primitives
+    pub fn renderSky(self: *AtmosphereSystem, params: rhi.SkyParams) rhi.RhiError!void {
+        const context = self.rhi.context();
 
-        var final_params = params;
-        final_params.view_proj = view_proj;
-        final_params.cam_pos = params.cam_pos;
+        const pipeline_u64 = context.vtable.getNativeSkyPipeline(context.ptr);
+        const layout_u64 = context.vtable.getNativeSkyPipelineLayout(context.ptr);
+        const descriptor_set_u64 = context.vtable.getNativeMainDescriptorSet(context.ptr);
+        const cmd_u64 = context.vtable.getNativeCommandBuffer(context.ptr);
 
-        // 1. Bind pipeline and push constants
-        self.rhi.beginCloudPass(final_params);
+        if (pipeline_u64 == 0 or layout_u64 == 0 or cmd_u64 == 0) {
+            // Note: This may happen during early initialization before the main renderer has completed setup.
+            log.log.warn("AtmosphereSystem: Sky rendering skipped, native handles missing (pipeline={}, layout={}, cmd={})", .{ pipeline_u64 != 0, layout_u64 != 0, cmd_u64 != 0 });
+            if (pipeline_u64 == 0) return error.SkyPipelineNotReady;
+            if (layout_u64 == 0) return error.SkyPipelineLayoutNotReady;
+            if (cmd_u64 == 0) return error.CommandBufferNotReady;
+            return error.ResourceNotReady;
+        }
 
-        // 2. Bind geometry (now owned by this system)
-        self.rhi.bindBuffer(self.cloud_vbo, .vertex);
-        self.rhi.bindBuffer(self.cloud_ebo, .index);
+        const pipeline = @as(c.VkPipeline, @ptrFromInt(pipeline_u64));
+        const layout = @as(c.VkPipelineLayout, @ptrFromInt(layout_u64));
+        const descriptor_set = @as(c.VkDescriptorSet, @ptrFromInt(descriptor_set_u64));
+        const cmd = @as(c.VkCommandBuffer, @ptrFromInt(cmd_u64));
 
-        // 3. Draw
-        self.rhi.drawIndexed(self.cloud_vbo, self.cloud_ebo, 6);
+        const pc = rhi.SkyPushConstants{
+            .cam_forward = .{ params.cam_forward.x, params.cam_forward.y, params.cam_forward.z, 0.0 },
+            .cam_right = .{ params.cam_right.x, params.cam_right.y, params.cam_right.z, 0.0 },
+            .cam_up = .{ params.cam_up.x, params.cam_up.y, params.cam_up.z, 0.0 },
+            .sun_dir = .{ params.sun_dir.x, params.sun_dir.y, params.sun_dir.z, 0.0 },
+            .sky_color = .{ params.sky_color.x, params.sky_color.y, params.sky_color.z, 1.0 },
+            .horizon_color = .{ params.horizon_color.x, params.horizon_color.y, params.horizon_color.z, 1.0 },
+            .params = .{ params.aspect, params.tan_half_fov, params.sun_intensity, params.moon_intensity },
+            .time = .{ params.time, params.cam_pos.x, params.cam_pos.y, params.cam_pos.z },
+        };
+
+        c.vkCmdBindPipeline(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+        // Main descriptor set is optional for sky rendering if it only uses push constants.
+        // It may be 0 if the render pass is starting but descriptors have not yet been updated for the current frame.
+        if (descriptor_set_u64 != 0) {
+            c.vkCmdBindDescriptorSets(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0, 1, &descriptor_set, 0, null);
+        }
+        c.vkCmdPushConstants(cmd, layout, c.VK_SHADER_STAGE_VERTEX_BIT | c.VK_SHADER_STAGE_FRAGMENT_BIT, 0, @sizeOf(rhi.SkyPushConstants), &pc);
+        c.vkCmdDraw(cmd, 3, 1, 0, 0);
+    }
+
+    pub fn renderClouds(self: *AtmosphereSystem, params: rhi.CloudParams, view_proj: Mat4) rhi.RhiError!void {
+        const context = self.rhi.context();
+        const pipeline_u64 = context.vtable.getNativeCloudPipeline(context.ptr);
+        const layout_u64 = context.vtable.getNativeCloudPipelineLayout(context.ptr);
+        const cmd_u64 = context.vtable.getNativeCommandBuffer(context.ptr);
+
+        if (pipeline_u64 == 0 or layout_u64 == 0 or cmd_u64 == 0) {
+            // Note: This may happen during early initialization before the main renderer has completed setup.
+            log.log.warn("AtmosphereSystem: Cloud rendering skipped, native handles missing (pipeline={}, layout={}, cmd={})", .{ pipeline_u64 != 0, layout_u64 != 0, cmd_u64 != 0 });
+            if (pipeline_u64 == 0) return error.CloudPipelineNotReady;
+            if (layout_u64 == 0) return error.CloudPipelineLayoutNotReady;
+            if (cmd_u64 == 0) return error.CommandBufferNotReady;
+            return error.ResourceNotReady;
+        }
+
+        const pipeline = @as(c.VkPipeline, @ptrFromInt(pipeline_u64));
+        const layout = @as(c.VkPipelineLayout, @ptrFromInt(layout_u64));
+        const cmd = @as(c.VkCommandBuffer, @ptrFromInt(cmd_u64));
+
+        const pc = rhi.CloudPushConstants{
+            .view_proj = view_proj.data,
+            .camera_pos = .{ params.cam_pos.x, params.cam_pos.y, params.cam_pos.z, params.cloud_height },
+            .cloud_params = .{ params.cloud_coverage, params.cloud_scale, params.wind_offset_x, params.wind_offset_z },
+            .sun_params = .{ params.sun_dir.x, params.sun_dir.y, params.sun_dir.z, params.sun_intensity },
+            .fog_params = .{ params.fog_color.x, params.fog_color.y, params.fog_color.z, params.fog_density },
+        };
+
+        c.vkCmdBindPipeline(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+        c.vkCmdPushConstants(cmd, layout, c.VK_SHADER_STAGE_VERTEX_BIT | c.VK_SHADER_STAGE_FRAGMENT_BIT, 0, @sizeOf(rhi.CloudPushConstants), &pc);
+
+        context.bindBuffer(self.cloud_vbo, .vertex);
+        context.bindBuffer(self.cloud_ebo, .index);
+        context.drawIndexed(self.cloud_vbo, self.cloud_ebo, 6);
     }
 };

--- a/src/engine/graphics/rhi_tests.zig
+++ b/src/engine/graphics/rhi_tests.zig
@@ -1,0 +1,358 @@
+const std = @import("std");
+const testing = std.testing;
+const rhi = @import("rhi.zig");
+const Mat4 = @import("../math/mat4.zig").Mat4;
+const Vec3 = @import("../math/vec3.zig").Vec3;
+
+const MockContext = struct {
+    bind_shader_called: bool = false,
+    bind_texture_called: bool = false,
+    draw_called: bool = false,
+    sky_pipeline_requested: bool = false,
+    cloud_pipeline_requested: bool = false,
+
+    fn bindShader(ptr: *anyopaque, handle: rhi.ShaderHandle) void {
+        const self: *MockContext = @ptrCast(@alignCast(ptr));
+        _ = handle;
+        self.bind_shader_called = true;
+    }
+    fn bindTexture(ptr: *anyopaque, handle: rhi.TextureHandle, slot: u32) void {
+        const self: *MockContext = @ptrCast(@alignCast(ptr));
+        _ = handle;
+        _ = slot;
+        self.bind_texture_called = true;
+    }
+    fn bindBuffer(ptr: *anyopaque, handle: rhi.BufferHandle, usage: rhi.BufferUsage) void {
+        _ = ptr;
+        _ = handle;
+        _ = usage;
+    }
+    fn pushConstants(ptr: *anyopaque, stages: rhi.ShaderStageFlags, offset: u32, size: u32, data: *const anyopaque) void {
+        _ = ptr;
+        _ = stages;
+        _ = offset;
+        _ = size;
+        _ = data;
+    }
+    fn draw(ptr: *anyopaque, handle: rhi.BufferHandle, count: u32, mode: rhi.DrawMode) void {
+        const self: *MockContext = @ptrCast(@alignCast(ptr));
+        _ = handle;
+        _ = count;
+        _ = mode;
+        self.draw_called = true;
+    }
+    fn drawOffset(ptr: *anyopaque, handle: rhi.BufferHandle, count: u32, mode: rhi.DrawMode, offset: usize) void {
+        _ = ptr;
+        _ = handle;
+        _ = count;
+        _ = mode;
+        _ = offset;
+    }
+    fn drawIndexed(ptr: *anyopaque, vbo: rhi.BufferHandle, ebo: rhi.BufferHandle, count: u32) void {
+        _ = ptr;
+        _ = vbo;
+        _ = ebo;
+        _ = count;
+    }
+    fn drawIndirect(ptr: *anyopaque, handle: rhi.BufferHandle, command_buffer: rhi.BufferHandle, offset: usize, draw_count: u32, stride: u32) void {
+        _ = ptr;
+        _ = handle;
+        _ = command_buffer;
+        _ = offset;
+        _ = draw_count;
+        _ = stride;
+    }
+    fn drawInstance(ptr: *anyopaque, handle: rhi.BufferHandle, count: u32, instance_index: u32) void {
+        _ = ptr;
+        _ = handle;
+        _ = count;
+        _ = instance_index;
+    }
+    fn setViewport(ptr: *anyopaque, width: u32, height: u32) void {
+        _ = ptr;
+        _ = width;
+        _ = height;
+    }
+
+    fn getNativeSkyPipeline(ptr: *anyopaque) u64 {
+        const self: *MockContext = @ptrCast(@alignCast(ptr));
+        self.sky_pipeline_requested = true;
+        return 0;
+    }
+    fn getNativeSkyPipelineLayout(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeCloudPipeline(ptr: *anyopaque) u64 {
+        const self: *MockContext = @ptrCast(@alignCast(ptr));
+        self.cloud_pipeline_requested = true;
+        return 0;
+    }
+    fn getNativeCloudPipelineLayout(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeMainDescriptorSet(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeSSAOPipeline(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeSSAOPipelineLayout(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeSSAOBlurPipeline(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeSSAOBlurPipelineLayout(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeSSAODescriptorSet(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeSSAOBlurDescriptorSet(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeCommandBuffer(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeSwapchainExtent(ptr: *anyopaque) [2]u32 {
+        _ = ptr;
+        return .{ 800, 600 };
+    }
+    fn getNativeSSAOFramebuffer(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeSSAOBlurFramebuffer(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeSSAORenderPass(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeSSAOBlurRenderPass(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeSSAOParamsBuffer(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeSSAOParamsMemory(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+    fn getNativeDevice(ptr: *anyopaque) u64 {
+        _ = ptr;
+        return 0;
+    }
+
+    fn getEncoder(ptr: *anyopaque) rhi.IGraphicsCommandEncoder {
+        return .{ .ptr = ptr, .vtable = &MOCK_ENCODER_VTABLE };
+    }
+
+    fn getStateContext(ptr: *anyopaque) rhi.IRenderStateContext {
+        return .{ .ptr = ptr, .vtable = &MOCK_STATE_VTABLE };
+    }
+
+    const MOCK_RENDER_VTABLE = rhi.IRenderContext.VTable{
+        .beginFrame = undefined,
+        .endFrame = undefined,
+        .abortFrame = undefined,
+        .beginMainPass = undefined,
+        .endMainPass = undefined,
+        .beginGPass = undefined,
+        .endGPass = undefined,
+        .getEncoder = MockContext.getEncoder,
+        .getStateContext = MockContext.getStateContext,
+        .setClearColor = undefined,
+        .getNativeSkyPipeline = getNativeSkyPipeline,
+        .getNativeSkyPipelineLayout = getNativeSkyPipelineLayout,
+        .getNativeCloudPipeline = getNativeCloudPipeline,
+        .getNativeCloudPipelineLayout = getNativeCloudPipelineLayout,
+        .getNativeMainDescriptorSet = getNativeMainDescriptorSet,
+        .getNativeSSAOPipeline = getNativeSSAOPipeline,
+        .getNativeSSAOPipelineLayout = getNativeSSAOPipelineLayout,
+        .getNativeSSAOBlurPipeline = getNativeSSAOBlurPipeline,
+        .getNativeSSAOBlurPipelineLayout = getNativeSSAOBlurPipelineLayout,
+        .getNativeSSAODescriptorSet = getNativeSSAODescriptorSet,
+        .getNativeSSAOBlurDescriptorSet = getNativeSSAOBlurDescriptorSet,
+        .getNativeCommandBuffer = getNativeCommandBuffer,
+        .getNativeSwapchainExtent = getNativeSwapchainExtent,
+        .getNativeSSAOFramebuffer = getNativeSSAOFramebuffer,
+        .getNativeSSAOBlurFramebuffer = getNativeSSAOBlurFramebuffer,
+        .getNativeSSAORenderPass = getNativeSSAORenderPass,
+        .getNativeSSAOBlurRenderPass = getNativeSSAOBlurRenderPass,
+        .getNativeSSAOParamsBuffer = getNativeSSAOParamsBuffer,
+        .getNativeSSAOParamsMemory = getNativeSSAOParamsMemory,
+        .getNativeDevice = getNativeDevice,
+        .computeSSAO = undefined,
+        .drawDebugShadowMap = undefined,
+    };
+
+    const MOCK_RESOURCES_VTABLE = rhi.IResourceFactory.VTable{
+        .createBuffer = createBuffer,
+        .uploadBuffer = uploadBuffer,
+        .updateBuffer = undefined,
+        .destroyBuffer = destroyBuffer,
+        .createTexture = undefined,
+        .destroyTexture = undefined,
+        .updateTexture = undefined,
+        .createShader = undefined,
+        .destroyShader = undefined,
+        .mapBuffer = undefined,
+        .unmapBuffer = undefined,
+    };
+
+    fn createBuffer(ptr: *anyopaque, size: usize, usage: rhi.BufferUsage) rhi.BufferHandle {
+        _ = ptr;
+        _ = size;
+        _ = usage;
+        return 1;
+    }
+    fn uploadBuffer(ptr: *anyopaque, handle: rhi.BufferHandle, data: []const u8) void {
+        _ = ptr;
+        _ = handle;
+        _ = data;
+    }
+    fn destroyBuffer(ptr: *anyopaque, handle: rhi.BufferHandle) void {
+        _ = ptr;
+        _ = handle;
+    }
+
+    const MOCK_QUERY_VTABLE = rhi.IDeviceQuery.VTable{
+        .getFrameIndex = undefined,
+        .supportsIndirectFirstInstance = undefined,
+        .getMaxAnisotropy = undefined,
+        .getMaxMSAASamples = undefined,
+        .getFaultCount = undefined,
+        .waitIdle = undefined,
+    };
+
+    const MOCK_VULKAN_RHI_VTABLE = rhi.RHI.VTable{
+        .init = undefined,
+        .deinit = undefined,
+        .resources = MOCK_RESOURCES_VTABLE,
+        .render = MOCK_RENDER_VTABLE,
+        .shadow = undefined,
+        .ui = undefined,
+        .query = MOCK_QUERY_VTABLE,
+        .setWireframe = undefined,
+        .setTexturesEnabled = undefined,
+        .setVSync = undefined,
+        .setAnisotropicFiltering = undefined,
+        .setVolumetricDensity = undefined,
+        .setMSAA = undefined,
+        .recover = undefined,
+    };
+
+    const MOCK_ENCODER_VTABLE = rhi.IGraphicsCommandEncoder.VTable{
+        .bindShader = bindShader,
+        .bindTexture = bindTexture,
+        .bindBuffer = bindBuffer,
+        .pushConstants = pushConstants,
+        .draw = draw,
+        .drawOffset = drawOffset,
+        .drawIndexed = drawIndexed,
+        .drawIndirect = drawIndirect,
+        .drawInstance = drawInstance,
+        .setViewport = setViewport,
+    };
+
+    const MOCK_STATE_VTABLE = rhi.IRenderStateContext.VTable{
+        .setModelMatrix = undefined,
+        .setInstanceBuffer = undefined,
+        .setLODInstanceBuffer = undefined,
+        .updateGlobalUniforms = undefined,
+        .setTextureUniforms = undefined,
+    };
+};
+
+test "IGraphicsCommandEncoder delegation" {
+    var mock = MockContext{};
+    const encoder = MockContext.getEncoder(&mock);
+
+    encoder.bindShader(1);
+    try testing.expect(mock.bind_shader_called);
+
+    encoder.bindTexture(2, 0);
+    try testing.expect(mock.bind_texture_called);
+
+    encoder.draw(3, 3, .triangles);
+    try testing.expect(mock.draw_called);
+}
+
+test "IRenderContext getEncoder" {
+    var mock = MockContext{};
+    const ctx = rhi.IRenderContext{ .ptr = &mock, .vtable = &MockContext.MOCK_RENDER_VTABLE };
+    const encoder = ctx.getEncoder();
+
+    try testing.expectEqual(@as(?*anyopaque, &mock), encoder.ptr);
+    try testing.expectEqual(&MockContext.MOCK_ENCODER_VTABLE, encoder.vtable);
+
+    const state = ctx.getState();
+    try testing.expectEqual(@as(?*anyopaque, &mock), state.ptr);
+    try testing.expectEqual(&MockContext.MOCK_STATE_VTABLE, state.vtable);
+}
+
+test "AtmosphereSystem.renderSky with null handles" {
+    var mock = MockContext{};
+    const rhi_instance = rhi.RHI{ .ptr = &mock, .vtable = &MockContext.MOCK_VULKAN_RHI_VTABLE, .device = null };
+
+    const AtmosphereSystem = @import("atmosphere_system.zig").AtmosphereSystem;
+    var system = try AtmosphereSystem.init(testing.allocator, rhi_instance);
+    defer system.deinit();
+
+    // Should return error.SkyPipelineNotReady if handles are missing
+    try testing.expectError(error.SkyPipelineNotReady, system.renderSky(.{
+        .cam_pos = Vec3.zero,
+        .cam_forward = Vec3.init(0, 0, 1),
+        .cam_right = Vec3.init(1, 0, 0),
+        .cam_up = Vec3.init(0, 1, 0),
+        .sun_dir = Vec3.init(0, -1, 0),
+        .sky_color = Vec3.init(0.5, 0.7, 1.0),
+        .horizon_color = Vec3.init(0.8, 0.9, 1.0),
+        .aspect = 1.77,
+        .tan_half_fov = 1.0,
+        .sun_intensity = 1.0,
+        .moon_intensity = 0.1,
+        .time = 0.0,
+    }));
+
+    try testing.expect(mock.sky_pipeline_requested);
+}
+
+test "AtmosphereSystem.renderClouds with null handles" {
+    var mock = MockContext{};
+    const rhi_instance = rhi.RHI{ .ptr = &mock, .vtable = &MockContext.MOCK_VULKAN_RHI_VTABLE, .device = null };
+
+    const AtmosphereSystem = @import("atmosphere_system.zig").AtmosphereSystem;
+    var system = try AtmosphereSystem.init(testing.allocator, rhi_instance);
+    defer system.deinit();
+
+    try testing.expectError(error.CloudPipelineNotReady, system.renderClouds(.{
+        .cam_pos = Vec3.zero,
+        .sun_dir = Vec3.init(0, -1, 0),
+        .sun_intensity = 1.0,
+        .cloud_coverage = 0.5,
+        .cloud_scale = 1.0,
+        .cloud_height = 100.0,
+        .wind_offset_x = 0.0,
+        .wind_offset_z = 0.0,
+        .fog_color = Vec3.init(0.8, 0.9, 1.0),
+        .fog_density = 0.01,
+        .view_proj = Mat4.identity,
+    }, Mat4.identity));
+
+    try testing.expect(mock.cloud_pipeline_requested);
+}

--- a/src/engine/graphics/rhi_vulkan.zig
+++ b/src/engine/graphics/rhi_vulkan.zig
@@ -5273,6 +5273,116 @@ fn drawSky(ctx_ptr: *anyopaque, params: rhi.SkyParams) void {
     c.vkCmdDraw(command_buffer, 3, 1, 0, 0);
 }
 
+fn getNativeSkyPipeline(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.sky_pipeline);
+}
+fn getNativeSkyPipelineLayout(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.sky_pipeline_layout);
+}
+fn getNativeCloudPipeline(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.cloud_pipeline);
+}
+fn getNativeCloudPipelineLayout(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.cloud_pipeline_layout);
+}
+fn getNativeMainDescriptorSet(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.descriptor_sets[ctx.current_sync_frame]);
+}
+fn getNativeSSAOPipeline(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.ssao_pipeline);
+}
+fn getNativeSSAOPipelineLayout(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.ssao_pipeline_layout);
+}
+fn getNativeSSAOBlurPipeline(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.ssao_blur_pipeline);
+}
+fn getNativeSSAOBlurPipelineLayout(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.ssao_blur_pipeline_layout);
+}
+fn getNativeSSAODescriptorSet(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.ssao_descriptor_sets[ctx.current_sync_frame]);
+}
+fn getNativeSSAOBlurDescriptorSet(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.ssao_blur_descriptor_sets[ctx.current_sync_frame]);
+}
+fn getNativeCommandBuffer(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.command_buffers[ctx.current_sync_frame]);
+}
+fn getNativeSwapchainExtent(ctx_ptr: *anyopaque) [2]u32 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return .{ ctx.vulkan_swapchain.extent.width, ctx.vulkan_swapchain.extent.height };
+}
+fn getNativeSSAOFramebuffer(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.ssao_framebuffer);
+}
+fn getNativeSSAOBlurFramebuffer(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.ssao_blur_framebuffer);
+}
+fn getNativeSSAORenderPass(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.ssao_render_pass);
+}
+fn getNativeSSAOBlurRenderPass(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.ssao_blur_render_pass);
+}
+fn getNativeSSAOParamsBuffer(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.ssao_kernel_ubo.buffer);
+}
+fn getNativeSSAOParamsMemory(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.ssao_kernel_ubo.memory);
+}
+fn getNativeDevice(ctx_ptr: *anyopaque) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return @intFromPtr(ctx.vulkan_device.vk_device);
+}
+
+fn getStateContext(ctx_ptr: *anyopaque) rhi.IRenderStateContext {
+    return .{ .ptr = ctx_ptr, .vtable = &VULKAN_STATE_CONTEXT_VTABLE };
+}
+
+const VULKAN_STATE_CONTEXT_VTABLE = rhi.IRenderStateContext.VTable{
+    .setModelMatrix = setModelMatrix,
+    .setInstanceBuffer = setInstanceBuffer,
+    .setLODInstanceBuffer = setLODInstanceBuffer,
+    .updateGlobalUniforms = updateGlobalUniforms,
+    .setTextureUniforms = setTextureUniforms,
+};
+
+fn getEncoder(ctx_ptr: *anyopaque) rhi.IGraphicsCommandEncoder {
+    return .{ .ptr = ctx_ptr, .vtable = &VULKAN_COMMAND_ENCODER_VTABLE };
+}
+
+const VULKAN_COMMAND_ENCODER_VTABLE = rhi.IGraphicsCommandEncoder.VTable{
+    .bindShader = bindShader,
+    .bindTexture = bindTexture,
+    .bindBuffer = bindBuffer,
+    .pushConstants = pushConstants,
+    .draw = draw,
+    .drawOffset = drawOffset,
+    .drawIndexed = drawIndexed,
+    .drawIndirect = drawIndirect,
+    .drawInstance = drawInstance,
+    .setViewport = setViewport,
+};
+
 const VULKAN_RHI_VTABLE = rhi.RHI.VTable{
     .init = initContext,
     .deinit = deinit,
@@ -5297,25 +5407,30 @@ const VULKAN_RHI_VTABLE = rhi.RHI.VTable{
         .endMainPass = endMainPass,
         .beginGPass = beginGPass,
         .endGPass = endGPass,
+        .getEncoder = getEncoder,
+        .getStateContext = getStateContext,
+        .getNativeSkyPipeline = getNativeSkyPipeline,
+        .getNativeSkyPipelineLayout = getNativeSkyPipelineLayout,
+        .getNativeCloudPipeline = getNativeCloudPipeline,
+        .getNativeCloudPipelineLayout = getNativeCloudPipelineLayout,
+        .getNativeMainDescriptorSet = getNativeMainDescriptorSet,
+        .getNativeSSAOPipeline = getNativeSSAOPipeline,
+        .getNativeSSAOPipelineLayout = getNativeSSAOPipelineLayout,
+        .getNativeSSAOBlurPipeline = getNativeSSAOBlurPipeline,
+        .getNativeSSAOBlurPipelineLayout = getNativeSSAOBlurPipelineLayout,
+        .getNativeSSAODescriptorSet = getNativeSSAODescriptorSet,
+        .getNativeSSAOBlurDescriptorSet = getNativeSSAOBlurDescriptorSet,
+        .getNativeCommandBuffer = getNativeCommandBuffer,
+        .getNativeSwapchainExtent = getNativeSwapchainExtent,
+        .getNativeSSAOFramebuffer = getNativeSSAOFramebuffer,
+        .getNativeSSAOBlurFramebuffer = getNativeSSAOBlurFramebuffer,
+        .getNativeSSAORenderPass = getNativeSSAORenderPass,
+        .getNativeSSAOBlurRenderPass = getNativeSSAOBlurRenderPass,
+        .getNativeSSAOParamsBuffer = getNativeSSAOParamsBuffer,
+        .getNativeSSAOParamsMemory = getNativeSSAOParamsMemory,
+        .getNativeDevice = getNativeDevice,
         .computeSSAO = computeSSAO,
-        .bindShader = bindShader,
-        .bindTexture = bindTexture,
-        .setModelMatrix = setModelMatrix,
-        .setInstanceBuffer = setInstanceBuffer,
-        .setLODInstanceBuffer = setLODInstanceBuffer,
-        .updateGlobalUniforms = updateGlobalUniforms,
-        .setTextureUniforms = setTextureUniforms,
-        .draw = draw,
-        .drawOffset = drawOffset,
-        .drawIndexed = drawIndexed,
-        .drawIndirect = drawIndirect,
-        .drawInstance = drawInstance,
-        .setViewport = setViewport,
-        .bindBuffer = bindBuffer,
-        .pushConstants = pushConstants,
         .setClearColor = setClearColor,
-        .drawSky = drawSky,
-        .beginCloudPass = beginCloudPass,
         .drawDebugShadowMap = drawDebugShadowMap,
     },
     .shadow = .{

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -45,6 +45,7 @@ test {
     _ = @import("ecs_tests.zig");
     _ = @import("engine/graphics/vulkan_device.zig");
     _ = @import("vulkan_tests.zig");
+    _ = @import("engine/graphics/rhi_tests.zig");
     _ = @import("world/worldgen/schematics.zig");
     _ = @import("world/worldgen/tree_registry.zig");
     _ = @import("engine/atmosphere/tests.zig");


### PR DESCRIPTION
## Summary
This PR refactors the `IRenderContext` interface in `src/engine/graphics/rhi.zig` to adhere to the Interface Segregation Principle (ISP), as described in issue #189.

### Key Changes
- **Extracted `IGraphicsCommandEncoder`**: Created a dedicated interface for low-level GPU commands (`bindShader`, `bindTexture`, `draw`, `pushConstants`, etc.).
- **Refactored `IRenderContext`**:
  - Added `getEncoder()` to provide access to the command stream.
  - Added resource accessors (e.g., `getSkyPipeline`, `getMainDescriptorSet`) to allow high-level systems to retrieve backend handles without the RHI implementing the rendering logic.
- **Relocated Rendering Logic**:
  - Moved sky rendering logic into `AtmosphereSystem`.
  - Updated `SkyPass` in `render_graph.zig` to delegate to `AtmosphereSystem`.
- **Backend Implementation**: Updated `rhi_vulkan.zig` to implement the new interfaces and accessors.

Fixes #189