### PR TITLE
fix(ci): add use_github_token to opencode workflows for Blacksmith runner

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -92,6 +92,7 @@ jobs:
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5
+          use_github_token: "true"
           prompt: |
             You are a senior Zig systems programming auditor performing a deep code audit.
 

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -41,6 +41,7 @@ jobs:
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5
+          use_github_token: "true"
           prompt: |
             Analyze this issue. You have access to the codebase context.
             **CRITICAL: Your only allowed action is to post a COMMENT on the issue. DO NOT create branches, pull requests, or attempt to modify the codebase.**

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -44,3 +44,4 @@ jobs:
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5
+          use_github_token: "true"


### PR DESCRIPTION
## Summary

Fixes the `User blacksmith-sh[bot] does not have write permissions` error in all opencode GitHub Action workflows.

**Root cause:** The `anomalyco/opencode/github` action defaults to OIDC app token exchange. On Blacksmith runners, this resolves to `blacksmith-sh[bot]` identity which lacks write permissions on the repo.

**Fix:** Add `use_github_token: "true"` to all three opencode action invocations. This tells the action to use the standard `GITHUB_TOKEN` (which has `issues: write` permission in the job config) and skip the collaborator permission check.

### Files Changed
- `opencode-triage.yml` — issue triage on issue open
- `opencode-audit.yml` — scheduled audit scans
- `opencode.yml` — comment-triggered `/oc` commands

Relates to #329 (failed triage run example).