### PR TITLE
fix(ci): resolve audit workflow permission denied and octal parsing errors

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -53,7 +53,7 @@ jobs:
             SELECTED="$INPUT_MODULE"
             echo "Manual dispatch: scanning ${SELECTED}"
           else
-            DAY=$(date +%j)
+            DAY=$((10#$(date +%j)))
             INDEX=$((DAY % COUNT))
             SELECTED="${MODULES[${INDEX}]}"
             echo "Scheduled run: day=${DAY} index=${INDEX} → ${SELECTED}"
@@ -78,11 +78,10 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
-      # Workaround: opencode binary from actions/cache may have wrong permissions
-      # preventing mkdir of ~/.cache/opencode. Pre-create dirs and redirect cache
-      # to /tmp (non-persistent — opencode binary itself is already cached separately).
       - name: Ensure opencode cache dir exists
-        run: mkdir -p ~/.cache/opencode ~/.local/share/opencode
+        run: |
+          sudo chmod u+w ~/.cache 2>/dev/null || true
+          mkdir -p /tmp/opencode-cache ~/.local/share/opencode
 
       - name: Run opencode audit
         uses: anomalyco/opencode/github@v1.3.3

--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -80,6 +80,7 @@ jobs:
 
       - name: Ensure opencode cache dir exists
         run: |
+          # Nix installer may restrict ~/.cache permissions; restore and use /tmp for non-persistent cache
           sudo chmod u+w ~/.cache 2>/dev/null || true
           mkdir -p /tmp/opencode-cache ~/.local/share/opencode
 


### PR DESCRIPTION
## Summary

- Fix `mkdir: cannot create directory '~/.cache/opencode': Permission denied` by restoring write permissions on `~/.cache` after Nix installer locks it down, and aligning the cache dir with `XDG_CACHE_HOME=/tmp/opencode-cache`
- Fix `090: value too great for base` error by forcing base-10 interpretation of `date +%j` output (leading zeros were being parsed as octal)

Fixes the failure in [run #23814935043](https://github.com/OpenStaticFish/ZigCraft/actions/runs/23814935043/job/69411796961).