### PR TITLE
refactor: add interface abstractions for world and render settings

### DIFF
--- a/src/engine/core/interfaces.zig
+++ b/src/engine/core/interfaces.zig
@@ -1,101 +1,93 @@
 //! Core engine interfaces following SOLID principles.
 //! These abstractions allow for dependency inversion and extensibility.
 
-const std = @import("std");
-const Mat4 = @import("../math/mat4.zig").Mat4;
-const Vec3 = @import("../math/vec3.zig").Vec3;
-
-/// Interface for anything that updates each frame
-pub const IUpdatable = struct {
+/// Interface for render settings (wireframe, vsync, bloom, etc.).
+/// Decouples screens and settings logic from the concrete RHI backend.
+pub const IRenderSettings = struct {
     ptr: *anyopaque,
     vtable: *const VTable,
 
     pub const VTable = struct {
-        update: *const fn (ptr: *anyopaque, delta_time: f32) void,
+        setWireframe: *const fn (ptr: *anyopaque, enabled: bool) void,
+        setVSync: *const fn (ptr: *anyopaque, enabled: bool) void,
+        setTexturesEnabled: *const fn (ptr: *anyopaque, enabled: bool) void,
+        setAnisotropicFiltering: *const fn (ptr: *anyopaque, level: u8) void,
+        setFXAA: *const fn (ptr: *anyopaque, enabled: bool) void,
+        setBloom: *const fn (ptr: *anyopaque, enabled: bool) void,
+        setBloomIntensity: *const fn (ptr: *anyopaque, intensity: f32) void,
+        setTAABlendFactor: *const fn (ptr: *anyopaque, value: f32) void,
+        setTAAVelocityRejection: *const fn (ptr: *anyopaque, value: f32) void,
+        setVignetteEnabled: *const fn (ptr: *anyopaque, enabled: bool) void,
+        setVignetteIntensity: *const fn (ptr: *anyopaque, intensity: f32) void,
+        setFilmGrainEnabled: *const fn (ptr: *anyopaque, enabled: bool) void,
+        setFilmGrainIntensity: *const fn (ptr: *anyopaque, intensity: f32) void,
+        setVolumetricDensity: *const fn (ptr: *anyopaque, density: f32) void,
+        setDebugShadowView: *const fn (ptr: *anyopaque, enabled: bool) void,
+        setMSAA: *const fn (ptr: *anyopaque, samples: u8) void,
     };
 
-    pub fn update(self: IUpdatable, delta_time: f32) void {
-        self.vtable.update(self.ptr, delta_time);
-    }
-};
-
-/// Interface for anything that can be rendered
-pub const IRenderable = struct {
-    ptr: *anyopaque,
-    vtable: *const VTable,
-
-    pub const VTable = struct {
-        render: *const fn (ptr: *anyopaque, view_proj: Mat4) void,
-    };
-
-    pub fn render(self: IRenderable, view_proj: Mat4) void {
-        self.vtable.render(self.ptr, view_proj);
-    }
-};
-
-/// Interface for anything that handles input events
-pub const IInputHandler = struct {
-    ptr: *anyopaque,
-    vtable: *const VTable,
-
-    pub const VTable = struct {
-        handleInput: *const fn (ptr: *anyopaque, event: InputEvent) bool,
-    };
-
-    pub fn handleInput(self: IInputHandler, event: InputEvent) bool {
-        return self.vtable.handleInput(self.ptr, event);
-    }
-};
-
-/// Interface for UI widgets
-pub const IWidget = struct {
-    ptr: *anyopaque,
-    vtable: *const VTable,
-
-    pub const VTable = struct {
-        draw: *const fn (ptr: *anyopaque) void,
-        handleInput: *const fn (ptr: *anyopaque, event: InputEvent) bool,
-        getBounds: *const fn (ptr: *anyopaque) Rect,
-    };
-
-    pub fn draw(self: IWidget) void {
-        self.vtable.draw(self.ptr);
+    pub fn setWireframe(self: IRenderSettings, enabled: bool) void {
+        self.vtable.setWireframe(self.ptr, enabled);
     }
 
-    pub fn handleInput(self: IWidget, event: InputEvent) bool {
-        return self.vtable.handleInput(self.ptr, event);
+    pub fn setVSync(self: IRenderSettings, enabled: bool) void {
+        self.vtable.setVSync(self.ptr, enabled);
     }
 
-    pub fn getBounds(self: IWidget) Rect {
-        return self.vtable.getBounds(self.ptr);
+    pub fn setTexturesEnabled(self: IRenderSettings, enabled: bool) void {
+        self.vtable.setTexturesEnabled(self.ptr, enabled);
     }
-};
 
-/// Interface for chunk data providers (world generation abstraction)
-pub const IChunkProvider = struct {
-    ptr: *anyopaque,
-    vtable: *const VTable,
-
-    pub const VTable = struct {
-        generateChunk: *const fn (ptr: *anyopaque, chunk_x: i32, chunk_z: i32, out_blocks: []u8) void,
-    };
-
-    pub fn generateChunk(self: IChunkProvider, chunk_x: i32, chunk_z: i32, out_blocks: []u8) void {
-        self.vtable.generateChunk(self.ptr, chunk_x, chunk_z, out_blocks);
+    pub fn setAnisotropicFiltering(self: IRenderSettings, level: u8) void {
+        self.vtable.setAnisotropicFiltering(self.ptr, level);
     }
-};
 
-/// Interface for mesh generation strategies (greedy, naive, etc.)
-pub const IMeshBuilder = struct {
-    ptr: *anyopaque,
-    vtable: *const VTable,
+    pub fn setFXAA(self: IRenderSettings, enabled: bool) void {
+        self.vtable.setFXAA(self.ptr, enabled);
+    }
 
-    pub const VTable = struct {
-        buildMesh: *const fn (ptr: *anyopaque, blocks: []const u8, out_vertices: *std.ArrayList(f32), out_indices: *std.ArrayList(u32)) void,
-    };
+    pub fn setBloom(self: IRenderSettings, enabled: bool) void {
+        self.vtable.setBloom(self.ptr, enabled);
+    }
 
-    pub fn buildMesh(self: IMeshBuilder, blocks: []const u8, out_vertices: *std.ArrayList(f32), out_indices: *std.ArrayList(u32)) void {
-        self.vtable.buildMesh(self.ptr, blocks, out_vertices, out_indices);
+    pub fn setBloomIntensity(self: IRenderSettings, intensity: f32) void {
+        self.vtable.setBloomIntensity(self.ptr, intensity);
+    }
+
+    pub fn setTAABlendFactor(self: IRenderSettings, value: f32) void {
+        self.vtable.setTAABlendFactor(self.ptr, value);
+    }
+
+    pub fn setTAAVelocityRejection(self: IRenderSettings, value: f32) void {
+        self.vtable.setTAAVelocityRejection(self.ptr, value);
+    }
+
+    pub fn setVignetteEnabled(self: IRenderSettings, enabled: bool) void {
+        self.vtable.setVignetteEnabled(self.ptr, enabled);
+    }
+
+    pub fn setVignetteIntensity(self: IRenderSettings, intensity: f32) void {
+        self.vtable.setVignetteIntensity(self.ptr, intensity);
+    }
+
+    pub fn setFilmGrainEnabled(self: IRenderSettings, enabled: bool) void {
+        self.vtable.setFilmGrainEnabled(self.ptr, enabled);
+    }
+
+    pub fn setFilmGrainIntensity(self: IRenderSettings, intensity: f32) void {
+        self.vtable.setFilmGrainIntensity(self.ptr, intensity);
+    }
+
+    pub fn setVolumetricDensity(self: IRenderSettings, density: f32) void {
+        self.vtable.setVolumetricDensity(self.ptr, density);
+    }
+
+    pub fn setDebugShadowView(self: IRenderSettings, enabled: bool) void {
+        self.vtable.setDebugShadowView(self.ptr, enabled);
+    }
+
+    pub fn setMSAA(self: IRenderSettings, samples: u8) void {
+        self.vtable.setMSAA(self.ptr, samples);
     }
 };
 

--- a/src/engine/graphics/render_graph.zig
+++ b/src/engine/graphics/render_graph.zig
@@ -39,7 +39,7 @@
 const std = @import("std");
 const c = @import("../../c.zig").c;
 const Camera = @import("camera.zig").Camera;
-const World = @import("../../world/world.zig").World;
+const IWorld = @import("../../world/world.zig").IWorld;
 const shadow_scene = @import("shadow_scene.zig");
 const rhi_pkg = @import("rhi.zig");
 const RenderContext = rhi_pkg.RenderContext;
@@ -57,7 +57,7 @@ pub const SceneContext = struct {
     shadow_ctx: ShadowSystemWrapper,
     ssao_ctx: ISSAOContext,
     timing: IDeviceTiming,
-    world: *World,
+    world: IWorld,
     shadow_scene: shadow_scene.IShadowScene,
     camera: *Camera,
     atmosphere_system: *AtmosphereSystem,

--- a/src/engine/graphics/render_settings.zig
+++ b/src/engine/graphics/render_settings.zig
@@ -1,0 +1,114 @@
+const rhi_pkg = @import("rhi.zig");
+const RHI = rhi_pkg.RHI;
+const IRenderSettings = @import("../core/interfaces.zig").IRenderSettings;
+
+pub const RenderSettingsAdapter = struct {
+    rhi: *RHI,
+
+    pub fn init(rhi: *RHI) RenderSettingsAdapter {
+        return .{ .rhi = rhi };
+    }
+
+    pub fn interface(self: *RenderSettingsAdapter) IRenderSettings {
+        return .{ .ptr = self, .vtable = &VTABLE };
+    }
+
+    const VTABLE = IRenderSettings.VTable{
+        .setWireframe = setWireframe,
+        .setVSync = setVSync,
+        .setTexturesEnabled = setTexturesEnabled,
+        .setAnisotropicFiltering = setAnisotropicFiltering,
+        .setFXAA = setFXAA,
+        .setBloom = setBloom,
+        .setBloomIntensity = setBloomIntensity,
+        .setTAABlendFactor = setTAABlendFactor,
+        .setTAAVelocityRejection = setTAAVelocityRejection,
+        .setVignetteEnabled = setVignetteEnabled,
+        .setVignetteIntensity = setVignetteIntensity,
+        .setFilmGrainEnabled = setFilmGrainEnabled,
+        .setFilmGrainIntensity = setFilmGrainIntensity,
+        .setVolumetricDensity = setVolumetricDensity,
+        .setDebugShadowView = setDebugShadowView,
+        .setMSAA = setMSAA,
+    };
+
+    fn setWireframe(ptr: *anyopaque, enabled: bool) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setWireframe(enabled);
+    }
+
+    fn setVSync(ptr: *anyopaque, enabled: bool) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setVSync(enabled);
+    }
+
+    fn setTexturesEnabled(ptr: *anyopaque, enabled: bool) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setTexturesEnabled(enabled);
+    }
+
+    fn setAnisotropicFiltering(ptr: *anyopaque, level: u8) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setAnisotropicFiltering(level);
+    }
+
+    fn setFXAA(ptr: *anyopaque, enabled: bool) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setFXAA(enabled);
+    }
+
+    fn setBloom(ptr: *anyopaque, enabled: bool) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setBloom(enabled);
+    }
+
+    fn setBloomIntensity(ptr: *anyopaque, intensity: f32) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setBloomIntensity(intensity);
+    }
+
+    fn setTAABlendFactor(ptr: *anyopaque, value: f32) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setTAABlendFactor(value);
+    }
+
+    fn setTAAVelocityRejection(ptr: *anyopaque, value: f32) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setTAAVelocityRejection(value);
+    }
+
+    fn setVignetteEnabled(ptr: *anyopaque, enabled: bool) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setVignetteEnabled(enabled);
+    }
+
+    fn setVignetteIntensity(ptr: *anyopaque, intensity: f32) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setVignetteIntensity(intensity);
+    }
+
+    fn setFilmGrainEnabled(ptr: *anyopaque, enabled: bool) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setFilmGrainEnabled(enabled);
+    }
+
+    fn setFilmGrainIntensity(ptr: *anyopaque, intensity: f32) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setFilmGrainIntensity(intensity);
+    }
+
+    fn setVolumetricDensity(ptr: *anyopaque, density: f32) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setVolumetricDensity(density);
+    }
+
+    fn setDebugShadowView(ptr: *anyopaque, enabled: bool) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setDebugShadowView(enabled);
+    }
+
+    fn setMSAA(ptr: *anyopaque, samples: u8) void {
+        const self: *RenderSettingsAdapter = @ptrCast(@alignCast(ptr));
+        self.rhi.setMSAA(samples);
+    }
+};

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -1,6 +1,4 @@
 const std = @import("std");
