### PR TITLE
feat(rhi): add UIRenderer wrapper and migrate UI consumers

### DIFF
--- a/src/engine/ecs/systems/render.zig
+++ b/src/engine/ecs/systems/render.zig
@@ -5,7 +5,8 @@ const std = @import("std");
 const Registry = @import("../manager.zig").Registry;
 const components = @import("../components.zig");
 const rhi_pkg = @import("../../graphics/rhi.zig");
-const RHI = rhi_pkg.RHI;
+const ResourceManager = rhi_pkg.ResourceManager;
+const RenderContext = rhi_pkg.RenderContext;
 const Mat4 = @import("../../math/mat4.zig").Mat4;
 const Vec3 = @import("../../math/vec3.zig").Vec3;
 const Vertex = rhi_pkg.Vertex;
@@ -13,31 +14,30 @@ const wireframe = @import("../../graphics/wireframe_cube.zig");
 
 pub const RenderSystem = struct {
     buffer_handle: rhi_pkg.BufferHandle,
-    rhi: *RHI,
+    resources: ResourceManager,
     missing_transform_logged: bool,
 
-    pub fn init(rhi: *RHI) !RenderSystem {
-        const buffer = try rhi.*.createBuffer(@sizeOf(@TypeOf(wireframe.line_vertices)), .vertex);
-        try rhi.*.uploadBuffer(buffer, std.mem.asBytes(&wireframe.line_vertices));
+    pub fn init(resources: ResourceManager) !RenderSystem {
+        const buffer = try resources.createBuffer(@sizeOf(@TypeOf(wireframe.line_vertices)), .vertex);
+        try resources.uploadBuffer(buffer, std.mem.asBytes(&wireframe.line_vertices));
 
         return .{
             .buffer_handle = buffer,
-            .rhi = rhi,
+            .resources = resources,
             .missing_transform_logged = false,
         };
     }
 
     pub fn deinit(self: *RenderSystem) void {
         if (self.buffer_handle != rhi_pkg.InvalidBufferHandle) {
-            self.rhi.*.destroyBuffer(self.buffer_handle);
+            self.resources.destroyBuffer(self.buffer_handle);
             self.buffer_handle = rhi_pkg.InvalidBufferHandle;
         }
     }
 
-    pub fn render(self: *RenderSystem, registry: *Registry, camera_pos: Vec3) void {
+    pub fn render(self: *RenderSystem, ctx: RenderContext, registry: *Registry, camera_pos: Vec3) void {
         const logger = @import("../../core/log.zig").log;
 
-        // Check for entities with Mesh but no Transform (potential configuration error)
         if (!self.missing_transform_logged) {
             for (registry.meshes.entities.items) |entity_id| {
                 if (!registry.transforms.has(entity_id)) {
@@ -56,30 +56,21 @@ pub const RenderSystem = struct {
 
             if (!mesh.visible) continue;
 
-            // Determine size from physics if available, otherwise default 1x1x1
             var size = Vec3.one;
             var offset = Vec3.zero;
 
             if (registry.physics.getPtr(entity_id)) |phys| {
                 size = phys.aabb_size;
-                // Physics position is at the feet (bottom center)
-                // Mesh vertex data is 0..1 (min=0, max=1)
-                // We want to center the mesh horizontally around the position,
-                // but keep y=0 at the feet.
-                // So we translate by (-width/2, 0, -depth/2)
                 offset = Vec3.init(-size.x / 2.0, 0, -size.z / 2.0);
             }
 
-            // Camera uses origin-centered view matrix, so we render relative to the camera.
             const rel_pos = transform.position.add(offset).sub(camera_pos);
 
-            // Create model matrix: Translate * Scale
             const model = Mat4.translate(rel_pos).multiply(Mat4.scale(size));
 
             if (self.buffer_handle != rhi_pkg.InvalidBufferHandle) {
-                self.rhi.*.setModelMatrix(model, mesh.color, 0);
-                // Draw line list (24 vertices = 12 edges)
-                self.rhi.*.draw(self.buffer_handle, wireframe.line_vertex_count, .lines);
+                ctx.setModelMatrix(model, mesh.color, 0);
+                ctx.draw(self.buffer_handle, wireframe.line_vertex_count, .lines);
             }
         }
     }

--- a/src/engine/graphics/atmosphere_system.zig
+++ b/src/engine/graphics/atmosphere_system.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const rhi = @import("rhi.zig");
-const RHI = rhi.RHI;
+const ResourceManager = rhi.ResourceManager;
+const RenderContext = rhi.RenderContext;
 const c = @import("../../c.zig").c;
 const Vec3 = @import("../math/vec3.zig").Vec3;
 const Mat4 = @import("../math/mat4.zig").Mat4;
@@ -8,20 +9,19 @@ const log = @import("../core/log.zig");
 
 pub const AtmosphereSystem = struct {
     allocator: std.mem.Allocator,
-    rhi: RHI,
+    resources: ResourceManager,
 
     cloud_vbo: rhi.BufferHandle = 0,
     cloud_ebo: rhi.BufferHandle = 0,
     cloud_mesh_size: f32 = 2000.0,
 
-    pub fn init(allocator: std.mem.Allocator, rhi_instance: RHI) !*AtmosphereSystem {
+    pub fn init(allocator: std.mem.Allocator, resources: ResourceManager) !*AtmosphereSystem {
         const self = try allocator.create(AtmosphereSystem);
         self.* = .{
             .allocator = allocator,
-            .rhi = rhi_instance,
+            .resources = resources,
         };
 
-        // Create cloud mesh (large quad centered on camera)
         const cloud_vertices = [_]f32{
             -self.cloud_mesh_size, -self.cloud_mesh_size,
             self.cloud_mesh_size,  -self.cloud_mesh_size,
@@ -30,31 +30,28 @@ pub const AtmosphereSystem = struct {
         };
         const cloud_indices = [_]u16{ 0, 1, 2, 0, 2, 3 };
 
-        self.cloud_vbo = try rhi_instance.createBuffer(@sizeOf(@TypeOf(cloud_vertices)), .vertex);
-        self.cloud_ebo = try rhi_instance.createBuffer(@sizeOf(@TypeOf(cloud_indices)), .index);
+        self.cloud_vbo = try resources.createBuffer(@sizeOf(@TypeOf(cloud_vertices)), .vertex);
+        self.cloud_ebo = try resources.createBuffer(@sizeOf(@TypeOf(cloud_indices)), .index);
 
-        try rhi_instance.uploadBuffer(self.cloud_vbo, std.mem.asBytes(&cloud_vertices));
-        try rhi_instance.uploadBuffer(self.cloud_ebo, std.mem.asBytes(&cloud_indices));
+        try resources.uploadBuffer(self.cloud_vbo, std.mem.asBytes(&cloud_vertices));
+        try resources.uploadBuffer(self.cloud_ebo, std.mem.asBytes(&cloud_indices));
 
         return self;
     }
 
     pub fn deinit(self: *AtmosphereSystem) void {
-        if (self.cloud_vbo != 0) self.rhi.destroyBuffer(self.cloud_vbo);
-        if (self.cloud_ebo != 0) self.rhi.destroyBuffer(self.cloud_ebo);
+        if (self.cloud_vbo != 0) self.resources.destroyBuffer(self.cloud_vbo);
+        if (self.cloud_ebo != 0) self.resources.destroyBuffer(self.cloud_ebo);
         self.allocator.destroy(self);
     }
 
-    pub fn renderSky(self: *AtmosphereSystem, params: rhi.SkyParams) rhi.RhiError!void {
-        const context = self.rhi.context();
-
-        const pipeline_u64 = context.vtable.getNativeSkyPipeline(context.ptr);
-        const layout_u64 = context.vtable.getNativeSkyPipelineLayout(context.ptr);
-        const descriptor_set_u64 = context.vtable.getNativeMainDescriptorSet(context.ptr);
-        const cmd_u64 = context.vtable.getNativeCommandBuffer(context.ptr);
+    pub fn renderSky(_: *AtmosphereSystem, ctx: RenderContext, params: rhi.SkyParams) rhi.RhiError!void {
+        const pipeline_u64 = ctx.getNativeSkyPipeline();
+        const layout_u64 = ctx.getNativeSkyPipelineLayout();
+        const descriptor_set_u64 = ctx.getNativeMainDescriptorSet();
+        const cmd_u64 = ctx.getNativeCommandBuffer();
 
         if (pipeline_u64 == 0 or layout_u64 == 0 or cmd_u64 == 0) {
-            // Note: This may happen during early initialization before the main renderer has completed setup.
             log.log.warn("AtmosphereSystem: Sky rendering skipped, native handles missing (pipeline={}, layout={}, cmd={})", .{ pipeline_u64 != 0, layout_u64 != 0, cmd_u64 != 0 });
             if (pipeline_u64 == 0) return error.SkyPipelineNotReady;
             if (layout_u64 == 0) return error.SkyPipelineLayoutNotReady;
@@ -79,8 +76,6 @@ pub const AtmosphereSystem = struct {
         };
 
         c.vkCmdBindPipeline(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
-        // Main descriptor set is optional for sky rendering if it only uses push constants.
-        // It may be 0 if the render pass is starting but descriptors have not yet been updated for the current frame.
         if (descriptor_set_u64 != 0) {
             c.vkCmdBindDescriptorSets(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0, 1, &descriptor_set, 0, null);
         }
@@ -88,14 +83,12 @@ pub const AtmosphereSystem = struct {
         c.vkCmdDraw(cmd, 3, 1, 0, 0);
     }
 
-    pub fn renderClouds(self: *AtmosphereSystem, params: rhi.CloudParams, view_proj: Mat4) rhi.RhiError!void {
-        const context = self.rhi.context();
-        const pipeline_u64 = context.vtable.getNativeCloudPipeline(context.ptr);
-        const layout_u64 = context.vtable.getNativeCloudPipelineLayout(context.ptr);
-        const cmd_u64 = context.vtable.getNativeCommandBuffer(context.ptr);
+    pub fn renderClouds(self: *AtmosphereSystem, ctx: RenderContext, params: rhi.CloudParams, view_proj: Mat4) rhi.RhiError!void {
+        const pipeline_u64 = ctx.getNativeCloudPipeline();
+        const layout_u64 = ctx.getNativeCloudPipelineLayout();
+        const cmd_u64 = ctx.getNativeCommandBuffer();
 
         if (pipeline_u64 == 0 or layout_u64 == 0 or cmd_u64 == 0) {
-            // Note: This may happen during early initialization before the main renderer has completed setup.
             log.log.warn("AtmosphereSystem: Cloud rendering skipped, native handles missing (pipeline={}, layout={}, cmd={})", .{ pipeline_u64 != 0, layout_u64 != 0, cmd_u64 != 0 });
             if (pipeline_u64 == 0) return error.CloudPipelineNotReady;
             if (layout_u64 == 0) return error.CloudPipelineLayoutNotReady;
@@ -118,8 +111,8 @@ pub const AtmosphereSystem = struct {
         c.vkCmdBindPipeline(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
         c.vkCmdPushConstants(cmd, layout, c.VK_SHADER_STAGE_VERTEX_BIT | c.VK_SHADER_STAGE_FRAGMENT_BIT, 0, @sizeOf(rhi.CloudPushConstants), &pc);
 
-        context.bindBuffer(self.cloud_vbo, .vertex);
-        context.bindBuffer(self.cloud_ebo, .index);
-        context.drawIndexed(self.cloud_vbo, self.cloud_ebo, 6);
+        ctx.bindBuffer(self.cloud_vbo, .vertex);
+        ctx.bindBuffer(self.cloud_ebo, .index);
+        ctx.drawIndexed(self.cloud_vbo, self.cloud_ebo, 6);
     }
 };

--- a/src/engine/graphics/material_system.zig
+++ b/src/engine/graphics/material_system.zig
@@ -1,18 +1,16 @@
 const std = @import("std");
 const rhi = @import("rhi.zig");
-const RHI = rhi.RHI;
+const RenderContext = rhi.RenderContext;
 const TextureAtlas = @import("texture_atlas.zig").TextureAtlas;
 
 pub const MaterialSystem = struct {
     allocator: std.mem.Allocator,
-    rhi: RHI,
     atlas: *TextureAtlas,
 
-    pub fn init(allocator: std.mem.Allocator, rhi_instance: RHI, atlas: *TextureAtlas) !*MaterialSystem {
+    pub fn init(allocator: std.mem.Allocator, atlas: *TextureAtlas) !*MaterialSystem {
         const self = try allocator.create(MaterialSystem);
         self.* = .{
             .allocator = allocator,
-            .rhi = rhi_instance,
             .atlas = atlas,
         };
         return self;
@@ -22,13 +20,12 @@ pub const MaterialSystem = struct {
         self.allocator.destroy(self);
     }
 
-    /// Binds the standard terrain material (diffuse, normal, roughness, etc.)
-    pub fn bindTerrainMaterial(self: *MaterialSystem, env_map_handle: rhi.TextureHandle) void {
-        self.rhi.bindTexture(self.atlas.texture.handle, 1);
-        if (self.atlas.normal_texture) |t| self.rhi.bindTexture(t.handle, 6);
-        if (self.atlas.roughness_texture) |t| self.rhi.bindTexture(t.handle, 7);
-        if (self.atlas.displacement_texture) |t| self.rhi.bindTexture(t.handle, 8);
-        if (env_map_handle != 0) self.rhi.bindTexture(env_map_handle, 9);
+    pub fn bindTerrainMaterial(self: *MaterialSystem, ctx: RenderContext, env_map_handle: rhi.TextureHandle) void {
+        ctx.bindTexture(self.atlas.texture.handle, 1);
+        if (self.atlas.normal_texture) |t| ctx.bindTexture(t.handle, 6);
+        if (self.atlas.roughness_texture) |t| ctx.bindTexture(t.handle, 7);
+        if (self.atlas.displacement_texture) |t| ctx.bindTexture(t.handle, 8);
+        if (env_map_handle != 0) ctx.bindTexture(env_map_handle, 9);
     }
 
     /// Gets the handles for the current texture atlas

--- a/src/engine/graphics/render_graph.zig
+++ b/src/engine/graphics/render_graph.zig
@@ -299,7 +299,7 @@ pub const SkyPass = struct {
 
     fn execute(ptr: *anyopaque, ctx: SceneContext) anyerror!void {
         _ = ptr;
-        ctx.atmosphere_system.renderSky(ctx.sky_params) catch |err| {
+        ctx.atmosphere_system.renderSky(ctx.render_ctx, ctx.sky_params) catch |err| {
             if (err != error.ResourceNotReady and
                 err != error.SkyPipelineNotReady and
                 err != error.SkyPipelineLayoutNotReady and
@@ -327,7 +327,7 @@ pub const OpaquePass = struct {
     fn execute(ptr: *anyopaque, ctx: SceneContext) anyerror!void {
         _ = ptr;
         ctx.render_ctx.bindShader(ctx.main_shader);
-        ctx.material_system.bindTerrainMaterial(ctx.env_map_handle);
+        ctx.material_system.bindTerrainMaterial(ctx.render_ctx, ctx.env_map_handle);
         ctx.render_ctx.bindTexture(ctx.lpv_texture_handle, 11);
         ctx.render_ctx.bindTexture(ctx.lpv_texture_handle_g, 12);
         ctx.render_ctx.bindTexture(ctx.lpv_texture_handle_b, 13);
@@ -353,7 +353,7 @@ pub const CloudPass = struct {
         _ = ptr;
         if (ctx.disable_clouds) return;
         const view_proj = ctx.camera.getJitteredProjectionMatrixReverseZ(ctx.aspect, ctx.viewport_width, ctx.viewport_height, ctx.taa_enabled).multiply(ctx.camera.getViewMatrixOriginCentered());
-        ctx.atmosphere_system.renderClouds(ctx.cloud_params, view_proj) catch |err| {
+        ctx.atmosphere_system.renderClouds(ctx.render_ctx, ctx.cloud_params, view_proj) catch |err| {
             if (err != error.ResourceNotReady and
                 err != error.CloudPipelineNotReady and
                 err != error.CloudPipelineLayoutNotReady and

--- a/src/engine/graphics/rhi.zig
+++ b/src/engine/graphics/rhi.zig
@@ -34,12 +34,16 @@
 //!
 //! ## Usage
 //!
-//! The RHI type is a composite struct that aggregates all interfaces:
+//! **DEPRECATED**: Use focused wrappers instead:
+//! - `ResourceManager` for resource lifecycle (`createBuffer`, `createTexture`, etc.)
+//! - `RenderContext` for frame rendering (`beginFrame`, `draw`, `bindTexture`, etc.)
+//! - `UIRenderer` for UI rendering (`beginPass`, `drawRect`, `drawTexture`, etc.)
+//! - `ShadowSystemWrapper` for shadow mapping
+//!
 //! ```zig
-//! const rhi: RHI = try VulkanRHI.init(allocator, window);
-//! try rhi.beginFrame();
-//! // ... rendering commands ...
-//! rhi.endFrame();
+//! const resources = rhi.resourceManager();
+//! const ctx = rhi.renderContext();
+//! const ui = rhi.uiRenderer();
 //! ```
 //!
 //! ## Backend Implementation
@@ -441,6 +445,41 @@ pub const IUIContext = struct {
     }
 };
 
+/// Focused wrapper for immediate-mode UI rendering.
+///
+/// Provides a clean interface for 2D drawing operations (rectangles,
+/// textures, depth textures) without exposing the full RHI composite.
+///
+/// ```zig
+/// const ui = rhi.uiRenderer();
+/// ui.beginPass(width, height);
+/// ui.drawRect(rect, color);
+/// ui.drawTexture(tex, rect);
+/// ui.endPass();
+/// ```
+pub const UIRenderer = struct {
+    ctx: IUIContext,
+
+    pub fn beginPass(self: UIRenderer, width: f32, height: f32) void {
+        self.ctx.beginPass(width, height);
+    }
+    pub fn endPass(self: UIRenderer) void {
+        self.ctx.endPass();
+    }
+    pub fn drawRect(self: UIRenderer, rect: Rect, color: Color) void {
+        self.ctx.drawRect(rect, color);
+    }
+    pub fn drawTexture(self: UIRenderer, texture: TextureHandle, rect: Rect) void {
+        self.ctx.drawTexture(texture, rect);
+    }
+    pub fn drawDepthTexture(self: UIRenderer, texture: TextureHandle, rect: Rect) void {
+        self.ctx.drawDepthTexture(texture, rect);
+    }
+    pub fn bindPipeline(self: UIRenderer, textured: bool) void {
+        self.ctx.bindPipeline(textured);
+    }
+};
+
 pub const IGraphicsCommandEncoder = struct {
     ptr: *anyopaque,
     vtable: *const VTable,
@@ -733,7 +772,17 @@ pub const IDeviceTiming = struct {
     }
 };
 
-/// Composite RHI structure for backward compatibility during refactoring
+/// DEPRECATED: This struct is retained as a composition root during the RHI
+/// modularization refactoring (issue #291 / #272). New code should use focused
+/// wrappers: `ResourceManager`, `RenderContext`, `UIRenderer`, `ShadowSystemWrapper`.
+///
+/// Migration guide:
+/// - Resource operations -> `rhi.resourceManager()`
+/// - Frame rendering -> `rhi.renderContext()`
+/// - UI rendering -> `rhi.uiRenderer()`
+/// - Shadow mapping -> `rhi.shadowSystem()`
+/// - Device timing -> `rhi.timing()`
+/// - Device query -> `rhi.query()`
 pub const RHI = struct {
     ptr: *anyopaque,
     vtable: *const VTable,
@@ -810,6 +859,9 @@ pub const RHI = struct {
     pub fn ui(self: RHI) IUIContext {
         return .{ .ptr = self.ptr, .vtable = &self.vtable.ui };
     }
+    pub fn uiRenderer(self: RHI) UIRenderer {
+        return .{ .ctx = self.ui() };
+    }
     pub fn query(self: RHI) IDeviceQuery {
         return .{ .ptr = self.ptr, .vtable = &self.vtable.query };
     }
@@ -817,7 +869,17 @@ pub const RHI = struct {
         return .{ .ptr = self.ptr, .vtable = &self.vtable.timing };
     }
 
-    // Legacy wrappers (redirecting to sub-interfaces)
+    // -------------------------------------------------------------------------
+    // DEPRECATED: Legacy passthrough methods. These delegate to focused wrappers
+    // and exist only during the #272 modularization transition.
+    // Use the focused wrappers directly instead:
+    //   rhi.resourceManager() -> ResourceManager (createBuffer, createTexture, etc.)
+    //   rhi.renderContext()   -> RenderContext (beginFrame, draw, bindTexture, etc.)
+    //   rhi.uiRenderer()      -> UIRenderer   (beginPass, drawRect, etc.)
+    //   rhi.shadowSystem()    -> ShadowSystemWrapper (beginPass, endPass, etc.)
+    // -------------------------------------------------------------------------
+    // Resource operations (use ResourceManager)
+    // -------------------------------------------------------------------------
     pub fn createBuffer(self: RHI, size: usize, usage: BufferUsage) RhiError!BufferHandle {
         return self.vtable.resources.createBuffer(self.ptr, size, usage);
     }

--- a/src/engine/graphics/rhi_tests.zig
+++ b/src/engine/graphics/rhi_tests.zig
@@ -400,11 +400,10 @@ test "AtmosphereSystem.renderSky with null handles" {
     const rhi_instance = rhi.RHI{ .ptr = &mock, .vtable = &MockContext.MOCK_VULKAN_RHI_VTABLE, .device = null };
 
     const AtmosphereSystem = @import("atmosphere_system.zig").AtmosphereSystem;
-    var system = try AtmosphereSystem.init(testing.allocator, rhi_instance);
+    var system = try AtmosphereSystem.init(testing.allocator, rhi_instance.resourceManager());
     defer system.deinit();
 
-    // Should return error.SkyPipelineNotReady if handles are missing
-    try testing.expectError(error.SkyPipelineNotReady, system.renderSky(.{
+    try testing.expectError(error.SkyPipelineNotReady, system.renderSky(rhi_instance.renderContext(), .{
         .cam_pos = Vec3.zero,
         .cam_forward = Vec3.init(0, 0, 1),
         .cam_right = Vec3.init(1, 0, 0),
@@ -427,10 +426,10 @@ test "AtmosphereSystem.renderClouds with null handles" {
     const rhi_instance = rhi.RHI{ .ptr = &mock, .vtable = &MockContext.MOCK_VULKAN_RHI_VTABLE, .device = null };
 
     const AtmosphereSystem = @import("atmosphere_system.zig").AtmosphereSystem;
-    var system = try AtmosphereSystem.init(testing.allocator, rhi_instance);
+    var system = try AtmosphereSystem.init(testing.allocator, rhi_instance.resourceManager());
     defer system.deinit();
 
-    try testing.expectError(error.CloudPipelineNotReady, system.renderClouds(.{
+    try testing.expectError(error.CloudPipelineNotReady, system.renderClouds(rhi_instance.renderContext(), .{
         .cam_pos = Vec3.zero,
         .sun_dir = Vec3.init(0, -1, 0),
         .sun_intensity = 1.0,
@@ -441,7 +440,6 @@ test "AtmosphereSystem.renderClouds with null handles" {
         .wind_offset_z = 0.0,
         .fog_color = Vec3.init(0.8, 0.9, 1.0),
         .fog_density = 0.01,
-        .view_proj = Mat4.identity,
     }, Mat4.identity));
 
     try testing.expect(mock.cloud_pipeline_requested);

--- a/src/engine/graphics/texture.zig
+++ b/src/engine/graphics/texture.zig
@@ -10,25 +10,25 @@ pub const Texture = struct {
     handle: rhi.TextureHandle,
     width: u32,
     height: u32,
-    rhi_instance: rhi.RHI,
+    resources: rhi.ResourceManager,
 
-    pub fn init(instance: rhi.RHI, width: u32, height: u32, format: TextureFormat, config: Config, data: ?[]const u8) rhi.RhiError!Texture {
-        const handle = try instance.createTexture(width, height, format, config, data);
+    pub fn init(resources: rhi.ResourceManager, width: u32, height: u32, format: TextureFormat, config: Config, data: ?[]const u8) rhi.RhiError!Texture {
+        const handle = try resources.createTexture(width, height, format, config, data);
         return .{
             .handle = handle,
             .width = width,
             .height = height,
-            .rhi_instance = instance,
+            .resources = resources,
         };
     }
 
-    pub fn initEmpty(instance: rhi.RHI, width: u32, height: u32, format: TextureFormat, config: Config) rhi.RhiError!Texture {
-        return init(instance, width, height, format, config, null);
+    pub fn initEmpty(resources: rhi.ResourceManager, width: u32, height: u32, format: TextureFormat, config: Config) rhi.RhiError!Texture {
+        return init(resources, width, height, format, config, null);
     }
 
-    pub fn initFloat(instance: rhi.RHI, width: u32, height: u32, data: []const f32) rhi.RhiError!Texture {
+    pub fn initFloat(resources: rhi.ResourceManager, width: u32, height: u32, data: []const f32) rhi.RhiError!Texture {
         const bytes = std.mem.sliceAsBytes(data);
-        const handle = try instance.createTexture(width, height, .rgba32f, .{
+        const handle = try resources.createTexture(width, height, .rgba32f, .{
             .min_filter = .linear_mipmap_linear,
             .mag_filter = .linear,
             .wrap_s = .clamp_to_edge,
@@ -39,24 +39,20 @@ pub const Texture = struct {
             .handle = handle,
             .width = width,
             .height = height,
-            .rhi_instance = instance,
+            .resources = resources,
         };
     }
 
-    pub fn initSolidColor(instance: rhi.RHI, r: u8, g: u8, b: u8, a: u8) rhi.RhiError!Texture {
+    pub fn initSolidColor(resources: rhi.ResourceManager, r: u8, g: u8, b: u8, a: u8) rhi.RhiError!Texture {
         const data = [_]u8{ r, g, b, a };
-        return init(instance, 1, 1, .rgba, .{}, &data);
+        return init(resources, 1, 1, .rgba, .{}, &data);
     }
 
     pub fn deinit(self: *Texture) void {
-        self.rhi_instance.destroyTexture(self.handle);
-    }
-
-    pub fn bind(self: *const Texture, slot: u32) void {
-        self.rhi_instance.bindTexture(self.handle, slot);
+        self.resources.destroyTexture(self.handle);
     }
 
     pub fn update(self: *const Texture, data: []const u8) rhi.RhiError!void {
-        try self.rhi_instance.updateTexture(self.handle, data);
+        try self.resources.updateTexture(self.handle, data);
     }
 };

--- a/src/engine/graphics/texture_atlas.zig
+++ b/src/engine/graphics/texture_atlas.zig
@@ -63,7 +63,7 @@ pub const TextureAtlas = struct {
         return self.tile_mappings[block_id];
     }
 
-    pub fn init(allocator: std.mem.Allocator, rhi_instance: rhi.RHI, pack_manager: ?*resource_pack.ResourcePackManager, max_resolution: u32) !TextureAtlas {
+    pub fn init(allocator: std.mem.Allocator, resources: rhi.ResourceManager, pack_manager: ?*resource_pack.ResourcePackManager, max_resolution: u32) !TextureAtlas {
         // 1. Detect tile size from pack textures
         const tile_size = detectTileSize(pack_manager, allocator, max_resolution);
         const atlas_size = tile_size * TILES_PER_ROW;
@@ -86,7 +86,7 @@ pub const TextureAtlas = struct {
         }
 
         // 4. Create GPU textures
-        const atlas_textures = try createRhiTextures(rhi_instance, atlas_size, &buffers);
+        const atlas_textures = try createRhiTextures(resources, atlas_size, &buffers);
 
         return .{
             .texture = atlas_textures.diffuse,
@@ -120,33 +120,6 @@ pub const TextureAtlas = struct {
         }
     }
 
-    /// Bind diffuse texture
-    pub fn bind(self: *const TextureAtlas, slot: u32) void {
-        self.texture.bind(slot);
-    }
-
-    /// Bind normal map texture (if available)
-    pub fn bindNormal(self: *const TextureAtlas, slot: u32) void {
-        if (self.normal_texture) |*t| {
-            t.bind(slot);
-        }
-    }
-
-    /// Bind roughness texture (if available)
-    pub fn bindRoughness(self: *const TextureAtlas, slot: u32) void {
-        if (self.roughness_texture) |*t| {
-            t.bind(slot);
-        }
-    }
-
-    /// Bind displacement texture (if available)
-    pub fn bindDisplacement(self: *const TextureAtlas, slot: u32) void {
-        if (self.displacement_texture) |*t| {
-            t.bind(slot);
-        }
-    }
-
-    /// Check if PBR textures are available
     pub fn hasPBR(self: *const TextureAtlas) bool {
         return self.has_pbr;
     }
@@ -326,10 +299,10 @@ const AtlasTextures = struct {
     roughness: ?Texture,
 };
 
-fn createRhiTextures(rhi_instance: rhi.RHI, atlas_size: u32, buffers: *const AtlasBuffers) !AtlasTextures {
+fn createRhiTextures(resources: rhi.ResourceManager, atlas_size: u32, buffers: *const AtlasBuffers) !AtlasTextures {
     // Disable mipmaps to prevent texture atlas bleeding between adjacent tiles
     // This is the only way to completely eliminate the "block outlines" (grid lines)
-    const diffuse = try Texture.init(rhi_instance, atlas_size, atlas_size, .rgba_srgb, .{
+    const diffuse = try Texture.init(resources, atlas_size, atlas_size, .rgba_srgb, .{
         .min_filter = .nearest,
         .mag_filter = .nearest,
         .generate_mipmaps = false,
@@ -339,7 +312,7 @@ fn createRhiTextures(rhi_instance: rhi.RHI, atlas_size: u32, buffers: *const Atl
     var roughness: ?Texture = null;
 
     if (buffers.normal) |np| {
-        normal = try Texture.init(rhi_instance, atlas_size, atlas_size, .rgba, .{
+        normal = try Texture.init(resources, atlas_size, atlas_size, .rgba, .{
             .min_filter = .nearest,
             .mag_filter = .nearest,
             .generate_mipmaps = false,
@@ -347,7 +320,7 @@ fn createRhiTextures(rhi_instance: rhi.RHI, atlas_size: u32, buffers: *const Atl
     }
 
     if (buffers.roughness) |rp| {
-        roughness = try Texture.init(rhi_instance, atlas_size, atlas_size, .rgba, .{
+        roughness = try Texture.init(resources, atlas_size, atlas_size, .rgba, .{
             .min_filter = .nearest,
             .mag_filter = .nearest,
             .generate_mipmaps = false,

--- a/src/engine/ui/ui_system.zig
+++ b/src/engine/ui/ui_system.zig
@@ -1,20 +1,19 @@
 //! UI System for rendering 2D interface elements.
 //! Uses orthographic projection and immediate-mode style rendering.
-//! Now abstracted through RHI for backend-agnostic rendering.
+//! Now abstracted through UIRenderer for backend-agnostic rendering.
 
 const std = @import("std");
 const rhi = @import("../graphics/rhi.zig");
 
-// Re-export Color and Rect from RHI for convenience
 pub const Color = rhi.Color;
 pub const Rect = rhi.Rect;
 
 pub const UISystem = struct {
-    renderer: rhi.RHI,
+    renderer: rhi.UIRenderer,
     screen_width: f32,
     screen_height: f32,
 
-    pub fn init(renderer: rhi.RHI, width: u32, height: u32) !UISystem {
+    pub fn init(renderer: rhi.UIRenderer, width: u32, height: u32) !UISystem {
         return .{
             .renderer = renderer,
             .screen_width = @floatFromInt(width),
@@ -24,7 +23,6 @@ pub const UISystem = struct {
 
     pub fn deinit(self: *UISystem) void {
         _ = self;
-        // RHI cleanup is handled by the RHI itself
     }
 
     pub fn resize(self: *UISystem, width: u32, height: u32) void {
@@ -32,24 +30,20 @@ pub const UISystem = struct {
         self.screen_height = @floatFromInt(height);
     }
 
-    /// Begin UI rendering (call before drawing any UI elements)
     pub fn begin(self: *UISystem) void {
-        self.renderer.begin2DPass(self.screen_width, self.screen_height);
+        self.renderer.beginPass(self.screen_width, self.screen_height);
     }
 
-    /// End UI rendering (call after drawing all UI elements)
     pub fn end(self: *UISystem) void {
-        self.renderer.end2DPass();
+        self.renderer.endPass();
     }
 
-    /// Draw a filled rectangle
     pub fn drawRect(self: *UISystem, rect: Rect, color: Color) void {
-        self.renderer.drawRect2D(rect, color);
+        self.renderer.drawRect(rect, color);
     }
 
-    /// Draw a textured rectangle
     pub fn drawTexture(self: *UISystem, texture_id: rhi.TextureHandle, rect: Rect) void {
-        self.renderer.drawTexture2D(texture_id, rect);
+        self.renderer.drawTexture(texture_id, rect);
     }
 
     /// Draw a rectangle outline

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -178,45 +178,34 @@ pub const App = struct {
             log.log.warn("ZIGCRAFT_DISABLE_CLOUDS enabled", .{});
         }
 
-        const atlas = try TextureAtlas.init(allocator, rhi, &resource_pack_manager, settings.max_texture_resolution);
+        const atlas = try TextureAtlas.init(allocator, rhi.resourceManager(), &resource_pack_manager, settings.max_texture_resolution);
         var atlas_mut = atlas;
         errdefer atlas_mut.deinit();
-        atlas.bind(1);
-        // Bind PBR textures if available
-        atlas.bindNormal(6);
-        atlas.bindRoughness(7);
-        atlas.bindDisplacement(8);
 
-        // Load EXR Environment Map
         var env_map: ?Texture = null;
         if (!std.mem.eql(u8, settings.environment_map, "default")) {
             if (resource_pack_manager.loadImageFileFloat(settings.environment_map)) |tex_data| {
-                env_map = try Texture.initFloat(rhi, tex_data.width, tex_data.height, tex_data.pixels);
-                env_map.?.bind(9);
+                env_map = try Texture.initFloat(rhi.resourceManager(), tex_data.width, tex_data.height, tex_data.pixels);
                 log.log.info("Loaded Environment Map: {s}", .{settings.environment_map});
                 var td = tex_data;
                 td.deinit(allocator);
             } else {
                 log.log.warn("Could not load environment map: {s}", .{settings.environment_map});
-                // Fallback to white
                 const white_pixel = [_]f32{ 1.0, 1.0, 1.0, 1.0 };
-                env_map = try Texture.initFloat(rhi, 1, 1, &white_pixel);
-                env_map.?.bind(9);
+                env_map = try Texture.initFloat(rhi.resourceManager(), 1, 1, &white_pixel);
             }
         } else {
-            // Default white
             const white_pixel = [_]f32{ 1.0, 1.0, 1.0, 1.0 };
-            env_map = try Texture.initFloat(rhi, 1, 1, &white_pixel);
-            env_map.?.bind(9);
+            env_map = try Texture.initFloat(rhi.resourceManager(), 1, 1, &white_pixel);
         }
         errdefer if (env_map) |*t| t.deinit();
 
-        const atmosphere_system = try AtmosphereSystem.init(allocator, rhi);
+        const atmosphere_system = try AtmosphereSystem.init(allocator, rhi.resourceManager());
         errdefer atmosphere_system.deinit();
         const audio_system = try AudioSystem.init(allocator);
         errdefer audio_system.deinit();
 
-        const ui = try UISystem.init(rhi, input.window_width, input.window_height);
+        const ui = try UISystem.init(rhi.uiRenderer(), input.window_width, input.window_height);
         var ui_mut = ui;
         errdefer ui_mut.deinit();
 
@@ -275,7 +264,7 @@ pub const App = struct {
 
         // EngineContext uses rhi as a pointer; App owns the instance.
 
-        app.material_system = try MaterialSystem.init(allocator, rhi, &app.atlas);
+        app.material_system = try MaterialSystem.init(allocator, &app.atlas);
         errdefer app.material_system.deinit();
         app.lpv_system = try LPVSystem.init(
             allocator,

--- a/src/game/block_outline.zig
+++ b/src/game/block_outline.zig
@@ -3,7 +3,8 @@
 
 const std = @import("std");
 const rhi_pkg = @import("../engine/graphics/rhi.zig");
-const RHI = rhi_pkg.RHI;
+const ResourceManager = rhi_pkg.ResourceManager;
+const RenderContext = rhi_pkg.RenderContext;
 const Mat4 = @import("../engine/math/mat4.zig").Mat4;
 const Vec3 = @import("../engine/math/vec3.zig").Vec3;
 const Vertex = rhi_pkg.Vertex;
@@ -139,35 +140,34 @@ const outline_vertices = blk: {
 
 pub const BlockOutline = struct {
     buffer_handle: rhi_pkg.BufferHandle,
-    rhi: RHI,
+    resources: ResourceManager,
 
-    pub fn init(rhi: RHI) !BlockOutline {
-        const buffer = try rhi.createBuffer(@sizeOf(@TypeOf(outline_vertices)), .vertex);
-        try rhi.uploadBuffer(buffer, std.mem.asBytes(&outline_vertices));
+    pub fn init(resources: ResourceManager) !BlockOutline {
+        const buffer = try resources.createBuffer(@sizeOf(@TypeOf(outline_vertices)), .vertex);
+        try resources.uploadBuffer(buffer, std.mem.asBytes(&outline_vertices));
 
         return .{
             .buffer_handle = buffer,
-            .rhi = rhi,
+            .resources = resources,
         };
     }
 
     pub fn deinit(self: *BlockOutline) void {
         if (self.buffer_handle != rhi_pkg.InvalidBufferHandle) {
-            self.rhi.destroyBuffer(self.buffer_handle);
+            self.resources.destroyBuffer(self.buffer_handle);
             self.buffer_handle = rhi_pkg.InvalidBufferHandle;
         }
     }
 
-    /// Draw outline at the given block position
-    pub fn draw(self: *const BlockOutline, block_x: i32, block_y: i32, block_z: i32, camera_pos: Vec3) void {
+    pub fn draw(self: *const BlockOutline, ctx: RenderContext, block_x: i32, block_y: i32, block_z: i32, camera_pos: Vec3) void {
         const rel_x = @as(f32, @floatFromInt(block_x)) - camera_pos.x;
         const rel_y = @as(f32, @floatFromInt(block_y)) - camera_pos.y;
         const rel_z = @as(f32, @floatFromInt(block_z)) - camera_pos.z;
 
         const model = Mat4.translate(Vec3.init(rel_x, rel_y, rel_z));
-        self.rhi.setSelectionMode(true);
-        self.rhi.setModelMatrix(model, Vec3.one, 0);
-        self.rhi.draw(self.buffer_handle, 288, .triangles);
-        self.rhi.setSelectionMode(false);
+        ctx.setSelectionMode(true);
+        ctx.setModelMatrix(model, Vec3.one, 0);
+        ctx.draw(self.buffer_handle, 288, .triangles);
+        ctx.setSelectionMode(false);
     }
 };

--- a/src/game/hand_renderer.zig
+++ b/src/game/hand_renderer.zig
@@ -3,7 +3,8 @@
 
 const std = @import("std");
 const rhi_pkg = @import("../engine/graphics/rhi.zig");
-const RHI = rhi_pkg.RHI;
+const ResourceManager = rhi_pkg.ResourceManager;
+const RenderContext = rhi_pkg.RenderContext;
 const Mat4 = @import("../engine/math/mat4.zig").Mat4;
 const Vec3 = @import("../engine/math/vec3.zig").Vec3;
 const Vertex = rhi_pkg.Vertex;
@@ -13,20 +14,19 @@ const block_registry = @import("../world/block_registry.zig");
 const Inventory = @import("inventory.zig").Inventory;
 
 pub const HandRenderer = struct {
-    rhi: RHI,
+    resources: ResourceManager,
     buffer_handle: rhi_pkg.BufferHandle,
     last_block: ?BlockType,
     visible: bool,
 
-    // Animation state
     swing_progress: f32,
     swinging: bool,
 
-    pub fn init(rhi: RHI) !HandRenderer {
-        const buffer = try rhi.createBuffer(36 * @sizeOf(Vertex), .vertex);
+    pub fn init(resources: ResourceManager) !HandRenderer {
+        const buffer = try resources.createBuffer(36 * @sizeOf(Vertex), .vertex);
 
         return .{
-            .rhi = rhi,
+            .resources = resources,
             .buffer_handle = buffer,
             .last_block = null,
             .visible = false,
@@ -37,7 +37,7 @@ pub const HandRenderer = struct {
 
     pub fn deinit(self: *HandRenderer) void {
         if (self.buffer_handle != rhi_pkg.InvalidBufferHandle) {
-            self.rhi.destroyBuffer(self.buffer_handle);
+            self.resources.destroyBuffer(self.buffer_handle);
             self.buffer_handle = rhi_pkg.InvalidBufferHandle;
         }
     }
@@ -113,7 +113,7 @@ pub const HandRenderer = struct {
         // West Face (x = n)
         addQuad(&vertices, &idx, .{ n, n, n }, .{ n, n, p }, .{ n, p, p }, .{ n, p, n }, faces[5].normal, faces[5].tile, color);
 
-        try self.rhi.uploadBuffer(self.buffer_handle, std.mem.asBytes(&vertices));
+        try self.resources.uploadBuffer(self.buffer_handle, std.mem.asBytes(&vertices));
     }
 
     fn addQuad(verts: *[36]Vertex, idx: *usize, p0: [3]f32, p1: [3]f32, p2: [3]f32, p3: [3]f32, normal: [3]f32, tile: u16, color: [3]f32) void {
@@ -139,7 +139,7 @@ pub const HandRenderer = struct {
         idx.* += 1;
     }
 
-    pub fn draw(self: *HandRenderer, camera_pos: Vec3, camera_yaw: f32, camera_pitch: f32) void {
+    pub fn draw(self: *HandRenderer, ctx: RenderContext, camera_pos: Vec3, camera_yaw: f32, camera_pitch: f32) void {
         if (!self.visible) return;
 
         // Position relative to camera:
@@ -218,10 +218,8 @@ pub const HandRenderer = struct {
         const swing_rot = Mat4.rotateZ(swing_rot_z);
         m = m.multiply(swing_rot);
 
-        self.rhi.setModelMatrix(m, Vec3.one, 0);
+        ctx.setModelMatrix(m, Vec3.one, 0);
 
-        // Use solid draw mode (triangles)
-        // Pass DrawMode.triangles
-        self.rhi.draw(self.buffer_handle, 36, .triangles);
+        ctx.draw(self.buffer_handle, 36, .triangles);
     }
 };

--- a/src/game/screens/environment.zig
+++ b/src/game/screens/environment.zig
@@ -150,21 +150,18 @@ pub const EnvironmentScreen = struct {
 
         if (!std.mem.eql(u8, ctx.settings.environment_map, "default")) {
             if (ctx.resource_pack_manager.loadImageFileFloat(ctx.settings.environment_map)) |tex_data| {
-                env_ptr.* = try Texture.initFloat(ctx.rhi.*, tex_data.width, tex_data.height, tex_data.pixels);
-                env_ptr.*.?.bind(9);
+                env_ptr.* = try Texture.initFloat(ctx.rhi.resourceManager(), tex_data.width, tex_data.height, tex_data.pixels);
                 log.log.info("Loaded Environment Map: {s}", .{ctx.settings.environment_map});
                 var td = tex_data;
                 td.deinit(ctx.allocator);
             } else {
                 log.log.warn("Could not load environment map: {s}", .{ctx.settings.environment_map});
                 const white_pixel = [_]f32{ 1.0, 1.0, 1.0, 1.0 };
-                env_ptr.* = try Texture.initFloat(ctx.rhi.*, 1, 1, &white_pixel);
-                env_ptr.*.?.bind(9);
+                env_ptr.* = try Texture.initFloat(ctx.rhi.resourceManager(), 1, 1, &white_pixel);
             }
         } else {
             const white_pixel = [_]f32{ 1.0, 1.0, 1.0, 1.0 };
-            env_ptr.* = try Texture.initFloat(ctx.rhi.*, 1, 1, &white_pixel);
-            env_ptr.*.?.bind(9);
+            env_ptr.* = try Texture.initFloat(ctx.rhi.resourceManager(), 1, 1, &white_pixel);
         }
     }
 

--- a/src/game/screens/resource_packs.zig
+++ b/src/game/screens/resource_packs.zig
@@ -132,13 +132,9 @@ pub const ResourcePacksScreen = struct {
 
     fn reloadAtlas(self: *@This()) !void {
         const ctx = self.context;
-        ctx.rhi.*.waitIdle();
+        ctx.rhi.waitIdle();
         ctx.atlas.deinit();
-        ctx.atlas.* = try TextureAtlas.init(ctx.allocator, ctx.rhi.*, ctx.resource_pack_manager, ctx.settings.max_texture_resolution);
-        ctx.atlas.bind(1);
-        ctx.atlas.bindNormal(6);
-        ctx.atlas.bindRoughness(7);
-        ctx.atlas.bindDisplacement(8);
+        ctx.atlas.* = try TextureAtlas.init(ctx.allocator, ctx.rhi.resourceManager(), ctx.resource_pack_manager, ctx.settings.max_texture_resolution);
     }
 
     pub fn screen(self: *@This()) IScreen {

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -321,9 +321,9 @@ pub const WorldScreen = struct {
 
     fn renderOverlay(scene_ctx: render_graph_pkg.SceneContext) void {
         const self: *WorldScreen = @ptrCast(@alignCast(scene_ctx.overlay_ctx.?));
-        if (self.session.player.target_block) |target| self.session.block_outline.draw(target.x, target.y, target.z, scene_ctx.camera.position);
-        self.session.renderEntities(scene_ctx.camera.position);
-        self.session.hand_renderer.draw(scene_ctx.camera.position, scene_ctx.camera.yaw, scene_ctx.camera.pitch);
+        if (self.session.player.target_block) |target| self.session.block_outline.draw(scene_ctx.render_ctx, target.x, target.y, target.z, scene_ctx.camera.position);
+        self.session.renderEntities(scene_ctx.render_ctx, scene_ctx.camera.position);
+        self.session.hand_renderer.draw(scene_ctx.render_ctx, scene_ctx.camera.position, scene_ctx.camera.yaw, scene_ctx.camera.pitch);
     }
 };
 

--- a/src/game/session.zig
+++ b/src/game/session.zig
@@ -12,6 +12,7 @@ const BlockOutline = @import("block_outline.zig").BlockOutline;
 const HandRenderer = @import("hand_renderer.zig").HandRenderer;
 const Camera = @import("../engine/graphics/camera.zig").Camera;
 const RHI = @import("../engine/graphics/rhi.zig").RHI;
+const RenderContext = @import("../engine/graphics/rhi.zig").RenderContext;
 const TextureAtlas = @import("../engine/graphics/texture_atlas.zig").TextureAtlas;
 const Input = @import("../engine/input/input.zig").Input;
 const IRawInputProvider = @import("../engine/input/interfaces.zig").IRawInputProvider;
@@ -144,7 +145,7 @@ pub const GameSession = struct {
         else
             try World.initGen(generator_index, allocator, effective_render_distance, seed, rhi.*, atlas);
 
-        const world_map = try WorldMap.init(rhi.*, 256, 256);
+        const world_map = try WorldMap.init(rhi.resourceManager(), 256, 256);
 
         // ecs_registry and ecs_render_system are initialized directly in the struct
 
@@ -161,11 +162,11 @@ pub const GameSession = struct {
             .player = player,
             .inventory = Inventory.init(),
             .inventory_ui_state = .{},
-            .block_outline = try BlockOutline.init(rhi.*),
-            .hand_renderer = try HandRenderer.init(rhi.*),
+            .block_outline = try BlockOutline.init(rhi.resourceManager()),
+            .hand_renderer = try HandRenderer.init(rhi.resourceManager()),
             .camera = player.camera,
             .ecs_registry = ECSRegistry.init(allocator),
-            .ecs_render_system = try ECSRenderSystem.init(rhi),
+            .ecs_render_system = try ECSRenderSystem.init(rhi.resourceManager()),
             .rhi = rhi,
             .atmosphere = atmosphere,
             .clouds = CloudState{},
@@ -267,8 +268,8 @@ pub const GameSession = struct {
         }
     }
 
-    pub fn renderEntities(self: *GameSession, camera_pos: Vec3) void {
-        self.ecs_render_system.render(&self.ecs_registry, camera_pos);
+    pub fn renderEntities(self: *GameSession, ctx: RenderContext, camera_pos: Vec3) void {
+        self.ecs_render_system.render(ctx, &self.ecs_registry, camera_pos);
     }
 
     pub fn drawHUD(self: *GameSession, ui: *UISystem, atlas: *const TextureAtlas, active_pack: ?[]const u8, fps: f32, screen_w: f32, screen_h: f32, mouse_x: f32, mouse_y: f32, mouse_clicked: bool) !void {

--- a/src/world/chunk_mesh.zig
+++ b/src/world/chunk_mesh.zig
@@ -11,7 +11,7 @@ const CHUNK_SIZE_X = @import("chunk.zig").CHUNK_SIZE_X;
 const CHUNK_SIZE_Z = @import("chunk.zig").CHUNK_SIZE_Z;
 const TextureAtlas = @import("../engine/graphics/texture_atlas.zig").TextureAtlas;
 const rhi_mod = @import("../engine/graphics/rhi.zig");
-const RHI = rhi_mod.RHI;
+const RenderContext = rhi_mod.RenderContext;
 const Vertex = rhi_mod.Vertex;
 const chunk_alloc_mod = @import("chunk_allocator.zig");
 const GlobalVertexAllocator = chunk_alloc_mod.GlobalVertexAllocator;
@@ -310,23 +310,23 @@ pub const ChunkMesh = struct {
     }
 
     /// Draw the chunk mesh with a single draw call per pass.
-    pub fn draw(self: *const ChunkMesh, rhi: RHI, pass: Pass) void {
+    pub fn draw(self: *const ChunkMesh, ctx: RenderContext, pass: Pass) void {
         if (!self.ready) return;
 
         switch (pass) {
             .solid => {
                 if (self.solid_allocation) |alloc| {
-                    rhi.drawOffset(alloc.handle, alloc.count, .triangles, alloc.offset);
+                    ctx.drawOffset(alloc.handle, alloc.count, .triangles, alloc.offset);
                 }
             },
             .cutout => {
                 if (self.cutout_allocation) |alloc| {
-                    rhi.drawOffset(alloc.handle, alloc.count, .triangles, alloc.offset);
+                    ctx.drawOffset(alloc.handle, alloc.count, .triangles, alloc.offset);
                 }
             },
             .fluid => {
                 if (self.fluid_allocation) |alloc| {
-                    rhi.drawOffset(alloc.handle, alloc.count, .triangles, alloc.offset);
+                    ctx.drawOffset(alloc.handle, alloc.count, .triangles, alloc.offset);
                 }
             },
         }

--- a/src/world/worldgen/world_map.zig
+++ b/src/world/worldgen/world_map.zig
@@ -13,12 +13,12 @@ pub const WorldMap = struct {
     width: u32,
     height: u32,
 
-    pub fn init(rhi_instance: rhi.RHI, width: u32, height: u32) !WorldMap {
+    pub fn init(resources: rhi.ResourceManager, width: u32, height: u32) !WorldMap {
         // Safety: ensure texture size is within typical hardware limits
         const safe_w = @min(width, 4096);
         const safe_h = @min(height, 4096);
 
-        const texture = try Texture.initEmpty(rhi_instance, safe_w, safe_h, .rgba, .{
+        const texture = try Texture.initEmpty(resources, safe_w, safe_h, .rgba, .{
             .min_filter = .nearest,
             .mag_filter = .nearest,
             .generate_mipmaps = false,


### PR DESCRIPTION
## Summary

- Add UIRenderer struct wrapping IUIContext (issue #291 / final step of #272)
- Migrate UISystem from rhi.RHI to rhi.UIRenderer
- Migrate Texture, TextureAtlas, WorldMap to ResourceManager
- Migrate MaterialSystem, ChunkMesh, BlockOutline, HandRenderer, ECSRenderSystem to take RenderContext as parameter for draw operations
- Migrate AtmosphereSystem to ResourceManager + RenderContext param
- Deprecate monolithic RHI struct with migration guide documentation
- Update all call sites in app.zig, screen files, and session.zig

## Breaking Changes

- UISystem.init(renderer: rhi.RHI, ...) -> UISystem.init(renderer: rhi.UIRenderer, ...)
- Texture.init(resources: rhi.ResourceManager, ...) (previously took rhi.RHI)
- MaterialSystem.bindTerrainMaterial(ctx: RenderContext, env_map) (previously took no ctx param)
- BlockOutline.draw(ctx: RenderContext, ...) (previously took no ctx param)
- HandRenderer.draw(ctx: RenderContext, ...) (previously took no ctx param)
- ECSRenderSystem.render(ctx: RenderContext, ...) (previously took no ctx param)
- AtmosphereSystem.renderSky/RenderClouds now take ctx: RenderContext param

## Verification

- [x] zig build test passes
- [x] zig build -Doptimize=ReleaseFast passes
- [x] zig fmt src/ applied

Closes #291