### PR TITLE
feat(ui): enhanced performance overlay (#298)

### DIFF
--- a/src/engine/graphics/render_device.zig
+++ b/src/engine/graphics/render_device.zig
@@ -379,11 +379,12 @@ const TexturePool = struct {
         var total: usize = 0;
         for (self.textures.items) |entry| {
             if (entry.alive) {
-                const bytes_per_pixel = switch (entry.format) {
+                const bytes_per_pixel: u32 = switch (entry.format) {
                     .rgb => 3,
-                    .rgba => 4,
+                    .rgba, .rgba_srgb => 4,
                     .red => 1,
                     .depth => 4,
+                    .rgba32f => 16,
                 };
                 total += @as(usize, entry.width) * entry.height * bytes_per_pixel;
             }

--- a/src/engine/ui/timing_overlay.zig
+++ b/src/engine/ui/timing_overlay.zig
@@ -4,6 +4,7 @@ const Color = @import("ui_system.zig").Color;
 const Rect = @import("ui_system.zig").Rect;
 const rhi = @import("../graphics/rhi.zig");
 const RenderDeviceStats = @import("../graphics/render_device.zig").Stats;
+const LODLevel = @import("../../world/lod_chunk.zig").LODLevel;
 const font = @import("font.zig");
 
 pub const TimingOverlay = struct {
@@ -152,6 +153,6 @@ pub const WorldStats = struct {
 };
 
 pub const LODStatsDisplay = struct {
-    loaded: [4]u32,
+    loaded: [LODLevel.count]u32,
     memory_used_mb: u32,
 };

--- a/src/engine/ui/timing_overlay.zig
+++ b/src/engine/ui/timing_overlay.zig
@@ -3,60 +3,147 @@ const UISystem = @import("ui_system.zig").UISystem;
 const Color = @import("ui_system.zig").Color;
 const Rect = @import("ui_system.zig").Rect;
 const rhi = @import("../graphics/rhi.zig");
+const RenderDeviceStats = @import("../graphics/render_device.zig").Stats;
 const font = @import("font.zig");
 
 pub const TimingOverlay = struct {
     enabled: bool = false,
 
-    pub fn draw(self: *TimingOverlay, ui: *UISystem, results: rhi.GpuTimingResults) void {
+    pub fn draw(self: *TimingOverlay, ui: *UISystem, data: PerformanceData) void {
         if (!self.enabled) return;
 
         const x: f32 = 10;
         var y: f32 = 10;
-        const width: f32 = 280;
+        const width: f32 = 340;
         const line_height: f32 = 15;
         const scale: f32 = 1.0;
-        const num_lines = 14; // Title + 12 passes + Total
-        const padding = 20; // Spacers and margins
+        const label_x = x + 10;
+        const value_x = x + width - 10;
 
-        // Background
-        ui.drawRect(.{ .x = x, .y = y, .width = width, .height = num_lines * line_height + padding }, .{ .r = 0, .g = 0, .b = 0, .a = 0.6 });
+        const num_lines = 2 + 1 + 13 + 1 + 6 + 1 + 8 + 1 + 4 + 1;
+        const padding = 25;
+
+        ui.drawRect(.{ .x = x, .y = y, .width = width, .height = num_lines * line_height + padding }, .{ .r = 0, .g = 0, .b = 0, .a = 0.7 });
         y += 5;
 
-        drawTimingLine(ui, "GPU PROFILER (MS)", -1.0, x + 10, &y, scale, Color.white);
-        y += 5;
-
-        drawTimingLine(ui, "SHADOW 0:", results.shadow_pass_ms[0], x + 10, &y, scale, Color.gray);
-        drawTimingLine(ui, "SHADOW 1:", results.shadow_pass_ms[1], x + 10, &y, scale, Color.gray);
-        drawTimingLine(ui, "SHADOW 2:", results.shadow_pass_ms[2], x + 10, &y, scale, Color.gray);
-        drawTimingLine(ui, "G-PASS:", results.g_pass_ms, x + 10, &y, scale, Color.gray);
-        drawTimingLine(ui, "SSAO:", results.ssao_pass_ms, x + 10, &y, scale, Color.gray);
-        drawTimingLine(ui, "LPV:", results.lpv_pass_ms, x + 10, &y, scale, Color.gray);
-        drawTimingLine(ui, "SKY:", results.sky_pass_ms, x + 10, &y, scale, Color.gray);
-        drawTimingLine(ui, "OPAQUE:", results.opaque_pass_ms, x + 10, &y, scale, Color.gray);
-        drawTimingLine(ui, "CLOUDS:", results.cloud_pass_ms, x + 10, &y, scale, Color.gray);
-        drawTimingLine(ui, "BLOOM:", results.bloom_pass_ms, x + 10, &y, scale, Color.gray);
-        drawTimingLine(ui, "FXAA:", results.fxaa_pass_ms, x + 10, &y, scale, Color.gray);
-        drawTimingLine(ui, "POST PROC:", results.post_process_pass_ms, x + 10, &y, scale, Color.gray);
-
-        y += 5;
-        drawTimingLine(ui, "TOTAL GPU:", results.total_gpu_ms, x + 10, &y, scale, Color.white);
-    }
-
-    fn drawTimingLine(ui: *UISystem, label: []const u8, value: f32, x: f32, y: *f32, scale: f32, color: Color) void {
-        font.drawText(ui, label, x, y.*, scale, color);
-
-        if (value >= 0.0) {
-            var buffer: [16]u8 = undefined;
-            const val_str = std.fmt.bufPrint(&buffer, "{d:.2}", .{value}) catch "0.00";
-            const val_x = x + 180;
-            font.drawText(ui, val_str, val_x, y.*, scale, color);
+        drawSectionHeader(ui, "PERFORMANCE", x + 10, &y, scale, Color.white);
+        {
+            var buf: [16]u8 = undefined;
+            const cpu_str = std.fmt.bufPrint(&buf, "CPU: {d:.2}MS  FPS: {d:.0}", .{ data.cpu_frame_ms, data.fps }) catch "";
+            font.drawText(ui, cpu_str, x + 10, y, scale, Color.white);
+            y += line_height + 3;
         }
 
+        drawSectionHeader(ui, "GPU PASSES (MS)", label_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "SHADOW 0:", data.gpu.shadow_pass_ms[0], label_x, value_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "SHADOW 1:", data.gpu.shadow_pass_ms[1], label_x, value_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "SHADOW 2:", data.gpu.shadow_pass_ms[2], label_x, value_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "G-PASS:", data.gpu.g_pass_ms, label_x, value_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "SSAO:", data.gpu.ssao_pass_ms, label_x, value_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "LPV:", data.gpu.lpv_pass_ms, label_x, value_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "SKY:", data.gpu.sky_pass_ms, label_x, value_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "OPAQUE:", data.gpu.opaque_pass_ms, label_x, value_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "CLOUDS:", data.gpu.cloud_pass_ms, label_x, value_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "MAIN:", data.gpu.main_pass_ms, label_x, value_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "BLOOM:", data.gpu.bloom_pass_ms, label_x, value_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "FXAA:", data.gpu.fxaa_pass_ms, label_x, value_x, &y, scale, Color.gray);
+        drawGpuLine(ui, "POST PROC:", data.gpu.post_process_pass_ms, label_x, value_x, &y, scale, Color.gray);
+        y += 3;
+        drawGpuLine(ui, "TOTAL GPU:", data.gpu.total_gpu_ms, label_x, value_x, &y, scale, Color.white);
+
+        if (data.world) |ws| {
+            drawSectionHeader(ui, "RENDER STATS", label_x, &y, scale, Color.rgba(0.4, 0.9, 1.0, 1.0));
+            drawStatLine(ui, "CHUNKS:", ws.chunks_rendered, label_x, value_x, &y, scale, Color.white);
+            drawStatLine(ui, "CHUNKS T:", ws.chunks_total, label_x, value_x, &y, scale, Color.white);
+            drawStatLine(ui, "CULLED:", ws.chunks_culled, label_x, value_x, &y, scale, Color.white);
+            drawStatLine(ui, "VERTS:", ws.vertices_rendered, label_x, value_x, &y, scale, Color.white);
+            drawQueueLine(ui, "QUEUES:", ws.gen_queue, ws.mesh_queue, ws.upload_queue, label_x, value_x, &y, scale, Color.white);
+
+            if (ws.lod) |ls| {
+                drawSectionHeader(ui, "LOD DISTRIBUTION", label_x, &y, scale, Color.rgba(0.5, 0.7, 1.0, 1.0));
+                drawStatLine(ui, "LOD0:", ls.loaded[0], label_x, value_x, &y, scale, Color.rgba(0.5, 0.7, 1.0, 1.0));
+                drawStatLine(ui, "LOD1:", ls.loaded[1], label_x, value_x, &y, scale, Color.rgba(0.5, 0.7, 1.0, 1.0));
+                drawStatLine(ui, "LOD2:", ls.loaded[2], label_x, value_x, &y, scale, Color.rgba(0.5, 0.7, 1.0, 1.0));
+                drawStatLine(ui, "LOD3:", ls.loaded[3], label_x, value_x, &y, scale, Color.rgba(0.5, 0.7, 1.0, 1.0));
+                drawStatLine(ui, "LOD MEM:", ls.memory_used_mb, label_x, value_x, &y, scale, Color.rgba(0.5, 0.7, 1.0, 1.0));
+            }
+        }
+
+        drawSectionHeader(ui, "GPU MEMORY", label_x, &y, scale, Color.rgba(1.0, 0.5, 1.0, 1.0));
+        drawMemoryLine(ui, "BUFS:", data.gpu_stats.buffer_count, data.gpu_stats.total_buffer_memory, label_x, value_x, &y, scale, Color.white);
+        drawMemoryLine(ui, "TEX:", data.gpu_stats.texture_count, data.gpu_stats.total_texture_memory, label_x, value_x, &y, scale, Color.white);
+        drawStatLine(ui, "SHADERS:", data.gpu_stats.shader_count, label_x, value_x, &y, scale, Color.white);
+    }
+
+    fn drawSectionHeader(ui: *UISystem, label: []const u8, x: f32, y: *f32, scale: f32, color: Color) void {
+        font.drawText(ui, label, x, y.*, scale, color);
+        y.* += 18;
+    }
+
+    fn drawGpuLine(ui: *UISystem, label: []const u8, value: f32, label_x: f32, right_x: f32, y: *f32, scale: f32, color: Color) void {
+        font.drawText(ui, label, label_x, y.*, scale, color);
+        if (value >= 0.0) {
+            var buf: [16]u8 = undefined;
+            const val_str = std.fmt.bufPrint(&buf, "{d:.2}", .{value}) catch "0.00";
+            const val_w = font.measureTextWidth(val_str, scale);
+            font.drawText(ui, val_str, right_x - val_w, y.*, scale, color);
+        }
+        y.* += 15;
+    }
+
+    fn drawStatLine(ui: *UISystem, label: []const u8, value: u64, label_x: f32, right_x: f32, y: *f32, scale: f32, color: Color) void {
+        font.drawText(ui, label, label_x, y.*, scale, color);
+        var buf: [32]u8 = undefined;
+        const val_str = std.fmt.bufPrint(&buf, "{d}", .{value}) catch "0";
+        const val_w = font.measureTextWidth(val_str, scale);
+        font.drawText(ui, val_str, right_x - val_w, y.*, scale, color);
+        y.* += 15;
+    }
+
+    fn drawQueueLine(ui: *UISystem, label: []const u8, g: usize, m: usize, u: usize, label_x: f32, right_x: f32, y: *f32, scale: f32, color: Color) void {
+        font.drawText(ui, label, label_x, y.*, scale, color);
+        var buf: [48]u8 = undefined;
+        const val_str = std.fmt.bufPrint(&buf, "{d}/{d}/{d}", .{ g, m, u }) catch "";
+        const val_w = font.measureTextWidth(val_str, scale);
+        font.drawText(ui, val_str, right_x - val_w, y.*, scale, color);
+        y.* += 15;
+    }
+
+    fn drawMemoryLine(ui: *UISystem, label: []const u8, count: u32, bytes: usize, label_x: f32, right_x: f32, y: *f32, scale: f32, color: Color) void {
+        font.drawText(ui, label, label_x, y.*, scale, color);
+        const mb = @as(f32, @floatFromInt(bytes)) / (1024.0 * 1024.0);
+        var buf: [32]u8 = undefined;
+        const val_str = std.fmt.bufPrint(&buf, "{d} ({d:.0}MB)", .{ count, mb }) catch "";
+        const val_w = font.measureTextWidth(val_str, scale);
+        font.drawText(ui, val_str, right_x - val_w, y.*, scale, color);
         y.* += 15;
     }
 
     pub fn toggle(self: *TimingOverlay) void {
         self.enabled = !self.enabled;
     }
+};
+
+pub const PerformanceData = struct {
+    gpu: rhi.GpuTimingResults,
+    cpu_frame_ms: f32,
+    fps: f32,
+    world: ?WorldStats,
+    gpu_stats: RenderDeviceStats,
+};
+
+pub const WorldStats = struct {
+    chunks_total: u32,
+    chunks_rendered: u32,
+    chunks_culled: u32,
+    vertices_rendered: u64,
+    gen_queue: usize,
+    mesh_queue: usize,
+    upload_queue: usize,
+    lod: ?LODStatsDisplay,
+};
+
+pub const LODStatsDisplay = struct {
+    loaded: [4]u32,
+    memory_used_mb: u32,
 };

--- a/src/engine/ui/timing_overlay.zig
+++ b/src/engine/ui/timing_overlay.zig
@@ -20,15 +20,23 @@ pub const TimingOverlay = struct {
         const label_x = x + 10;
         const value_x = x + width - 10;
 
-        const num_lines = 2 + 1 + 13 + 1 + 6 + 1 + 8 + 1 + 4 + 1;
-        const padding = 25;
+        comptime std.debug.assert(rhi.SHADOW_CASCADE_COUNT >= 3);
+
+        var num_lines: f32 = 2 + 1 + 13 + 1 + 6 + 1 + 4 + 1;
+        if (data.world) |ws| {
+            num_lines += 1 + 6;
+            if (ws.lod != null) {
+                num_lines += 1 + 6;
+            }
+        }
+        const padding: f32 = 25;
 
         ui.drawRect(.{ .x = x, .y = y, .width = width, .height = num_lines * line_height + padding }, .{ .r = 0, .g = 0, .b = 0, .a = 0.7 });
         y += 5;
 
         drawSectionHeader(ui, "PERFORMANCE", x + 10, &y, scale, Color.white);
         {
-            var buf: [16]u8 = undefined;
+            var buf: [32]u8 = undefined;
             const cpu_str = std.fmt.bufPrint(&buf, "CPU: {d:.2}MS  FPS: {d:.0}", .{ data.cpu_frame_ms, data.fps }) catch "";
             font.drawText(ui, cpu_str, x + 10, y, scale, Color.white);
             y += line_height + 3;
@@ -113,7 +121,7 @@ pub const TimingOverlay = struct {
         font.drawText(ui, label, label_x, y.*, scale, color);
         const mb = @as(f32, @floatFromInt(bytes)) / (1024.0 * 1024.0);
         var buf: [32]u8 = undefined;
-        const val_str = std.fmt.bufPrint(&buf, "{d} ({d:.0}MB)", .{ count, mb }) catch "";
+        const val_str = std.fmt.bufPrint(&buf, "{d} ({d:.1}MB)", .{ count, mb }) catch "";
         const val_w = font.measureTextWidth(val_str, scale);
         font.drawText(ui, val_str, right_x - val_w, y.*, scale, color);
         y.* += 15;

--- a/src/engine/ui/ui_system_manager.zig
+++ b/src/engine/ui/ui_system_manager.zig
@@ -4,6 +4,9 @@
 const std = @import("std");
 const UISystem = @import("ui_system.zig").UISystem;
 const TimingOverlay = @import("timing_overlay.zig").TimingOverlay;
+const PerformanceData = @import("timing_overlay.zig").PerformanceData;
+const WorldStats = @import("timing_overlay.zig").WorldStats;
+const RenderDeviceStats = @import("../graphics/render_device.zig").Stats;
 const rhi = @import("../graphics/rhi.zig");
 const IRawInputProvider = @import("../input/interfaces.zig").IRawInputProvider;
 const IInputMapper = @import("../../game/input_mapper.zig").IInputMapper;
@@ -42,15 +45,28 @@ pub const UISystemManager = struct {
         }
     }
 
-    pub fn draw(self: *UISystemManager, screen_manager: *ScreenManager, rhi_ptr: *rhi.RHI) !void {
+    pub fn draw(self: *UISystemManager, screen_manager: *ScreenManager, rhi_ptr: *rhi.RHI, world_stats: ?WorldStats, cpu_frame_ms: f32, fps: f32) !void {
         if (self.ui) |*u| {
             try screen_manager.draw(u);
 
             if (self.timing_overlay.enabled) {
                 u.begin();
                 const timing = rhi_ptr.timing();
-                const results = timing.getTimingResults();
-                self.timing_overlay.draw(u, results);
+                const gpu_timing = timing.getTimingResults();
+
+                var gpu_stats = std.mem.zeroes(RenderDeviceStats);
+                if (rhi_ptr.device) |device| {
+                    gpu_stats = device.getStats();
+                }
+
+                const data = PerformanceData{
+                    .gpu = gpu_timing,
+                    .cpu_frame_ms = cpu_frame_ms,
+                    .fps = fps,
+                    .world = world_stats,
+                    .gpu_stats = gpu_stats,
+                };
+                self.timing_overlay.draw(u, data);
                 u.end();
             }
         }

--- a/src/engine/ui/ui_system_manager.zig
+++ b/src/engine/ui/ui_system_manager.zig
@@ -54,10 +54,7 @@ pub const UISystemManager = struct {
                 const timing = rhi_ptr.timing();
                 const gpu_timing = timing.getTimingResults();
 
-                var gpu_stats = std.mem.zeroes(RenderDeviceStats);
-                if (rhi_ptr.device) |device| {
-                    gpu_stats = device.getStats();
-                }
+                const gpu_stats = if (rhi_ptr.device) |device| device.getStats() else std.mem.zeroes(RenderDeviceStats);
 
                 const data = PerformanceData{
                     .gpu = gpu_timing,

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -8,6 +8,7 @@ const WindowManager = @import("../engine/core/window.zig").WindowManager;
 const Input = @import("../engine/input/input.zig").Input;
 const Time = @import("../engine/core/time.zig").Time;
 const UISystemManager = @import("../engine/ui/ui_system_manager.zig").UISystemManager;
+const WorldStats = @import("../engine/ui/timing_overlay.zig").WorldStats;
 const Vec3 = @import("../engine/math/vec3.zig").Vec3;
 const Mat4 = @import("../engine/math/mat4.zig").Mat4;
 const InputMapper = @import("input_mapper.zig").InputMapper;
@@ -161,6 +162,12 @@ pub const App = struct {
         };
     }
 
+    fn getWorldStats(self: *const App) ?WorldStats {
+        if (self.screen_manager.stack.items.len == 0) return null;
+        const top = self.screen_manager.stack.items[self.screen_manager.stack.items.len - 1];
+        return top.getWorldStats();
+    }
+
     pub fn runSingleFrame(self: *App) !void {
         self.time.update();
         self.audio_manager.update();
@@ -215,7 +222,9 @@ pub const App = struct {
             return;
         }
 
-        try self.ui_manager.draw(&self.screen_manager, self.render_system.getRHI());
+        const world_stats = self.getWorldStats();
+        const cpu_ms = self.time.delta_time * 1000.0;
+        try self.ui_manager.draw(&self.screen_manager, self.render_system.getRHI(), world_stats, cpu_ms, self.time.fps);
 
         self.render_system.endFrame();
 

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -164,7 +164,7 @@ pub const App = struct {
 
     fn getWorldStats(self: *const App) ?WorldStats {
         if (self.screen_manager.stack.items.len == 0) return null;
-        const top = self.screen_manager.stack.items[self.screen_manager.stack.items.len - 1];
+        const top = self.screen_manager.stack.getLast();
         return top.getWorldStats();
     }
 

--- a/src/game/screen.zig
+++ b/src/game/screen.zig
@@ -10,6 +10,7 @@ const WindowManager = @import("../engine/core/window.zig").WindowManager;
 const RenderSystem = @import("../engine/graphics/render_system.zig").RenderSystem;
 const AudioSystem = @import("../engine/audio/system.zig").AudioSystem;
 const UISystemManager = @import("../engine/ui/ui_system_manager.zig").UISystemManager;
+const WorldStats = @import("../engine/ui/timing_overlay.zig").WorldStats;
 const settings_pkg = @import("settings.zig");
 const Settings = settings_pkg.Settings;
 
@@ -44,6 +45,7 @@ pub const IScreen = struct {
         draw: ?*const fn (ptr: *anyopaque, ui: *UISystem) anyerror!void = null,
         onEnter: ?*const fn (ptr: *anyopaque) void = null,
         onExit: ?*const fn (ptr: *anyopaque) void = null,
+        getWorldStats: ?*const fn (ptr: *anyopaque) ?WorldStats = null,
     };
 
     pub fn deinit(self: IScreen) void {
@@ -72,6 +74,13 @@ pub const IScreen = struct {
         if (self.vtable.onExit) |onExit_fn| {
             onExit_fn(self.ptr);
         }
+    }
+
+    pub fn getWorldStats(self: IScreen) ?WorldStats {
+        if (self.vtable.getWorldStats) |getStats_fn| {
+            return getStats_fn(self.ptr);
+        }
+        return null;
     }
 };
 

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -4,6 +4,8 @@ const Screen = @import("../screen.zig");
 const IScreen = Screen.IScreen;
 const EngineContext = Screen.EngineContext;
 const GameSession = @import("../session.zig").GameSession;
+const World = @import("../../world/world.zig").World;
+const LODStats = @import("../../world/lod_manager.zig").LODStats;
 const Vec3 = @import("../../engine/math/vec3.zig").Vec3;
 const rhi_pkg = @import("../../engine/graphics/rhi.zig");
 const RenderSystem = @import("../../engine/graphics/render_system.zig").RenderSystem;
@@ -14,6 +16,8 @@ const DebugLPVOverlay = @import("../../engine/ui/debug_lpv_overlay.zig").DebugLP
 const DebugMenuOverlay = @import("../../engine/ui/debug_menu.zig").DebugMenuOverlay;
 const DebugFeature = @import("../../engine/ui/debug_menu.zig").DebugFeature;
 const Font = @import("../../engine/ui/font.zig");
+const WorldStats = @import("../../engine/ui/timing_overlay.zig").WorldStats;
+const LODStatsDisplay = @import("../../engine/ui/timing_overlay.zig").LODStatsDisplay;
 const log = @import("../../engine/core/log.zig");
 
 pub const WorldScreen = struct {
@@ -28,6 +32,7 @@ pub const WorldScreen = struct {
         .draw = draw,
         .onEnter = onEnter,
         .onExit = onExit,
+        .getWorldStats = getWorldStatsIScreen,
     };
 
     pub fn init(allocator: std.mem.Allocator, context: EngineContext, seed: u64, generator_index: usize) !*WorldScreen {
@@ -352,6 +357,34 @@ pub const WorldScreen = struct {
 
     pub fn screen(self: *@This()) IScreen {
         return Screen.makeScreen(@This(), self);
+    }
+
+    pub fn getWorldStats(self: *WorldScreen) ?WorldStats {
+        const ws = self.session.world;
+        const rs = ws.getRenderStats();
+        const stats = ws.getStats();
+        var lod_display: ?LODStatsDisplay = null;
+        if (ws.getLODStats()) |ls| {
+            lod_display = .{
+                .loaded = ls.loaded,
+                .memory_used_mb = ls.memory_used_mb,
+            };
+        }
+        return .{
+            .chunks_total = rs.chunks_total,
+            .chunks_rendered = rs.chunks_rendered,
+            .chunks_culled = rs.chunks_culled,
+            .vertices_rendered = rs.vertices_rendered,
+            .gen_queue = stats.gen_queue,
+            .mesh_queue = stats.mesh_queue,
+            .upload_queue = stats.upload_queue,
+            .lod = lod_display,
+        };
+    }
+
+    fn getWorldStatsIScreen(ptr: *anyopaque) ?WorldStats {
+        const self: *WorldScreen = @ptrCast(@alignCast(ptr));
+        return self.getWorldStats();
     }
 
     fn collectDebugStates(self: *WorldScreen, ctx: EngineContext, render_system: *RenderSystem) [DebugFeature.count]bool {


### PR DESCRIPTION
## Summary

Extends the existing `TimingOverlay` (F4 toggle) with CPU frame timing, GPU memory stats, and LOD statistics.

### Changes

- **`src/engine/ui/timing_overlay.zig`**: Added `PerformanceData`, `WorldStats`, and `LODStatsDisplay` structs. Rewrote `draw()` with a 5-section layout: PERFORMANCE (CPU ms + FPS), GPU PASSES, RENDER STATS, LOD DISTRIBUTION, GPU MEMORY.
- **`src/engine/ui/ui_system_manager.zig`**: Updated `draw()` signature to accept `world_stats`, `cpu_frame_ms`, and `fps`. Builds `PerformanceData` from RHI timing results and `RenderDevice.Stats`.
- **`src/game/screen.zig`**: Added `getWorldStats()` to `IScreen` interface with a default null implementation. Added vtable entry.
- **`src/game/screens/world.zig`**: Added `getWorldStats()` to `WorldScreen` that converts world data into `WorldStats` format.
- **`src/game/app.zig`**: Added `getWorldStats()` helper on `App`. Passes world stats, CPU frame time, and FPS to `UISystemManager.draw()`.
- **`src/engine/graphics/render_device.zig`**: Fixed pre-existing bug in `TexturePool.totalMemory()` where `rgba_srgb` and `rgba32f` format variants were not handled.

### Acceptance Criteria

- [x] CPU frame time displayed
- [x] GPU memory stats shown (buffers/textures/shaders + MB)
- [x] LOD level distribution visible (LOD0-3 loaded counts + memory MB)
- [x] Enhanced overlay coexists with basic timing overlay (same F4 toggle, same panel)

### Panel Layout

```
PERFORMANCE          CPU: 2.34MS  FPS: 60
────────────────────────────────────────
GPU PASSES (MS)
  SHADOW 0:    0.12     SHADOW 1:    0.08
  ...
  TOTAL GPU:   4.21

RENDER STATS
  CHUNKS:     127       CHUNKS T:   512
  CULLED:     385       VERTS:     1.2M
  QUEUES:     3/12/0

LOD DISTRIBUTION
  LOD0:        64       LOD1:        32
  LOD2:        16       LOD3:         8
  LOD MEM:    128MB

GPU MEMORY
  BUFS:   24 (45MB)    TEX:    48 (120MB)
  SHADERS: 12
```