### PR TITLE
fix: use nix run for imagemagick in visual-test workflow

### DIFF
--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -64,7 +64,7 @@ jobs:
         id: screenshot
         continue-on-error: true
         env:
-          ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
+          ZIG_GLOBAL_CACHE_DIR: /tmp/zig-cache-global
           XDG_RUNTIME_DIR: /tmp/runtime-runner
           WAYLAND_DISPLAY: headless
           ZIGCRAFT_SMOKE_FRAMES: "5"

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -42,10 +42,12 @@ jobs:
         run: |
           mkdir -p /tmp/runtime-runner
           chmod 700 /tmp/runtime-runner
+          mkdir -p /tmp/opencode-cache
           export XDG_RUNTIME_DIR=/tmp/runtime-runner
           nix develop --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 &
           echo "WAYLAND_DISPLAY=headless" >> $GITHUB_ENV
           echo "XDG_RUNTIME_DIR=/tmp/runtime-runner" >> $GITHUB_ENV
+          echo "XDG_CACHE_HOME=/tmp/opencode-cache" >> $GITHUB_ENV
           sleep 5
 
       - name: Ensure visual-test label exists

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Convert PPM to PNG
         run: |
           if [ -f screenshot.ppm ]; then
-            nix develop --command convert screenshot.ppm screenshot.png
+            nix run nixpkgs#imagemagick -- screenshot.ppm screenshot.png
             echo "screenshot_exists=true" >> $GITHUB_OUTPUT
           else
             echo "screenshot_exists=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Run menu screenshot capture
         id: screenshot
+        continue-on-error: true
         env:
           ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
           XDG_RUNTIME_DIR: /tmp/runtime-runner
