### PR TITLE
feat: add screenshot capture and visual regression test workflow

### DIFF
--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -1,0 +1,162 @@
+name: visual-test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  visual-test:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix (primary)
+        id: nix_install_primary
+        continue-on-error: true
+        uses: DeterminateSystems/nix-installer-action@v16
+
+      - name: Install Nix (fallback)
+        if: steps.nix_install_primary.outcome == 'failure'
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Verify Nix installation
+        run: nix --version
+
+      - name: Cache Nix Store
+        continue-on-error: true
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          paths: ~/.cache/nix
+
+      - name: Start headless Wayland compositor
+        run: |
+          mkdir -p /tmp/runtime-runner
+          chmod 700 /tmp/runtime-runner
+          export XDG_RUNTIME_DIR=/tmp/runtime-runner
+          nix develop --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 &
+          echo "WAYLAND_DISPLAY=headless" >> $GITHUB_ENV
+          echo "XDG_RUNTIME_DIR=/tmp/runtime-runner" >> $GITHUB_ENV
+          sleep 5
+
+      - name: Ensure visual-test label exists
+        run: |
+          if ! gh label list --json name --jq '.[].name' | grep -q '^visual-test$'; then
+            gh label create "visual-test" \
+              --description "Issues from automated visual regression tests" \
+              --color "E06C75"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run menu screenshot capture
+        id: screenshot
+        env:
+          ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
+          XDG_RUNTIME_DIR: /tmp/runtime-runner
+          WAYLAND_DISPLAY: headless
+          ZIGCRAFT_SMOKE_FRAMES: "5"
+          ZIGCRAFT_SAFE_MODE: "1"
+        run: |
+          LVP_PATH=$(nix build --no-link --print-out-paths nixpkgs#mesa.drivers)/share/vulkan/icd.d/lvp_icd.x86_64.json
+          LAYER_PATH=$(nix build --no-link --print-out-paths nixpkgs#vulkan-validation-layers)/share/vulkan/explicit_layer.d
+          export VK_ICD_FILENAMES=$LVP_PATH
+          export VK_LAYER_PATH=$LAYER_PATH
+          nix develop --command zig build run -Dscreenshot-path=screenshot.ppm -Dskip-present=true
+
+      - name: Convert PPM to PNG
+        run: |
+          if [ -f screenshot.ppm ]; then
+            nix develop --command convert screenshot.ppm screenshot.png
+            echo "screenshot_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "screenshot_exists=false" >> $GITHUB_OUTPUT
+            echo "::error::Screenshot file not found - capture failed"
+            exit 1
+          fi
+
+      - name: Upload screenshot artifact
+        if: steps.screenshot.outputs.screenshot_exists == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: menu-screenshot
+          path: |
+            screenshot.png
+            screenshot.ppm
+          retention-days: 30
+
+      - name: Run opencode visual verification
+        if: steps.screenshot.outputs.screenshot_exists == 'true'
+        uses: anomalyco/opencode/github@v1.3.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
+        with:
+          model: kimi-for-coding/k2p5
+          prompt: |
+            You are a visual QA tester for a game engine. A screenshot of the main menu has been captured during a headless CI run using Lavapipe (software Vulkan).
+
+            ## YOUR TASK
+
+            1. Read the file `screenshot.png` in the workspace root. This is a screenshot of the ZigCraft main menu.
+
+            2. Analyze the screenshot and verify ALL of the following:
+               - The screen is NOT blank, black, or empty
+               - The title "ZIG VOXEL ENGINE" is visible at the top
+               - At least 2 menu buttons are visible (e.g., SINGLEPLAYER, SETTINGS, QUIT)
+               - The UI layout looks reasonable (buttons centered, not overlapping, not off-screen)
+               - There are no obvious rendering artifacts (complete blackness, garbled pixels, missing geometry)
+
+            3. If the screenshot passes ALL checks:
+               - Do nothing. A passing test means silence.
+               - Run: `echo "VISUAL TEST PASSED: Menu screenshot looks correct"`
+
+            4. If the screenshot FAILS any check:
+               - Create a GitHub issue with label `visual-test` describing exactly what is wrong.
+               - Use this title format: `[Visual Test] Menu screenshot shows {problem}`
+               - Include the check that failed and a description of what you see vs what you expected.
+
+            ## CRITICAL CONSTRAINTS
+            - You may ONLY create a single GitHub issue. Do NOT create branches, PRs, or modify files.
+            - If the screenshot looks correct, file NO issue. Silence is better than noise.
+            - Be lenient with software rendering artifacts (Lavapipe may not render identically to a real GPU).
+            - Font rendering may be slightly different in software mode - that is acceptable.
+            - The important thing is that the menu is FUNCTIONAL (visible text, clickable buttons, proper layout).
+
+      - name: Create failure issue on error
+        if: failure() && steps.screenshot.outputs.screenshot_exists != 'true'
+        run: |
+          gh issue create \
+            --title "[Visual Test] Menu screenshot capture failed" \
+            --label "visual-test" \
+            --body "$(cat <<'EOF'
+          ## Visual Test Failure
+
+          The automated visual test workflow failed to capture a screenshot of the main menu.
+
+          ### Possible Causes
+          - Vulkan initialization failed with Lavapipe
+          - The application crashed before rendering any frames
+          - The screenshot capture code failed to write the PPM file
+          - Build error in screenshot mode
+
+          ### Workflow Run
+          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          ### Steps to Reproduce
+          1. Run: `zig build run -Dscreenshot-path=screenshot.ppm -Dskip-present=true`
+          2. With Lavapipe ICD and headless Weston compositor
+          3. Check if `screenshot.ppm` is created
+          EOF
+          )"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -65,7 +65,7 @@ jobs:
           XDG_RUNTIME_DIR: /tmp/runtime-runner
           WAYLAND_DISPLAY: headless
           ZIGCRAFT_SMOKE_FRAMES: "5"
-          ZIGCRAFT_SAFE_MODE: "1"
+          ZIGCRAFT_SAFE_RENDER: "1"
         run: |
           LVP_PATH=$(nix build --no-link --print-out-paths nixpkgs#mesa.drivers)/share/vulkan/icd.d/lvp_icd.x86_64.json
           LAYER_PATH=$(nix build --no-link --print-out-paths nixpkgs#vulkan-validation-layers)/share/vulkan/explicit_layer.d

--- a/build.zig
+++ b/build.zig
@@ -14,6 +14,9 @@ pub fn build(b: *std.Build) void {
     const skip_present = b.option(bool, "skip-present", "Skip presentation (headless mode) to avoid driver crashes") orelse false;
     options.addOption(bool, "skip_present", skip_present);
 
+    const screenshot_path = b.option([]const u8, "screenshot-path", "Capture a PPM screenshot after N frames and exit (menu mode)") orelse "";
+    options.addOption([]const u8, "screenshot_path", screenshot_path);
+
     const zig_math = b.createModule(.{
         .root_source_file = b.path("libs/zig-math/math.zig"),
         .target = target,

--- a/src/engine/graphics/rhi.zig
+++ b/src/engine/graphics/rhi.zig
@@ -823,6 +823,7 @@ pub const RHI = struct {
         setColorGradingIntensity: *const fn (ctx: *anyopaque, intensity: f32) void,
         setTAABlendFactor: *const fn (ctx: *anyopaque, value: f32) void,
         setTAAVelocityRejection: *const fn (ctx: *anyopaque, value: f32) void,
+        captureFrame: *const fn (ctx: *anyopaque, path: []const u8) bool,
     };
 
     pub fn factory(self: RHI) IResourceFactory {
@@ -1113,5 +1114,8 @@ pub const RHI = struct {
     }
     pub fn setTAAVelocityRejection(self: RHI, value: f32) void {
         self.vtable.setTAAVelocityRejection(self.ptr, value);
+    }
+    pub fn captureFrame(self: RHI, path: []const u8) bool {
+        return self.vtable.captureFrame(self.ptr, path);
     }
 };

--- a/src/engine/graphics/rhi_tests.zig
+++ b/src/engine/graphics/rhi_tests.zig
@@ -344,6 +344,7 @@ const MockContext = struct {
         .setColorGradingIntensity = undefined,
         .setTAABlendFactor = undefined,
         .setTAAVelocityRejection = undefined,
+        .captureFrame = undefined,
     };
 
     const MOCK_ENCODER_VTABLE = rhi.IGraphicsCommandEncoder.VTable{

--- a/src/engine/graphics/rhi_vulkan.zig
+++ b/src/engine/graphics/rhi_vulkan.zig
@@ -17,6 +17,7 @@ const native_access = @import("vulkan/rhi_native_access.zig");
 const render_state = @import("vulkan/rhi_render_state.zig");
 const init_deinit = @import("vulkan/rhi_init_deinit.zig");
 const rhi_timing = @import("vulkan/rhi_timing.zig");
+const screenshot = @import("vulkan/screenshot.zig");
 
 const QUERY_COUNT_PER_FRAME = rhi_timing.QUERY_COUNT_PER_FRAME;
 
@@ -267,6 +268,11 @@ fn setTAABlendFactor(ctx_ptr: *anyopaque, value: f32) void {
 fn setTAAVelocityRejection(ctx_ptr: *anyopaque, value: f32) void {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
     ctx.taa.velocity_rejection = std.math.clamp(value, 0.0, 0.25);
+}
+
+fn captureFrame(ctx_ptr: *anyopaque, path: []const u8) bool {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return screenshot.captureScreenshot(ctx, path);
 }
 
 fn endFrame(ctx_ptr: *anyopaque) void {
@@ -805,6 +811,7 @@ const VULKAN_RHI_VTABLE = rhi.RHI.VTable{
     .setColorGradingIntensity = setColorGradingIntensity,
     .setTAABlendFactor = setTAABlendFactor,
     .setTAAVelocityRejection = setTAAVelocityRejection,
+    .captureFrame = captureFrame,
 };
 
 fn beginPassTiming(ctx_ptr: *anyopaque, pass_name: []const u8) void {

--- a/src/engine/graphics/vulkan/screenshot.zig
+++ b/src/engine/graphics/vulkan/screenshot.zig
@@ -1,0 +1,206 @@
+const std = @import("std");
+const c = @import("../../../c.zig").c;
+const log = @import("../../core/log.zig");
+const Utils = @import("utils.zig");
+const VulkanContext = @import("rhi_context_types.zig").VulkanContext;
+
+pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
+    const device = &ctx.vulkan_device;
+    const vk = device.vk_device;
+
+    if (ctx.swapchain.swapchain.images.items.len == 0) {
+        log.log.err("screenshot: no swapchain images available", .{});
+        return false;
+    }
+
+    const image_index = ctx.frames.current_image_index;
+    const swapchain_image = ctx.swapchain.swapchain.images.items[image_index];
+    const extent = ctx.swapchain.getExtent();
+    const image_format = ctx.swapchain.getImageFormat();
+    const width = extent.width;
+    const height = extent.height;
+
+    _ = c.vkDeviceWaitIdle(vk);
+
+    const image_size: u64 = @as(u64, width) * height * 4;
+
+    const staging = Utils.createVulkanBuffer(
+        device,
+        image_size,
+        c.VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        c.VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | c.VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+    ) catch {
+        log.log.err("screenshot: failed to create staging buffer", .{});
+        return false;
+    };
+    defer {
+        c.vkDestroyBuffer(vk, staging.buffer, null);
+        c.vkFreeMemory(vk, staging.memory, null);
+    }
+
+    var pool_info = std.mem.zeroes(c.VkCommandPoolCreateInfo);
+    pool_info.sType = c.VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    pool_info.queueFamilyIndex = device.graphics_family;
+    pool_info.flags = c.VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+
+    var command_pool: c.VkCommandPool = null;
+    Utils.checkVk(c.vkCreateCommandPool(vk, &pool_info, null, &command_pool)) catch {
+        log.log.err("screenshot: failed to create command pool", .{});
+        return false;
+    };
+    defer c.vkDestroyCommandPool(vk, command_pool, null);
+
+    var cmd_alloc_info = std.mem.zeroes(c.VkCommandBufferAllocateInfo);
+    cmd_alloc_info.sType = c.VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    cmd_alloc_info.commandPool = command_pool;
+    cmd_alloc_info.level = c.VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    cmd_alloc_info.commandBufferCount = 1;
+
+    var cmd_buffer: c.VkCommandBuffer = null;
+    Utils.checkVk(c.vkAllocateCommandBuffers(vk, &cmd_alloc_info, &cmd_buffer)) catch {
+        log.log.err("screenshot: failed to allocate command buffer", .{});
+        return false;
+    };
+
+    var begin_info = std.mem.zeroes(c.VkCommandBufferBeginInfo);
+    begin_info.sType = c.VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    begin_info.flags = c.VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    _ = c.vkBeginCommandBuffer(cmd_buffer, &begin_info);
+
+    var barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
+    barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.srcAccessMask = c.VK_ACCESS_MEMORY_READ_BIT;
+    barrier.dstAccessMask = c.VK_ACCESS_TRANSFER_READ_BIT;
+    barrier.oldLayout = c.VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    barrier.newLayout = c.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    barrier.image = swapchain_image;
+    barrier.subresourceRange = .{
+        .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT,
+        .baseMipLevel = 0,
+        .levelCount = 1,
+        .baseArrayLayer = 0,
+        .layerCount = 1,
+    };
+
+    c.vkCmdPipelineBarrier(
+        cmd_buffer,
+        c.VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+        c.VK_PIPELINE_STAGE_TRANSFER_BIT,
+        0,
+        0,
+        null,
+        0,
+        null,
+        1,
+        &barrier,
+    );
+
+    var region = std.mem.zeroes(c.VkBufferImageCopy);
+    region.bufferOffset = 0;
+    region.bufferRowLength = 0;
+    region.bufferImageHeight = 0;
+    region.imageSubresource = .{
+        .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT,
+        .mipLevel = 0,
+        .baseArrayLayer = 0,
+        .layerCount = 1,
+    };
+    region.imageOffset = .{ .x = 0, .y = 0, .z = 0 };
+    region.imageExtent = .{ .width = width, .height = height, .depth = 1 };
+
+    c.vkCmdCopyImageToBuffer(
+        cmd_buffer,
+        swapchain_image,
+        c.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+        staging.buffer,
+        1,
+        &region,
+    );
+
+    barrier.srcAccessMask = c.VK_ACCESS_TRANSFER_READ_BIT;
+    barrier.dstAccessMask = c.VK_ACCESS_MEMORY_READ_BIT;
+    barrier.oldLayout = c.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    barrier.newLayout = c.VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+
+    c.vkCmdPipelineBarrier(
+        cmd_buffer,
+        c.VK_PIPELINE_STAGE_TRANSFER_BIT,
+        c.VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+        0,
+        0,
+        null,
+        0,
+        null,
+        1,
+        &barrier,
+    );
+
+    _ = c.vkEndCommandBuffer(cmd_buffer);
+
+    var fence_info = std.mem.zeroes(c.VkFenceCreateInfo);
+    fence_info.sType = c.VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    var fence: c.VkFence = null;
+    Utils.checkVk(c.vkCreateFence(vk, &fence_info, null, &fence)) catch {
+        log.log.err("screenshot: failed to create fence", .{});
+        return false;
+    };
+    defer c.vkDestroyFence(vk, fence, null);
+
+    var submit_info = std.mem.zeroes(c.VkSubmitInfo);
+    submit_info.sType = c.VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit_info.commandBufferCount = 1;
+    submit_info.pCommandBuffers = &cmd_buffer;
+
+    Utils.checkVk(c.vkQueueSubmit(device.queue, 1, &submit_info, fence)) catch {
+        log.log.err("screenshot: failed to submit command buffer", .{});
+        return false;
+    };
+    _ = c.vkWaitForFences(vk, 1, &fence, c.VK_TRUE, std.math.maxInt(u64));
+
+    const mapped_ptr = staging.mapped_ptr orelse {
+        log.log.err("screenshot: staging buffer not mapped", .{});
+        return false;
+    };
+    const bytes: [*]const u8 = @ptrCast(@alignCast(mapped_ptr));
+
+    writePPM(bytes, width, height, path, image_format);
+
+    return true;
+}
+
+fn writePPM(data: [*]const u8, width: u32, height: u32, path: []const u8, format: c.VkFormat) void {
+    const file = std.fs.cwd().createFile(path, .{}) catch {
+        log.log.err("screenshot: failed to create file '{s}'", .{path});
+        return;
+    };
+    defer file.close();
+
+    var header_buf: [64]u8 = undefined;
+    const header = std.fmt.bufPrint(&header_buf, "P6\n{d} {d}\n255\n", .{ width, height }) catch return;
+    file.writeAll(header) catch return;
+
+    const is_bgra = format == c.VK_FORMAT_B8G8R8A8_UNORM or format == c.VK_FORMAT_B8G8R8A8_SRGB;
+
+    var y: u32 = 0;
+    while (y < height) : (y += 1) {
+        var row_buf: [4096 * 3]u8 = undefined;
+        const row_bytes = width * 3;
+        var x: u32 = 0;
+        while (x < width) : (x += 1) {
+            const src_offset: usize = (@as(usize, y) * width + x) * 4;
+            const dst_offset: usize = x * 3;
+            if (is_bgra) {
+                row_buf[dst_offset] = data[src_offset + 2];
+                row_buf[dst_offset + 1] = data[src_offset + 1];
+                row_buf[dst_offset + 2] = data[src_offset];
+            } else {
+                row_buf[dst_offset] = data[src_offset];
+                row_buf[dst_offset + 1] = data[src_offset + 1];
+                row_buf[dst_offset + 2] = data[src_offset + 2];
+            }
+        }
+        file.writeAll(row_buf[0..row_bytes]) catch return;
+    }
+
+    log.log.info("screenshot: saved {}x{} to '{s}'", .{ width, height, path });
+}

--- a/src/engine/graphics/vulkan/screenshot.zig
+++ b/src/engine/graphics/vulkan/screenshot.zig
@@ -20,8 +20,6 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
     const width = extent.width;
     const height = extent.height;
 
-    _ = c.vkDeviceWaitIdle(vk);
-
     const image_size: u64 = @as(u64, width) * height * 4;
 
     const staging = Utils.createVulkanBuffer(
@@ -69,7 +67,7 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
 
     var barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
     barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-    barrier.srcAccessMask = c.VK_ACCESS_MEMORY_READ_BIT;
+    barrier.srcAccessMask = c.VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | c.VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     barrier.dstAccessMask = c.VK_ACCESS_TRANSFER_READ_BIT;
     barrier.oldLayout = c.VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     barrier.newLayout = c.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
@@ -155,7 +153,11 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
         log.log.err("screenshot: failed to submit command buffer", .{});
         return false;
     };
-    _ = c.vkWaitForFences(vk, 1, &fence, c.VK_TRUE, std.math.maxInt(u64));
+    const fence_result = c.vkWaitForFences(vk, 1, &fence, c.VK_TRUE, 5_000_000_000);
+    if (fence_result != c.VK_SUCCESS) {
+        log.log.err("screenshot: fence wait failed or timed out ({})", .{fence_result});
+        return false;
+    }
 
     const mapped_ptr = staging.mapped_ptr orelse {
         log.log.err("screenshot: staging buffer not mapped", .{});
@@ -169,6 +171,11 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
 }
 
 fn writePPM(data: [*]const u8, width: u32, height: u32, path: []const u8, format: c.VkFormat) void {
+    if (width > 16384) {
+        log.log.err("screenshot: width {} exceeds max supported 16384", .{width});
+        return;
+    }
+
     const file = std.fs.cwd().createFile(path, .{}) catch {
         log.log.err("screenshot: failed to create file '{s}'", .{path});
         return;
@@ -181,14 +188,15 @@ fn writePPM(data: [*]const u8, width: u32, height: u32, path: []const u8, format
 
     const is_bgra = format == c.VK_FORMAT_B8G8R8A8_UNORM or format == c.VK_FORMAT_B8G8R8A8_SRGB;
 
+    var row_buf: [16384 * 3]u8 = undefined;
+    const row_bytes: usize = @as(usize, width) * 3;
+
     var y: u32 = 0;
     while (y < height) : (y += 1) {
-        var row_buf: [4096 * 3]u8 = undefined;
-        const row_bytes = width * 3;
         var x: u32 = 0;
         while (x < width) : (x += 1) {
             const src_offset: usize = (@as(usize, y) * width + x) * 4;
-            const dst_offset: usize = x * 3;
+            const dst_offset: usize = @as(usize, x) * 3;
             if (is_bgra) {
                 row_buf[dst_offset] = data[src_offset + 2];
                 row_buf[dst_offset + 1] = data[src_offset + 1];

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -103,23 +103,19 @@ pub const App = struct {
         };
         errdefer app.screen_manager.deinit();
 
-        if (build_options.smoke_test) {
-            app.render_system.getRHI().timing().setTimingEnabled(true);
-        }
-
-        if (build_options.screenshot_path.len > 0) {
+        if (build_options.smoke_test or build_options.screenshot_path.len > 0) {
             app.render_system.getRHI().timing().setTimingEnabled(true);
         }
 
         const engine_ctx = app.engineContext();
-        if (build_options.smoke_test) {
-            log.log.info("SMOKE TEST MODE: Bypassing menu and loading world", .{});
-            const world_screen = try WorldScreen.init(allocator, engine_ctx, 12345, 0);
-            app.screen_manager.setScreen(world_screen.screen());
-        } else if (build_options.screenshot_path.len > 0) {
+        if (build_options.screenshot_path.len > 0) {
             log.log.info("SCREENSHOT MODE: Loading menu for screenshot capture to '{s}'", .{build_options.screenshot_path});
             const home_screen = try HomeScreen.init(allocator, engine_ctx);
             app.screen_manager.setScreen(home_screen.screen());
+        } else if (build_options.smoke_test) {
+            log.log.info("SMOKE TEST MODE: Bypassing menu and loading world", .{});
+            const world_screen = try WorldScreen.init(allocator, engine_ctx, 12345, 0);
+            app.screen_manager.setScreen(world_screen.screen());
         } else {
             const home_screen = try HomeScreen.init(allocator, engine_ctx);
             app.screen_manager.setScreen(home_screen.screen());

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -107,11 +107,19 @@ pub const App = struct {
             app.render_system.getRHI().timing().setTimingEnabled(true);
         }
 
+        if (build_options.screenshot_path.len > 0) {
+            app.render_system.getRHI().timing().setTimingEnabled(true);
+        }
+
         const engine_ctx = app.engineContext();
         if (build_options.smoke_test) {
             log.log.info("SMOKE TEST MODE: Bypassing menu and loading world", .{});
             const world_screen = try WorldScreen.init(allocator, engine_ctx, 12345, 0);
             app.screen_manager.setScreen(world_screen.screen());
+        } else if (build_options.screenshot_path.len > 0) {
+            log.log.info("SCREENSHOT MODE: Loading menu for screenshot capture to '{s}'", .{build_options.screenshot_path});
+            const home_screen = try HomeScreen.init(allocator, engine_ctx);
+            app.screen_manager.setScreen(home_screen.screen());
         } else {
             const home_screen = try HomeScreen.init(allocator, engine_ctx);
             app.screen_manager.setScreen(home_screen.screen());
@@ -226,7 +234,7 @@ pub const App = struct {
 
         self.render_system.endFrame();
 
-        if (build_options.smoke_test) {
+        if (build_options.smoke_test or build_options.screenshot_path.len > 0) {
             self.smoke_test_frames += 1;
             var target_frames: u32 = 120;
             if (std.posix.getenv("ZIGCRAFT_SMOKE_FRAMES")) |val| {
@@ -236,6 +244,12 @@ pub const App = struct {
             }
 
             if (self.smoke_test_frames >= target_frames) {
+                if (build_options.screenshot_path.len > 0) {
+                    log.log.info("SCREENSHOT: Capturing frame to '{s}'", .{build_options.screenshot_path});
+                    if (!self.render_system.getRHI().captureFrame(build_options.screenshot_path)) {
+                        log.log.err("SCREENSHOT: Failed to capture screenshot", .{});
+                    }
+                }
                 log.log.info("SMOKE TEST COMPLETE: {} frames rendered. Exiting.", .{target_frames});
                 self.input.should_quit = true;
             }


### PR DESCRIPTION
## Summary

- Add `-Dscreenshot-path` build option that renders the **HomeScreen menu** (not WorldScreen), captures a PPM screenshot via `vkCmdCopyImageToBuffer`, and exits after N frames
- New `captureFrame()` method on the RHI VTable with Vulkan implementation in `src/engine/graphics/vulkan/screenshot.zig`
- New **visual-test** workflow (triggered via `workflow_dispatch`) that runs the game headless with Lavapipe, captures a screenshot, converts PPM→PNG, then uses an opencode AI agent to verify the menu is not blank/empty
- Failures are automatically logged as GitHub issues with the `visual-test` label

## Changes

| File | Change |
|------|--------|
| `build.zig` | Added `-Dscreenshot-path` build option |
| `src/engine/graphics/rhi.zig` | Added `captureFrame` to RHI VTable |
| `src/engine/graphics/vulkan/screenshot.zig` | **New** — Vulkan screenshot capture (staging buffer + PPM writer) |
| `src/engine/graphics/rhi_vulkan.zig` | Wires `captureFrame` to screenshot module |
| `src/game/app.zig` | Screenshot mode: loads HomeScreen, counts frames, captures, exits |
| `.github/workflows/visual-test.yml` | **New** — visual regression test workflow |

## Test Plan

- [x] `zig build` compiles cleanly
- [x] `zig build test` passes (all unit tests + shader validation)
- [x] `zig fmt src/` — formatting clean
- [x] Pre-push hooks passed (format check + full test suite)
- [ ] Manual: trigger `visual-test` workflow via GitHub Actions UI and verify screenshot artifact