### PR TITLE
fix(ci): restore opencode workflow GitHub interactions

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -93,6 +93,7 @@ jobs:
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:
           model: kimi-for-coding/k2p5
+          use_github_token: true
           prompt: |
             You are a senior Zig systems programming auditor performing a deep code audit.
 

--- a/.github/workflows/opencode-pr.yml
+++ b/.github/workflows/opencode-pr.yml
@@ -29,7 +29,7 @@ jobs:
       id-token: write
       contents: write
       pull-requests: write
-      issues: read
+      issues: write
 
     steps:
       - name: Resolve PR context
@@ -102,14 +102,18 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5
+          use_github_token: true
           prompt: |
             You are reviewing a pull request for the ZigCraft repository.
 
             **PR to review:** #${{ steps.resolve-pr.outputs.pr_number }}
             Use `gh pr diff ${{ steps.resolve-pr.outputs.pr_number }}` and `gh pr view ${{ steps.resolve-pr.outputs.pr_number }}` to examine the changes.
+
+            Give full review coverage to PRs created by the automated test writer, especially PRs labeled `automated-test`, and verify whether any linked issues are fully addressed.
 
             ZigCraft is a high-performance Minecraft-style voxel engine built with Zig, SDL3, and Vulkan. It uses Nix for dependency management, a custom RHI (Render Hardware Interface) abstraction layer, and a multithreaded job system for world generation and meshing.
 

--- a/.github/workflows/opencode-pr.yml
+++ b/.github/workflows/opencode-pr.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           ref: ${{ steps.resolve-pr.outputs.pr_head_sha }}
           fetch-depth: 0
-          token: ${{ secrets.OPENCODE_PAT }}
+          token: ${{ github.token }}
 
       - name: Configure git
         run: |
@@ -90,7 +90,7 @@ jobs:
           
           echo "Previous reviews fetched and formatted for context"
         env:
-          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
@@ -101,8 +101,8 @@ jobs:
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
-          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -199,6 +199,7 @@ jobs:
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:
           model: kimi-for-coding/k2p5
+          use_github_token: true
           prompt: |
             You are a senior Zig systems programmer writing unit tests for a voxel engine. Your job is to find untested code, write thorough tests, and submit a pull request.
 

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
         if: steps.check.outputs.result == 'true'
         with:
-          token: ${{ secrets.OPENCODE_PAT }}
+          token: ${{ github.token }}
 
       - name: Configure git
         if: steps.check.outputs.result == 'true'
@@ -51,8 +51,8 @@ jobs:
       - uses: anomalyco/opencode/github@latest
         if: steps.check.outputs.result == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
-          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -19,6 +19,16 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const trustedBots = new Set([
+              'opencode-agent[bot]',
+              'github-actions[bot]',
+            ]);
+            const labels = (context.payload.issue.labels || []).map(label => label.name);
+
+            if (trustedBots.has(context.payload.issue.user.login) || labels.includes('automated-audit')) {
+              return true;
+            }
+
             const user = await github.rest.users.getByUsername({
               username: context.payload.issue.user.login
             });
@@ -42,12 +52,16 @@ jobs:
         if: steps.check.outputs.result == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5
+          use_github_token: true
           prompt: |
             Analyze this issue. You have access to the codebase context.
             **CRITICAL: Your only allowed action is to post a COMMENT on the issue. DO NOT create branches, pull requests, or attempt to modify the codebase.**
+
+            If this issue has the `automated-audit` label, treat it as a trusted machine-generated finding and focus on validating the report, checking for duplicates or related PRs, and suggesting the clearest next implementation steps.
 
             1. **Classify**: Determine if this is a Bug, Feature Request, or Question.
             2. **Validate & Request Info**:

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -44,6 +44,8 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5
+          use_github_token: true

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.OPENCODE_PAT }}
+          token: ${{ github.token }}
 
       - name: Configure git
         run: |
@@ -43,8 +43,8 @@ jobs:
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
-          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k2p5


### PR DESCRIPTION
## Summary
- make the opencode workflows use the provided GitHub token directly so audit, triage, review, and comment actions can write back to GitHub
- let issue triage reliably process trusted bot-created `automated-audit` issues instead of filtering them out on account age
- give the PR review workflow explicit issue access and stronger guidance for automated test PRs and linked issues