### PR TITLE
refactor(world): make World a pure facade for chunk storage (#292)

### DIFF
--- a/src/world/chunk_storage.zig
+++ b/src/world/chunk_storage.zig
@@ -69,10 +69,24 @@ pub const ChunkStorage = struct {
         self.chunks.deinit();
     }
 
-    pub fn count(self: *const ChunkStorage) usize {
+    pub fn count(self: *ChunkStorage) usize {
         self.chunks_mutex.lockShared();
         defer self.chunks_mutex.unlockShared();
         return self.chunks.count();
+    }
+
+    /// Sum total vertex count across all chunk meshes
+    pub fn totalVertexCount(self: *ChunkStorage) u64 {
+        self.chunks_mutex.lockShared();
+        defer self.chunks_mutex.unlockShared();
+        var total: u64 = 0;
+        var iter = self.chunks.iterator();
+        while (iter.next()) |entry| {
+            if (entry.value_ptr.*.mesh.solid_allocation) |alloc| total += alloc.count;
+            if (entry.value_ptr.*.mesh.cutout_allocation) |alloc| total += alloc.count;
+            if (entry.value_ptr.*.mesh.fluid_allocation) |alloc| total += alloc.count;
+        }
+        return total;
     }
 
     pub fn get(self: *ChunkStorage, cx: i32, cz: i32) ?*ChunkData {

--- a/src/world/world.zig
+++ b/src/world/world.zig
@@ -7,7 +7,6 @@ const NeighborChunks = @import("chunk_mesh.zig").NeighborChunks;
 const BlockType = @import("block.zig").BlockType;
 const ChunkStorage = @import("chunk_storage.zig").ChunkStorage;
 const ChunkData = @import("chunk_storage.zig").ChunkData;
-const ChunkKey = @import("chunk_storage.zig").ChunkKey;
 const worldToChunk = @import("chunk.zig").worldToChunk;
 const worldToLocal = @import("chunk.zig").worldToLocal;
 const CHUNK_SIZE_X = @import("chunk.zig").CHUNK_SIZE_X;
@@ -249,9 +248,7 @@ pub const World = struct {
     /// and used before the next call to World.update (which may unload chunks).
     /// If accessing from a background thread, the chunk must be pinned first.
     pub fn getChunk(self: *World, cx: i32, cz: i32) ?*ChunkData {
-        self.storage.chunks_mutex.lockShared();
-        defer self.storage.chunks_mutex.unlockShared();
-        return self.storage.chunks.get(ChunkKey{ .x = cx, .z = cz });
+        return self.storage.get(cx, cz);
     }
 
     pub fn update(self: *World, player_pos: Vec3, dt: f32) !void {
@@ -311,20 +308,11 @@ pub const World = struct {
     }
 
     pub fn getStats(self: *World) struct { chunks_loaded: usize, total_vertices: u64, gen_queue: usize, mesh_queue: usize, upload_queue: usize } {
-        self.storage.chunks_mutex.lockShared();
-        defer self.storage.chunks_mutex.unlockShared();
-        var total_verts: u64 = 0;
-        var iter = self.storage.iteratorUnsafe();
-        while (iter.next()) |entry| {
-            if (entry.value_ptr.*.mesh.solid_allocation) |alloc| total_verts += alloc.count;
-            if (entry.value_ptr.*.mesh.cutout_allocation) |alloc| total_verts += alloc.count;
-            if (entry.value_ptr.*.mesh.fluid_allocation) |alloc| total_verts += alloc.count;
-        }
-
+        const total_verts = self.storage.totalVertexCount();
         const streamer_stats = self.streamer.getStats();
 
         return .{
-            .chunks_loaded = self.storage.chunks.count(),
+            .chunks_loaded = self.storage.count(),
             .total_vertices = total_verts,
             .gen_queue = streamer_stats.gen_queue,
             .mesh_queue = streamer_stats.mesh_queue,

--- a/src/world/world.zig
+++ b/src/world/world.zig
@@ -268,17 +268,6 @@ pub const World = struct {
         // NOTE: LOD Manager update is handled inside streamer.update() now
     }
 
-    pub fn isChunkRenderable(chunk_x: i32, chunk_z: i32, ctx: *anyopaque) bool {
-        const storage: *ChunkStorage = @ptrCast(@alignCast(ctx));
-        storage.chunks_mutex.lockShared();
-        defer storage.chunks_mutex.unlockShared();
-
-        if (storage.chunks.get(.{ .x = chunk_x, .z = chunk_z })) |data| {
-            return data.chunk.state == .renderable or data.mesh.solid_allocation != null or data.mesh.cutout_allocation != null or data.mesh.fluid_allocation != null;
-        }
-        return false;
-    }
-
     pub fn render(self: *World, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         const lod_mgr = if (self.lod_enabled) self.lod_manager else null;
         self.renderer.render(view_proj, camera_pos, self.render_distance, lod_mgr, self.lod_enabled and render_lod);

--- a/src/world/world_renderer.zig
+++ b/src/world/world_renderer.zig
@@ -15,8 +15,6 @@ const LODManager = @import("lod_manager.zig").LODManager;
 const Vec3 = @import("../engine/math/vec3.zig").Vec3;
 const Mat4 = @import("../engine/math/mat4.zig").Mat4;
 const Frustum = @import("../engine/math/frustum.zig").Frustum;
-const World = @import("world.zig").World; // Circular dependency if not careful, better avoid. But isChunkRenderable callback needs it?
-// Actually isChunkRenderable uses World* but only needs access to storage/chunk state.
 
 pub const RenderStats = struct {
     chunks_total: u32 = 0,


### PR DESCRIPTION
## Summary
- Delegate `getChunk()` to `ChunkStorage.get()` instead of direct map access
- Add `totalVertexCount()` to `ChunkStorage` and use in `getStats()`
- Remove unused `ChunkKey` import from `world.zig`

World no longer directly accesses storage internals (`chunks`, `chunks_mutex`). All storage access is now properly encapsulated in `ChunkStorage`.

Closes #292