### PR TITLE
ci: optimize build workflow costs and add path-based filtering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,24 @@ name: Build
 on:
   push:
     branches: [ main, dev ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/workflows/opencode.yml'
+      - '.github/workflows/opencode-*.yml'
+      - '.github/workflows/visual-test.yml'
+      - '.github/workflows/repo-automation.yml'
+      - 'LICENSE'
   pull_request:
     branches: [ main, dev ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/workflows/opencode.yml'
+      - '.github/workflows/opencode-*.yml'
+      - '.github/workflows/visual-test.yml'
+      - '.github/workflows/repo-automation.yml'
+      - 'LICENSE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,6 +32,29 @@ env:
   GIT_CONFIG_VALUE_0: main
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      integration: ${{ steps.filter.outputs.integration }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          integration:
+            - 'src/engine/graphics/**'
+            - 'src/world/**'
+            - 'src/game/**'
+            - 'assets/shaders/**'
+            - 'src/engine/core/window.zig'
+            - 'src/c.zig'
+            - 'build.zig'
+            - 'flake.nix'
+            - 'flake.lock'
+
   build:
     permissions:
       contents: read
@@ -47,7 +86,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: build
     steps:
@@ -65,9 +104,10 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: unit-test
+    needs: [build, changes]
+    if: needs.changes.outputs.integration == 'true'
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/opencode-pr.yml
+++ b/.github/workflows/opencode-pr.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.resolve-pr.outputs.pr_head_sha }}
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ secrets.OPENCODE_PAT }}
 
       - name: Configure git


### PR DESCRIPTION
## Summary

- **Add `paths-ignore`** to build triggers — skip entire workflow for docs, non-build CI workflows, and LICENSE changes
- **Add lightweight `changes` job** using `dorny/paths-filter@v3` to gate the integration-test behind path detection (no Nix, ~10s)
- **Move `unit-test` and `integration-test`** from paid `blacksmith-2vcpu-ubuntu-2404` to free `ubuntu-latest`
- **Make `integration-test` parallel with `unit-test`** (both now depend only on `build`, not sequentially)
- **Gate `integration-test`** to only run when engine/world/game/shader/build files change
- **Reduce `opencode-pr.yml` checkout** from `fetch-depth: 0` (full history) to `fetch-depth: 1` (shallow)

## New Build DAG

```
build (Blacksmith) ──────→ unit-test (ubuntu-latest, always)
changes (ubuntu-latest) ──→ integration-test (ubuntu-latest, conditional on path changes)
```

## Expected Savings

- Docs/CI-only PRs skip the build entirely (saves ~5-10 min per irrelevant PR)
- Integration tests skip when only non-GUI code changes (saves ~10 min per qualifying PR)
- Two test jobs moved off Blacksmith to free runners
- PR reviewer clones faster with shallow fetch