### PR TITLE
fix: only skip audit-scheduled PRs in opencode-pr reviewer

### DIFF
--- a/.github/workflows/opencode-pr.yml
+++ b/.github/workflows/opencode-pr.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   opencode:
     if: >
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.user.login != 'opencode-agent[bot]') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false && !startsWith(github.event.pull_request.head.ref, 'opencode/schedule-')) ||
       github.event_name == 'workflow_dispatch'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

The previous fix blocked *all* bot-authored PRs from review. This was too broad — PRs from `opencode.yml` (issue-comment triggered, e.g. `opencode/issue359-*`) should still get reviewed. Only audit-scheduled PRs (branches matching `opencode/schedule-*`) should be skipped.

## Changes

- `opencode-pr.yml`: Changed condition from blocking `opencode-agent[bot]` author to only skipping PRs with branches starting with `opencode/schedule-`

## Test plan

- [x] PR #360 (branch `opencode/issue359-*`) will now be reviewed instead of skipped
- [x] Any future audit rogue PRs (branch `opencode/schedule-*`) will still be skipped