### PR TITLE
feat(ui): add chunk inspector overlay (#297)

### DIFF
--- a/src/engine/ui/chunk_inspector_overlay.zig
+++ b/src/engine/ui/chunk_inspector_overlay.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const UISystem = @import("ui_system.zig").UISystem;
+const Color = @import("ui_system.zig").Color;
+const RenderStats = @import("../../world/world_renderer.zig").RenderStats;
+const Font = @import("font.zig");
+
+pub const ChunkStateCounts = struct {
+    total: u32 = 0,
+    missing: u32 = 0,
+    generating: u32 = 0,
+    meshing: u32 = 0,
+    renderable: u32 = 0,
+    other_states: u32 = 0,
+    dirty: u32 = 0,
+};
+
+pub const ChunkInspectorOverlay = struct {
+    enabled: bool = false,
+
+    pub fn toggle(self: *ChunkInspectorOverlay) void {
+        self.enabled = !self.enabled;
+    }
+
+    pub fn draw(self: *ChunkInspectorOverlay, ui: *UISystem, render_stats: RenderStats, counts: ChunkStateCounts) void {
+        if (!self.enabled) return;
+
+        const x: f32 = 10;
+        var y: f32 = 10;
+        const width: f32 = 260;
+        const line_height: f32 = 15;
+        const scale: f32 = 1.0;
+        const num_lines = 13;
+        const padding = 20;
+
+        ui.drawRect(.{ .x = x, .y = y, .width = width, .height = num_lines * line_height + padding }, .{ .r = 0, .g = 0, .b = 0, .a = 0.6 });
+        y += 5;
+
+        Font.drawText(ui, "CHUNK INSPECTOR", x + 10, y, scale, Color.white);
+        y += line_height + 5;
+
+        Font.drawText(ui, "RENDER STATS", x + 10, y, scale, Color.gray);
+        y += line_height;
+        drawLine(ui, "TOTAL:", render_stats.chunks_total, x, &y, scale, line_height);
+        drawLine(ui, "RENDERED:", render_stats.chunks_rendered, x, &y, scale, line_height);
+        drawLine(ui, "CULLED:", render_stats.chunks_culled, x, &y, scale, line_height);
+        drawLine(ui, "VERTICES:", render_stats.vertices_rendered, x, &y, scale, line_height);
+        y += 5;
+
+        Font.drawText(ui, "STATE DISTRIBUTION", x + 10, y, scale, Color.gray);
+        y += line_height;
+        drawLine(ui, "MISSING:", counts.missing, x, &y, scale, line_height);
+        drawLine(ui, "GENERATING:", counts.generating, x, &y, scale, line_height);
+        drawLine(ui, "MESHING:", counts.meshing, x, &y, scale, line_height);
+        drawLine(ui, "RENDERABLE:", counts.renderable, x, &y, scale, line_height);
+        drawLine(ui, "OTHER:", counts.other_states, x, &y, scale, line_height);
+        drawLine(ui, "DIRTY*:", counts.dirty, x, &y, scale, line_height);
+        Font.drawText(ui, "* dirty is orthogonal to state", x + 10, y, scale * 0.8, Color.gray);
+    }
+
+    fn drawLine(ui: *UISystem, label: []const u8, value: u64, x: f32, y: *f32, scale: f32, line_height: f32) void {
+        Font.drawText(ui, label, x + 10, y.*, scale, Color.gray);
+
+        var buf: [32]u8 = undefined;
+        const val_str = std.fmt.bufPrint(&buf, "{}", .{value}) catch "0";
+        Font.drawText(ui, val_str, x + 160, y.*, scale, Color.white);
+        y.* += line_height;
+    }
+};

--- a/src/engine/ui/debug_menu.zig
+++ b/src/engine/ui/debug_menu.zig
@@ -24,6 +24,7 @@ pub const DebugFeature = enum(u8) {
     lpv_overlay,
     creative_mode,
     time_pause,
+    chunk_inspector,
 
     pub const count = @typeInfo(DebugFeature).@"enum".fields.len;
 };
@@ -51,6 +52,7 @@ pub const FEATURE_INFOS = [DebugFeature.count]FeatureInfo{
     .{ .label = "LPV OVERLAY", .hotkey = "F11" },
     .{ .label = "CREATIVE MODE", .hotkey = "F12" },
     .{ .label = "TIME PAUSE", .hotkey = "N" },
+    .{ .label = "CHUNK INSPECTOR", .hotkey = "J" },
 };
 
 pub const DebugMenuOverlay = struct {

--- a/src/game/input_mapper.zig
+++ b/src/game/input_mapper.zig
@@ -159,6 +159,8 @@ pub const GameAction = enum(u8) {
     toggle_fog,
     /// Toggle LPV debug overlay
     toggle_lpv_overlay,
+    /// Toggle chunk inspector overlay
+    toggle_chunk_inspector,
 
     pub const count = @typeInfo(GameAction).@"enum".fields.len;
 };
@@ -353,6 +355,7 @@ pub const DEFAULT_BINDINGS = blk: {
     bindings[@intFromEnum(GameAction.toggle_clouds)] = ActionBinding.init(.{ .key = .f9 });
     bindings[@intFromEnum(GameAction.toggle_fog)] = ActionBinding.init(.{ .key = .f10 });
     bindings[@intFromEnum(GameAction.toggle_lpv_overlay)] = ActionBinding.init(.{ .key = .f11 });
+    bindings[@intFromEnum(GameAction.toggle_chunk_inspector)] = ActionBinding.init(.{ .key = .j });
 
     // Map controls
     bindings[@intFromEnum(GameAction.toggle_map)] = ActionBinding.init(.{ .key = .m });

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -13,6 +13,7 @@ const DebugShadowOverlay = @import("../../engine/ui/debug_shadow_overlay.zig").D
 const DebugLPVOverlay = @import("../../engine/ui/debug_lpv_overlay.zig").DebugLPVOverlay;
 const DebugMenuOverlay = @import("../../engine/ui/debug_menu.zig").DebugMenuOverlay;
 const DebugFeature = @import("../../engine/ui/debug_menu.zig").DebugFeature;
+const ChunkInspectorOverlay = @import("../../engine/ui/chunk_inspector_overlay.zig").ChunkInspectorOverlay;
 const Font = @import("../../engine/ui/font.zig");
 const log = @import("../../engine/core/log.zig");
 
@@ -21,6 +22,7 @@ pub const WorldScreen = struct {
     session: *GameSession,
     last_debug_toggle_time: f32 = 0,
     debug_menu: DebugMenuOverlay,
+    chunk_inspector_overlay: ChunkInspectorOverlay = .{},
 
     pub const vtable = IScreen.VTable{
         .deinit = deinit,
@@ -135,6 +137,11 @@ pub const WorldScreen = struct {
         if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_lpv_overlay)) {
             ctx.settings.debug_lpv_overlay_active = !ctx.settings.debug_lpv_overlay_active;
             log.log.info("LPV overlay {s}", .{if (ctx.settings.debug_lpv_overlay_active) "enabled" else "disabled"});
+            self.last_debug_toggle_time = now;
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_chunk_inspector)) {
+            self.chunk_inspector_overlay.toggle();
+            log.log.info("Chunk inspector {s}", .{if (self.chunk_inspector_overlay.enabled) "enabled" else "disabled"});
             self.last_debug_toggle_time = now;
         }
 
@@ -331,6 +338,14 @@ pub const WorldScreen = struct {
             Font.drawText(ui, line3, text_x, text_y + 30.0, 1.5, .{ .r = 0.95, .g = 0.98, .b = 1.0, .a = 1.0 });
         }
 
+        if (self.chunk_inspector_overlay.enabled) {
+            self.chunk_inspector_overlay.draw(
+                ui,
+                self.session.world.getRenderStats(),
+                self.session.world.getChunkStateCounts(),
+            );
+        }
+
         if (self.debug_menu.enabled) {
             const feature_states = self.collectDebugStates(ctx, render_system);
             const scroll_delta = ctx.input.getScrollDelta();
@@ -371,6 +386,7 @@ pub const WorldScreen = struct {
         states[@intFromEnum(DebugFeature.lpv_overlay)] = ctx.settings.debug_lpv_overlay_active;
         states[@intFromEnum(DebugFeature.creative_mode)] = self.session.creative_mode;
         states[@intFromEnum(DebugFeature.time_pause)] = self.session.atmosphere.time.time_scale == 0.0;
+        states[@intFromEnum(DebugFeature.chunk_inspector)] = self.chunk_inspector_overlay.enabled;
         return states;
     }
 
@@ -434,6 +450,9 @@ pub const WorldScreen = struct {
             },
             .time_pause => {
                 self.session.atmosphere.time.time_scale = if (self.session.atmosphere.time.time_scale > 0) @as(f32, 0.0) else @as(f32, 1.0);
+            },
+            .chunk_inspector => {
+                self.chunk_inspector_overlay.toggle();
             },
         }
     }

--- a/src/world/world.zig
+++ b/src/world/world.zig
@@ -27,6 +27,7 @@ const WorldStreamer = @import("world_streamer.zig").WorldStreamer;
 const TextureAtlas = @import("../engine/graphics/texture_atlas.zig").TextureAtlas;
 const WorldRenderer = @import("world_renderer.zig").WorldRenderer;
 const RenderStats = @import("world_renderer.zig").RenderStats;
+const ChunkStateCounts = @import("../engine/ui/chunk_inspector_overlay.zig").ChunkStateCounts;
 const JobQueue = @import("../engine/core/job_system.zig").JobQueue;
 const WorkerPool = @import("../engine/core/job_system.zig").WorkerPool;
 const Job = @import("../engine/core/job_system.zig").Job;
@@ -262,6 +263,31 @@ pub const World = struct {
 
     pub fn getRenderStats(self: *const World) RenderStats {
         return self.renderer.last_render_stats;
+    }
+
+    /// Counts chunks by state for the debug inspector overlay.
+    /// Note: Holds a shared mutex lock while iterating all chunks.
+    /// May cause minor contention with world streamer threads under heavy load.
+    pub fn getChunkStateCounts(self: *World) ChunkStateCounts {
+        self.storage.chunks_mutex.lockShared();
+        defer self.storage.chunks_mutex.unlockShared();
+
+        var counts: ChunkStateCounts = .{};
+        counts.total = @intCast(self.storage.chunks.count());
+
+        var iter = self.storage.chunks.iterator();
+        while (iter.next()) |entry| {
+            const state = entry.value_ptr.*.chunk.state;
+            switch (state) {
+                .missing => counts.missing += 1,
+                .generating => counts.generating += 1,
+                .meshing => counts.meshing += 1,
+                .renderable => counts.renderable += 1,
+                else => counts.other_states += 1,
+            }
+            if (entry.value_ptr.*.chunk.dirty) counts.dirty += 1;
+        }
+        return counts;
     }
 
     pub fn getStats(self: *World) struct { chunks_loaded: usize, total_vertices: u64, gen_queue: usize, mesh_queue: usize, upload_queue: usize } {


### PR DESCRIPTION
## Summary
- Add `ChunkInspectorOverlay` struct following `TimingOverlay` pattern
- Displays chunk state distribution (missing/generating/meshing/renderable/other/dirty)
- Shows `RenderStats` data (total chunks, rendered, culled, vertices)
- Integrated via F3 debug menu as a toggleable feature

## Files Changed
- **New**: `src/engine/ui/chunk_inspector_overlay.zig` - Overlay implementation
- **Modified**: `src/world/world.zig` - Added `getChunkStateCounts()` method
- **Modified**: `src/engine/ui/debug_menu.zig` - Added `.chunk_inspector` to `DebugFeature` enum
- **Modified**: `src/game/screens/world.zig` - Integrated toggle and draw

## Testing
- `zig build test` passes
- `zig fmt` applied