### PR TITLE
feat(ui): centralized debug menu system (#295)

### DIFF
--- a/src/engine/ui/debug_menu.zig
+++ b/src/engine/ui/debug_menu.zig
@@ -1,0 +1,117 @@
+//! Centralized debug menu overlay.
+//! Lists all debug features with toggle state and hotkey labels.
+//! Opened via F3 (toggle_debug_menu action).
+
+const UISystem = @import("ui_system.zig").UISystem;
+const Color = @import("ui_system.zig").Color;
+const Rect = @import("ui_system.zig").Rect;
+const Font = @import("font.zig");
+
+pub const DebugFeature = enum(u8) {
+    wireframe,
+    textures,
+    vsync,
+    fps_counter,
+    block_info,
+    shadow_debug,
+    timing_overlay,
+    lod_render,
+    gpass_render,
+    ssao,
+    clouds,
+    fog,
+    lpv_overlay,
+    creative_mode,
+    time_pause,
+
+    pub const count = @typeInfo(DebugFeature).@"enum".fields.len;
+};
+
+pub const FeatureInfo = struct {
+    label: []const u8,
+    hotkey: []const u8,
+};
+
+pub const FEATURE_INFOS = [DebugFeature.count]FeatureInfo{
+    .{ .label = "WIREFRAME", .hotkey = "F" },
+    .{ .label = "TEXTURES", .hotkey = "T" },
+    .{ .label = "VSYNC", .hotkey = "V" },
+    .{ .label = "FPS COUNTER", .hotkey = "F2" },
+    .{ .label = "BLOCK INFO", .hotkey = "F5" },
+    .{ .label = "SHADOW DEBUG", .hotkey = "G" },
+    .{ .label = "TIMING OVERLAY", .hotkey = "F4" },
+    .{ .label = "LOD RENDER", .hotkey = "F6" },
+    .{ .label = "G-PASS RENDER", .hotkey = "F7" },
+    .{ .label = "SSAO", .hotkey = "F8" },
+    .{ .label = "CLOUDS", .hotkey = "F9" },
+    .{ .label = "FOG", .hotkey = "F10" },
+    .{ .label = "LPV OVERLAY", .hotkey = "F11" },
+    .{ .label = "CREATIVE MODE", .hotkey = "F12" },
+    .{ .label = "TIME PAUSE", .hotkey = "N" },
+};
+
+pub const DebugMenuOverlay = struct {
+    enabled: bool = false,
+
+    const PANEL_X: f32 = 10.0;
+    const PANEL_Y: f32 = 10.0;
+    const PANEL_WIDTH: f32 = 300.0;
+    const LINE_HEIGHT: f32 = 18.0;
+    const HEADER_HEIGHT: f32 = 28.0;
+    const PADDING: f32 = 8.0;
+    const TITLE_SCALE: f32 = 1.5;
+    const TEXT_SCALE: f32 = 1.2;
+
+    pub fn toggle(self: *DebugMenuOverlay) void {
+        self.enabled = !self.enabled;
+    }
+
+    pub const ClickResult = struct {
+        feature: DebugFeature,
+    };
+
+    pub fn draw(self: *DebugMenuOverlay, ui: *UISystem, feature_states: [DebugFeature.count]bool, mouse_x: f32, mouse_y: f32, mouse_clicked: bool) ?ClickResult {
+        if (!self.enabled) return null;
+
+        const panel_height = HEADER_HEIGHT + PADDING * 2 + @as(f32, @floatFromInt(DebugFeature.count)) * LINE_HEIGHT;
+        const panel_rect = Rect{ .x = PANEL_X, .y = PANEL_Y, .width = PANEL_WIDTH, .height = panel_height };
+
+        ui.drawRect(panel_rect, Color.rgba(0.0, 0.0, 0.0, 0.7));
+        ui.drawRectOutline(panel_rect, Color.rgba(0.4, 0.6, 0.8, 0.8), 2.0);
+
+        var y = PANEL_Y + PADDING;
+        Font.drawText(ui, "DEBUG MENU", PANEL_X + PADDING, y, TITLE_SCALE, Color.rgba(0.95, 0.98, 1.0, 1.0));
+        y += HEADER_HEIGHT;
+
+        var result: ?ClickResult = null;
+
+        for (0..DebugFeature.count) |i| {
+            const feature: DebugFeature = @enumFromInt(i);
+            const info = FEATURE_INFOS[i];
+            const state = feature_states[i];
+            const row_rect = Rect{ .x = PANEL_X + 2, .y = y - 2, .width = PANEL_WIDTH - 4, .height = LINE_HEIGHT };
+            const hovered = row_rect.contains(mouse_x, mouse_y);
+
+            if (hovered) {
+                ui.drawRect(row_rect, Color.rgba(0.2, 0.3, 0.45, 0.5));
+                if (mouse_clicked) {
+                    result = .{ .feature = feature };
+                }
+            }
+
+            Font.drawText(ui, info.label, PANEL_X + PADDING + 4, y, TEXT_SCALE, Color.rgba(0.85, 0.88, 0.92, 1.0));
+
+            const state_text = if (state) "ON" else "OFF";
+            const state_color = if (state) Color.rgba(0.3, 1.0, 0.4, 1.0) else Color.rgba(0.7, 0.35, 0.35, 1.0);
+            const state_x = PANEL_X + PANEL_WIDTH - PADDING - 4 - Font.measureTextWidth(state_text, TEXT_SCALE) - 50.0;
+            Font.drawText(ui, state_text, state_x, y, TEXT_SCALE, state_color);
+
+            const hotkey_x = PANEL_X + PANEL_WIDTH - PADDING - 4 - Font.measureTextWidth(info.hotkey, TEXT_SCALE);
+            Font.drawText(ui, info.hotkey, hotkey_x, y, TEXT_SCALE, Color.rgba(0.55, 0.58, 0.65, 1.0));
+
+            y += LINE_HEIGHT;
+        }
+
+        return result;
+    }
+};

--- a/src/engine/ui/debug_menu.zig
+++ b/src/engine/ui/debug_menu.zig
@@ -33,6 +33,8 @@ pub const FeatureInfo = struct {
     hotkey: []const u8,
 };
 
+/// Hotkey labels reflect the default bindings in `input_mapper.zig`.
+/// Shown for reference — features are toggled by clicking menu rows.
 pub const FEATURE_INFOS = [DebugFeature.count]FeatureInfo{
     .{ .label = "WIREFRAME", .hotkey = "F" },
     .{ .label = "TEXTURES", .hotkey = "T" },

--- a/src/engine/ui/debug_menu.zig
+++ b/src/engine/ui/debug_menu.zig
@@ -53,6 +53,7 @@ pub const FEATURE_INFOS = [DebugFeature.count]FeatureInfo{
 
 pub const DebugMenuOverlay = struct {
     enabled: bool = false,
+    scroll_offset: usize = 0,
 
     const BASE_PANEL_X: f32 = 10.0;
     const BASE_PANEL_Y: f32 = 10.0;
@@ -62,17 +63,19 @@ pub const DebugMenuOverlay = struct {
     const BASE_PADDING: f32 = 8.0;
     const BASE_TITLE_SCALE: f32 = 1.5;
     const BASE_TEXT_SCALE: f32 = 1.2;
-    const MAX_VISIBLE_ROWS: usize = 15;
+    const SCROLL_ARROW_HEIGHT: f32 = 16.0;
+    const SCROLL_THUMB_MIN_HEIGHT: f32 = 20.0;
 
     pub fn toggle(self: *DebugMenuOverlay) void {
         self.enabled = !self.enabled;
+        self.scroll_offset = 0;
     }
 
     pub const ClickResult = struct {
         feature: DebugFeature,
     };
 
-    pub fn draw(self: *DebugMenuOverlay, ui: *UISystem, feature_states: [DebugFeature.count]bool, mouse_x: f32, mouse_y: f32, mouse_clicked: bool, ui_scale: f32) ?ClickResult {
+    pub fn draw(self: *DebugMenuOverlay, ui: *UISystem, feature_states: [DebugFeature.count]bool, mouse_x: f32, mouse_y: f32, mouse_clicked: bool, ui_scale: f32, scroll_delta_y: f32) ?ClickResult {
         if (!self.enabled) return null;
 
         const panel_x = BASE_PANEL_X * ui_scale;
@@ -84,8 +87,22 @@ pub const DebugMenuOverlay = struct {
         const title_scale = BASE_TITLE_SCALE * ui_scale;
         const text_scale = BASE_TEXT_SCALE * ui_scale;
 
-        const visible_rows = @min(DebugFeature.count, MAX_VISIBLE_ROWS);
-        const panel_height = header_height + padding * 2 + @as(f32, @floatFromInt(visible_rows)) * line_height;
+        const panel_top_margin = panel_y + padding + header_height;
+        const screen_h: f32 = ui.screen_height;
+        const max_possible_rows: usize = @intFromFloat(@divTrunc(screen_h * 0.85 - panel_top_margin, line_height));
+        const max_visible_rows = @max(3, @min(max_possible_rows, DebugFeature.count));
+
+        if (scroll_delta_y != 0) {
+            const rows_to_scroll: usize = if (@abs(scroll_delta_y) >= 1.0) @as(usize, @intFromFloat(@round(@abs(scroll_delta_y)))) else 0;
+            if (scroll_delta_y > 0) {
+                if (self.scroll_offset > 0) self.scroll_offset -= @min(rows_to_scroll, self.scroll_offset);
+            } else {
+                const max_offset = DebugFeature.count - max_visible_rows;
+                self.scroll_offset += @min(rows_to_scroll, max_offset - self.scroll_offset);
+            }
+        }
+
+        const panel_height = header_height + padding * 2 + @as(f32, @floatFromInt(max_visible_rows)) * line_height;
         const panel_rect = Rect{ .x = panel_x, .y = panel_y, .width = panel_width, .height = panel_height };
 
         ui.drawRect(panel_rect, Color.rgba(0.0, 0.0, 0.0, 0.7));
@@ -97,10 +114,13 @@ pub const DebugMenuOverlay = struct {
 
         var result: ?ClickResult = null;
 
-        for (0..visible_rows) |i| {
-            const feature: DebugFeature = @enumFromInt(i);
-            const info = FEATURE_INFOS[i];
-            const state = feature_states[i];
+        for (0..max_visible_rows) |i| {
+            const feature_idx = self.scroll_offset + i;
+            if (feature_idx >= DebugFeature.count) break;
+
+            const feature: DebugFeature = @enumFromInt(feature_idx);
+            const info = FEATURE_INFOS[feature_idx];
+            const state = feature_states[feature_idx];
             const row_rect = Rect{ .x = panel_x + 2 * ui_scale, .y = y - 2 * ui_scale, .width = panel_width - 4 * ui_scale, .height = line_height };
             const hovered = row_rect.contains(mouse_x, mouse_y);
 
@@ -122,6 +142,18 @@ pub const DebugMenuOverlay = struct {
             Font.drawText(ui, info.hotkey, hotkey_x, y, text_scale, Color.rgba(0.55, 0.58, 0.65, 1.0));
 
             y += line_height;
+        }
+
+        if (DebugFeature.count > max_visible_rows) {
+            const scroll_bar_x = panel_x + panel_width - 8.0 * ui_scale;
+            const scroll_bar_top = panel_y + header_height + padding;
+            const scroll_bar_height = panel_height - header_height - padding * 2;
+            const thumb_height = @max(SCROLL_THUMB_MIN_HEIGHT * ui_scale, @as(f32, @floatFromInt(max_visible_rows)) / @as(f32, @floatFromInt(DebugFeature.count)) * scroll_bar_height);
+            const thumb_ratio = @as(f32, @floatFromInt(self.scroll_offset)) / @as(f32, @floatFromInt(DebugFeature.count - max_visible_rows));
+            const thumb_y = scroll_bar_top + thumb_ratio * (scroll_bar_height - thumb_height);
+
+            ui.drawRect(.{ .x = scroll_bar_x, .y = scroll_bar_top, .width = 4.0 * ui_scale, .height = scroll_bar_height }, Color.rgba(0.25, 0.3, 0.4, 0.6));
+            ui.drawRect(.{ .x = scroll_bar_x, .y = thumb_y, .width = 4.0 * ui_scale, .height = thumb_height }, Color.rgba(0.5, 0.65, 0.85, 0.9));
         }
 
         return result;

--- a/src/engine/ui/debug_menu.zig
+++ b/src/engine/ui/debug_menu.zig
@@ -2,6 +2,7 @@
 //! Lists all debug features with toggle state and hotkey labels.
 //! Opened via F3 (toggle_debug_menu action).
 
+const std = @import("std");
 const UISystem = @import("ui_system.zig").UISystem;
 const Color = @import("ui_system.zig").Color;
 const Rect = @import("ui_system.zig").Rect;
@@ -53,14 +54,15 @@ pub const FEATURE_INFOS = [DebugFeature.count]FeatureInfo{
 pub const DebugMenuOverlay = struct {
     enabled: bool = false,
 
-    const PANEL_X: f32 = 10.0;
-    const PANEL_Y: f32 = 10.0;
-    const PANEL_WIDTH: f32 = 300.0;
-    const LINE_HEIGHT: f32 = 18.0;
-    const HEADER_HEIGHT: f32 = 28.0;
-    const PADDING: f32 = 8.0;
-    const TITLE_SCALE: f32 = 1.5;
-    const TEXT_SCALE: f32 = 1.2;
+    const BASE_PANEL_X: f32 = 10.0;
+    const BASE_PANEL_Y: f32 = 10.0;
+    const BASE_PANEL_WIDTH: f32 = 300.0;
+    const BASE_LINE_HEIGHT: f32 = 18.0;
+    const BASE_HEADER_HEIGHT: f32 = 28.0;
+    const BASE_PADDING: f32 = 8.0;
+    const BASE_TITLE_SCALE: f32 = 1.5;
+    const BASE_TEXT_SCALE: f32 = 1.2;
+    const MAX_VISIBLE_ROWS: usize = 15;
 
     pub fn toggle(self: *DebugMenuOverlay) void {
         self.enabled = !self.enabled;
@@ -70,26 +72,36 @@ pub const DebugMenuOverlay = struct {
         feature: DebugFeature,
     };
 
-    pub fn draw(self: *DebugMenuOverlay, ui: *UISystem, feature_states: [DebugFeature.count]bool, mouse_x: f32, mouse_y: f32, mouse_clicked: bool) ?ClickResult {
+    pub fn draw(self: *DebugMenuOverlay, ui: *UISystem, feature_states: [DebugFeature.count]bool, mouse_x: f32, mouse_y: f32, mouse_clicked: bool, ui_scale: f32) ?ClickResult {
         if (!self.enabled) return null;
 
-        const panel_height = HEADER_HEIGHT + PADDING * 2 + @as(f32, @floatFromInt(DebugFeature.count)) * LINE_HEIGHT;
-        const panel_rect = Rect{ .x = PANEL_X, .y = PANEL_Y, .width = PANEL_WIDTH, .height = panel_height };
+        const panel_x = BASE_PANEL_X * ui_scale;
+        const panel_y = BASE_PANEL_Y * ui_scale;
+        const panel_width = BASE_PANEL_WIDTH * ui_scale;
+        const line_height = BASE_LINE_HEIGHT * ui_scale;
+        const header_height = BASE_HEADER_HEIGHT * ui_scale;
+        const padding = BASE_PADDING * ui_scale;
+        const title_scale = BASE_TITLE_SCALE * ui_scale;
+        const text_scale = BASE_TEXT_SCALE * ui_scale;
+
+        const visible_rows = @min(DebugFeature.count, MAX_VISIBLE_ROWS);
+        const panel_height = header_height + padding * 2 + @as(f32, @floatFromInt(visible_rows)) * line_height;
+        const panel_rect = Rect{ .x = panel_x, .y = panel_y, .width = panel_width, .height = panel_height };
 
         ui.drawRect(panel_rect, Color.rgba(0.0, 0.0, 0.0, 0.7));
-        ui.drawRectOutline(panel_rect, Color.rgba(0.4, 0.6, 0.8, 0.8), 2.0);
+        ui.drawRectOutline(panel_rect, Color.rgba(0.4, 0.6, 0.8, 0.8), 2.0 * ui_scale);
 
-        var y = PANEL_Y + PADDING;
-        Font.drawText(ui, "DEBUG MENU", PANEL_X + PADDING, y, TITLE_SCALE, Color.rgba(0.95, 0.98, 1.0, 1.0));
-        y += HEADER_HEIGHT;
+        var y = panel_y + padding;
+        Font.drawText(ui, "DEBUG MENU", panel_x + padding, y, title_scale, Color.rgba(0.95, 0.98, 1.0, 1.0));
+        y += header_height;
 
         var result: ?ClickResult = null;
 
-        for (0..DebugFeature.count) |i| {
+        for (0..visible_rows) |i| {
             const feature: DebugFeature = @enumFromInt(i);
             const info = FEATURE_INFOS[i];
             const state = feature_states[i];
-            const row_rect = Rect{ .x = PANEL_X + 2, .y = y - 2, .width = PANEL_WIDTH - 4, .height = LINE_HEIGHT };
+            const row_rect = Rect{ .x = panel_x + 2 * ui_scale, .y = y - 2 * ui_scale, .width = panel_width - 4 * ui_scale, .height = line_height };
             const hovered = row_rect.contains(mouse_x, mouse_y);
 
             if (hovered) {
@@ -99,17 +111,17 @@ pub const DebugMenuOverlay = struct {
                 }
             }
 
-            Font.drawText(ui, info.label, PANEL_X + PADDING + 4, y, TEXT_SCALE, Color.rgba(0.85, 0.88, 0.92, 1.0));
+            Font.drawText(ui, info.label, panel_x + padding + 4 * ui_scale, y, text_scale, Color.rgba(0.85, 0.88, 0.92, 1.0));
 
             const state_text = if (state) "ON" else "OFF";
             const state_color = if (state) Color.rgba(0.3, 1.0, 0.4, 1.0) else Color.rgba(0.7, 0.35, 0.35, 1.0);
-            const state_x = PANEL_X + PANEL_WIDTH - PADDING - 4 - Font.measureTextWidth(state_text, TEXT_SCALE) - 50.0;
-            Font.drawText(ui, state_text, state_x, y, TEXT_SCALE, state_color);
+            const state_x = panel_x + panel_width - padding - 4 * ui_scale - Font.measureTextWidth(state_text, text_scale) - 50.0 * ui_scale;
+            Font.drawText(ui, state_text, state_x, y, text_scale, state_color);
 
-            const hotkey_x = PANEL_X + PANEL_WIDTH - PADDING - 4 - Font.measureTextWidth(info.hotkey, TEXT_SCALE);
-            Font.drawText(ui, info.hotkey, hotkey_x, y, TEXT_SCALE, Color.rgba(0.55, 0.58, 0.65, 1.0));
+            const hotkey_x = panel_x + panel_width - padding - 4 * ui_scale - Font.measureTextWidth(info.hotkey, text_scale);
+            Font.drawText(ui, info.hotkey, hotkey_x, y, text_scale, Color.rgba(0.55, 0.58, 0.65, 1.0));
 
-            y += LINE_HEIGHT;
+            y += line_height;
         }
 
         return result;

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -144,6 +144,7 @@ pub const App = struct {
             .window_manager = &self.window_manager,
             .render_system = self.render_system,
             .audio_system = self.audio_manager.audio_system,
+            .ui_manager = &self.ui_manager,
             .settings = self.settings_manager.ptr(),
             .input = self.input.interface(),
             .input_mapper = self.input_mapper.interface(),

--- a/src/game/input_mapper.zig
+++ b/src/game/input_mapper.zig
@@ -119,8 +119,10 @@ pub const GameAction = enum(u8) {
     cycle_cascade,
     /// Pause/resume time
     toggle_time_scale,
-    /// Toggle creative mode (Default: F3)
+    /// Toggle creative mode (Default: F12)
     toggle_creative,
+    /// Toggle debug menu overlay (Default: F3)
+    toggle_debug_menu,
 
     // Map controls
     /// Open/close world map
@@ -342,7 +344,8 @@ pub const DEFAULT_BINDINGS = blk: {
     bindings[@intFromEnum(GameAction.toggle_shadow_debug_vis)] = ActionBinding.init(.{ .key = .g });
     bindings[@intFromEnum(GameAction.cycle_cascade)] = ActionBinding.init(.{ .key = .k });
     bindings[@intFromEnum(GameAction.toggle_time_scale)] = ActionBinding.init(.{ .key = .n });
-    bindings[@intFromEnum(GameAction.toggle_creative)] = ActionBinding.init(.{ .key = .f3 });
+    bindings[@intFromEnum(GameAction.toggle_creative)] = ActionBinding.init(.{ .key = .f12 });
+    bindings[@intFromEnum(GameAction.toggle_debug_menu)] = ActionBinding.init(.{ .key = .f3 });
     bindings[@intFromEnum(GameAction.toggle_timing_overlay)] = ActionBinding.init(.{ .key = .f4 });
     bindings[@intFromEnum(GameAction.toggle_lod_render)] = ActionBinding.init(.{ .key = .f6 });
     bindings[@intFromEnum(GameAction.toggle_gpass_render)] = ActionBinding.init(.{ .key = .f7 });

--- a/src/game/screen.zig
+++ b/src/game/screen.zig
@@ -9,6 +9,7 @@ const Time = @import("../engine/core/time.zig").Time;
 const WindowManager = @import("../engine/core/window.zig").WindowManager;
 const RenderSystem = @import("../engine/graphics/render_system.zig").RenderSystem;
 const AudioSystem = @import("../engine/audio/system.zig").AudioSystem;
+const UISystemManager = @import("../engine/ui/ui_system_manager.zig").UISystemManager;
 const settings_pkg = @import("settings.zig");
 const Settings = settings_pkg.Settings;
 
@@ -17,6 +18,7 @@ pub const EngineContext = struct {
     window_manager: *WindowManager,
     render_system: *RenderSystem,
     audio_system: *AudioSystem,
+    ui_manager: *UISystemManager,
     settings: *Settings,
     input: IRawInputProvider,
     input_mapper: IInputMapper,

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -6,10 +6,13 @@ const EngineContext = Screen.EngineContext;
 const GameSession = @import("../session.zig").GameSession;
 const Vec3 = @import("../../engine/math/vec3.zig").Vec3;
 const rhi_pkg = @import("../../engine/graphics/rhi.zig");
+const RenderSystem = @import("../../engine/graphics/render_system.zig").RenderSystem;
 const render_graph_pkg = @import("../../engine/graphics/render_graph.zig");
 const PausedScreen = @import("paused.zig").PausedScreen;
 const DebugShadowOverlay = @import("../../engine/ui/debug_shadow_overlay.zig").DebugShadowOverlay;
 const DebugLPVOverlay = @import("../../engine/ui/debug_lpv_overlay.zig").DebugLPVOverlay;
+const DebugMenuOverlay = @import("../../engine/ui/debug_menu.zig").DebugMenuOverlay;
+const DebugFeature = @import("../../engine/ui/debug_menu.zig").DebugFeature;
 const Font = @import("../../engine/ui/font.zig");
 const log = @import("../../engine/core/log.zig");
 
@@ -17,6 +20,7 @@ pub const WorldScreen = struct {
     context: EngineContext,
     session: *GameSession,
     last_debug_toggle_time: f32 = 0,
+    debug_menu: DebugMenuOverlay,
 
     pub const vtable = IScreen.VTable{
         .deinit = deinit,
@@ -36,6 +40,7 @@ pub const WorldScreen = struct {
             .context = context,
             .session = session,
             .last_debug_toggle_time = 0,
+            .debug_menu = .{},
         };
         return self;
     }
@@ -53,6 +58,16 @@ pub const WorldScreen = struct {
         const rhi = render_system.getRHI();
         const now = ctx.time.elapsed;
         const can_toggle_debug = now - self.last_debug_toggle_time > 0.2;
+
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_debug_menu)) {
+            self.debug_menu.toggle();
+            if (self.debug_menu.enabled) {
+                ctx.input.setMouseCapture(@ptrCast(@alignCast(ctx.window_manager.window)), false);
+            } else {
+                ctx.input.setMouseCapture(@ptrCast(@alignCast(ctx.window_manager.window)), true);
+            }
+            self.last_debug_toggle_time = now;
+        }
 
         if (ctx.input_mapper.isActionPressed(ctx.input, .ui_back)) {
             const paused_screen = try PausedScreen.init(ctx.allocator, ctx);
@@ -314,6 +329,13 @@ pub const WorldScreen = struct {
             Font.drawText(ui, line2, text_x, text_y + 20.0, 1.5, .{ .r = 0.95, .g = 0.98, .b = 1.0, .a = 1.0 });
             Font.drawText(ui, line3, text_x, text_y + 30.0, 1.5, .{ .r = 0.95, .g = 0.98, .b = 1.0, .a = 1.0 });
         }
+
+        if (self.debug_menu.enabled) {
+            const feature_states = self.collectDebugStates(ctx, render_system);
+            if (self.debug_menu.draw(ui, feature_states, mouse_x, mouse_y, mouse_clicked)) |click| {
+                self.applyDebugFeatureToggle(click.feature, ctx, render_system, rhi);
+            }
+        }
     }
 
     pub fn onEnter(ptr: *anyopaque) void {
@@ -328,6 +350,88 @@ pub const WorldScreen = struct {
 
     pub fn screen(self: *@This()) IScreen {
         return Screen.makeScreen(@This(), self);
+    }
+
+    fn collectDebugStates(self: *WorldScreen, ctx: EngineContext, render_system: *RenderSystem) [DebugFeature.count]bool {
+        var states: [DebugFeature.count]bool = @splat(false);
+        states[@intFromEnum(DebugFeature.wireframe)] = ctx.settings.wireframe_enabled;
+        states[@intFromEnum(DebugFeature.textures)] = ctx.settings.textures_enabled;
+        states[@intFromEnum(DebugFeature.vsync)] = ctx.settings.vsync;
+        states[@intFromEnum(DebugFeature.fps_counter)] = self.session.debug_show_fps;
+        states[@intFromEnum(DebugFeature.block_info)] = self.session.debug_show_block_info;
+        states[@intFromEnum(DebugFeature.shadow_debug)] = ctx.settings.debug_shadows_active;
+        states[@intFromEnum(DebugFeature.timing_overlay)] = false;
+        states[@intFromEnum(DebugFeature.lod_render)] = self.session.world.lod_enabled;
+        states[@intFromEnum(DebugFeature.gpass_render)] = !render_system.getDisableGPassDraw();
+        states[@intFromEnum(DebugFeature.ssao)] = !render_system.getDisableSSAO();
+        states[@intFromEnum(DebugFeature.clouds)] = !render_system.getDisableClouds();
+        states[@intFromEnum(DebugFeature.fog)] = self.session.atmosphere.fog_enabled;
+        states[@intFromEnum(DebugFeature.lpv_overlay)] = ctx.settings.debug_lpv_overlay_active;
+        states[@intFromEnum(DebugFeature.creative_mode)] = self.session.creative_mode;
+        states[@intFromEnum(DebugFeature.time_pause)] = self.session.atmosphere.time.time_scale == 0.0;
+        return states;
+    }
+
+    fn applyDebugFeatureToggle(self: *WorldScreen, feature: DebugFeature, ctx: EngineContext, render_system: *RenderSystem, rhi: *rhi_pkg.RHI) void {
+        switch (feature) {
+            .wireframe => {
+                ctx.settings.wireframe_enabled = !ctx.settings.wireframe_enabled;
+                rhi.setWireframe(ctx.settings.wireframe_enabled);
+            },
+            .textures => {
+                ctx.settings.textures_enabled = !ctx.settings.textures_enabled;
+                rhi.setTexturesEnabled(ctx.settings.textures_enabled);
+            },
+            .vsync => {
+                ctx.settings.vsync = !ctx.settings.vsync;
+                rhi.setVSync(ctx.settings.vsync);
+            },
+            .fps_counter => {
+                self.session.debug_show_fps = !self.session.debug_show_fps;
+            },
+            .block_info => {
+                self.session.debug_show_block_info = !self.session.debug_show_block_info;
+            },
+            .shadow_debug => {
+                ctx.settings.debug_shadows_active = !ctx.settings.debug_shadows_active;
+                rhi.setDebugShadowView(ctx.settings.debug_shadows_active);
+            },
+            .timing_overlay => {
+                log.log.info("Timing overlay toggle requested via debug menu", .{});
+            },
+            .lod_render => {
+                if (self.session.world.lod == null) {
+                    log.log.warn("LOD toggle requested but LOD system is not initialized", .{});
+                } else {
+                    self.session.world.lod_enabled = !self.session.world.lod_enabled;
+                }
+            },
+            .gpass_render => {
+                const new_val = !render_system.getDisableGPassDraw();
+                render_system.setDisableGPassDraw(new_val);
+            },
+            .ssao => {
+                const new_val = !render_system.getDisableSSAO();
+                render_system.setDisableSSAO(new_val);
+            },
+            .clouds => {
+                const new_val = !render_system.getDisableClouds();
+                render_system.setDisableClouds(new_val);
+            },
+            .fog => {
+                self.session.atmosphere.fog_enabled = !self.session.atmosphere.fog_enabled;
+            },
+            .lpv_overlay => {
+                ctx.settings.debug_lpv_overlay_active = !ctx.settings.debug_lpv_overlay_active;
+            },
+            .creative_mode => {
+                self.session.creative_mode = !self.session.creative_mode;
+                self.session.player.setCreativeMode(self.session.creative_mode);
+            },
+            .time_pause => {
+                self.session.atmosphere.time.time_scale = if (self.session.atmosphere.time.time_scale > 0) @as(f32, 0.0) else @as(f32, 1.0);
+            },
+        }
     }
 
     fn renderOverlay(scene_ctx: render_graph_pkg.SceneContext) void {

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -295,8 +295,9 @@ pub const WorldScreen = struct {
         const mouse_x: f32 = @floatFromInt(mouse_pos.x);
         const mouse_y: f32 = @floatFromInt(mouse_pos.y);
         const mouse_clicked = ctx.input.isMouseButtonPressed(.left);
+        const hud_clicked = if (self.debug_menu.enabled) false else mouse_clicked;
 
-        try self.session.drawHUD(ui, render_system.getAtlas(), render_system.getResourcePackManager().active_pack, ctx.time.fps, screen_w, screen_h, mouse_x, mouse_y, mouse_clicked);
+        try self.session.drawHUD(ui, render_system.getAtlas(), render_system.getResourcePackManager().active_pack, ctx.time.fps, screen_w, screen_h, mouse_x, mouse_y, hud_clicked);
 
         if (ctx.settings.debug_shadows_active) {
             DebugShadowOverlay.draw(rhi.ui(), rhi.shadowSystem(), screen_w, screen_h, .{});
@@ -332,8 +333,8 @@ pub const WorldScreen = struct {
 
         if (self.debug_menu.enabled) {
             const feature_states = self.collectDebugStates(ctx, render_system);
-            if (self.debug_menu.draw(ui, feature_states, mouse_x, mouse_y, mouse_clicked)) |click| {
-                self.applyDebugFeatureToggle(click.feature, ctx, render_system, rhi);
+            if (self.debug_menu.draw(ui, feature_states, mouse_x, mouse_y, mouse_clicked, ctx.settings.ui_scale)) |click| {
+                self.applyDebugFeatureToggle(click.feature, ctx, render_system, rhi, ctx.time.elapsed);
             }
         }
     }
@@ -360,7 +361,7 @@ pub const WorldScreen = struct {
         states[@intFromEnum(DebugFeature.fps_counter)] = self.session.debug_show_fps;
         states[@intFromEnum(DebugFeature.block_info)] = self.session.debug_show_block_info;
         states[@intFromEnum(DebugFeature.shadow_debug)] = ctx.settings.debug_shadows_active;
-        states[@intFromEnum(DebugFeature.timing_overlay)] = false;
+        states[@intFromEnum(DebugFeature.timing_overlay)] = ctx.ui_manager.timing_overlay.enabled;
         states[@intFromEnum(DebugFeature.lod_render)] = self.session.world.lod_enabled;
         states[@intFromEnum(DebugFeature.gpass_render)] = !render_system.getDisableGPassDraw();
         states[@intFromEnum(DebugFeature.ssao)] = !render_system.getDisableSSAO();
@@ -372,7 +373,8 @@ pub const WorldScreen = struct {
         return states;
     }
 
-    fn applyDebugFeatureToggle(self: *WorldScreen, feature: DebugFeature, ctx: EngineContext, render_system: *RenderSystem, rhi: *rhi_pkg.RHI) void {
+    fn applyDebugFeatureToggle(self: *WorldScreen, feature: DebugFeature, ctx: EngineContext, render_system: *RenderSystem, rhi: *rhi_pkg.RHI, now: f32) void {
+        self.last_debug_toggle_time = now;
         switch (feature) {
             .wireframe => {
                 ctx.settings.wireframe_enabled = !ctx.settings.wireframe_enabled;
@@ -397,7 +399,8 @@ pub const WorldScreen = struct {
                 rhi.setDebugShadowView(ctx.settings.debug_shadows_active);
             },
             .timing_overlay => {
-                log.log.info("Timing overlay toggle requested via debug menu", .{});
+                ctx.ui_manager.timing_overlay.toggle();
+                rhi.timing().setTimingEnabled(ctx.ui_manager.timing_overlay.enabled);
             },
             .lod_render => {
                 if (self.session.world.lod == null) {

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -333,7 +333,8 @@ pub const WorldScreen = struct {
 
         if (self.debug_menu.enabled) {
             const feature_states = self.collectDebugStates(ctx, render_system);
-            if (self.debug_menu.draw(ui, feature_states, mouse_x, mouse_y, mouse_clicked, ctx.settings.ui_scale)) |click| {
+            const scroll_delta = ctx.input.getScrollDelta();
+            if (self.debug_menu.draw(ui, feature_states, mouse_x, mouse_y, mouse_clicked, ctx.settings.ui_scale, scroll_delta.y)) |click| {
                 self.applyDebugFeatureToggle(click.feature, ctx, render_system, rhi, ctx.time.elapsed);
             }
         }


### PR DESCRIPTION
## Summary
- Adds a centralized debug menu overlay toggled by **F3**, listing 15 debug features with ON/OFF states and hotkey labels
- Click any row to toggle the feature with immediate visual feedback; world keeps rendering while menu is open
- Moves creative mode toggle from F3 to F12 to avoid conflict

## Changes
| File | Change |
|------|--------|
| `src/engine/ui/debug_menu.zig` | **New** — `DebugMenuOverlay` struct with `DebugFeature` enum (15 features), hover/click rendering |
| `src/game/input_mapper.zig` | Added `toggle_debug_menu` action (F3); rebound `toggle_creative` to F12 |
| `src/game/screens/world.zig` | Integrated debug menu: toggle on F3, mouse capture release/recapture, `collectDebugStates` + `applyDebugFeatureToggle` helpers |

## Acceptance Criteria (#295)
- [x] F3 opens debug menu
- [x] Menu lists available debug overlays/tools (15 features)
- [x] Can toggle each feature on/off (click-to-toggle)
- [x] Integrates with existing overlay system (uses `UISystem`/`Font`/`Color` primitives)

## Test Plan
- [x] `zig fmt src/` passes
- [x] `zig build test` passes (unit tests + shader validation)
- [x] `zig build` compiles successfully
- [x] Pre-push hooks (format + full test suite) passed