### PR TITLE
test: add world/worldgen caves and coastal generator tests

### DIFF
--- a/src/tests.zig
+++ b/src/tests.zig
@@ -78,6 +78,8 @@ test {
     _ = @import("engine/math/utils_tests.zig");
     _ = @import("world/worldgen/schematics.zig");
     _ = @import("world/worldgen/tree_registry.zig");
+    _ = @import("world/worldgen/caves_tests.zig");
+    _ = @import("world/worldgen/coastal_generator_tests.zig");
     _ = @import("world/lod_manager.zig");
     _ = @import("world/lod_renderer.zig");
     _ = @import("engine/atmosphere/tests.zig");

--- a/src/world/worldgen/caves_tests.zig
+++ b/src/world/worldgen/caves_tests.zig
@@ -1,0 +1,340 @@
+//! Unit tests for the cave generation system
+//!
+//! Tests focus on:
+//! - CaveCarveMap operations (init, deinit, get, set)
+//! - CaveSystem initialization and determinism
+//! - Cave region detection and thresholds
+//! - Edge cases and boundary conditions
+
+const std = @import("std");
+const testing = std.testing;
+const caves = @import("caves.zig");
+const CaveCarveMap = caves.CaveCarveMap;
+const CaveSystem = caves.CaveSystem;
+const CaveParams = caves.CaveParams;
+
+const CHUNK_SIZE_X = @import("../chunk.zig").CHUNK_SIZE_X;
+const CHUNK_SIZE_Y = @import("../chunk.zig").CHUNK_SIZE_Y;
+const CHUNK_SIZE_Z = @import("../chunk.zig").CHUNK_SIZE_Z;
+
+// ============================================================================
+// CaveCarveMap Tests
+// ============================================================================
+
+test "CaveCarveMap initialization zeros all values" {
+    var carve_map = try CaveCarveMap.init(testing.allocator);
+    defer carve_map.deinit();
+
+    // All values should be initialized to false
+    var x: u32 = 0;
+    while (x < CHUNK_SIZE_X) : (x += 1) {
+        var y: u32 = 0;
+        while (y < CHUNK_SIZE_Y) : (y += 1) {
+            var z: u32 = 0;
+            while (z < CHUNK_SIZE_Z) : (z += 1) {
+                try testing.expectEqual(false, carve_map.get(x, y, z));
+            }
+        }
+    }
+}
+
+test "CaveCarveMap set and get operations" {
+    var carve_map = try CaveCarveMap.init(testing.allocator);
+    defer carve_map.deinit();
+
+    // Set a single cell
+    carve_map.set(5, 64, 7, true);
+    try testing.expectEqual(true, carve_map.get(5, 64, 7));
+
+    // Neighboring cells should be unaffected
+    try testing.expectEqual(false, carve_map.get(4, 64, 7));
+    try testing.expectEqual(false, carve_map.get(5, 63, 7));
+    try testing.expectEqual(false, carve_map.get(5, 64, 6));
+
+    // Set and unset
+    carve_map.set(5, 64, 7, false);
+    try testing.expectEqual(false, carve_map.get(5, 64, 7));
+}
+
+test "CaveCarveMap bounds checking - out of bounds returns false" {
+    var carve_map = try CaveCarveMap.init(testing.allocator);
+    defer carve_map.deinit();
+
+    // Set should silently ignore out-of-bounds
+    carve_map.set(100, 64, 7, true);
+    carve_map.set(5, 300, 7, true);
+    carve_map.set(5, 64, 100, true);
+
+    // Get should return false for out-of-bounds
+    try testing.expectEqual(false, carve_map.get(100, 64, 7));
+    try testing.expectEqual(false, carve_map.get(5, 300, 7));
+    try testing.expectEqual(false, carve_map.get(5, 64, 100));
+}
+
+test "CaveCarveMap bounds checking - boundary values" {
+    var carve_map = try CaveCarveMap.init(testing.allocator);
+    defer carve_map.deinit();
+
+    // Set at exact boundaries
+    carve_map.set(0, 0, 0, true);
+    carve_map.set(CHUNK_SIZE_X - 1, CHUNK_SIZE_Y - 1, CHUNK_SIZE_Z - 1, true);
+
+    try testing.expectEqual(true, carve_map.get(0, 0, 0));
+    try testing.expectEqual(true, carve_map.get(CHUNK_SIZE_X - 1, CHUNK_SIZE_Y - 1, CHUNK_SIZE_Z - 1));
+
+    // Just outside boundaries should return false
+    try testing.expectEqual(false, carve_map.get(CHUNK_SIZE_X, 0, 0));
+    try testing.expectEqual(false, carve_map.get(0, CHUNK_SIZE_Y, 0));
+    try testing.expectEqual(false, carve_map.get(0, 0, CHUNK_SIZE_Z));
+}
+
+test "CaveCarveMap multiple cells independently tracked" {
+    var carve_map = try CaveCarveMap.init(testing.allocator);
+    defer carve_map.deinit();
+
+    // Set a pattern of cells
+    carve_map.set(0, 10, 0, true);
+    carve_map.set(8, 64, 8, true);
+    carve_map.set(15, 128, 15, true);
+
+    // Verify all are set independently
+    try testing.expectEqual(true, carve_map.get(0, 10, 0));
+    try testing.expectEqual(true, carve_map.get(8, 64, 8));
+    try testing.expectEqual(true, carve_map.get(15, 128, 15));
+
+    // Verify unset cells remain false
+    try testing.expectEqual(false, carve_map.get(1, 10, 0));
+    try testing.expectEqual(false, carve_map.get(8, 65, 8));
+    try testing.expectEqual(false, carve_map.get(14, 128, 15));
+}
+
+// ============================================================================
+// CaveSystem Initialization Tests
+// ============================================================================
+
+test "CaveSystem initialization with seed" {
+    const cave_system = CaveSystem.init(12345);
+
+    // Verify seed is stored
+    try testing.expectEqual(@as(u64, 12345), cave_system.seed);
+
+    // Verify default params are set
+    try testing.expectEqual(@as(f32, 1.0 / 900.0), cave_system.params.region_scale);
+    try testing.expectEqual(@as(f32, 0.42), cave_system.params.region_threshold);
+    try testing.expectEqual(@as(i32, 8), cave_system.params.min_surface_depth);
+}
+
+test "CaveSystem initialization produces different seeds for sub-noises" {
+    // Different seeds should produce different internal noise states
+    const cs1 = CaveSystem.init(100);
+    const cs2 = CaveSystem.init(200);
+
+    // The internal noise generators should have different states
+    // This is verified by checking different outputs at same position
+    const val1 = cs1.getCaveRegionValue(100.0, 100.0);
+    const val2 = cs2.getCaveRegionValue(100.0, 100.0);
+
+    try testing.expect(val1 != val2);
+}
+
+test "CaveSystem deterministic with same seed" {
+    const cs1 = CaveSystem.init(54321);
+    const cs2 = CaveSystem.init(54321);
+
+    // Same seed should produce identical outputs
+    const val1 = cs1.getCaveRegionValue(50.0, 50.0);
+    const val2 = cs2.getCaveRegionValue(50.0, 50.0);
+
+    try testing.expectEqual(val1, val2);
+}
+
+// ============================================================================
+// Cave Region Detection Tests
+// ============================================================================
+
+test "CaveSystem getCaveRegionValue returns value in valid range" {
+    const cave_system = CaveSystem.init(42);
+
+    // Sample multiple positions
+    var x: f32 = 0;
+    while (x < 1000) : (x += 100) {
+        var z: f32 = 0;
+        while (z < 1000) : (z += 100) {
+            const val = cave_system.getCaveRegionValue(x, z);
+            // fBm normalized should be in [0, 1]
+            try testing.expect(val >= 0.0);
+            try testing.expect(val <= 1.0);
+        }
+    }
+}
+
+test "CaveSystem isCaveRegion respects threshold" {
+    // Use a fixed seed and check behavior
+    const cave_system = CaveSystem.init(99999);
+
+    // The threshold is 0.42 by default
+    // We can't predict exact values, but we can verify consistency
+    var cave_count: u32 = 0;
+    var total_samples: u32 = 0;
+
+    var x: f32 = 0;
+    while (x < 5000) : (x += 50) {
+        var z: f32 = 0;
+        while (z < 5000) : (z += 50) {
+            total_samples += 1;
+            if (cave_system.isCaveRegion(x, z)) {
+                cave_count += 1;
+                // If isCaveRegion returns true, value must be >= threshold
+                try testing.expect(cave_system.getCaveRegionValue(x, z) >= cave_system.params.region_threshold);
+            }
+        }
+    }
+
+    // Some regions should have caves (not all or none)
+    try testing.expect(cave_count > 0);
+    try testing.expect(cave_count < total_samples);
+}
+
+test "CaveSystem cave region detection is deterministic" {
+    const cs1 = CaveSystem.init(77777);
+    const cs2 = CaveSystem.init(77777);
+
+    // Same positions should give same region results
+    var x: f32 = 0;
+    while (x < 1000) : (x += 100) {
+        var z: f32 = 0;
+        while (z < 1000) : (z += 100) {
+            try testing.expectEqual(cs1.isCaveRegion(x, z), cs2.isCaveRegion(x, z));
+        }
+    }
+}
+
+// ============================================================================
+// CaveParams Tests
+// ============================================================================
+
+test "CaveParams default values" {
+    const params = CaveParams{};
+
+    // Region mask
+    try testing.expectEqual(@as(f32, 1.0 / 900.0), params.region_scale);
+    try testing.expectEqual(@as(f32, 0.42), params.region_threshold);
+
+    // Surface protection
+    try testing.expectEqual(@as(i32, 8), params.min_surface_depth);
+
+    // Worm cave parameters
+    try testing.expectEqual(@as(u32, 1), params.worms_per_chunk_min);
+    try testing.expectEqual(@as(u32, 3), params.worms_per_chunk_max);
+    try testing.expectEqual(@as(i32, 15), params.worm_y_min);
+    try testing.expectEqual(@as(i32, 110), params.worm_y_max);
+    try testing.expectEqual(@as(f32, 2.5), params.worm_radius_min);
+    try testing.expectEqual(@as(f32, 5.0), params.worm_radius_max);
+
+    // Cavern parameters
+    try testing.expectEqual(@as(f32, 0.6), params.cavern_threshold);
+    try testing.expectEqual(@as(i32, 32), params.cavern_y_max);
+
+    // Sea level
+    try testing.expectEqual(@as(i32, 64), params.sea_level);
+}
+
+test "CaveParams custom values" {
+    const params = CaveParams{
+        .region_scale = 0.001,
+        .region_threshold = 0.5,
+        .min_surface_depth = 12,
+        .worms_per_chunk_min = 2,
+        .worms_per_chunk_max = 5,
+        .worm_y_min = 20,
+        .worm_y_max = 100,
+        .sea_level = 62,
+    };
+
+    try testing.expectEqual(@as(f32, 0.001), params.region_scale);
+    try testing.expectEqual(@as(f32, 0.5), params.region_threshold);
+    try testing.expectEqual(@as(i32, 12), params.min_surface_depth);
+    try testing.expectEqual(@as(u32, 2), params.worms_per_chunk_min);
+    try testing.expectEqual(@as(u32, 5), params.worms_per_chunk_max);
+    try testing.expectEqual(@as(i32, 20), params.worm_y_min);
+    try testing.expectEqual(@as(i32, 100), params.worm_y_max);
+    try testing.expectEqual(@as(i32, 62), params.sea_level);
+}
+
+// ============================================================================
+// Edge Case Tests
+// ============================================================================
+
+test "CaveSystem handles large coordinates" {
+    const cave_system = CaveSystem.init(12345);
+
+    // Large coordinates should not panic or produce invalid values
+    // Note: The noise library uses i64 internally, so stay within safe range
+    const large_coords = [_][2]f32{
+        .{ 100000.0, 100000.0 },
+        .{ -100000.0, -100000.0 },
+        .{ 500000.0, -250000.0 },
+        .{ 1000000.0, 0 },
+    };
+
+    for (large_coords) |coord| {
+        const val = cave_system.getCaveRegionValue(coord[0], coord[1]);
+        // Should still be in valid range
+        try testing.expect(val >= 0.0);
+        try testing.expect(val <= 1.0);
+    }
+}
+
+test "CaveSystem handles zero coordinates" {
+    const cave_system = CaveSystem.init(42);
+
+    const val = cave_system.getCaveRegionValue(0.0, 0.0);
+    try testing.expect(val >= 0.0);
+    try testing.expect(val <= 1.0);
+}
+
+test "CaveCarveMap handles all chunk coordinates" {
+    var carve_map = try CaveCarveMap.init(testing.allocator);
+    defer carve_map.deinit();
+
+    // Set every possible coordinate
+    var x: u32 = 0;
+    while (x < CHUNK_SIZE_X) : (x += 1) {
+        var y: u32 = 0;
+        while (y < CHUNK_SIZE_Y) : (y += 1) {
+            var z: u32 = 0;
+            while (z < CHUNK_SIZE_Z) : (z += 1) {
+                // Set alternating pattern
+                const should_set = (x + y + z) % 2 == 0;
+                carve_map.set(x, y, z, should_set);
+            }
+        }
+    }
+
+    // Verify all values
+    x = 0;
+    while (x < CHUNK_SIZE_X) : (x += 1) {
+        var y: u32 = 0;
+        while (y < CHUNK_SIZE_Y) : (y += 1) {
+            var z: u32 = 0;
+            while (z < CHUNK_SIZE_Z) : (z += 1) {
+                const expected = (x + y + z) % 2 == 0;
+                try testing.expectEqual(expected, carve_map.get(x, y, z));
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Memory Safety Tests
+// ============================================================================
+
+test "CaveCarveMap memory allocation succeeds" {
+    // This test verifies that allocation doesn't fail
+    var carve_map = try CaveCarveMap.init(testing.allocator);
+    defer carve_map.deinit();
+
+    // Verify the allocation succeeded by checking we can use it
+    carve_map.set(0, 0, 0, true);
+    try testing.expectEqual(true, carve_map.get(0, 0, 0));
+}

--- a/src/world/worldgen/coastal_generator_tests.zig
+++ b/src/world/worldgen/coastal_generator_tests.zig
@@ -1,0 +1,174 @@
+//! Unit tests for the coastal generator
+//!
+//! Tests focus on:
+//! - CoastalGenerator initialization
+//! - applyCoastJitter clamping behavior
+//! - Ocean/inland water detection logic
+
+const std = @import("std");
+const testing = std.testing;
+const coastal_generator = @import("coastal_generator.zig");
+const CoastalGenerator = coastal_generator.CoastalGenerator;
+const surface_builder_mod = @import("surface_builder.zig");
+const SurfaceBuilder = surface_builder_mod.SurfaceBuilder;
+const SurfaceParams = surface_builder_mod.SurfaceParams;
+const CoastalSurfaceType = surface_builder_mod.CoastalSurfaceType;
+
+// ============================================================================
+// CoastalGenerator Initialization Tests
+// ============================================================================
+
+test "CoastalGenerator initialization stores ocean threshold" {
+    const cg = CoastalGenerator.init(0.35);
+    try testing.expectEqual(@as(f32, 0.35), cg.ocean_threshold);
+}
+
+test "CoastalGenerator initialization with different thresholds" {
+    const cg1 = CoastalGenerator.init(0.0);
+    try testing.expectEqual(@as(f32, 0.0), cg1.ocean_threshold);
+
+    const cg2 = CoastalGenerator.init(0.5);
+    try testing.expectEqual(@as(f32, 0.5), cg2.ocean_threshold);
+
+    const cg3 = CoastalGenerator.init(1.0);
+    try testing.expectEqual(@as(f32, 1.0), cg3.ocean_threshold);
+}
+
+// ============================================================================
+// applyCoastJitter Tests
+// ============================================================================
+
+test "applyCoastJitter adds jitter to base value" {
+    const base = 0.5;
+    const jitter = 0.1;
+    const result = CoastalGenerator.applyCoastJitter(base, jitter);
+
+    // Should add jitter to base
+    try testing.expectApproxEqAbs(@as(f32, 0.6), result, 0.0001);
+}
+
+test "applyCoastJitter negative jitter reduces value" {
+    const base = 0.5;
+    const jitter = -0.1;
+    const result = CoastalGenerator.applyCoastJitter(base, jitter);
+
+    try testing.expectApproxEqAbs(@as(f32, 0.4), result, 0.0001);
+}
+
+test "applyCoastJitter clamps to minimum 0" {
+    // Value would go below 0
+    const base = 0.1;
+    const jitter = -0.2;
+    const result = CoastalGenerator.applyCoastJitter(base, jitter);
+
+    try testing.expectEqual(@as(f32, 0.0), result);
+}
+
+test "applyCoastJitter clamps to maximum 1" {
+    // Value would go above 1
+    const base = 0.9;
+    const jitter = 0.2;
+    const result = CoastalGenerator.applyCoastJitter(base, jitter);
+
+    try testing.expectEqual(@as(f32, 1.0), result);
+}
+
+test "applyCoastJitter with zero jitter returns base" {
+    const base = 0.5;
+    const jitter = 0.0;
+    const result = CoastalGenerator.applyCoastJitter(base, jitter);
+
+    try testing.expectApproxEqAbs(base, result, 0.0001);
+}
+
+test "applyCoastJitter edge cases at boundaries" {
+    // At 0 boundary
+    const r1 = CoastalGenerator.applyCoastJitter(0.0, 0.0);
+    try testing.expectEqual(@as(f32, 0.0), r1);
+
+    const r2 = CoastalGenerator.applyCoastJitter(0.0, 0.5);
+    try testing.expectEqual(@as(f32, 0.5), r2);
+
+    const r3 = CoastalGenerator.applyCoastJitter(0.0, -0.5);
+    try testing.expectEqual(@as(f32, 0.0), r3);
+
+    // At 1 boundary
+    const r4 = CoastalGenerator.applyCoastJitter(1.0, 0.0);
+    try testing.expectEqual(@as(f32, 1.0), r4);
+
+    const r5 = CoastalGenerator.applyCoastJitter(1.0, 0.5);
+    try testing.expectEqual(@as(f32, 1.0), r5);
+
+    const r6 = CoastalGenerator.applyCoastJitter(1.0, -0.5);
+    try testing.expectEqual(@as(f32, 0.5), r6);
+}
+
+test "applyCoastJitter handles extreme jitter values" {
+    // Very large positive jitter
+    const r1 = CoastalGenerator.applyCoastJitter(0.5, 100.0);
+    try testing.expectEqual(@as(f32, 1.0), r1);
+
+    // Very large negative jitter
+    const r2 = CoastalGenerator.applyCoastJitter(0.5, -100.0);
+    try testing.expectEqual(@as(f32, 0.0), r2);
+}
+
+// ============================================================================
+// getSurfaceType Delegation Tests
+// ============================================================================
+
+test "getSurfaceType delegates to SurfaceBuilder" {
+    const p = SurfaceParams{};
+    const surface_builder = SurfaceBuilder.init();
+
+    // Sand beach: continentalness in [ocean_threshold, ocean_threshold+beach_band),
+    //   slope <= beach_max_slope, height within beach_max_height_above_sea of sea_level
+    const near_ocean_continentalness = p.ocean_threshold + p.beach_band * 0.4;
+    const sand = CoastalGenerator.getSurfaceType(
+        &surface_builder,
+        near_ocean_continentalness,
+        p.beach_max_slope,
+        p.sea_level + 1,
+        p.gravel_erosion_threshold - 0.1,
+    );
+    try testing.expectEqual(CoastalSurfaceType.sand_beach, sand);
+
+    // Cliff: same coastal zone but slope >= cliff_min_slope
+    const cliff = CoastalGenerator.getSurfaceType(
+        &surface_builder,
+        near_ocean_continentalness,
+        p.cliff_min_slope + 1,
+        p.sea_level + 1,
+        p.gravel_erosion_threshold - 0.1,
+    );
+    try testing.expectEqual(CoastalSurfaceType.cliff, cliff);
+
+    // Not coastal: height exceeds beach_max_height_above_sea above sea_level
+    const inland = CoastalGenerator.getSurfaceType(
+        &surface_builder,
+        p.ocean_threshold + p.beach_band + 0.1,
+        p.beach_max_slope,
+        p.sea_level + p.beach_max_height_above_sea + 1,
+        0.3,
+    );
+    try testing.expectEqual(CoastalSurfaceType.none, inland);
+}
+
+// ============================================================================
+// Ocean Threshold Logic Tests
+// ============================================================================
+
+test "CoastalGenerator ocean threshold comparison" {
+    const cg = CoastalGenerator.init(0.35);
+
+    // Values strictly less than threshold are considered ocean (isOceanWater uses c < threshold)
+    try testing.expect(cg.ocean_threshold > 0.0);
+    try testing.expect(cg.ocean_threshold < 1.0);
+
+    // Test boundary logic
+    const just_below = cg.ocean_threshold - 0.01;
+    const just_above = cg.ocean_threshold + 0.01;
+
+    try testing.expect(just_below < cg.ocean_threshold);
+    try testing.expect(just_above > cg.ocean_threshold);
+}


### PR DESCRIPTION
## Module
`world/worldgen` (automated test coverage)

## Summary
Added comprehensive unit tests for cave generation and coastal generator systems.

## Tests Added
- 17 tests for caves.zig (CaveCarveMap, CaveSystem, CaveParams)
- 10 tests for coastal_generator.zig (initialization, applyCoastJitter)

## Testing Gaps Remaining
- CaveSystem.generateWormCaves() - requires Chunk mocking
- CaveSystem.shouldCarve() - requires surface context
- CoastalGenerator water detection - requires NoiseSampler

## Verification
- [x] `nix develop --command zig fmt src/` passes
- [x] `nix develop --command zig build test` passes
- [x] No non-test source files were modified