-const c = @import("../c.zig").c;
-const builtin = @import("builtin");
 const build_options = @import("build_options");
 
 const log = @import("../engine/core/log.zig");
@@ -12,13 +10,9 @@ const WorldStats = @import("../engine/ui/timing_overlay.zig").WorldStats;
 const Vec3 = @import("../engine/math/vec3.zig").Vec3;
 const Mat4 = @import("../engine/math/mat4.zig").Mat4;
 const InputMapper = @import("input_mapper.zig").InputMapper;
-const rhi_pkg = @import("../engine/graphics/rhi.zig");
 const RenderSystem = @import("../engine/graphics/render_system.zig").RenderSystem;
-const AudioSystem = @import("../engine/audio/system.zig").AudioSystem;
 const AudioSystemManager = @import("audio_system_manager.zig").AudioSystemManager;
 
-const settings_pkg = @import("settings.zig");
-const Settings = settings_pkg.Settings;
 const SettingsManager = @import("settings_manager.zig").SettingsManager;
 const InputSettings = @import("input_settings.zig").InputSettings;
 
@@ -27,6 +21,7 @@ const ScreenManager = screen_pkg.ScreenManager;
 const EngineContext = screen_pkg.EngineContext;
 const HomeScreen = @import("screens/home.zig").HomeScreen;
 const WorldScreen = @import("screens/world.zig").WorldScreen;
