### PR TITLE
feat(rhi): ResourceManager wrapper for IResourceFactory (#288)

### DIFF
--- a/src/engine/graphics/rhi.zig
+++ b/src/engine/graphics/rhi.zig
@@ -149,6 +149,47 @@ pub const IResourceFactory = struct {
     }
 };
 
+pub const ResourceManager = struct {
+    factory: IResourceFactory,
+
+    pub fn createBuffer(self: ResourceManager, size: usize, usage: BufferUsage) RhiError!BufferHandle {
+        return self.factory.createBuffer(size, usage);
+    }
+    pub fn uploadBuffer(self: ResourceManager, handle: BufferHandle, data: []const u8) RhiError!void {
+        return self.factory.uploadBuffer(handle, data);
+    }
+    pub fn updateBuffer(self: ResourceManager, handle: BufferHandle, offset: usize, data: []const u8) RhiError!void {
+        return self.factory.updateBuffer(handle, offset, data);
+    }
+    pub fn destroyBuffer(self: ResourceManager, handle: BufferHandle) void {
+        self.factory.destroyBuffer(handle);
+    }
+    pub fn createTexture(self: ResourceManager, width: u32, height: u32, format: TextureFormat, config: TextureConfig, data: ?[]const u8) RhiError!TextureHandle {
+        return self.factory.createTexture(width, height, format, config, data);
+    }
+    pub fn createTexture3D(self: ResourceManager, width: u32, height: u32, depth: u32, format: TextureFormat, config: TextureConfig, data: ?[]const u8) RhiError!TextureHandle {
+        return self.factory.createTexture3D(width, height, depth, format, config, data);
+    }
+    pub fn destroyTexture(self: ResourceManager, handle: TextureHandle) void {
+        self.factory.destroyTexture(handle);
+    }
+    pub fn updateTexture(self: ResourceManager, handle: TextureHandle, data: []const u8) RhiError!void {
+        return self.factory.updateTexture(handle, data);
+    }
+    pub fn createShader(self: ResourceManager, vertex_src: [*c]const u8, fragment_src: [*c]const u8) RhiError!ShaderHandle {
+        return self.factory.createShader(vertex_src, fragment_src);
+    }
+    pub fn destroyShader(self: ResourceManager, handle: ShaderHandle) void {
+        self.factory.destroyShader(handle);
+    }
+    pub fn mapBuffer(self: ResourceManager, handle: BufferHandle) RhiError!?*anyopaque {
+        return self.factory.mapBuffer(handle);
+    }
+    pub fn unmapBuffer(self: ResourceManager, handle: BufferHandle) void {
+        self.factory.unmapBuffer(handle);
+    }
+};
+
 pub const IShadowContext = struct {
     ptr: *anyopaque,
     vtable: *const VTable,
@@ -543,6 +584,9 @@ pub const RHI = struct {
 
     pub fn factory(self: RHI) IResourceFactory {
         return .{ .ptr = self.ptr, .vtable = &self.vtable.resources };
+    }
+    pub fn resourceManager(self: RHI) ResourceManager {
+        return .{ .factory = self.factory() };
     }
     pub fn context(self: RHI) IRenderContext {
         return .{ .ptr = self.ptr, .vtable = &self.vtable.render };

--- a/src/engine/graphics/rhi.zig
+++ b/src/engine/graphics/rhi.zig
@@ -149,6 +149,17 @@ pub const IResourceFactory = struct {
     }
 };
 
+/// Concrete wrapper around `IResourceFactory` for GPU resource lifecycle operations.
+///
+/// Use this when a subsystem only needs buffer/texture/shader creation and
+/// destruction, without accessing the full `RHI` composite. Obtain via
+/// `rhi.resourceManager()`. Reduces coupling and clarifies intent.
+///
+/// ```zig
+/// const rm = rhi.resourceManager();
+/// const buffer = try rm.createBuffer(size, .vertex);
+/// defer rm.destroyBuffer(buffer);
+/// ```
 pub const ResourceManager = struct {
     factory: IResourceFactory,
 

--- a/src/integration_test.zig
+++ b/src/integration_test.zig
@@ -34,14 +34,15 @@ const UploadScreen = struct {
 
     pub fn init(allocator: std.mem.Allocator, context: EngineContext) !*UploadScreen {
         const upload_screen = try allocator.create(UploadScreen);
-        const buffer = try context.rhi.createBuffer(upload_screen.payload.len, .vertex);
+        const rm = context.rhi.resourceManager();
+        const buffer = try rm.createBuffer(upload_screen.payload.len, .vertex);
         upload_screen.* = .{ .context = context, .buffer = buffer };
         return upload_screen;
     }
 
     fn deinit(ptr: *anyopaque) void {
         const self: *UploadScreen = @ptrCast(@alignCast(ptr));
-        self.context.rhi.destroyBuffer(self.buffer);
+        self.context.rhi.resourceManager().destroyBuffer(self.buffer);
         self.context.allocator.destroy(self);
     }
 
@@ -49,7 +50,7 @@ const UploadScreen = struct {
         const self: *UploadScreen = @ptrCast(@alignCast(ptr));
         self.payload[0] = self.tick;
         self.tick +%= 1;
-        try self.context.rhi.updateBuffer(self.buffer, 0, self.payload[0..]);
+        try self.context.rhi.resourceManager().updateBuffer(self.buffer, 0, self.payload[0..]);
     }
 
     fn draw(_: *anyopaque, ui: *UISystem) !void {

--- a/src/world/chunk_allocator.zig
+++ b/src/world/chunk_allocator.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const rhi_mod = @import("../engine/graphics/rhi.zig");
-const RHI = rhi_mod.RHI;
+const ResourceManager = rhi_mod.ResourceManager;
+const IDeviceQuery = rhi_mod.IDeviceQuery;
 const Vertex = rhi_mod.Vertex;
 
 pub const VertexAllocation = struct {
@@ -17,7 +18,8 @@ pub const GlobalVertexAllocator = struct {
         size: usize,
     };
 
-    rhi: RHI,
+    resources: ResourceManager,
+    query: IDeviceQuery,
     buffer: rhi_mod.BufferHandle,
     capacity: usize,
     allocator: std.mem.Allocator,
@@ -26,9 +28,9 @@ pub const GlobalVertexAllocator = struct {
     deferred_frees: [rhi_mod.MAX_FRAMES_IN_FLIGHT]std.ArrayListUnmanaged(VertexAllocation),
     mutex: std.Thread.Mutex,
 
-    pub fn init(allocator: std.mem.Allocator, rhi: RHI, capacity_mb: usize) !GlobalVertexAllocator {
+    pub fn init(allocator: std.mem.Allocator, resources: ResourceManager, query: IDeviceQuery, capacity_mb: usize) !GlobalVertexAllocator {
         const capacity = capacity_mb * 1024 * 1024;
-        const buffer = try rhi.createBuffer(capacity, .vertex);
+        const buffer = try resources.createBuffer(capacity, .vertex);
 
         var free_blocks = std.ArrayListUnmanaged(FreeBlock){};
         try free_blocks.append(allocator, .{ .offset = 0, .size = capacity });
@@ -41,7 +43,8 @@ pub const GlobalVertexAllocator = struct {
         }
 
         return .{
-            .rhi = rhi,
+            .resources = resources,
+            .query = query,
             .buffer = buffer,
             .capacity = capacity,
             .allocator = allocator,
@@ -52,7 +55,7 @@ pub const GlobalVertexAllocator = struct {
     }
 
     pub fn deinit(self: *GlobalVertexAllocator) void {
-        self.rhi.destroyBuffer(self.buffer);
+        self.resources.destroyBuffer(self.buffer);
         self.free_blocks.deinit(self.allocator);
         for (0..rhi_mod.MAX_FRAMES_IN_FLIGHT) |i| {
             self.deferred_frees[i].deinit(self.allocator);
@@ -102,7 +105,7 @@ pub const GlobalVertexAllocator = struct {
             };
 
             // Upload at the correct offset within the megabuffer
-            try self.rhi.updateBuffer(self.buffer, block.offset, std.mem.sliceAsBytes(vertices));
+            try self.resources.updateBuffer(self.buffer, block.offset, std.mem.sliceAsBytes(vertices));
 
             // Update free block
             if (block.size > size_needed) {
@@ -148,7 +151,7 @@ pub const GlobalVertexAllocator = struct {
         // HOWEVER, we must be careful with reuse.
         // A safer way is to queue for (frame_index + 1) % MAX_FRAMES_IN_FLIGHT.
 
-        const frame_idx = self.rhi.getFrameIndex();
+        const frame_idx = self.query.getFrameIndex();
         self.deferred_frees[frame_idx].append(self.allocator, allocation) catch {
             // Fallback to immediate free if queue is full (better than leak, though slightly risky)
             std.log.warn("Deferred free queue full, falling back to immediate free", .{});

--- a/src/world/chunk_allocator.zig
+++ b/src/world/chunk_allocator.zig
@@ -18,8 +18,8 @@ pub const GlobalVertexAllocator = struct {
         size: usize,
     };
 
-    resources: ResourceManager,
-    query: IDeviceQuery,
+    resource_manager: ResourceManager,
+    device_query: IDeviceQuery,
     buffer: rhi_mod.BufferHandle,
     capacity: usize,
     allocator: std.mem.Allocator,
@@ -43,8 +43,8 @@ pub const GlobalVertexAllocator = struct {
         }
 
         return .{
-            .resources = resources,
-            .query = query,
+            .resource_manager = resources,
+            .device_query = query,
             .buffer = buffer,
             .capacity = capacity,
             .allocator = allocator,
@@ -55,7 +55,7 @@ pub const GlobalVertexAllocator = struct {
     }
 
     pub fn deinit(self: *GlobalVertexAllocator) void {
-        self.resources.destroyBuffer(self.buffer);
+        self.resource_manager.destroyBuffer(self.buffer);
         self.free_blocks.deinit(self.allocator);
         for (0..rhi_mod.MAX_FRAMES_IN_FLIGHT) |i| {
             self.deferred_frees[i].deinit(self.allocator);
@@ -105,7 +105,7 @@ pub const GlobalVertexAllocator = struct {
             };
 
             // Upload at the correct offset within the megabuffer
-            try self.resources.updateBuffer(self.buffer, block.offset, std.mem.sliceAsBytes(vertices));
+            try self.resource_manager.updateBuffer(self.buffer, block.offset, std.mem.sliceAsBytes(vertices));
 
             // Update free block
             if (block.size > size_needed) {
@@ -151,7 +151,7 @@ pub const GlobalVertexAllocator = struct {
         // HOWEVER, we must be careful with reuse.
         // A safer way is to queue for (frame_index + 1) % MAX_FRAMES_IN_FLIGHT.
 
-        const frame_idx = self.query.getFrameIndex();
+        const frame_idx = self.device_query.getFrameIndex();
         self.deferred_frees[frame_idx].append(self.allocator, allocation) catch {
             // Fallback to immediate free if queue is full (better than leak, though slightly risky)
             std.log.warn("Deferred free queue full, falling back to immediate free", .{});

--- a/src/world/world_renderer.zig
+++ b/src/world/world_renderer.zig
@@ -57,7 +57,7 @@ pub const WorldRenderer = struct {
         }
 
         const vertex_allocator = try allocator.create(GlobalVertexAllocator);
-        vertex_allocator.* = try GlobalVertexAllocator.init(allocator, rhi, vertex_capacity_mb);
+        vertex_allocator.* = try GlobalVertexAllocator.init(allocator, rhi.resourceManager(), rhi.query(), vertex_capacity_mb);
 
         const max_chunks = 16384;
         var instance_buffers: [rhi_mod.MAX_FRAMES_IN_FLIGHT]rhi_mod.BufferHandle = undefined;


### PR DESCRIPTION
## Summary

- Add `ResourceManager` struct to `rhi.zig` wrapping `IResourceFactory` with all 12 resource CRUD methods (buffer/texture/shader lifecycle)
- Add `RHI.resourceManager()` accessor to create a `ResourceManager` from an `RHI` instance
- Migrate `GlobalVertexAllocator` in `chunk_allocator.zig` to accept `ResourceManager` + `IDeviceQuery` instead of the full `RHI` composite
- Update `world_renderer.zig` and `integration_test.zig` call sites accordingly

## Context

Sub-issue of #272 (Simplify RHI composite). This is the lowest-risk first migration step — callers that only need resource creation no longer depend on the full RHI God Object. The Vulkan backend is unchanged.

Closes #288

## Acceptance Criteria

- [x] `ResourceManager` struct created wrapping `IResourceFactory`
- [x] Callers updated to use `ResourceManager` instead of full RHI
- [x] No change to Vulkan backend implementation
- [x] Tests pass (`zig build test` + pre-push hooks)