### PR TITLE
fix: resolve actionlint shellcheck failures in workflow files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,8 +129,10 @@ jobs:
         chmod 700 /tmp/runtime-runner
         export XDG_RUNTIME_DIR=/tmp/runtime-runner
         nix develop --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 &
-        echo "WAYLAND_DISPLAY=headless" >> $GITHUB_ENV
-        echo "XDG_RUNTIME_DIR=/tmp/runtime-runner" >> $GITHUB_ENV
+        {
+          echo "WAYLAND_DISPLAY=headless"
+          echo "XDG_RUNTIME_DIR=/tmp/runtime-runner"
+        } >> "$GITHUB_ENV"
         sleep 5
 
     - name: Run integration smoke test

--- a/.github/workflows/opencode-pr.yml
+++ b/.github/workflows/opencode-pr.yml
@@ -98,7 +98,7 @@ jobs:
         uses: ./.github/actions/setup-nix
 
       - name: Prepare opencode cache
-        run: mkdir -p /tmp/opencode-cache && echo "XDG_CACHE_HOME=/tmp/opencode-cache" >> $GITHUB_ENV
+        run: mkdir -p /tmp/opencode-cache && echo "XDG_CACHE_HOME=/tmp/opencode-cache" >> "$GITHUB_ENV"
 
       - name: Run opencode
         uses: anomalyco/opencode/github@latest

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -59,7 +59,6 @@ jobs:
           else
             GRAPHICS_COUNT=${#GRAPHICS_MODULES[@]}
             OTHER_COUNT=${#OTHER_MODULES[@]}
-            TOTAL=$((GRAPHICS_COUNT + OTHER_COUNT))
 
             SLOT=$(($(date +%s) / 28800))
             PARITY=$((SLOT % 2))

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/setup-nix
 
       - name: Prepare opencode cache
-        run: mkdir -p /tmp/opencode-cache && echo "XDG_CACHE_HOME=/tmp/opencode-cache" >> $GITHUB_ENV
+        run: mkdir -p /tmp/opencode-cache && echo "XDG_CACHE_HOME=/tmp/opencode-cache" >> "$GITHUB_ENV"
 
       - name: Run opencode
         uses: anomalyco/opencode/github@latest

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -25,9 +25,11 @@ jobs:
           mkdir -p /tmp/opencode-cache
           export XDG_RUNTIME_DIR=/tmp/runtime-runner
           nix develop --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 &
-          echo "WAYLAND_DISPLAY=headless" >> $GITHUB_ENV
-          echo "XDG_RUNTIME_DIR=/tmp/runtime-runner" >> $GITHUB_ENV
-          echo "XDG_CACHE_HOME=/tmp/opencode-cache" >> $GITHUB_ENV
+          {
+            echo "WAYLAND_DISPLAY=headless"
+            echo "XDG_RUNTIME_DIR=/tmp/runtime-runner"
+            echo "XDG_CACHE_HOME=/tmp/opencode-cache"
+          } >> "$GITHUB_ENV"
           sleep 5
 
       - name: Ensure visual-test label exists
@@ -62,9 +64,9 @@ jobs:
         run: |
           if [ -f screenshot.ppm ]; then
             nix run nixpkgs#imagemagick -- screenshot.ppm screenshot.png
-            echo "screenshot_exists=true" >> $GITHUB_OUTPUT
+            echo "screenshot_exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "screenshot_exists=false" >> $GITHUB_OUTPUT
+            echo "screenshot_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload screenshot artifact
@@ -80,7 +82,7 @@ jobs:
       - name: Check build log exists
         id: check_log
         if: always()
-        run: 'test -f build-output.log && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT'
+        run: 'test -f build-output.log && echo "exists=true" >> "$GITHUB_OUTPUT" || echo "exists=false" >> "$GITHUB_OUTPUT"'
 
       - name: Upload build log artifact
         if: always() && steps.check_log.outputs.exists == 'true'


### PR DESCRIPTION
## Summary
Fixes all shellcheck issues reported by the actionlint CI job (run #23869757250).

## Changes
- **SC2129**: Grouped multiple `echo >> $GITHUB_ENV` redirects into `{ ... } >> "$GITHUB_ENV"` in `visual-test.yml` and `build.yml`
- **SC2086**: Quoted `$GITHUB_ENV` and `$GITHUB_OUTPUT` across 5 workflow files to prevent globbing/word splitting
- **SC2034**: Removed unused `TOTAL` variable in `opencode-test-writer.yml`

## Files Changed
- `.github/workflows/visual-test.yml` — SC2129 + SC2086 (3 locations)
- `.github/workflows/build.yml` — SC2086 (Wayland compositor step)
- `.github/workflows/opencode-test-writer.yml` — SC2034 (unused TOTAL)
- `.github/workflows/opencode-pr.yml` — SC2086 (cache prep)
- `.github/workflows/opencode.yml` — SC2086 (cache prep)