### PR TITLE
fix: resolve opencode workflow crashes

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
+      # Workaround: opencode binary from actions/cache may have wrong permissions
+      # preventing mkdir of ~/.cache/opencode. Pre-create dirs and redirect cache
+      # to /tmp (non-persistent — opencode binary itself is already cached separately).
       - name: Ensure opencode cache dir exists
         run: mkdir -p ~/.cache/opencode ~/.local/share/opencode
 
@@ -263,7 +266,7 @@ jobs:
           CUTOFF=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           NEW_PRS=$(gh pr list --author "$BOT_LOGIN" --state open --limit 10 \
             --json number,title,headRefName,createdAt,body \
-            --jq ".[] | select(.createdAt >= \"$CUTOFF\")")
+            --jq '.[] | select(.createdAt >= "'"$CUTOFF"'")')
 
           if [ -n "$NEW_PRS" ]; then
             echo "::error::Compliance violation detected: agent created pull request(s) instead of issue(s)"

--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -78,11 +78,15 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
+      - name: Ensure opencode cache dir exists
+        run: mkdir -p ~/.cache/opencode ~/.local/share/opencode
+
       - name: Run opencode audit
         uses: anomalyco/opencode/github@v1.3.3
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
+          XDG_CACHE_HOME: /tmp/opencode-cache
         with:
           model: kimi-for-coding/k2p5
           prompt: |
@@ -256,10 +260,10 @@ jobs:
 
           VIOLATIONS=0
 
+          CUTOFF=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
           NEW_PRS=$(gh pr list --author "$BOT_LOGIN" --state open --limit 10 \
             --json number,title,headRefName,createdAt,body \
-            --jq --arg run_time "$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" \
-            '.[] | select(.createdAt >= $run_time)')
+            --jq ".[] | select(.createdAt >= \"$CUTOFF\")")
 
           if [ -n "$NEW_PRS" ]; then
             echo "::error::Compliance violation detected: agent created pull request(s) instead of issue(s)"

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -160,7 +160,7 @@ jobs:
             --state open \
             --limit 20 \
             --json title,headRefName \
-            --jq ".[] | select(.title | startswith(\"test: [${MODULE}]\")) | .headRefName" || echo "")
+            --jq '.[] | select(.title | startswith("test: ['"$MODULE"']")) | .headRefName' || echo "")
           if [ -n "$EXISTING" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Existing PR found on branch: ${EXISTING}"
@@ -188,6 +188,7 @@ jobs:
         if: steps.check-existing.outputs.skip != 'true'
         uses: ./.github/actions/setup-nix
 
+      # XDG_CACHE_HOME=/tmp — non-persistent but avoids permission issues (see opencode-audit.yml)
       - name: Run opencode test writer
         if: steps.check-existing.outputs.skip != 'true'
         uses: anomalyco/opencode/github@v1.3.3

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -160,7 +160,7 @@ jobs:
             --state open \
             --limit 20 \
             --json title,headRefName \
-            --jq --arg m "$MODULE" '.[] | select(.title | startswith("test: [\($m)]")) | .headRefName' || echo "")
+            --jq ".[] | select(.title | startswith(\"test: [${MODULE}]\")) | .headRefName" || echo "")
           if [ -n "$EXISTING" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Existing PR found on branch: ${EXISTING}"
@@ -194,6 +194,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
+          XDG_CACHE_HOME: /tmp/opencode-cache
         with:
           model: kimi-for-coding/k2p5
           prompt: |


### PR DESCRIPTION
## Summary

Fixes two crashes in the automated opencode workflows:

1. **`EACCES: permission denied` on cache dir** — opencode couldn't create `~/.cache/opencode`. Fixed by pre-creating the directory and redirecting cache via `XDG_CACHE_HOME=/tmp/opencode-cache`.

2. **Broken `gh pr list --jq --arg` syntax** — `gh` CLI doesn't support `--arg` with `--jq`. The `--arg` flag is a `jq` feature, not a `gh` feature. Fixed by using inline string interpolation in the `--jq` expression instead. Affected both the audit compliance guard and the test-writer's "check for existing PR" step.

## Files Changed
- `.github/workflows/opencode-audit.yml` — cache dir fix + compliance guard jq fix
- `.github/workflows/opencode-test-writer.yml` — cache dir fix + existing PR check jq fix

## Verification
- [x] Pre-push checks passed (format + full test suite)
- [x] No source code changes, only workflow YAML

## Related
- Audit run that failed: #23786096650
- Test writer run that skipped PR creation: #23782364255