### PR TITLE
feat(ui): add streaming status and world info to chunk inspector (#300)

### DIFF
--- a/src/engine/ui/chunk_inspector_overlay.zig
+++ b/src/engine/ui/chunk_inspector_overlay.zig
@@ -14,6 +14,14 @@ pub const ChunkStateCounts = struct {
     dirty: u32 = 0,
 };
 
+pub const WorldStateData = struct {
+    generator_name: []const u8,
+    seed: u64,
+    gen_queue: usize,
+    mesh_queue: usize,
+    upload_queue: usize,
+};
+
 pub const ChunkInspectorOverlay = struct {
     enabled: bool = false,
 
@@ -21,7 +29,7 @@ pub const ChunkInspectorOverlay = struct {
         self.enabled = !self.enabled;
     }
 
-    pub fn draw(self: *ChunkInspectorOverlay, ui: *UISystem, render_stats: RenderStats, counts: ChunkStateCounts) void {
+    pub fn draw(self: *ChunkInspectorOverlay, ui: *UISystem, render_stats: RenderStats, counts: ChunkStateCounts, world_state: WorldStateData) void {
         if (!self.enabled) return;
 
         const x: f32 = 10;
@@ -29,7 +37,7 @@ pub const ChunkInspectorOverlay = struct {
         const width: f32 = 260;
         const line_height: f32 = 15;
         const scale: f32 = 1.0;
-        const num_lines = 13;
+        const num_lines = 21;
         const padding = 20;
 
         ui.drawRect(.{ .x = x, .y = y, .width = width, .height = num_lines * line_height + padding }, .{ .r = 0, .g = 0, .b = 0, .a = 0.6 });
@@ -54,7 +62,21 @@ pub const ChunkInspectorOverlay = struct {
         drawLine(ui, "RENDERABLE:", counts.renderable, x, &y, scale, line_height);
         drawLine(ui, "OTHER:", counts.other_states, x, &y, scale, line_height);
         drawLine(ui, "DIRTY*:", counts.dirty, x, &y, scale, line_height);
-        Font.drawText(ui, "* dirty is orthogonal to state", x + 10, y, scale * 0.8, Color.gray);
+        y += 5;
+
+        Font.drawText(ui, "STREAMING STATUS", x + 10, y, scale, Color.gray);
+        y += line_height;
+        drawLine(ui, "GEN QUEUE:", world_state.gen_queue, x, &y, scale, line_height);
+        drawLine(ui, "MESH QUEUE:", world_state.mesh_queue, x, &y, scale, line_height);
+        drawLine(ui, "UPLOAD QUEUE:", world_state.upload_queue, x, &y, scale, line_height);
+        y += 5;
+
+        Font.drawText(ui, "WORLD INFO", x + 10, y, scale, Color.gray);
+        y += line_height;
+        Font.drawText(ui, "GENERATOR:", x + 10, y, scale, Color.gray);
+        Font.drawText(ui, world_state.generator_name, x + 160, y, scale, Color.white);
+        y += line_height;
+        drawLine(ui, "SEED:", world_state.seed, x, &y, scale, line_height);
     }
 
     fn drawLine(ui: *UISystem, label: []const u8, value: u64, x: f32, y: *f32, scale: f32, line_height: f32) void {

--- a/src/engine/ui/chunk_inspector_overlay.zig
+++ b/src/engine/ui/chunk_inspector_overlay.zig
@@ -17,9 +17,9 @@ pub const ChunkStateCounts = struct {
 pub const WorldStateData = struct {
     generator_name: []const u8,
     seed: u64,
-    gen_queue: usize,
-    mesh_queue: usize,
-    upload_queue: usize,
+    gen_queue: u32,
+    mesh_queue: u32,
+    upload_queue: u32,
 };
 
 pub const ChunkInspectorOverlay = struct {
@@ -37,10 +37,10 @@ pub const ChunkInspectorOverlay = struct {
         const width: f32 = 260;
         const line_height: f32 = 15;
         const scale: f32 = 1.0;
-        const num_lines = 21;
         const padding = 20;
 
-        ui.drawRect(.{ .x = x, .y = y, .width = width, .height = num_lines * line_height + padding }, .{ .r = 0, .g = 0, .b = 0, .a = 0.6 });
+        const final_y = calcHeight(render_stats, counts, world_state, line_height);
+        ui.drawRect(.{ .x = x, .y = y, .width = width, .height = final_y - y + padding }, .{ .r = 0, .g = 0, .b = 0, .a = 0.6 });
         y += 5;
 
         Font.drawText(ui, "CHUNK INSPECTOR", x + 10, y, scale, Color.white);
@@ -73,18 +73,37 @@ pub const ChunkInspectorOverlay = struct {
 
         Font.drawText(ui, "WORLD INFO", x + 10, y, scale, Color.gray);
         y += line_height;
-        Font.drawText(ui, "GENERATOR:", x + 10, y, scale, Color.gray);
-        Font.drawText(ui, world_state.generator_name, x + 160, y, scale, Color.white);
-        y += line_height;
+        drawLine(ui, "GENERATOR:", world_state.generator_name, x, &y, scale, line_height);
         drawLine(ui, "SEED:", world_state.seed, x, &y, scale, line_height);
     }
 
-    fn drawLine(ui: *UISystem, label: []const u8, value: u64, x: f32, y: *f32, scale: f32, line_height: f32) void {
+    fn calcHeight(_: RenderStats, _: ChunkStateCounts, _: WorldStateData, line_height: f32) f32 {
+        var y: f32 = 0;
+        y += line_height + 5;
+        y += line_height;
+        y += 4 * line_height;
+        y += 5;
+        y += line_height;
+        y += 6 * line_height;
+        y += 5;
+        y += line_height;
+        y += 3 * line_height;
+        y += 5;
+        y += line_height;
+        y += 2 * line_height;
+        return y;
+    }
+
+    fn drawLine(ui: *UISystem, label: []const u8, value: anytype, x: f32, y: *f32, scale: f32, line_height: f32) void {
         Font.drawText(ui, label, x + 10, y.*, scale, Color.gray);
 
-        var buf: [32]u8 = undefined;
-        const val_str = std.fmt.bufPrint(&buf, "{}", .{value}) catch "0";
-        Font.drawText(ui, val_str, x + 160, y.*, scale, Color.white);
+        if (@TypeOf(value) == []const u8) {
+            Font.drawText(ui, value, x + 160, y.*, scale, Color.white);
+        } else {
+            var buf: [64]u8 = undefined;
+            const val_str = std.fmt.bufPrint(&buf, "{}", .{value}) catch "0";
+            Font.drawText(ui, val_str, x + 160, y.*, scale, Color.white);
+        }
         y.* += line_height;
     }
 };

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -19,7 +19,6 @@ const DebugFrustum = @import("../../engine/ui/debug_frustum.zig");
 const DebugFrustumOverlay = DebugFrustum.DebugFrustum;
 const FRUSTUM_VERTEX_COUNT = DebugFrustum.FRUSTUM_VERTEX_COUNT;
 const ChunkInspectorOverlay = @import("../../engine/ui/chunk_inspector_overlay.zig").ChunkInspectorOverlay;
-const WorldStateData = @import("../../engine/ui/chunk_inspector_overlay.zig").WorldStateData;
 const Font = @import("../../engine/ui/font.zig");
 const WorldStats = @import("../../engine/ui/timing_overlay.zig").WorldStats;
 const LODStatsDisplay = @import("../../engine/ui/timing_overlay.zig").LODStatsDisplay;
@@ -398,14 +397,7 @@ pub const WorldScreen = struct {
         }
 
         if (self.chunk_inspector_overlay.enabled) {
-            const world_stats = self.session.world.getStats();
-            const world_state = WorldStateData{
-                .generator_name = self.session.world.generator.info.name,
-                .seed = self.session.world.generator.getSeed(),
-                .gen_queue = world_stats.gen_queue,
-                .mesh_queue = world_stats.mesh_queue,
-                .upload_queue = world_stats.upload_queue,
-            };
+            const world_state = self.session.world.getWorldStateData();
             self.chunk_inspector_overlay.draw(
                 ui,
                 self.session.world.getRenderStats(),

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -19,6 +19,7 @@ const DebugFrustum = @import("../../engine/ui/debug_frustum.zig");
 const DebugFrustumOverlay = DebugFrustum.DebugFrustum;
 const FRUSTUM_VERTEX_COUNT = DebugFrustum.FRUSTUM_VERTEX_COUNT;
 const ChunkInspectorOverlay = @import("../../engine/ui/chunk_inspector_overlay.zig").ChunkInspectorOverlay;
+const WorldStateData = @import("../../engine/ui/chunk_inspector_overlay.zig").WorldStateData;
 const Font = @import("../../engine/ui/font.zig");
 const WorldStats = @import("../../engine/ui/timing_overlay.zig").WorldStats;
 const LODStatsDisplay = @import("../../engine/ui/timing_overlay.zig").LODStatsDisplay;
@@ -397,10 +398,19 @@ pub const WorldScreen = struct {
         }
 
         if (self.chunk_inspector_overlay.enabled) {
+            const world_stats = self.session.world.getStats();
+            const world_state = WorldStateData{
+                .generator_name = self.session.world.generator.info.name,
+                .seed = self.session.world.generator.getSeed(),
+                .gen_queue = world_stats.gen_queue,
+                .mesh_queue = world_stats.mesh_queue,
+                .upload_queue = world_stats.upload_queue,
+            };
             self.chunk_inspector_overlay.draw(
                 ui,
                 self.session.world.getRenderStats(),
                 self.session.world.getChunkStateCounts(),
+                world_state,
             );
         }
 

--- a/src/world/world.zig
+++ b/src/world/world.zig
@@ -28,6 +28,7 @@ const TextureAtlas = @import("../engine/graphics/texture_atlas.zig").TextureAtla
 const WorldRenderer = @import("world_renderer.zig").WorldRenderer;
 const RenderStats = @import("world_renderer.zig").RenderStats;
 const ChunkStateCounts = @import("../engine/ui/chunk_inspector_overlay.zig").ChunkStateCounts;
+const WorldStateData = @import("../engine/ui/chunk_inspector_overlay.zig").WorldStateData;
 const JobQueue = @import("../engine/core/job_system.zig").JobQueue;
 const WorkerPool = @import("../engine/core/job_system.zig").WorkerPool;
 const Job = @import("../engine/core/job_system.zig").Job;
@@ -357,6 +358,17 @@ pub const World = struct {
             .gen_queue = streamer_stats.gen_queue,
             .mesh_queue = streamer_stats.mesh_queue,
             .upload_queue = streamer_stats.upload_queue,
+        };
+    }
+
+    pub fn getWorldStateData(self: *World) WorldStateData {
+        const stats = self.getStats();
+        return .{
+            .generator_name = self.generator.info.name,
+            .seed = self.generator.getSeed(),
+            .gen_queue = @as(u32, @intCast(stats.gen_queue)),
+            .mesh_queue = @as(u32, @intCast(stats.mesh_queue)),
+            .upload_queue = @as(u32, @intCast(stats.upload_queue)),
         };
     }
 


### PR DESCRIPTION
## Summary
- Add STREAMING STATUS section to chunk inspector overlay showing gen/mesh/upload queue depths
- Add WORLD INFO section showing generator name and world seed
- Fulfills issue #300 acceptance criteria

## Changes
- `src/engine/ui/chunk_inspector_overlay.zig`: Added `WorldStateData` struct and extended `draw()` to display new sections
- `src/game/screens/world.zig`: Build and pass `WorldStateData` to the overlay

## Testing
- Press `J` to toggle chunk inspector overlay
- Verify new "STREAMING STATUS" and "WORLD INFO" sections appear

## Acceptance Criteria (issue #300)
- [x] Can inspect individual chunk data
- [x] Shows streaming queue status
- [x] Shows world generation progress
- [x] Integrates with existing debug overlays

Closes #300