### PR TITLE
fix(ci): use OPENCODE_PAT to trigger workflows on bot-created PRs

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -74,7 +74,7 @@ jobs:
               --color "1D76DB"
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
@@ -89,7 +89,7 @@ jobs:
       - name: Run opencode audit
         uses: anomalyco/opencode/github@v1.3.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5

--- a/.github/workflows/opencode-pr.yml
+++ b/.github/workflows/opencode-pr.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           ref: ${{ steps.resolve-pr.outputs.pr_head_sha }}
           fetch-depth: 0
+          token: ${{ secrets.OPENCODE_PAT }}
 
       - name: Configure git
         run: |
@@ -93,7 +94,7 @@ jobs:
           
           echo "Previous reviews fetched and formatted for context"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
@@ -108,7 +109,7 @@ jobs:
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -140,6 +140,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
+          token: ${{ secrets.OPENCODE_PAT }}
 
       - name: Ensure test label exists
         run: |
@@ -149,7 +150,7 @@ jobs:
               --color "0E8A16"
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
 
       - name: Check for existing PR
         id: check-existing
@@ -169,7 +170,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
 
       - name: Validate scan paths exist
         if: steps.check-existing.outputs.skip != 'true'
@@ -201,7 +202,7 @@ jobs:
         if: steps.check-existing.outputs.skip != 'true'
         uses: anomalyco/opencode/github@v1.3.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5
@@ -403,4 +404,4 @@ jobs:
             echo "No PR found on branch ${BRANCH}, skipping review trigger."
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -28,6 +28,8 @@ jobs:
 
       - uses: actions/checkout@v4
         if: steps.check.outputs.result == 'true'
+        with:
+          token: ${{ secrets.OPENCODE_PAT }}
 
       - name: Configure git
         if: steps.check.outputs.result == 'true'
@@ -38,7 +40,7 @@ jobs:
       - uses: anomalyco/opencode/github@latest
         if: steps.check.outputs.result == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.OPENCODE_PAT }}
 
       - name: Configure git
         run: |
@@ -41,7 +43,7 @@ jobs:
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -58,7 +58,7 @@ jobs:
               --color "E06C75"
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
 
       - name: Run menu screenshot capture
         id: screenshot
@@ -114,7 +114,7 @@ jobs:
         if: steps.convert.outputs.screenshot_exists == 'true'
         uses: anomalyco/opencode/github@v1.3.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5
@@ -152,7 +152,7 @@ jobs:
         if: failure() || steps.screenshot.outcome == 'failure' || steps.convert.outputs.screenshot_exists != 'true'
         uses: anomalyco/opencode/github@v1.3.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5


### PR DESCRIPTION
## Summary
- Replace `GITHUB_TOKEN` with `OPENCODE_PAT` in all opencode workflows (test-writer, pr review, audit, triage, interactive, visual-test)
- Update checkout steps to use PAT token so bot can push branches

## Problem
PRs created by `opencode-test-writer` (via `github-actions[bot]`) never triggered `build.yml` or `opencode-pr.yml` because GitHub blocks `pull_request` events from `GITHUB_TOKEN` to prevent infinite loops. The "Trigger PR review workflow" step also used `GITHUB_TOKEN` for `gh workflow run`, which is subject to the same restriction.

## Fix
- All `GITHUB_TOKEN` / `GH_TOKEN` references in opencode workflows now use `secrets.OPENCODE_PAT`
- Checkout steps that need push access now pass `token: ${{ secrets.OPENCODE_PAT }}`
- PAT-created PRs/commits will trigger `pull_request` events normally, so `build.yml` and `opencode-pr.yml` will run on bot-created PRs

## Files Changed
- `opencode-test-writer.yml` — PAT for gh commands, opencode action, checkout
- `opencode-pr.yml` — PAT for gh commands, opencode action, checkout
- `opencode-audit.yml` — PAT for gh commands, opencode action
- `opencode-triage.yml` — PAT for opencode action, checkout
- `opencode.yml` — PAT for opencode action, checkout
- `visual-test.yml` — PAT for gh commands, opencode action

## Requires
- Repo secret `OPENCODE_PAT` must be set (fine-grained PAT with contents, PR, issues, workflows permissions)