@@ -71,21 +72,21 @@ jobs:
           LAYER_PATH=$(nix build --no-link --print-out-paths nixpkgs#vulkan-validation-layers)/share/vulkan/explicit_layer.d
           export VK_ICD_FILENAMES=$LVP_PATH
           export VK_LAYER_PATH=$LAYER_PATH
-          nix develop --command zig build run -Dscreenshot-path=screenshot.ppm -Dskip-present=true
+          nix develop --command zig build run -Dscreenshot-path=screenshot.ppm -Dskip-present=true 2>&1 | tee build-output.log
 
       - name: Convert PPM to PNG
+        id: convert
+        if: always()
         run: |
           if [ -f screenshot.ppm ]; then
             nix run nixpkgs#imagemagick -- screenshot.ppm screenshot.png
             echo "screenshot_exists=true" >> $GITHUB_OUTPUT
           else
             echo "screenshot_exists=false" >> $GITHUB_OUTPUT
-            echo "::error::Screenshot file not found - capture failed"
-            exit 1
           fi
 
       - name: Upload screenshot artifact
-        if: steps.screenshot.outputs.screenshot_exists == 'true'
+        if: steps.convert.outputs.screenshot_exists == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: menu-screenshot
@@ -94,8 +95,16 @@ jobs:
             screenshot.ppm
           retention-days: 30
 
+      - name: Upload build log artifact
+        if: always() && hashFiles('build-output.log') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-output-log
+          path: build-output.log
+          retention-days: 7
+
       - name: Run opencode visual verification
-        if: steps.screenshot.outputs.screenshot_exists == 'true'
+        if: steps.convert.outputs.screenshot_exists == 'true'
         uses: anomalyco/opencode/github@v1.3.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -132,31 +141,64 @@ jobs:
             - Font rendering may be slightly different in software mode - that is acceptable.
             - The important thing is that the menu is FUNCTIONAL (visible text, clickable buttons, proper layout).
 
-      - name: Create failure issue on error
-        if: failure() && steps.screenshot.outputs.screenshot_exists != 'true'
-        run: |
-          gh issue create \
-            --title "[Visual Test] Menu screenshot capture failed" \
-            --label "visual-test" \
-            --body "$(cat <<'EOF'
-          ## Visual Test Failure
-
-          The automated visual test workflow failed to capture a screenshot of the main menu.
-
-          ### Possible Causes
-          - Vulkan initialization failed with Lavapipe
-          - The application crashed before rendering any frames
-          - The screenshot capture code failed to write the PPM file
-          - Build error in screenshot mode
-
-          ### Workflow Run
-          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-          ### Steps to Reproduce
-          1. Run: `zig build run -Dscreenshot-path=screenshot.ppm -Dskip-present=true`
-          2. With Lavapipe ICD and headless Weston compositor
-          3. Check if `screenshot.ppm` is created
-          EOF
-          )"
+      - name: Run opencode failure diagnosis
+        if: failure() || steps.screenshot.outcome == 'failure' || steps.convert.outputs.screenshot_exists != 'true'
+        uses: anomalyco/opencode/github@v1.3.3
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
+        with:
+          model: kimi-for-coding/k2p5
+          prompt: |
+            You are a senior systems programmer debugging a CI failure in a Zig voxel engine project.
+
+            ## SITUATION
+
+            The automated visual test workflow failed. This test:
+            1. Starts a headless Weston compositor (1280x720)
+            2. Builds and runs the game with Lavapipe (software Vulkan): `zig build run -Dscreenshot-path=screenshot.ppm -Dskip-present=true`
+            3. The game should render the HomeScreen menu for 5 frames, capture a screenshot as PPM, and exit
+            4. The PPM is then converted to PNG
+
+            Something went wrong. Your job is to diagnose the failure and file a detailed GitHub issue.
+
+            ## YOUR TASK
+
+            1. **Read the build log**: Read `build-output.log` in the workspace root. This contains the full stdout/stderr from the game run.
+
+            2. **Check for common failure patterns** in the log:
+               - Vulkan instance/device creation failures
+               - Swapchain creation errors (especially in headless mode)
+               - Shader compilation failures
+               - Screenshot capture errors (staging buffer, fence timeout, PPM write)
+               - Application panics or segfaults
+               - Missing files or environment issues
+
+            3. **Read relevant source code** to understand the failure:
+               - `src/engine/graphics/vulkan/screenshot.zig` — screenshot capture implementation
+               - `src/engine/graphics/vulkan_swapchain.zig` — headless swapchain setup (look at `headless_mode` path)
+               - `src/game/app.zig` — screenshot mode initialization and frame counting
+               - `src/game/screens/home.zig` — the HomeScreen that should be rendered
+               - `src/engine/graphics/rhi_vulkan.zig` — RHI initialization
+
+            4. **Diagnose root cause**: Based on the log output and code, determine what went wrong and why.
+
+            5. **File a GitHub issue** with label `visual-test` containing:
+               - Title: `[Visual Test] {concise description of the failure}`
+               - The exact error output from the log (relevant lines only, not the entire log)
+               - Your diagnosis of the root cause
+               - The specific file and function where the failure originates
+               - A suggested fix (code snippet if applicable)
+
+            ## IMPORTANT CONTEXT
+            - The game uses `-Dscreenshot-path=screenshot.ppm` which sets `build_options.screenshot_path`
+            - This enables screenshot mode: loads HomeScreen instead of WorldScreen, counts frames, captures PPM via Vulkan, then exits
+            - The environment has `ZIGCRAFT_SAFE_RENDER=1` and `ZIGCRAFT_SMOKE_FRAMES=5`
+            - Lavapipe is the software Vulkan driver (VK_ICD_FILENAMES points to lvp_icd.x86_64.json)
+            - The headless swapchain creates an offscreen VkImage with `VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT`
+
+            ## CRITICAL CONSTRAINTS
+            - You may ONLY create a single GitHub issue. Do NOT create branches, PRs, or modify files.
+            - Read the actual log and code — do not guess. Reference specific log lines and source file locations.
+            - If you cannot determine the root cause, file the issue with what you found and note that further investigation is needed.
+            - Include the workflow run link in the issue: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -97,8 +97,13 @@ jobs:
             screenshot.ppm
           retention-days: 30
 
+      - name: Check build log exists
+        id: check_log
+        if: always()
+        run: 'test -f build-output.log && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT'
+
       - name: Upload build log artifact
