### PR TITLE
fix: add missing mutex lock in destroyTexture

### DIFF
--- a/src/engine/graphics/rhi_vulkan.zig
+++ b/src/engine/graphics/rhi_vulkan.zig
@@ -376,6 +376,8 @@ fn createTexture3D(ctx_ptr: *anyopaque, width: u32, height: u32, depth: u32, for
 
 fn destroyTexture(ctx_ptr: *anyopaque, handle: rhi.TextureHandle) void {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    ctx.mutex.lock();
+    defer ctx.mutex.unlock();
     ctx.resources.destroyTexture(handle);
 }
 


### PR DESCRIPTION
## Summary
- Adds missing `ctx.mutex.lock()` / `defer ctx.mutex.unlock()` to `destroyTexture` in `src/engine/graphics/rhi_vulkan.zig:377-380`
- Brings `destroyTexture` in line with the thread-safety pattern used by all other RHI resource operations (`destroyBuffer`, `createTexture`, `createTexture3D`, `updateTexture`, `bindTexture`)

Closes #333