### PR TITLE
feat(ui): debug visualizations - frustum, shadow cascades, LPV (#299)

### DIFF
--- a/src/engine/ui/debug_frustum.zig
+++ b/src/engine/ui/debug_frustum.zig
@@ -1,0 +1,103 @@
+//! Debug frustum wireframe visualization.
+//! Renders the camera frustum as a 3D wireframe overlay.
+
+const std = @import("std");
+const rhi = @import("../graphics/rhi.zig");
+const RenderContext = rhi.RenderContext;
+const Vec3 = @import("../math/vec3.zig").Vec3;
+const Mat4 = @import("../math/mat4.zig").Mat4;
+const Vertex = rhi.Vertex;
+
+pub const FRUSTUM_EDGE_COUNT: u32 = 12;
+pub const FRUSTUM_VERTEX_COUNT: u32 = FRUSTUM_EDGE_COUNT * 2;
+
+fn makeVertex(x: f32, y: f32, z: f32, r: f32, g: f32, b: f32) Vertex {
+    return .{
+        .pos = .{ x, y, z },
+        .color = .{ r, g, b },
+        .normal = .{ 0, 1, 0 },
+        .uv = .{ 0, 0 },
+        .tile_id = 0,
+        .skylight = 15,
+        .blocklight = .{ 15, 15, 15 },
+        .ao = 1.0,
+    };
+}
+
+pub const DebugFrustum = struct {
+    pub const Color = struct {
+        r: f32,
+        g: f32,
+        b: f32,
+    };
+
+    pub const DefaultColor = Color{ .r = 0.0, .g = 0.9, .b = 0.9 };
+
+    pub fn extractCorners(proj: Mat4, view: Mat4) [8]Vec3 {
+        const inv_vp = proj.multiply(view).inverse();
+        const m = inv_vp.data;
+
+        const corners_ndc = [8][4]f32{
+            .{ -1.0, -1.0, 0.0, 1.0 },
+            .{ 1.0, -1.0, 0.0, 1.0 },
+            .{ 1.0, 1.0, 0.0, 1.0 },
+            .{ -1.0, 1.0, 0.0, 1.0 },
+            .{ -1.0, -1.0, 1.0, 1.0 },
+            .{ 1.0, -1.0, 1.0, 1.0 },
+            .{ 1.0, 1.0, 1.0, 1.0 },
+            .{ -1.0, 1.0, 1.0, 1.0 },
+        };
+
+        var world_corners: [8]Vec3 = undefined;
+        for (0..8) |i| {
+            const nx = corners_ndc[i][0];
+            const ny = corners_ndc[i][1];
+            const nz = corners_ndc[i][2];
+            const nw = corners_ndc[i][3];
+
+            // Mat4 uses column-major layout: m[col][row]
+            // Transform from clip space to world space
+            const wx = m[0][0] * nx + m[1][0] * ny + m[2][0] * nz + m[3][0] * nw;
+            const wy = m[0][1] * nx + m[1][1] * ny + m[2][1] * nz + m[3][1] * nw;
+            const wz = m[0][2] * nx + m[1][2] * ny + m[2][2] * nz + m[3][2] * nw;
+            const ww = m[0][3] * nx + m[1][3] * ny + m[2][3] * nz + m[3][3] * nw;
+
+            world_corners[i] = Vec3.init(wx / ww, wy / ww, wz / ww);
+        }
+
+        return world_corners;
+    }
+
+    pub fn buildLineVertices(corners: [8]Vec3, color: Color) [FRUSTUM_VERTEX_COUNT]Vertex {
+        const c = corners;
+
+        const edge_pairs = [12][2]usize{
+            .{ 0, 1 }, .{ 1, 2 }, .{ 2, 3 }, .{ 3, 0 },
+            .{ 4, 5 }, .{ 5, 6 }, .{ 6, 7 }, .{ 7, 4 },
+            .{ 0, 4 }, .{ 1, 5 }, .{ 2, 6 }, .{ 3, 7 },
+        };
+
+        var verts: [FRUSTUM_VERTEX_COUNT]Vertex = undefined;
+        for (0..FRUSTUM_EDGE_COUNT) |i| {
+            const a = c[edge_pairs[i][0]];
+            const b = c[edge_pairs[i][1]];
+            verts[i * 2] = makeVertex(a.x, a.y, a.z, color.r, color.g, color.b);
+            verts[i * 2 + 1] = makeVertex(b.x, b.y, b.z, color.r, color.g, color.b);
+        }
+        return verts;
+    }
+
+    pub fn draw(
+        rc: RenderContext,
+        buffer_handle: rhi.BufferHandle,
+        vertex_count: u32,
+        cam_pos: Vec3,
+    ) void {
+        const rel_x = -cam_pos.x;
+        const rel_y = -cam_pos.y;
+        const rel_z = -cam_pos.z;
+        const model = Mat4.translate(Vec3.init(rel_x, rel_y, rel_z));
+        rc.setModelMatrix(model, Vec3.init(DefaultColor.r, DefaultColor.g, DefaultColor.b), 0);
+        rc.draw(buffer_handle, @as(u32, @intCast(vertex_count)), .lines);
+    }
+};

--- a/src/engine/ui/debug_menu.zig
+++ b/src/engine/ui/debug_menu.zig
@@ -22,6 +22,7 @@ pub const DebugFeature = enum(u8) {
     clouds,
     fog,
     lpv_overlay,
+    frustum_debug,
     creative_mode,
     time_pause,
 
@@ -49,6 +50,7 @@ pub const FEATURE_INFOS = [DebugFeature.count]FeatureInfo{
     .{ .label = "CLOUDS", .hotkey = "F9" },
     .{ .label = "FOG", .hotkey = "F10" },
     .{ .label = "LPV OVERLAY", .hotkey = "F11" },
+    .{ .label = "FRUSTUM DEBUG", .hotkey = "J" },
     .{ .label = "CREATIVE MODE", .hotkey = "F12" },
     .{ .label = "TIME PAUSE", .hotkey = "N" },
 };

--- a/src/engine/ui/debug_shadow_overlay.zig
+++ b/src/engine/ui/debug_shadow_overlay.zig
@@ -1,37 +1,59 @@
 const std = @import("std");
 const rhi = @import("../graphics/rhi.zig");
-const IUIContext = rhi.IUIContext;
+const UISystem = @import("ui_system.zig").UISystem;
 const ShadowSystemWrapper = rhi.ShadowSystemWrapper;
+const Font = @import("font.zig");
 
-/// System for rendering debug shadow cascade overlays.
 pub const DebugShadowOverlay = struct {
-    /// Layout configuration for the debug overlay.
     pub const Config = struct {
-        /// Default size of each shadow cascade thumbnail in pixels.
         size: f32 = 200.0,
-        /// Default spacing between cascade thumbnails and screen edges in pixels.
         spacing: f32 = 10.0,
+        show_labels: bool = true,
     };
 
-    /// Draws the shadow cascade thumbnails to the screen.
-    /// Requires an active UI context and a shadow system to retrieve handles.
-    pub fn draw(ui: IUIContext, shadow: ShadowSystemWrapper, screen_width: f32, screen_height: f32, config: Config) void {
-        ui.beginPass(screen_width, screen_height);
-        defer ui.endPass();
+    pub fn draw(
+        ui: *UISystem,
+        shadow: ShadowSystemWrapper,
+        _: f32,
+        _: f32,
+        config: Config,
+        cascade_splits: []const f32,
+    ) void {
+        ui.begin();
+        defer ui.end();
+
+        const label_height: f32 = 16.0;
 
         for (0..rhi.SHADOW_CASCADE_COUNT) |i| {
             const handle = shadow.getShadowMapHandle(@intCast(i));
             if (handle == 0) continue;
 
-            const x = config.spacing + @as(f32, @floatFromInt(i)) * (config.size + config.spacing);
+            const extra_width: f32 = if (config.show_labels) @as(f32, 50.0) else @as(f32, 0.0);
+            const cell_width = config.size + extra_width;
+            const x = config.spacing + @as(f32, @floatFromInt(i)) * (cell_width + config.spacing);
             const y = config.spacing;
 
-            ui.drawDepthTexture(handle, .{
+            const tex_rect = rhi.Rect{
                 .x = x,
-                .y = y,
+                .y = if (config.show_labels) y + label_height else y,
                 .width = config.size,
                 .height = config.size,
-            });
+            };
+
+            ui.drawDepthTexture(handle, tex_rect);
+
+            if (config.show_labels) {
+                var idx_buf: [8]u8 = undefined;
+                const idx_text = std.fmt.bufPrint(&idx_buf, "C{d}", .{i}) catch "C?";
+                Font.drawText(ui, idx_text, x, y, 1.5, .{ .r = 0.95, .g = 0.95, .b = 1.0, .a = 1.0 });
+
+                if (i < cascade_splits.len) {
+                    var dist_buf: [16]u8 = undefined;
+                    const dist_val = @as(i32, @intFromFloat(@round(cascade_splits[i])));
+                    const dist_text = std.fmt.bufPrint(&dist_buf, "{d}m", .{dist_val}) catch "?m";
+                    Font.drawText(ui, dist_text, x, y + label_height + config.size, 1.2, .{ .r = 0.6, .g = 0.8, .b = 1.0, .a = 1.0 });
+                }
+            }
         }
     }
 };

--- a/src/engine/ui/ui_system.zig
+++ b/src/engine/ui/ui_system.zig
@@ -46,6 +46,10 @@ pub const UISystem = struct {
         self.renderer.drawTexture(texture_id, rect);
     }
 
+    pub fn drawDepthTexture(self: *UISystem, texture: rhi.TextureHandle, rect: Rect) void {
+        self.renderer.drawDepthTexture(texture, rect);
+    }
+
     /// Draw a rectangle outline
     pub fn drawRectOutline(self: *UISystem, rect: Rect, color: Color, thickness: f32) void {
         // Top

--- a/src/game/input_mapper.zig
+++ b/src/game/input_mapper.zig
@@ -159,6 +159,8 @@ pub const GameAction = enum(u8) {
     toggle_fog,
     /// Toggle LPV debug overlay
     toggle_lpv_overlay,
+    /// Toggle frustum debug overlay
+    toggle_frustum_debug,
 
     pub const count = @typeInfo(GameAction).@"enum".fields.len;
 };
@@ -353,6 +355,7 @@ pub const DEFAULT_BINDINGS = blk: {
     bindings[@intFromEnum(GameAction.toggle_clouds)] = ActionBinding.init(.{ .key = .f9 });
     bindings[@intFromEnum(GameAction.toggle_fog)] = ActionBinding.init(.{ .key = .f10 });
     bindings[@intFromEnum(GameAction.toggle_lpv_overlay)] = ActionBinding.init(.{ .key = .f11 });
+    bindings[@intFromEnum(GameAction.toggle_frustum_debug)] = ActionBinding.init(.{ .key = .j });
 
     // Map controls
     bindings[@intFromEnum(GameAction.toggle_map)] = ActionBinding.init(.{ .key = .m });

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -13,14 +13,18 @@ const DebugShadowOverlay = @import("../../engine/ui/debug_shadow_overlay.zig").D
 const DebugLPVOverlay = @import("../../engine/ui/debug_lpv_overlay.zig").DebugLPVOverlay;
 const DebugMenuOverlay = @import("../../engine/ui/debug_menu.zig").DebugMenuOverlay;
 const DebugFeature = @import("../../engine/ui/debug_menu.zig").DebugFeature;
+const DebugFrustum = @import("../../engine/ui/debug_frustum.zig").DebugFrustum;
 const Font = @import("../../engine/ui/font.zig");
 const log = @import("../../engine/core/log.zig");
+const CSM = @import("../../engine/graphics/csm.zig");
 
 pub const WorldScreen = struct {
     context: EngineContext,
     session: *GameSession,
     last_debug_toggle_time: f32 = 0,
     debug_menu: DebugMenuOverlay,
+    frustum_buffer: rhi_pkg.BufferHandle = 0,
+    frustum_initialized: bool = false,
 
     pub const vtable = IScreen.VTable{
         .deinit = deinit,
@@ -47,6 +51,9 @@ pub const WorldScreen = struct {
 
     pub fn deinit(ptr: *anyopaque) void {
         const self: *@This() = @ptrCast(@alignCast(ptr));
+        if (self.frustum_initialized) {
+            self.context.render_system.getRHI().resourceManager().destroyBuffer(self.frustum_buffer);
+        }
         self.session.deinit();
         self.context.allocator.destroy(self);
     }
@@ -135,6 +142,11 @@ pub const WorldScreen = struct {
         if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_lpv_overlay)) {
             ctx.settings.debug_lpv_overlay_active = !ctx.settings.debug_lpv_overlay_active;
             log.log.info("LPV overlay {s}", .{if (ctx.settings.debug_lpv_overlay_active) "enabled" else "disabled"});
+            self.last_debug_toggle_time = now;
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_frustum_debug)) {
+            ctx.settings.debug_frustum_active = !ctx.settings.debug_frustum_active;
+            log.log.info("Frustum debug {s}", .{if (ctx.settings.debug_frustum_active) "enabled" else "disabled"});
             self.last_debug_toggle_time = now;
         }
 
@@ -300,7 +312,19 @@ pub const WorldScreen = struct {
         try self.session.drawHUD(ui, render_system.getAtlas(), render_system.getResourcePackManager().active_pack, ctx.time.fps, screen_w, screen_h, mouse_x, mouse_y, hud_clicked);
 
         if (ctx.settings.debug_shadows_active) {
-            DebugShadowOverlay.draw(rhi.ui(), rhi.shadowSystem(), screen_w, screen_h, .{});
+            const shadow_res = ctx.settings.getShadowResolution();
+            const shadow_dist = ctx.settings.shadow_distance;
+            const debug_cascades = CSM.computeCascades(
+                shadow_res,
+                camera.fov,
+                aspect,
+                0.1,
+                shadow_dist,
+                self.session.atmosphere.celestial.sun_dir,
+                camera.getViewMatrixOriginCentered(),
+                true,
+            );
+            DebugShadowOverlay.draw(ui, rhi.shadowSystem(), screen_w, screen_h, .{}, &debug_cascades.cascade_splits);
         }
         if (ctx.settings.debug_lpv_overlay_active) {
             const overlay_size = std.math.clamp(220.0 * ctx.settings.ui_scale, 160.0, screen_h * 0.4);
@@ -329,6 +353,30 @@ pub const WorldScreen = struct {
             Font.drawText(ui, line1, text_x, text_y + 10.0, 1.5, .{ .r = 0.95, .g = 0.98, .b = 1.0, .a = 1.0 });
             Font.drawText(ui, line2, text_x, text_y + 20.0, 1.5, .{ .r = 0.95, .g = 0.98, .b = 1.0, .a = 1.0 });
             Font.drawText(ui, line3, text_x, text_y + 30.0, 1.5, .{ .r = 0.95, .g = 0.98, .b = 1.0, .a = 1.0 });
+        }
+
+        if (ctx.settings.debug_frustum_active) {
+            if (!self.frustum_initialized) {
+                self.frustum_buffer = try render_system.getRHI().resourceManager().createBuffer(
+                    @sizeOf([DebugFrustum.FRUSTUM_VERTEX_COUNT]rhi_pkg.Vertex),
+                    .vertex,
+                );
+                self.frustum_initialized = true;
+            }
+
+            const corners = DebugFrustum.extractCorners(view_proj_render, camera.getViewMatrixOriginCentered());
+            const frustum_verts = DebugFrustum.buildLineVertices(corners, DebugFrustum.DefaultColor);
+            try render_system.getRHI().resourceManager().uploadBuffer(
+                self.frustum_buffer,
+                std.mem.asBytes(&frustum_verts),
+            );
+
+            DebugFrustum.draw(
+                rhi.renderContext(),
+                self.frustum_buffer,
+                DebugFrustum.FRUSTUM_VERTEX_COUNT,
+                camera.position,
+            );
         }
 
         if (self.debug_menu.enabled) {
@@ -369,6 +417,7 @@ pub const WorldScreen = struct {
         states[@intFromEnum(DebugFeature.clouds)] = !render_system.getDisableClouds();
         states[@intFromEnum(DebugFeature.fog)] = self.session.atmosphere.fog_enabled;
         states[@intFromEnum(DebugFeature.lpv_overlay)] = ctx.settings.debug_lpv_overlay_active;
+        states[@intFromEnum(DebugFeature.frustum_debug)] = ctx.settings.debug_frustum_active;
         states[@intFromEnum(DebugFeature.creative_mode)] = self.session.creative_mode;
         states[@intFromEnum(DebugFeature.time_pause)] = self.session.atmosphere.time.time_scale == 0.0;
         return states;
@@ -427,6 +476,9 @@ pub const WorldScreen = struct {
             },
             .lpv_overlay => {
                 ctx.settings.debug_lpv_overlay_active = !ctx.settings.debug_lpv_overlay_active;
+            },
+            .frustum_debug => {
+                ctx.settings.debug_frustum_active = !ctx.settings.debug_frustum_active;
             },
             .creative_mode => {
                 self.session.creative_mode = !self.session.creative_mode;

--- a/src/game/settings/data.zig
+++ b/src/game/settings/data.zig
@@ -37,6 +37,7 @@ pub const Settings = struct {
     wireframe_enabled: bool = false,
     debug_shadows_active: bool = false, // Reverted to false for normal gameplay
     debug_lpv_overlay_active: bool = false,
+    debug_frustum_active: bool = false,
     shadow_quality: u32 = 2, // 0=Low, 1=Medium, 2=High, 3=Ultra
     shadow_distance: f32 = 250.0,
     anisotropic_filtering: u8 = 16,


### PR DESCRIPTION
## Summary
- Add frustum wireframe debug overlay (toggleable via J key or F3 menu)
- Extend shadow cascade debug overlay with cascade index (C0-C3) and split distance labels
- Wire all 3 debug channels (frustum, shadow, LPV) as independently toggleable via DebugFeature enum
- Add `drawDepthTexture` to `UISystem` for debug overlay text rendering

## Acceptance Criteria
- [x] Frustum wireframe visualization toggleable (J key / F3 menu)
- [x] Shadow cascade index/coverage debug labels shown on cascade thumbnails
- [x] LPV propagation stats already displayed (existing)
- [x] All debug channels toggleable independently
- [x] `zig build test` passes
- [x] `zig fmt src/` formatted

## Files Changed
- `src/engine/ui/debug_frustum.zig` (new) - frustum corner extraction + wireframe rendering
- `src/engine/ui/debug_shadow_overlay.zig` - cascade index/split labels added
- `src/engine/ui/ui_system.zig` - add `drawDepthTexture` wrapper
- `src/engine/ui/debug_menu.zig` - add `frustum_debug` to DebugFeature
- `src/game/settings/data.zig` - add `debug_frustum_active`
- `src/game/input_mapper.zig` - add `toggle_frustum_debug` action (J key)
- `src/game/screens/world.zig` - wire up all debug features