### PR TITLE
fix(ci): add GH_TOKEN to opencode workflow steps for PR/issue creation

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -88,6 +88,7 @@ jobs:
         uses: anomalyco/opencode/github@v1.3.3
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -194,6 +194,7 @@ jobs:
         uses: anomalyco/opencode/github@v1.3.3
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:


### PR DESCRIPTION
## Summary
- Adds `GH_TOKEN: ${{ secrets.OPENCODE_PAT }}` to the `opencode-test-writer` and `opencode-audit` workflow steps that use the `anomalyco/opencode/github` action
- The `gh` CLI prefers `GH_TOKEN` over `GITHUB_TOKEN`. Without it, the action falls back to the restricted Actions `GITHUB_TOKEN` which lacks permission to create PRs and issues, causing the failures seen in recent scheduled runs

## Verification
- [x] `nix develop --command zig fmt src/` passes (no source changes)
- [x] `nix develop --command zig build test` passes
- [x] No non-workflow files modified