### PR TITLE
feat(rhi): add ShadowSystemWrapper for focused shadow mapping interface

### DIFF
--- a/src/engine/graphics/render_graph.zig
+++ b/src/engine/graphics/render_graph.zig
@@ -43,7 +43,7 @@ const World = @import("../../world/world.zig").World;
 const shadow_scene = @import("shadow_scene.zig");
 const rhi_pkg = @import("rhi.zig");
 const RenderContext = rhi_pkg.RenderContext;
-const IShadowContext = rhi_pkg.IShadowContext;
+const ShadowSystemWrapper = rhi_pkg.ShadowSystemWrapper;
 const ISSAOContext = rhi_pkg.ISSAOContext;
 const IDeviceTiming = rhi_pkg.IDeviceTiming;
 const Vec3 = @import("../math/vec3.zig").Vec3;
@@ -54,7 +54,7 @@ const MaterialSystem = @import("material_system.zig").MaterialSystem;
 
 pub const SceneContext = struct {
     render_ctx: RenderContext,
-    shadow_ctx: IShadowContext,
+    shadow_ctx: ShadowSystemWrapper,
     ssao_ctx: ISSAOContext,
     timing: IDeviceTiming,
     world: *World,

--- a/src/engine/graphics/rhi.zig
+++ b/src/engine/graphics/rhi.zig
@@ -378,6 +378,36 @@ pub const IShadowContext = struct {
     }
 };
 
+/// Concrete wrapper around `IShadowContext` for shadow mapping operations.
+///
+/// Use this when a subsystem only needs shadow map rendering without accessing
+/// the full `RHI` composite. Obtain via `rhi.shadowSystem()`. Reduces coupling
+/// and clarifies intent.
+///
+/// ```zig
+/// const ss = rhi.shadowSystem();
+/// ss.beginPass(0, light_space_matrix);
+/// // ... render shadow casters ...
+/// ss.endPass();
+/// const handle = ss.getShadowMapHandle(0);
+/// ```
+pub const ShadowSystemWrapper = struct {
+    ctx: IShadowContext,
+
+    pub fn beginPass(self: ShadowSystemWrapper, cascade_index: u32, light_space_matrix: Mat4) void {
+        self.ctx.beginPass(cascade_index, light_space_matrix);
+    }
+    pub fn endPass(self: ShadowSystemWrapper) void {
+        self.ctx.endPass();
+    }
+    pub fn updateUniforms(self: ShadowSystemWrapper, params: ShadowParams) !void {
+        try self.ctx.updateUniforms(params);
+    }
+    pub fn getShadowMapHandle(self: ShadowSystemWrapper, cascade_index: u32) TextureHandle {
+        return self.ctx.getShadowMapHandle(cascade_index);
+    }
+};
+
 pub const IUIContext = struct {
     ptr: *anyopaque,
     vtable: *const VTable,
@@ -773,6 +803,9 @@ pub const RHI = struct {
     }
     pub fn shadow(self: RHI) IShadowContext {
         return .{ .ptr = self.ptr, .vtable = &self.vtable.shadow };
+    }
+    pub fn shadowSystem(self: RHI) ShadowSystemWrapper {
+        return .{ .ctx = self.shadow() };
     }
     pub fn ui(self: RHI) IUIContext {
         return .{ .ptr = self.ptr, .vtable = &self.vtable.ui };

--- a/src/engine/ui/debug_shadow_overlay.zig
+++ b/src/engine/ui/debug_shadow_overlay.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const rhi = @import("../graphics/rhi.zig");
 const IUIContext = rhi.IUIContext;
-const IShadowContext = rhi.IShadowContext;
+const ShadowSystemWrapper = rhi.ShadowSystemWrapper;
 
 /// System for rendering debug shadow cascade overlays.
 pub const DebugShadowOverlay = struct {
@@ -14,8 +14,8 @@ pub const DebugShadowOverlay = struct {
     };
 
     /// Draws the shadow cascade thumbnails to the screen.
-    /// Requires an active UI context and a shadow context to retrieve handles.
-    pub fn draw(ui: IUIContext, shadow: IShadowContext, screen_width: f32, screen_height: f32, config: Config) void {
+    /// Requires an active UI context and a shadow system to retrieve handles.
+    pub fn draw(ui: IUIContext, shadow: ShadowSystemWrapper, screen_width: f32, screen_height: f32, config: Config) void {
         ui.beginPass(screen_width, screen_height);
         defer ui.endPass();
 

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -222,7 +222,7 @@ pub const WorldScreen = struct {
 
             const render_ctx = render_graph_pkg.SceneContext{
                 .render_ctx = ctx.rhi.*.renderContext(),
-                .shadow_ctx = ctx.rhi.*.shadow(),
+                .shadow_ctx = ctx.rhi.*.shadowSystem(),
                 .ssao_ctx = ctx.rhi.*.ssao(),
                 .timing = ctx.rhi.*.timing(),
                 .world = self.session.world,
@@ -273,7 +273,7 @@ pub const WorldScreen = struct {
         try self.session.drawHUD(ui, ctx.atlas, ctx.resource_pack_manager.active_pack, ctx.time.fps, screen_w, screen_h, mouse_x, mouse_y, mouse_clicked);
 
         if (ctx.settings.debug_shadows_active) {
-            DebugShadowOverlay.draw(ctx.rhi.ui(), ctx.rhi.shadow(), screen_w, screen_h, .{});
+            DebugShadowOverlay.draw(ctx.rhi.ui(), ctx.rhi.shadowSystem(), screen_w, screen_h, .{});
         }
         if (ctx.settings.debug_lpv_overlay_active) {
             const overlay_size = std.math.clamp(220.0 * ctx.settings.ui_scale, 160.0, screen_h * 0.4);


### PR DESCRIPTION
## Summary
- Add `ShadowSystemWrapper` to `rhi.zig` that wraps `IShadowContext`, following the existing `ResourceManager`/`RenderContext` pattern
- Update `SceneContext.shadow_ctx` field from `IShadowContext` to `ShadowSystemWrapper`
- Update `DebugShadowOverlay.draw()` and its caller to use `ShadowSystemWrapper`
- No changes to Vulkan backend or shadow rendering behavior

## Acceptance Criteria
- [x] `ShadowSystemWrapper` struct created wrapping `IShadowContext`
- [x] Callers updated to use `ShadowSystemWrapper`
- [x] No change to Vulkan backend
- [x] Shadow rendering behavior unchanged
- [x] All tests pass (including shader validation)

Closes #290