+const RenderSettingsAdapter = @import("../engine/graphics/render_settings.zig").RenderSettingsAdapter;
 
 pub const App = struct {
     allocator: std.mem.Allocator,
@@ -41,6 +36,7 @@ pub const App = struct {
     screen_manager: ScreenManager,
     skip_world_update: bool,
     smoke_test_frames: u32 = 0,
+    render_settings_adapter: RenderSettingsAdapter,
 
     pub fn init(allocator: std.mem.Allocator) !*App {
         log.log.info("Initializing engine systems...", .{});
@@ -103,6 +99,7 @@ pub const App = struct {
             .screen_manager = ScreenManager.init(allocator),
             .skip_world_update = skip_world_update,
             .smoke_test_frames = 0,
+            .render_settings_adapter = RenderSettingsAdapter.init(render_system.getRHI()),
         };
         errdefer app.screen_manager.deinit();
 
@@ -152,6 +149,7 @@ pub const App = struct {
             .time = &self.time,
             .screen_manager = &self.screen_manager,
             .skip_world_update = self.skip_world_update,
+            .render_settings = self.render_settings_adapter.interface(),
         };
     }
 

--- a/src/game/screen.zig
+++ b/src/game/screen.zig
@@ -1,9 +1,7 @@
 const std = @import("std");
 const UISystem = @import("../engine/ui/ui_system.zig").UISystem;
-const Input = @import("../engine/input/input.zig").Input;
 const IRawInputProvider = @import("../engine/input/interfaces.zig").IRawInputProvider;
 const input_mapper_pkg = @import("input_mapper.zig");
-const InputMapper = input_mapper_pkg.InputMapper;
 const IInputMapper = input_mapper_pkg.IInputMapper;
 const Time = @import("../engine/core/time.zig").Time;
 const WindowManager = @import("../engine/core/window.zig").WindowManager;
@@ -11,6 +9,7 @@ const RenderSystem = @import("../engine/graphics/render_system.zig").RenderSyste
 const AudioSystem = @import("../engine/audio/system.zig").AudioSystem;
 const UISystemManager = @import("../engine/ui/ui_system_manager.zig").UISystemManager;
 const WorldStats = @import("../engine/ui/timing_overlay.zig").WorldStats;
+const IRenderSettings = @import("../engine/core/interfaces.zig").IRenderSettings;
 const settings_pkg = @import("settings.zig");
 const Settings = settings_pkg.Settings;
 
@@ -26,6 +25,7 @@ pub const EngineContext = struct {
     time: *Time,
     screen_manager: *ScreenManager,
     skip_world_update: bool,
+    render_settings: IRenderSettings,
 
     pub fn saveSettings(self: EngineContext) void {
         settings_pkg.persistence.save(self.settings, self.allocator);

--- a/src/game/screens/graphics.zig
+++ b/src/game/screens/graphics.zig
@@ -51,7 +51,7 @@ pub const GraphicsScreen = struct {
         const self: *@This() = @ptrCast(@alignCast(ptr));
         const ctx = self.context;
         const settings = ctx.settings;
-        const rhi = ctx.render_system.getRHI();
+        const rs = ctx.render_settings;
 
         // Draw background screen if it exists
         try ctx.screen_manager.drawParentScreen(ptr, ui);
@@ -99,15 +99,15 @@ pub const GraphicsScreen = struct {
                 const next_idx = (preset_idx + 1) % (settings_pkg.json_presets.graphics_presets.items.len + 1);
                 if (next_idx < settings_pkg.json_presets.graphics_presets.items.len) {
                     settings_pkg.json_presets.apply(settings, next_idx);
-                    rhi.setAnisotropicFiltering(settings.anisotropic_filtering);
-                    rhi.setTexturesEnabled(settings.textures_enabled);
-                    rhi.setTAABlendFactor(settings.taa_blend_factor);
-                    rhi.setTAAVelocityRejection(settings.taa_velocity_rejection);
+                    rs.setAnisotropicFiltering(settings.anisotropic_filtering);
+                    rs.setTexturesEnabled(settings.textures_enabled);
+                    rs.setTAABlendFactor(settings.taa_blend_factor);
+                    rs.setTAAVelocityRejection(settings.taa_velocity_rejection);
                     if (settings.taa_enabled) {
                         settings.fxaa_enabled = false;
-                        rhi.setFXAA(false);
+                        rs.setFXAA(false);
                     } else {
-                        rhi.setFXAA(settings.fxaa_enabled);
+                        rs.setFXAA(settings.fxaa_enabled);
                     }
                 } else {
                     // Custom selected, nothing changes in values but UI label updates to CUSTOM (via getPresetIndex next frame)
@@ -215,41 +215,41 @@ pub const GraphicsScreen = struct {
             // Handle side effects
             if (val_ptr.* != old_val) {
                 if (std.mem.eql(u8, decl.name, "anisotropic_filtering")) {
-                    rhi.setAnisotropicFiltering(settings.anisotropic_filtering);
+                    rs.setAnisotropicFiltering(settings.anisotropic_filtering);
                 } else if (std.mem.eql(u8, decl.name, "textures_enabled")) {
-                    rhi.setTexturesEnabled(settings.textures_enabled);
+                    rs.setTexturesEnabled(settings.textures_enabled);
                 } else if (std.mem.eql(u8, decl.name, "vsync")) {
-                    rhi.setVSync(settings.vsync);
+                    rs.setVSync(settings.vsync);
                 } else if (std.mem.eql(u8, decl.name, "volumetric_density")) {
-                    rhi.setVolumetricDensity(settings.volumetric_density);
+                    rs.setVolumetricDensity(settings.volumetric_density);
                 } else if (std.mem.eql(u8, decl.name, "taa_enabled")) {
                     if (settings.taa_enabled) {
                         settings.fxaa_enabled = false;
-                        rhi.setFXAA(false);
+                        rs.setFXAA(false);
                     }
                 } else if (std.mem.eql(u8, decl.name, "taa_blend_factor")) {
-                    rhi.setTAABlendFactor(settings.taa_blend_factor);
+                    rs.setTAABlendFactor(settings.taa_blend_factor);
                 } else if (std.mem.eql(u8, decl.name, "taa_velocity_rejection")) {
-                    rhi.setTAAVelocityRejection(settings.taa_velocity_rejection);
+                    rs.setTAAVelocityRejection(settings.taa_velocity_rejection);
                 } else if (std.mem.eql(u8, decl.name, "fxaa_enabled")) {
                     if (settings.taa_enabled and settings.fxaa_enabled) {
                         settings.fxaa_enabled = false;
-                        rhi.setFXAA(false);
+                        rs.setFXAA(false);
                     } else {
-                        rhi.setFXAA(settings.fxaa_enabled);
+                        rs.setFXAA(settings.fxaa_enabled);
                     }
                 } else if (std.mem.eql(u8, decl.name, "bloom_enabled")) {
-                    rhi.setBloom(settings.bloom_enabled);
+                    rs.setBloom(settings.bloom_enabled);
                 } else if (std.mem.eql(u8, decl.name, "bloom_intensity")) {
-                    rhi.setBloomIntensity(settings.bloom_intensity);
+                    rs.setBloomIntensity(settings.bloom_intensity);
                 } else if (std.mem.eql(u8, decl.name, "vignette_enabled")) {
-                    rhi.setVignetteEnabled(settings.vignette_enabled);
+                    rs.setVignetteEnabled(settings.vignette_enabled);
                 } else if (std.mem.eql(u8, decl.name, "vignette_intensity")) {
-                    rhi.setVignetteIntensity(settings.vignette_intensity);
+                    rs.setVignetteIntensity(settings.vignette_intensity);
                 } else if (std.mem.eql(u8, decl.name, "film_grain_enabled")) {
-                    rhi.setFilmGrainEnabled(settings.film_grain_enabled);
+                    rs.setFilmGrainEnabled(settings.film_grain_enabled);
                 } else if (std.mem.eql(u8, decl.name, "film_grain_intensity")) {
-                    rhi.setFilmGrainIntensity(settings.film_grain_intensity);
+                    rs.setFilmGrainIntensity(settings.film_grain_intensity);
                 }
             }
 

--- a/src/game/screens/settings.zig
+++ b/src/game/screens/settings.zig
@@ -53,7 +53,7 @@ pub const SettingsScreen = struct {
         const self: *@This() = @ptrCast(@alignCast(ptr));
         const ctx = self.context;
         const settings = ctx.settings;
-        const rhi = ctx.render_system.getRHI();
+        const rs = ctx.render_settings;
 
         // Draw background screen if it exists
         try ctx.screen_manager.drawParentScreen(ptr, ui);
@@ -139,7 +139,7 @@ pub const SettingsScreen = struct {
         Font.drawText(ui, "VSYNC", lx, sy, label_scale, Color.white);
         if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, if (settings.vsync) "ENABLED" else "DISABLED", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             settings.vsync = !settings.vsync;
-            apply_logic.applyToRHI(settings, rhi);
+            apply_logic.applyToRenderSettings(settings, rs);
         }
         sy += row_height + 15.0 * ui_scale;
 
@@ -170,7 +170,7 @@ pub const SettingsScreen = struct {
         Font.drawText(ui, "TEXTURES", lx, sy, label_scale, Color.white);
         if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, if (settings.textures_enabled) "ENABLED" else "DISABLED", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             settings.textures_enabled = !settings.textures_enabled;
-            apply_logic.applyToRHI(settings, rhi);
+            apply_logic.applyToRenderSettings(settings, rs);
         }
         sy += row_height;
 
@@ -178,7 +178,7 @@ pub const SettingsScreen = struct {
         Font.drawText(ui, "WIREFRAME", lx, sy, label_scale, Color.rgba(0.7, 0.7, 0.8, 1.0));
         if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, if (settings.wireframe_enabled) "ENABLED" else "DISABLED", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             settings.wireframe_enabled = !settings.wireframe_enabled;
-            apply_logic.applyToRHI(settings, rhi);
+            apply_logic.applyToRenderSettings(settings, rs);
         }
         Font.drawText(ui, "(DEBUG)", vx + toggle_width + 10.0, sy, 1.5 * ui_scale, Color.rgba(0.5, 0.5, 0.6, 1.0));
 

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -4,7 +4,7 @@ const Screen = @import("../screen.zig");
 const IScreen = Screen.IScreen;
 const EngineContext = Screen.EngineContext;
 const GameSession = @import("../session.zig").GameSession;
-const World = @import("../../world/world.zig").World;
+const IWorld = @import("../../world/world.zig").IWorld;
 const LODStats = @import("../../world/lod_manager.zig").LODStats;
 const Vec3 = @import("../../engine/math/vec3.zig").Vec3;
 const rhi_pkg = @import("../../engine/graphics/rhi.zig");
@@ -28,6 +28,7 @@ const CSM = @import("../../engine/graphics/csm.zig");
 pub const WorldScreen = struct {
     context: EngineContext,
     session: *GameSession,
+    world: IWorld,
     last_debug_toggle_time: f32 = 0,
     debug_menu: DebugMenuOverlay,
     frustum_buffer: rhi_pkg.BufferHandle = 0,
@@ -47,11 +48,13 @@ pub const WorldScreen = struct {
         const render_system = context.render_system;
         const session = try GameSession.init(allocator, render_system.getRHI(), render_system.getAtlas(), seed, context.settings.render_distance, context.settings.lod_enabled, generator_index);
         errdefer session.deinit();
+        const world = session.world.interface();
 
         const self = try allocator.create(WorldScreen);
         self.* = .{
             .context = context,
             .session = session,
+            .world = world,
             .last_debug_toggle_time = 0,
             .debug_menu = .{},
         };
@@ -117,7 +120,7 @@ pub const WorldScreen = struct {
             self.last_debug_toggle_time = now;
         }
         if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_lod_render)) {
-            if (self.session.world.lod == null) {
+            if (!self.world.isLODEnabled()) {
                 log.log.warn("LOD toggle requested but LOD system is not initialized", .{});
             } else {
                 self.session.world.lod_enabled = !self.session.world.lod_enabled;
@@ -277,8 +280,8 @@ pub const WorldScreen = struct {
                 .shadow_ctx = rhi.shadowSystem(),
                 .ssao_ctx = rhi.ssao(),
                 .timing = rhi.timing(),
-                .world = self.session.world,
-                .shadow_scene = self.session.world.shadowScene(),
+                .world = self.world,
+                .shadow_scene = self.world.shadowScene(),
                 .camera = camera,
                 .atmosphere_system = render_system.getAtmosphereSystem(),
                 .material_system = render_system.getMaterialSystem(),
@@ -425,7 +428,7 @@ pub const WorldScreen = struct {
     }
 
     pub fn getWorldStats(self: *WorldScreen) ?WorldStats {
-        const ws = self.session.world;
+        const ws = self.world;
         const rs = ws.getRenderStats();
         const stats = ws.getStats();
         var lod_display: ?LODStatsDisplay = null;

--- a/src/game/settings/apply.zig
+++ b/src/game/settings/apply.zig
@@ -1,5 +1,6 @@
 const Settings = @import("data.zig").Settings;
 const RHI = @import("../../engine/graphics/rhi.zig").RHI;
+const IRenderSettings = @import("../../engine/core/interfaces.zig").IRenderSettings;
 
 /// Applies settings that have direct RHI setters. Call this after any settings change.
 ///
@@ -42,4 +43,15 @@ pub fn applyToRHI(settings: *const Settings, rhi: *RHI) void {
     rhi.setMSAA(settings.msaa_samples);
     rhi.setTAABlendFactor(settings.taa_blend_factor);
     rhi.setTAAVelocityRejection(settings.taa_velocity_rejection);
+}
+
+pub fn applyToRenderSettings(settings: *const Settings, rs: IRenderSettings) void {
+    rs.setVSync(settings.vsync);
+    rs.setWireframe(settings.wireframe_enabled);
+    rs.setTexturesEnabled(settings.textures_enabled);
+    rs.setDebugShadowView(settings.debug_shadows_active);
+    rs.setAnisotropicFiltering(settings.anisotropic_filtering);
+    rs.setMSAA(settings.msaa_samples);
+    rs.setTAABlendFactor(settings.taa_blend_factor);
+    rs.setTAAVelocityRejection(settings.taa_velocity_rejection);
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2315,8 +2315,10 @@ const MockChunkStorage = struct {
     get_calls: usize = 0,
     count_calls: usize = 0,
     total_calls: usize = 0,
+    renderable_calls: usize = 0,
     count_value: usize = 11,
     total_value: u64 = 22,
+    renderable_value: bool = true,
 
     pub fn interface(self: *MockChunkStorage) IChunkStorage {
         return .{ .ptr = self, .vtable = &VTABLE };
@@ -2326,6 +2328,7 @@ const MockChunkStorage = struct {
         .get = get,
         .count = count,
         .totalVertexCount = totalVertexCount,
+        .isChunkRenderable = isChunkRenderable,
     };
 
     fn get(ptr: *anyopaque, cx: i32, cz: i32) ?*ChunkData {
@@ -2346,6 +2349,14 @@ const MockChunkStorage = struct {
         const self: *MockChunkStorage = @ptrCast(@alignCast(ptr));
         self.total_calls += 1;
         return self.total_value;
+    }
+
+    fn isChunkRenderable(ptr: *anyopaque, cx: i32, cz: i32) bool {
+        _ = cx;
+        _ = cz;
+        const self: *MockChunkStorage = @ptrCast(@alignCast(ptr));
+        self.renderable_calls += 1;
+        return self.renderable_value;
     }
 };
 
@@ -2588,9 +2599,11 @@ test "IChunkStorage mock dispatch" {
     try testing.expect(storage_if.get(1, 2) == null);
     try testing.expectEqual(@as(usize, 11), storage_if.count());
     try testing.expectEqual(@as(u64, 22), storage_if.totalVertexCount());
+    try testing.expect(storage_if.isChunkRenderable(4, 5));
     try testing.expectEqual(@as(usize, 1), storage.get_calls);
     try testing.expectEqual(@as(usize, 1), storage.count_calls);
     try testing.expectEqual(@as(usize, 1), storage.total_calls);
+    try testing.expectEqual(@as(usize, 1), storage.renderable_calls);
 }
 
 test "ChunkStorage interface forwards empty storage" {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -34,6 +34,17 @@ const BlockType = @import("world/block.zig").BlockType;
 const block_registry = @import("world/block_registry.zig");
 const TextureAtlas = @import("engine/graphics/texture_atlas.zig").TextureAtlas;
 const BiomeId = @import("world/worldgen/biome.zig").BiomeId;
+const IRenderSettings = @import("engine/core/interfaces.zig").IRenderSettings;
+const IChunkStorage = @import("world/chunk_storage.zig").IChunkStorage;
+const ChunkStorage = @import("world/chunk_storage.zig").ChunkStorage;
+const ChunkData = @import("world/chunk_storage.zig").ChunkData;
+const IWorld = @import("world/world.zig").IWorld;
+const WorldStatsData = @import("world/world.zig").WorldStatsData;
+const RenderStats = @import("world/world_renderer.zig").RenderStats;
+const shadow_scene = @import("engine/graphics/shadow_scene.zig");
+const ShadowConfig = @import("engine/graphics/rhi_types.zig").ShadowConfig;
+const Settings = @import("game/settings/data.zig").Settings;
+const settings_apply = @import("game/settings/apply.zig");
 
 // Meshing stage modules
 const ao_calculator = @import("world/meshing/ao_calculator.zig");
@@ -2298,4 +2309,353 @@ test "BiomeSource selectBiomeWithEdge no edge returns primary only" {
     const result = source.selectBiomeWithEdge(climate, structural, 0.0, edge_info);
     try testing.expectEqual(result.primary, result.secondary);
     try testing.expectEqual(result.blend_factor, 0.0);
+}
+
+const MockChunkStorage = struct {
+    get_calls: usize = 0,
+    count_calls: usize = 0,
+    total_calls: usize = 0,
+    count_value: usize = 11,
+    total_value: u64 = 22,
+
+    pub fn interface(self: *MockChunkStorage) IChunkStorage {
+        return .{ .ptr = self, .vtable = &VTABLE };
+    }
+
+    const VTABLE = IChunkStorage.VTable{
+        .get = get,
+        .count = count,
+        .totalVertexCount = totalVertexCount,
+    };
+
+    fn get(ptr: *anyopaque, cx: i32, cz: i32) ?*ChunkData {
+        _ = cx;
+        _ = cz;
+        const self: *MockChunkStorage = @ptrCast(@alignCast(ptr));
+        self.get_calls += 1;
+        return null;
+    }
+
+    fn count(ptr: *anyopaque) usize {
+        const self: *MockChunkStorage = @ptrCast(@alignCast(ptr));
+        self.count_calls += 1;
+        return self.count_value;
+    }
+
+    fn totalVertexCount(ptr: *anyopaque) u64 {
+        const self: *MockChunkStorage = @ptrCast(@alignCast(ptr));
+        self.total_calls += 1;
+        return self.total_value;
+    }
+};
+
+const MockRenderSettings = struct {
+    call_count: usize = 0,
+    wireframe: bool = false,
+    vsync: bool = false,
+    textures_enabled: bool = false,
+    anisotropic_filtering: u8 = 0,
+    fxaa: bool = false,
+    bloom: bool = false,
+    bloom_intensity: f32 = 0,
+    taa_blend_factor: f32 = 0,
+    taa_velocity_rejection: f32 = 0,
+    vignette_enabled: bool = false,
+    vignette_intensity: f32 = 0,
+    film_grain_enabled: bool = false,
+    film_grain_intensity: f32 = 0,
+    volumetric_density: f32 = 0,
+    debug_shadow_view: bool = false,
+    msaa_samples: u8 = 0,
+
+    pub fn interface(self: *MockRenderSettings) IRenderSettings {
+        return .{ .ptr = self, .vtable = &VTABLE };
+    }
+
+    const VTABLE = IRenderSettings.VTable{
+        .setWireframe = setWireframe,
+        .setVSync = setVSync,
+        .setTexturesEnabled = setTexturesEnabled,
+        .setAnisotropicFiltering = setAnisotropicFiltering,
+        .setFXAA = setFXAA,
+        .setBloom = setBloom,
+        .setBloomIntensity = setBloomIntensity,
+        .setTAABlendFactor = setTAABlendFactor,
+        .setTAAVelocityRejection = setTAAVelocityRejection,
+        .setVignetteEnabled = setVignetteEnabled,
+        .setVignetteIntensity = setVignetteIntensity,
+        .setFilmGrainEnabled = setFilmGrainEnabled,
+        .setFilmGrainIntensity = setFilmGrainIntensity,
+        .setVolumetricDensity = setVolumetricDensity,
+        .setDebugShadowView = setDebugShadowView,
+        .setMSAA = setMSAA,
+    };
+
+    fn setWireframe(ptr: *anyopaque, enabled: bool) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.wireframe = enabled;
+        self.call_count += 1;
+    }
+
+    fn setVSync(ptr: *anyopaque, enabled: bool) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.vsync = enabled;
+        self.call_count += 1;
+    }
+
+    fn setTexturesEnabled(ptr: *anyopaque, enabled: bool) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.textures_enabled = enabled;
+        self.call_count += 1;
+    }
+
+    fn setAnisotropicFiltering(ptr: *anyopaque, level: u8) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.anisotropic_filtering = level;
+        self.call_count += 1;
+    }
+
+    fn setFXAA(ptr: *anyopaque, enabled: bool) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.fxaa = enabled;
+        self.call_count += 1;
+    }
+
+    fn setBloom(ptr: *anyopaque, enabled: bool) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.bloom = enabled;
+        self.call_count += 1;
+    }
+
+    fn setBloomIntensity(ptr: *anyopaque, intensity: f32) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.bloom_intensity = intensity;
+        self.call_count += 1;
+    }
+
+    fn setTAABlendFactor(ptr: *anyopaque, value: f32) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.taa_blend_factor = value;
+        self.call_count += 1;
+    }
+
+    fn setTAAVelocityRejection(ptr: *anyopaque, value: f32) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.taa_velocity_rejection = value;
+        self.call_count += 1;
+    }
+
+    fn setVignetteEnabled(ptr: *anyopaque, enabled: bool) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.vignette_enabled = enabled;
+        self.call_count += 1;
+    }
+
+    fn setVignetteIntensity(ptr: *anyopaque, intensity: f32) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.vignette_intensity = intensity;
+        self.call_count += 1;
+    }
+
+    fn setFilmGrainEnabled(ptr: *anyopaque, enabled: bool) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.film_grain_enabled = enabled;
+        self.call_count += 1;
+    }
+
+    fn setFilmGrainIntensity(ptr: *anyopaque, intensity: f32) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.film_grain_intensity = intensity;
+        self.call_count += 1;
+    }
+
+    fn setVolumetricDensity(ptr: *anyopaque, density: f32) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.volumetric_density = density;
+        self.call_count += 1;
+    }
+
+    fn setDebugShadowView(ptr: *anyopaque, enabled: bool) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.debug_shadow_view = enabled;
+        self.call_count += 1;
+    }
+
+    fn setMSAA(ptr: *anyopaque, samples: u8) void {
+        const self: *MockRenderSettings = @ptrCast(@alignCast(ptr));
+        self.msaa_samples = samples;
+        self.call_count += 1;
+    }
+};
+
+const MockWorld = struct {
+    update_calls: usize = 0,
+    render_calls: usize = 0,
+    deinit_calls: usize = 0,
+    get_render_stats_calls: usize = 0,
+    get_stats_calls: usize = 0,
+    get_lod_stats_calls: usize = 0,
+    is_lod_enabled_calls: usize = 0,
+    shadow_scene_calls: usize = 0,
+    shadow_pass_calls: usize = 0,
+    last_render_lod: bool = false,
+    render_stats: RenderStats = .{ .chunks_total = 4, .chunks_rendered = 3, .chunks_culled = 1, .vertices_rendered = 99 },
+    stats: WorldStatsData = .{ .chunks_loaded = 8, .total_vertices = 123, .gen_queue = 5, .mesh_queue = 6, .upload_queue = 7 },
+    lod_enabled: bool = false,
+
+    pub fn interface(self: *MockWorld) IWorld {
+        return .{ .ptr = self, .vtable = &VTABLE };
+    }
+
+    const VTABLE = IWorld.VTable{
+        .update = update,
+        .render = render,
+        .deinit = deinit,
+        .getRenderStats = getRenderStats,
+        .getStats = getStats,
+        .getLODStats = getLODStats,
+        .isLODEnabled = isLODEnabled,
+        .shadowScene = shadowScene,
+    };
+
+    const SHADOW_VTABLE = shadow_scene.IShadowScene.VTable{
+        .renderShadowPass = renderShadowPass,
+    };
+
+    fn update(ptr: *anyopaque, player_pos: Vec3, dt: f32) anyerror!void {
+        _ = player_pos;
+        _ = dt;
+        const self: *MockWorld = @ptrCast(@alignCast(ptr));
+        self.update_calls += 1;
+    }
+
+    fn render(ptr: *anyopaque, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
+        _ = view_proj;
+        _ = camera_pos;
+        const self: *MockWorld = @ptrCast(@alignCast(ptr));
+        self.render_calls += 1;
+        self.last_render_lod = render_lod;
+    }
+
+    fn deinit(ptr: *anyopaque) void {
+        const self: *MockWorld = @ptrCast(@alignCast(ptr));
+        self.deinit_calls += 1;
+    }
+
+    fn getRenderStats(ptr: *anyopaque) RenderStats {
+        const self: *MockWorld = @ptrCast(@alignCast(ptr));
+        self.get_render_stats_calls += 1;
+        return self.render_stats;
+    }
+
+    fn getStats(ptr: *anyopaque) WorldStatsData {
+        const self: *MockWorld = @ptrCast(@alignCast(ptr));
+        self.get_stats_calls += 1;
+        return self.stats;
+    }
+
+    fn getLODStats(ptr: *anyopaque) ?@import("world/lod_manager.zig").LODStats {
+        const self: *MockWorld = @ptrCast(@alignCast(ptr));
+        self.get_lod_stats_calls += 1;
+        return null;
+    }
+
+    fn isLODEnabled(ptr: *anyopaque) bool {
+        const self: *MockWorld = @ptrCast(@alignCast(ptr));
+        self.is_lod_enabled_calls += 1;
+        return self.lod_enabled;
+    }
+
+    fn shadowScene(ptr: *anyopaque) shadow_scene.IShadowScene {
+        const self: *MockWorld = @ptrCast(@alignCast(ptr));
+        self.shadow_scene_calls += 1;
+        return .{ .ptr = self, .vtable = &SHADOW_VTABLE };
+    }
+
+    fn renderShadowPass(ptr: *anyopaque, light_space_matrix: Mat4, camera_pos: Vec3, shadow_config: ShadowConfig) void {
+        _ = light_space_matrix;
+        _ = camera_pos;
+        _ = shadow_config;
+        const self: *MockWorld = @ptrCast(@alignCast(ptr));
+        self.shadow_pass_calls += 1;
+    }
+};
+
+test "IChunkStorage mock dispatch" {
+    var storage = MockChunkStorage{};
+    const storage_if = storage.interface();
+
+    try testing.expect(storage_if.get(1, 2) == null);
+    try testing.expectEqual(@as(usize, 11), storage_if.count());
+    try testing.expectEqual(@as(u64, 22), storage_if.totalVertexCount());
+    try testing.expectEqual(@as(usize, 1), storage.get_calls);
+    try testing.expectEqual(@as(usize, 1), storage.count_calls);
+    try testing.expectEqual(@as(usize, 1), storage.total_calls);
+}
+
+test "ChunkStorage interface forwards empty storage" {
+    var storage = ChunkStorage.init(testing.allocator);
+    defer storage.deinitWithoutRHI();
+
+    const storage_if = storage.interface();
+    try testing.expect(storage_if.get(0, 0) == null);
+    try testing.expectEqual(@as(usize, 0), storage_if.count());
+    try testing.expectEqual(@as(u64, 0), storage_if.totalVertexCount());
+}
+
+test "Render settings interface applies settings" {
+    var settings = Settings{};
+    settings.vsync = false;
+    settings.wireframe_enabled = true;
+    settings.textures_enabled = false;
+    settings.debug_shadows_active = true;
+    settings.anisotropic_filtering = 8;
+    settings.msaa_samples = 2;
+    settings.taa_blend_factor = 0.75;
+    settings.taa_velocity_rejection = 0.11;
+
+    var mock = MockRenderSettings{};
+    settings_apply.applyToRenderSettings(&settings, mock.interface());
+
+    try testing.expectEqual(false, mock.vsync);
+    try testing.expectEqual(true, mock.wireframe);
+    try testing.expectEqual(false, mock.textures_enabled);
+    try testing.expectEqual(true, mock.debug_shadow_view);
+    try testing.expectEqual(@as(u8, 8), mock.anisotropic_filtering);
+    try testing.expectEqual(@as(u8, 2), mock.msaa_samples);
+    try testing.expectApproxEqAbs(@as(f32, 0.75), mock.taa_blend_factor, 0.0001);
+    try testing.expectApproxEqAbs(@as(f32, 0.11), mock.taa_velocity_rejection, 0.0001);
+    try testing.expectEqual(@as(usize, 8), mock.call_count);
+}
+
+test "IWorld mock dispatch" {
+    var world = MockWorld{};
+    const world_if = world.interface();
+
+    try world_if.update(Vec3.init(1, 2, 3), 0.25);
+    world_if.render(Mat4.identity, Vec3.zero, true);
+    try testing.expect(world.last_render_lod);
+
+    const render_stats = world_if.getRenderStats();
+    const stats = world_if.getStats();
+    try testing.expectEqual(@as(u32, 4), render_stats.chunks_total);
+    try testing.expectEqual(@as(u32, 3), render_stats.chunks_rendered);
+    try testing.expectEqual(@as(usize, 8), stats.chunks_loaded);
+    try testing.expectEqual(@as(u64, 123), stats.total_vertices);
+    try testing.expect(world_if.getLODStats() == null);
+    try testing.expect(!world_if.isLODEnabled());
+
+    const shadow = world_if.shadowScene();
+    shadow.renderShadowPass(Mat4.identity, Vec3.zero, .{});
+    world_if.deinit();
+
+    try testing.expectEqual(@as(usize, 1), world.update_calls);
+    try testing.expectEqual(@as(usize, 1), world.render_calls);
+    try testing.expectEqual(@as(usize, 1), world.get_render_stats_calls);
+    try testing.expectEqual(@as(usize, 1), world.get_stats_calls);
+    try testing.expectEqual(@as(usize, 1), world.get_lod_stats_calls);
+    try testing.expectEqual(@as(usize, 1), world.is_lod_enabled_calls);
+    try testing.expectEqual(@as(usize, 1), world.shadow_scene_calls);
+    try testing.expectEqual(@as(usize, 1), world.shadow_pass_calls);
+    try testing.expectEqual(@as(usize, 1), world.deinit_calls);
 }

--- a/src/world/chunk_storage.zig
+++ b/src/world/chunk_storage.zig
@@ -4,6 +4,29 @@ const std = @import("std");
 const Chunk = @import("chunk.zig").Chunk;
 const ChunkMesh = @import("chunk_mesh.zig").ChunkMesh;
 
+pub const IChunkStorage = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        get: *const fn (ptr: *anyopaque, cx: i32, cz: i32) ?*ChunkData,
+        count: *const fn (ptr: *anyopaque) usize,
+        totalVertexCount: *const fn (ptr: *anyopaque) u64,
+    };
+
+    pub fn get(self: IChunkStorage, cx: i32, cz: i32) ?*ChunkData {
+        return self.vtable.get(self.ptr, cx, cz);
+    }
+
+    pub fn count(self: IChunkStorage) usize {
+        return self.vtable.count(self.ptr);
+    }
+
+    pub fn totalVertexCount(self: IChunkStorage) u64 {
+        return self.vtable.totalVertexCount(self.ptr);
+    }
+};
+
 pub const ChunkKey = struct {
     x: i32,
     z: i32,
@@ -49,6 +72,31 @@ pub const ChunkStorage = struct {
             .allocator = allocator,
             .next_job_token = 1,
         };
+    }
+
+    pub fn interface(self: *ChunkStorage) IChunkStorage {
+        return .{ .ptr = self, .vtable = &ICHUNKSTORAGE_VTABLE };
+    }
+
+    const ICHUNKSTORAGE_VTABLE = IChunkStorage.VTable{
+        .get = iget,
+        .count = icount,
+        .totalVertexCount = itotalVertexCount,
+    };
+
+    fn iget(ptr: *anyopaque, cx: i32, cz: i32) ?*ChunkData {
+        const self: *ChunkStorage = @ptrCast(@alignCast(ptr));
+        return self.get(cx, cz);
+    }
+
+    fn icount(ptr: *anyopaque) usize {
+        const self: *ChunkStorage = @ptrCast(@alignCast(ptr));
+        return self.count();
+    }
+
+    fn itotalVertexCount(ptr: *anyopaque) u64 {
+        const self: *ChunkStorage = @ptrCast(@alignCast(ptr));
+        return self.totalVertexCount();
     }
 
     pub fn deinit(self: *ChunkStorage, vertex_allocator: anytype) void {

--- a/src/world/chunk_storage.zig
+++ b/src/world/chunk_storage.zig
@@ -12,6 +12,7 @@ pub const IChunkStorage = struct {
         get: *const fn (ptr: *anyopaque, cx: i32, cz: i32) ?*ChunkData,
         count: *const fn (ptr: *anyopaque) usize,
         totalVertexCount: *const fn (ptr: *anyopaque) u64,
+        isChunkRenderable: *const fn (ptr: *anyopaque, cx: i32, cz: i32) bool,
     };
 
     pub fn get(self: IChunkStorage, cx: i32, cz: i32) ?*ChunkData {
@@ -24,6 +25,10 @@ pub const IChunkStorage = struct {
 
     pub fn totalVertexCount(self: IChunkStorage) u64 {
         return self.vtable.totalVertexCount(self.ptr);
+    }
+
+    pub fn isChunkRenderable(self: IChunkStorage, cx: i32, cz: i32) bool {
+        return self.vtable.isChunkRenderable(self.ptr, cx, cz);
     }
 };
 
@@ -82,6 +87,7 @@ pub const ChunkStorage = struct {
         .get = iget,
         .count = icount,
         .totalVertexCount = itotalVertexCount,
+        .isChunkRenderable = iisChunkRenderable,
     };
 
     fn iget(ptr: *anyopaque, cx: i32, cz: i32) ?*ChunkData {
@@ -97,6 +103,10 @@ pub const ChunkStorage = struct {
     fn itotalVertexCount(ptr: *anyopaque) u64 {
         const self: *ChunkStorage = @ptrCast(@alignCast(ptr));
         return self.totalVertexCount();
+    }
+
+    fn iisChunkRenderable(ptr: *anyopaque, cx: i32, cz: i32) bool {
+        return isChunkRenderable(cx, cz, ptr);
     }
 
     pub fn deinit(self: *ChunkStorage, vertex_allocator: anytype) void {

--- a/src/world/world.zig
+++ b/src/world/world.zig
@@ -42,6 +42,63 @@ const CHUNK_UNLOAD_BUFFER = @import("chunk.zig").CHUNK_UNLOAD_BUFFER;
 /// Prevents thrashing when player moves near chunk boundaries.
 // const CHUNK_UNLOAD_BUFFER: i32 = 1;
 
+/// Named statistics struct for World (extracted from anonymous return type for interface use).
+pub const WorldStatsData = struct {
+    chunks_loaded: usize,
+    total_vertices: u64,
+    gen_queue: usize,
+    mesh_queue: usize,
+    upload_queue: usize,
+};
+
+pub const IWorld = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        update: *const fn (ptr: *anyopaque, player_pos: Vec3, dt: f32) anyerror!void,
+        render: *const fn (ptr: *anyopaque, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void,
+        deinit: *const fn (ptr: *anyopaque) void,
+        getRenderStats: *const fn (ptr: *anyopaque) RenderStats,
+        getStats: *const fn (ptr: *anyopaque) WorldStatsData,
+        getLODStats: *const fn (ptr: *anyopaque) ?@import("lod_manager.zig").LODStats,
+        isLODEnabled: *const fn (ptr: *anyopaque) bool,
+        shadowScene: *const fn (ptr: *anyopaque) shadow_scene.IShadowScene,
+    };
+
+    pub fn update(self: IWorld, player_pos: Vec3, dt: f32) !void {
+        try self.vtable.update(self.ptr, player_pos, dt);
+    }
+
+    pub fn render(self: IWorld, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
+        self.vtable.render(self.ptr, view_proj, camera_pos, render_lod);
+    }
+
+    pub fn deinit(self: IWorld) void {
+        self.vtable.deinit(self.ptr);
+    }
+
+    pub fn getRenderStats(self: IWorld) RenderStats {
+        return self.vtable.getRenderStats(self.ptr);
+    }
+
+    pub fn getStats(self: IWorld) WorldStatsData {
+        return self.vtable.getStats(self.ptr);
+    }
+
+    pub fn getLODStats(self: IWorld) ?@import("lod_manager.zig").LODStats {
+        return self.vtable.getLODStats(self.ptr);
+    }
+
+    pub fn isLODEnabled(self: IWorld) bool {
+        return self.vtable.isLODEnabled(self.ptr);
+    }
+
+    pub fn shadowScene(self: IWorld) shadow_scene.IShadowScene {
+        return self.vtable.shadowScene(self.ptr);
+    }
+};
+
 pub const ChunkPos = struct { x: i32, z: i32 };
 
 pub const World = struct {
@@ -290,7 +347,7 @@ pub const World = struct {
         return counts;
     }
 
-    pub fn getStats(self: *World) struct { chunks_loaded: usize, total_vertices: u64, gen_queue: usize, mesh_queue: usize, upload_queue: usize } {
+    pub fn getStats(self: *World) WorldStatsData {
         const total_verts = self.storage.totalVertexCount();
         const streamer_stats = self.streamer.getStats();
 
@@ -301,6 +358,61 @@ pub const World = struct {
             .mesh_queue = streamer_stats.mesh_queue,
             .upload_queue = streamer_stats.upload_queue,
         };
+    }
+
+    pub fn interface(self: *World) IWorld {
+        return .{ .ptr = self, .vtable = &IWORLD_VTABLE };
+    }
+
+    const IWORLD_VTABLE = IWorld.VTable{
+        .update = iupdate,
+        .render = irender,
+        .deinit = ideinit,
+        .getRenderStats = igetRenderStats,
+        .getStats = igetStats,
+        .getLODStats = igetLODStats,
+        .isLODEnabled = iisLODEnabled,
+        .shadowScene = ishadowScene,
+    };
+
+    fn iupdate(ptr: *anyopaque, player_pos: Vec3, dt: f32) anyerror!void {
+        const self: *World = @ptrCast(@alignCast(ptr));
+        return self.update(player_pos, dt);
+    }
+
+    fn irender(ptr: *anyopaque, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
+        const self: *World = @ptrCast(@alignCast(ptr));
+        self.render(view_proj, camera_pos, render_lod);
+    }
+
+    fn ideinit(ptr: *anyopaque) void {
+        const self: *World = @ptrCast(@alignCast(ptr));
+        self.deinit();
+    }
+
+    fn igetRenderStats(ptr: *anyopaque) RenderStats {
+        const self: *World = @ptrCast(@alignCast(ptr));
+        return self.getRenderStats();
+    }
+
+    fn igetStats(ptr: *anyopaque) WorldStatsData {
+        const self: *World = @ptrCast(@alignCast(ptr));
+        return self.getStats();
+    }
+
+    fn igetLODStats(ptr: *anyopaque) ?@import("lod_manager.zig").LODStats {
+        const self: *World = @ptrCast(@alignCast(ptr));
+        return self.getLODStats();
+    }
+
+    fn iisLODEnabled(ptr: *anyopaque) bool {
+        const self: *World = @ptrCast(@alignCast(ptr));
+        return self.isLODEnabled();
+    }
+
+    fn ishadowScene(ptr: *anyopaque) shadow_scene.IShadowScene {
+        const self: *World = @ptrCast(@alignCast(ptr));
+        return self.shadowScene();
     }
 
     /// Get LOD system statistics (returns null if LOD not enabled)


### PR DESCRIPTION
## Summary
- add `IRenderSettings`, `IChunkStorage`, and `IWorld` abstractions to reduce concrete coupling
- route graphics/settings/world screen paths through interfaces where it matters
- add mock-based interface tests plus a render-settings adapter around `RHI`

## Testing
- `nix develop --command zig fmt src/`
- `nix develop --command zig build test`

Fixes #277