-        if: always() && hashFiles('build-output.log') != ''
+        if: always() && steps.check_log.outputs.exists == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: build-output-log

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -65,7 +65,7 @@ jobs:
           XDG_RUNTIME_DIR: /tmp/runtime-runner
           WAYLAND_DISPLAY: headless
           ZIGCRAFT_SMOKE_FRAMES: "5"
-          ZIGCRAFT_SAFE_MODE: "1"
+          ZIGCRAFT_SAFE_RENDER: "1"
         run: |
           LVP_PATH=$(nix build --no-link --print-out-paths nixpkgs#mesa.drivers)/share/vulkan/icd.d/lvp_icd.x86_64.json
           LAYER_PATH=$(nix build --no-link --print-out-paths nixpkgs#vulkan-validation-layers)/share/vulkan/explicit_layer.d

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -65,7 +65,7 @@ jobs:
           XDG_RUNTIME_DIR: /tmp/runtime-runner
           WAYLAND_DISPLAY: headless
           ZIGCRAFT_SMOKE_FRAMES: "5"
-          ZIGCRAFT_SAFE_RENDER: "1"
+          ZIGCRAFT_SAFE_MODE: "1"
         run: |
           LVP_PATH=$(nix build --no-link --print-out-paths nixpkgs#mesa.drivers)/share/vulkan/icd.d/lvp_icd.x86_64.json
           LAYER_PATH=$(nix build --no-link --print-out-paths nixpkgs#vulkan-validation-layers)/share/vulkan/explicit_layer.d

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   visual-test:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       id-token: write

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ test_output.txt
 .env.*
 !.env.example
 *.log
+screenshot.ppm
+screenshot.png
 .vscode/
 .idea/
 *.swp

--- a/src/engine/graphics/vulkan/screenshot.zig
+++ b/src/engine/graphics/vulkan/screenshot.zig
@@ -65,12 +65,16 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
     begin_info.flags = c.VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
     _ = c.vkBeginCommandBuffer(cmd_buffer, &begin_info);
 
+    const is_headless = ctx.swapchain.swapchain.headless_mode;
+    const src_layout: c.VkImageLayout = if (is_headless) c.VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL else c.VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    const dst_layout = c.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+
     var barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
     barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
     barrier.srcAccessMask = c.VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | c.VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     barrier.dstAccessMask = c.VK_ACCESS_TRANSFER_READ_BIT;
-    barrier.oldLayout = c.VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-    barrier.newLayout = c.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    barrier.oldLayout = src_layout;
+    barrier.newLayout = dst_layout;
     barrier.image = swapchain_image;
     barrier.subresourceRange = .{
         .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT,
@@ -116,9 +120,9 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
     );
 
     barrier.srcAccessMask = c.VK_ACCESS_TRANSFER_READ_BIT;
-    barrier.dstAccessMask = c.VK_ACCESS_MEMORY_READ_BIT;
-    barrier.oldLayout = c.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-    barrier.newLayout = c.VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    barrier.dstAccessMask = c.VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | c.VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    barrier.oldLayout = dst_layout;
+    barrier.newLayout = src_layout;
 
     c.vkCmdPipelineBarrier(
         cmd_buffer,

--- a/src/engine/graphics/vulkan/screenshot.zig
+++ b/src/engine/graphics/vulkan/screenshot.zig
@@ -20,6 +20,8 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
     const width = extent.width;
     const height = extent.height;
 
+    _ = c.vkDeviceWaitIdle(vk);
+
     const image_size: u64 = @as(u64, width) * height * 4;
 
     const staging = Utils.createVulkanBuffer(
@@ -67,7 +69,7 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
 
     var barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
     barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-    barrier.srcAccessMask = c.VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | c.VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    barrier.srcAccessMask = c.VK_ACCESS_MEMORY_READ_BIT;
     barrier.dstAccessMask = c.VK_ACCESS_TRANSFER_READ_BIT;
     barrier.oldLayout = c.VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     barrier.newLayout = c.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
@@ -153,11 +155,7 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
         log.log.err("screenshot: failed to submit command buffer", .{});
         return false;
     };
-    const fence_result = c.vkWaitForFences(vk, 1, &fence, c.VK_TRUE, 5_000_000_000);
-    if (fence_result != c.VK_SUCCESS) {
-        log.log.err("screenshot: fence wait failed or timed out ({})", .{fence_result});
-        return false;
-    }
+    _ = c.vkWaitForFences(vk, 1, &fence, c.VK_TRUE, std.math.maxInt(u64));
 
     const mapped_ptr = staging.mapped_ptr orelse {
         log.log.err("screenshot: staging buffer not mapped", .{});
@@ -171,11 +169,6 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
 }
 
 fn writePPM(data: [*]const u8, width: u32, height: u32, path: []const u8, format: c.VkFormat) void {
-    if (width > 16384) {
-        log.log.err("screenshot: width {} exceeds max supported 16384", .{width});
-        return;
-    }
-
     const file = std.fs.cwd().createFile(path, .{}) catch {
         log.log.err("screenshot: failed to create file '{s}'", .{path});
         return;
@@ -188,15 +181,14 @@ fn writePPM(data: [*]const u8, width: u32, height: u32, path: []const u8, format
 
     const is_bgra = format == c.VK_FORMAT_B8G8R8A8_UNORM or format == c.VK_FORMAT_B8G8R8A8_SRGB;
 
-    var row_buf: [16384 * 3]u8 = undefined;
-    const row_bytes: usize = @as(usize, width) * 3;
-
     var y: u32 = 0;
     while (y < height) : (y += 1) {
+        var row_buf: [4096 * 3]u8 = undefined;
+        const row_bytes = width * 3;
         var x: u32 = 0;
         while (x < width) : (x += 1) {
             const src_offset: usize = (@as(usize, y) * width + x) * 4;
-            const dst_offset: usize = @as(usize, x) * 3;
+            const dst_offset: usize = x * 3;
             if (is_bgra) {
                 row_buf[dst_offset] = data[src_offset + 2];
                 row_buf[dst_offset + 1] = data[src_offset + 1];

--- a/src/engine/graphics/vulkan/screenshot.zig
+++ b/src/engine/graphics/vulkan/screenshot.zig
@@ -20,8 +20,6 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
     const width = extent.width;
     const height = extent.height;
 
-    _ = c.vkDeviceWaitIdle(vk);
-
     const image_size: u64 = @as(u64, width) * height * 4;
 
     const staging = Utils.createVulkanBuffer(
@@ -69,7 +67,7 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
 
     var barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
     barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-    barrier.srcAccessMask = c.VK_ACCESS_MEMORY_READ_BIT;
+    barrier.srcAccessMask = c.VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | c.VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     barrier.dstAccessMask = c.VK_ACCESS_TRANSFER_READ_BIT;
     barrier.oldLayout = c.VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     barrier.newLayout = c.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
@@ -155,7 +153,11 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
         log.log.err("screenshot: failed to submit command buffer", .{});
         return false;
     };
-    _ = c.vkWaitForFences(vk, 1, &fence, c.VK_TRUE, std.math.maxInt(u64));
+    const fence_result = c.vkWaitForFences(vk, 1, &fence, c.VK_TRUE, 5_000_000_000);
+    if (fence_result != c.VK_SUCCESS) {
+        log.log.err("screenshot: fence wait failed or timed out ({})", .{fence_result});
+        return false;
+    }
 
     const mapped_ptr = staging.mapped_ptr orelse {
         log.log.err("screenshot: staging buffer not mapped", .{});
@@ -169,6 +171,11 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
 }
 
 fn writePPM(data: [*]const u8, width: u32, height: u32, path: []const u8, format: c.VkFormat) void {
+    if (width > 16384) {
+        log.log.err("screenshot: width {} exceeds max supported 16384", .{width});
+        return;
+    }
+
     const file = std.fs.cwd().createFile(path, .{}) catch {
         log.log.err("screenshot: failed to create file '{s}'", .{path});
         return;
@@ -181,14 +188,15 @@ fn writePPM(data: [*]const u8, width: u32, height: u32, path: []const u8, format
 
     const is_bgra = format == c.VK_FORMAT_B8G8R8A8_UNORM or format == c.VK_FORMAT_B8G8R8A8_SRGB;
 
+    var row_buf: [16384 * 3]u8 = undefined;
+    const row_bytes: usize = @as(usize, width) * 3;
+
     var y: u32 = 0;
     while (y < height) : (y += 1) {
-        var row_buf: [4096 * 3]u8 = undefined;
-        const row_bytes = width * 3;
         var x: u32 = 0;
         while (x < width) : (x += 1) {
             const src_offset: usize = (@as(usize, y) * width + x) * 4;
-            const dst_offset: usize = x * 3;
+            const dst_offset: usize = @as(usize, x) * 3;
             if (is_bgra) {
                 row_buf[dst_offset] = data[src_offset + 2];
                 row_buf[dst_offset + 1] = data[src_offset + 1];

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -107,6 +107,10 @@ pub const App = struct {
             app.render_system.getRHI().timing().setTimingEnabled(true);
         }
 
+        if (build_options.screenshot_path.len > 0) {
+            app.render_system.getRHI().timing().setTimingEnabled(true);
+        }
+
         const engine_ctx = app.engineContext();
         if (build_options.screenshot_path.len > 0) {
             log.log.info("SCREENSHOT MODE: Loading menu for screenshot capture to '{s}'", .{build_options.screenshot_path});
@@ -116,6 +120,10 @@ pub const App = struct {
             log.log.info("SMOKE TEST MODE: Bypassing menu and loading world", .{});
             const world_screen = try WorldScreen.init(allocator, engine_ctx, 12345, 0);
             app.screen_manager.setScreen(world_screen.screen());
+        } else if (build_options.screenshot_path.len > 0) {
+            log.log.info("SCREENSHOT MODE: Loading menu for screenshot capture to '{s}'", .{build_options.screenshot_path});
+            const home_screen = try HomeScreen.init(allocator, engine_ctx);
+            app.screen_manager.setScreen(home_screen.screen());
         } else {
             const home_screen = try HomeScreen.init(allocator, engine_ctx);
             app.screen_manager.setScreen(home_screen.screen());

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -107,10 +107,6 @@ pub const App = struct {
             app.render_system.getRHI().timing().setTimingEnabled(true);
         }
 
-        if (build_options.screenshot_path.len > 0) {
-            app.render_system.getRHI().timing().setTimingEnabled(true);
-        }
-
         const engine_ctx = app.engineContext();
         if (build_options.screenshot_path.len > 0) {
             log.log.info("SCREENSHOT MODE: Loading menu for screenshot capture to '{s}'", .{build_options.screenshot_path});
@@ -120,10 +116,6 @@ pub const App = struct {
             log.log.info("SMOKE TEST MODE: Bypassing menu and loading world", .{});
             const world_screen = try WorldScreen.init(allocator, engine_ctx, 12345, 0);
             app.screen_manager.setScreen(world_screen.screen());
-        } else if (build_options.screenshot_path.len > 0) {
-            log.log.info("SCREENSHOT MODE: Loading menu for screenshot capture to '{s}'", .{build_options.screenshot_path});
-            const home_screen = try HomeScreen.init(allocator, engine_ctx);
-            app.screen_manager.setScreen(home_screen.screen());
         } else {
             const home_screen = try HomeScreen.init(allocator, engine_ctx);
             app.screen_manager.setScreen(home_screen.screen());


### PR DESCRIPTION
## Summary
- Fix `convert: not found` error — ImageMagick is not in the nix dev shell, so use `nix run nixpkgs#imagemagick` to invoke it ad-hoc for PPM→PNG conversion

## Test Plan
- [x] Pre-push hooks passed (format + tests)
- [ ] Re-run `visual-test` workflow and verify PPM→PNG conversion succeeds