### PR TITLE
fix(ci): pass GITHUB_TOKEN to all opencode actions

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -89,10 +89,10 @@ jobs:
       - name: Run opencode audit
         uses: anomalyco/opencode/github@v1.3.3
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5
-          use_github_token: "true"
           prompt: |
             You are a senior Zig systems programming auditor performing a deep code audit.
 

--- a/.github/workflows/opencode-pr.yml
+++ b/.github/workflows/opencode-pr.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -38,10 +38,10 @@ jobs:
       - uses: anomalyco/opencode/github@latest
         if: steps.check.outputs.result == 'true'
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5
-          use_github_token: "true"
           prompt: |
             Analyze this issue. You have access to the codebase context.
             **CRITICAL: Your only allowed action is to post a COMMENT on the issue. DO NOT create branches, pull requests, or attempt to modify the codebase.**

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5
-          use_github_token: "true"


### PR DESCRIPTION
## Summary

The opencode action requires `GITHUB_TOKEN` to be explicitly set in the `env` block. The `use_github_token: "true"` flag tells the action to *use* it, but doesn't *provide* it — causing `GITHUB_TOKEN environment variable is not set` errors.

## Changes

- **opencode.yml** — add `GITHUB_TOKEN` to env, remove `use_github_token` flag
- **opencode-pr.yml** — add `GITHUB_TOKEN` to env
- **opencode-triage.yml** — add `GITHUB_TOKEN` to env, remove `use_github_token` flag
- **opencode-audit.yml** — add `GITHUB_TOKEN` to env, remove `use_github_token` flag