### PR TITLE
feat: save/load UI with WorldListScreen and level.dat persistence

### DIFF
--- a/src/game/screens/singleplayer.zig
+++ b/src/game/screens/singleplayer.zig
@@ -174,7 +174,10 @@ fn saveNewWorld(allocator: std.mem.Allocator, seed: u64, generator_index: usize)
         return err;
     };
     var dir_name_buf: [128]u8 = undefined;
-    const timestamp: i64 = std.time.milliTimestamp();
+    const timestamp: i64 = blk: {
+        const t = try std.posix.clock_gettime(std.posix.CLOCK.REALTIME);
+        break :blk t.sec * 1000 + @divTrunc(t.nsec, 1000000);
+    };
     const dir_name = std.fmt.bufPrint(&dir_name_buf, "world_{}", .{timestamp}) catch "world_new";
     const world_dir_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ world_list.SAVE_DIR, dir_name });
     defer allocator.free(world_dir_path);

--- a/src/game/screens/singleplayer.zig
+++ b/src/game/screens/singleplayer.zig
@@ -162,33 +162,34 @@ pub const SingleplayerScreen = struct {
 fn saveNewWorld(allocator: std.mem.Allocator, seed: u64, generator_index: usize) !void {
     const home = std.posix.getenv("HOME") orelse {
         log.log.warn("Cannot save world: HOME not set", .{});
-        return;
+        return error.NoHome;
     };
     var home_dir = std.fs.openDirAbsolute(home, .{}) catch |err| {
         log.log.warn("Cannot save world: failed to open home dir: {}", .{err});
-        return;
+        return err;
     };
     defer home_dir.close();
     home_dir.makePath(world_list.SAVE_DIR) catch |err| {
         log.log.warn("Cannot save world: failed to create saves dir: {}", .{err});
-        return;
+        return err;
     };
     var dir_name_buf: [128]u8 = undefined;
-    const timestamp: i64 = @as(i64, @bitCast(seed_gen.randomSeedValue()));
+    const timestamp: i64 = std.time.milliTimestamp();
     const dir_name = std.fmt.bufPrint(&dir_name_buf, "world_{}", .{timestamp}) catch "world_new";
     const world_dir_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ world_list.SAVE_DIR, dir_name });
     defer allocator.free(world_dir_path);
     home_dir.makePath(world_dir_path) catch |err| {
         log.log.warn("Cannot save world: failed to create world dir: {}", .{err});
-        return;
+        return err;
     };
     var save_dir = home_dir.openDir(world_dir_path, .{}) catch |err| {
         log.log.warn("Cannot save world: failed to open world dir: {}", .{err});
-        return;
+        return err;
     };
     defer save_dir.close();
     world_list.writeLevelDat(allocator, save_dir, dir_name, seed, generator_index, timestamp) catch |err| {
         log.log.warn("Cannot save world: failed to write level.dat: {}", .{err});
+        return err;
     };
 }
 

--- a/src/game/screens/singleplayer.zig
+++ b/src/game/screens/singleplayer.zig
@@ -13,6 +13,8 @@ const Key = @import("../../engine/core/interfaces.zig").Key;
 const IRawInputProvider = @import("../../engine/input/interfaces.zig").IRawInputProvider;
 const Input = @import("../../engine/input/input.zig").Input;
 const WorldScreen = @import("world.zig").WorldScreen;
+const WorldListScreen = @import("world_list.zig").WorldListScreen;
+const world_list = @import("world_list.zig");
 const registry = @import("../../world/worldgen/registry.zig");
 const gen_interface = @import("../../world/worldgen/generator_interface.zig");
 
@@ -127,16 +129,25 @@ pub const SingleplayerScreen = struct {
         }
         Font.drawText(ui, g_info.description, px + 30.0 * ui_scale, g_rect.y + g_rect.height + 10.0 * ui_scale, label_scale * 0.7, LABEL_COLOR);
 
-        const byy: f32 = py + ph - 80.0 * ui_scale;
+        const byy: f32 = py + ph - 135.0 * ui_scale;
         const hw: f32 = (pw - 30.0 * ui_scale - 15.0 * ui_scale - 30.0 * ui_scale) / 2.0;
-        const btn_h: f32 = 50.0 * ui_scale;
-        if (Widgets.drawButton(ui, .{ .x = px + 30.0 * ui_scale, .y = byy, .width = hw, .height = btn_h }, "BACK", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        const btn_h: f32 = 45.0 * ui_scale;
+        if (Widgets.drawButton(ui, .{ .x = px + 30.0 * ui_scale, .y = byy, .width = pw - 60.0 * ui_scale, .height = btn_h }, "LOAD WORLD", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+            const wl_screen = try WorldListScreen.init(ctx.allocator, ctx);
+            errdefer wl_screen.deinit(wl_screen);
+            ctx.screen_manager.pushScreen(wl_screen.screen());
+        }
+
+        const byy2: f32 = byy + btn_h + 15.0 * ui_scale;
+        if (Widgets.drawButton(ui, .{ .x = px + 30.0 * ui_scale, .y = byy2, .width = hw, .height = btn_h }, "BACK", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             ctx.screen_manager.popScreen();
         }
-        if (Widgets.drawButton(ui, .{ .x = px + 30.0 * ui_scale + hw + 15.0 * ui_scale, .y = byy, .width = hw, .height = btn_h }, "CREATE", btn_scale, mouse_x, mouse_y, mouse_clicked) or ctx.input_mapper.isActionPressed(ctx.input, .ui_confirm)) {
-            // Seed is a 64-bit unsigned integer. If left blank, a random one is generated.
+        if (Widgets.drawButton(ui, .{ .x = px + 30.0 * ui_scale + hw + 15.0 * ui_scale, .y = byy2, .width = hw, .height = btn_h }, "CREATE", btn_scale, mouse_x, mouse_y, mouse_clicked) or ctx.input_mapper.isActionPressed(ctx.input, .ui_confirm)) {
             const seed = try seed_gen.resolveSeed(&self.seed_input, ctx.allocator);
             log.log.info("World seed: {} | Type: {s}", .{ seed, registry.getGeneratorInfo(self.selected_generator_index).name });
+            saveNewWorld(ctx.allocator, seed, self.selected_generator_index) catch |err| {
+                log.log.warn("Failed to save level.dat for new world: {}", .{err});
+            };
             const world_screen = try WorldScreen.init(ctx.allocator, ctx, seed, self.selected_generator_index);
             errdefer world_screen.deinit(world_screen);
             ctx.screen_manager.setScreen(world_screen.screen());
@@ -147,6 +158,39 @@ pub const SingleplayerScreen = struct {
         return Screen.makeScreen(@This(), self);
     }
 };
+
+fn saveNewWorld(allocator: std.mem.Allocator, seed: u64, generator_index: usize) !void {
+    const home = std.posix.getenv("HOME") orelse {
+        log.log.warn("Cannot save world: HOME not set", .{});
+        return;
+    };
+    var home_dir = std.fs.openDirAbsolute(home, .{}) catch |err| {
+        log.log.warn("Cannot save world: failed to open home dir: {}", .{err});
+        return;
+    };
+    defer home_dir.close();
+    home_dir.makePath(world_list.SAVE_DIR) catch |err| {
+        log.log.warn("Cannot save world: failed to create saves dir: {}", .{err});
+        return;
+    };
+    var dir_name_buf: [128]u8 = undefined;
+    const timestamp: i64 = @as(i64, @bitCast(seed_gen.randomSeedValue()));
+    const dir_name = std.fmt.bufPrint(&dir_name_buf, "world_{}", .{timestamp}) catch "world_new";
+    const world_dir_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ world_list.SAVE_DIR, dir_name });
+    defer allocator.free(world_dir_path);
+    home_dir.makePath(world_dir_path) catch |err| {
+        log.log.warn("Cannot save world: failed to create world dir: {}", .{err});
+        return;
+    };
+    var save_dir = home_dir.openDir(world_dir_path, .{}) catch |err| {
+        log.log.warn("Cannot save world: failed to open world dir: {}", .{err});
+        return;
+    };
+    defer save_dir.close();
+    world_list.writeLevelDat(allocator, save_dir, dir_name, seed, generator_index, timestamp) catch |err| {
+        log.log.warn("Cannot save world: failed to write level.dat: {}", .{err});
+    };
+}
 
 fn handleSeedTyping(seed_input: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, input: IRawInputProvider, max_len: usize) !void {
     if (input.isKeyPressed(.backspace)) {

--- a/src/game/screens/world_list.zig
+++ b/src/game/screens/world_list.zig
@@ -71,22 +71,25 @@ pub fn readLevelDat(allocator: std.mem.Allocator, save_dir: std.fs.Dir) ?LevelDa
         .string => |s| s,
         else => return null,
     };
+    const seed: u64 = switch (seed_val) {
+        .integer => |i| @intCast(i),
+        else => return null,
+    };
+    const last_played: i64 = if (last_val) |lv| switch (lv) {
+        .integer => |i| i,
+        else => 0,
+    } else 0;
+    const generator_index: usize = switch (gen_val) {
+        .integer => |i| @intCast(i),
+        else => 0,
+    };
     const name_copy = allocator.dupe(u8, name_str) catch return null;
     errdefer allocator.free(name_copy);
     return .{
         .name = name_copy,
-        .seed = switch (seed_val) {
-            .integer => |i| @intCast(i),
-            else => return null,
-        },
-        .last_played = if (last_val) |lv| switch (lv) {
-            .integer => |i| i,
-            else => 0,
-        } else 0,
-        .generator_index = switch (gen_val) {
-            .integer => |i| @intCast(i),
-            else => 0,
-        },
+        .seed = seed,
+        .last_played = last_played,
+        .generator_index = generator_index,
     };
 }
 
@@ -111,7 +114,10 @@ pub fn scanWorlds(allocator: std.mem.Allocator) ![]const WorldEntry {
         const name_alloc = allocator.dupe(u8, entry.name) catch continue;
         errdefer allocator.free(name_alloc);
         const level = readLevelDat(allocator, saves_dir);
-        const dir_buf = std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ home, SAVE_DIR, entry.name }) catch continue;
+        const dir_buf = std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ home, SAVE_DIR, entry.name }) catch {
+            allocator.free(name_alloc);
+            continue;
+        };
         errdefer allocator.free(dir_buf);
         if (level) |ld| {
             try entries.append(allocator, .{
@@ -140,6 +146,8 @@ fn compareWorldsByLastPlayed(_: void, a: WorldEntry, b: WorldEntry) bool {
     return a.last_played > b.last_played;
 }
 
+/// Deletes a world directory and frees dir_path.
+/// Logs errors but does not return them. Caller must not use dir_path after call.
 pub fn deleteWorld(allocator: std.mem.Allocator, dir_path: []const u8) void {
     const parent_path = std.fs.path.dirname(dir_path) orelse return;
     const base = std.fs.path.basename(dir_path);

--- a/src/game/screens/world_list.zig
+++ b/src/game/screens/world_list.zig
@@ -8,7 +8,6 @@ const Screen = @import("../screen.zig");
 const IScreen = Screen.IScreen;
 const EngineContext = Screen.EngineContext;
 const WorldScreen = @import("world.zig").WorldScreen;
-const c = @import("../../c.zig").c;
 const log = @import("../../engine/core/log.zig");
 
 const PANEL_WIDTH_MAX = 700.0;
@@ -350,8 +349,6 @@ pub const WorldListScreen = struct {
 
     fn confirmDelete(self: *@This(), idx: usize) !void {
         const allocator = self.context.allocator;
-        const entry_name = allocator.dupe(u8, self.worlds[idx].name) catch "<unknown>";
-        defer allocator.free(entry_name);
         const dir_path = self.worlds[idx].dir_path;
         deleteWorld(allocator, dir_path);
         for (self.worlds) |e| {
@@ -367,7 +364,7 @@ pub const WorldListScreen = struct {
 
 fn formatTimestamp(ts: i64) []const u8 {
     if (ts <= 0) return "NEVER";
-    const now: i64 = @as(i64, @intCast(c.SDL_GetTicks()));
+    const now: i64 = std.time.milliTimestamp();
     const diff = now - ts;
     if (diff < 0) return "NEVER";
     if (diff < 60000) return "JUST NOW";

--- a/src/game/screens/world_list.zig
+++ b/src/game/screens/world_list.zig
@@ -1,0 +1,374 @@
+const std = @import("std");
+const UISystem = @import("../../engine/ui/ui_system.zig").UISystem;
+const Color = @import("../../engine/ui/ui_system.zig").Color;
+const Rect = @import("../../engine/ui/ui_system.zig").Rect;
+const Font = @import("../../engine/ui/font.zig");
+const Widgets = @import("../../engine/ui/widgets.zig");
+const Screen = @import("../screen.zig");
+const IScreen = Screen.IScreen;
+const EngineContext = Screen.EngineContext;
+const WorldScreen = @import("world.zig").WorldScreen;
+const c = @import("../../c.zig").c;
+const log = @import("../../engine/core/log.zig");
+
+const PANEL_WIDTH_MAX = 700.0;
+const PANEL_HEIGHT_BASE = 500.0;
+const BG_COLOR = Color.rgba(0.12, 0.14, 0.18, 0.92);
+const BORDER_COLOR = Color.rgba(0.28, 0.33, 0.42, 1.0);
+const TITLE_COLOR = Color.rgba(0.92, 0.94, 0.97, 1.0);
+const LABEL_COLOR = Color.rgba(0.72, 0.78, 0.86, 1.0);
+const SELECTED_BG = Color.rgba(0.18, 0.24, 0.35, 0.95);
+const ROW_HOVER_BG = Color.rgba(0.16, 0.20, 0.28, 0.90);
+const ROW_BG = Color.rgba(0.10, 0.12, 0.16, 0.85);
+const DELETE_COLOR = Color.rgba(0.85, 0.25, 0.25, 1.0);
+const CONFIRM_BG = Color.rgba(0.18, 0.10, 0.10, 0.97);
+const CONFIRM_BORDER = Color.rgba(0.7, 0.2, 0.2, 1.0);
+
+pub const SAVE_DIR = ".local/share/zigcraft/saves";
+
+pub const WorldEntry = struct {
+    name: []const u8,
+    seed: u64,
+    last_played: i64,
+    generator_index: usize,
+    dir_path: []const u8,
+};
+
+pub const LevelDat = struct {
+    name: []const u8,
+    seed: u64,
+    last_played: i64,
+    generator_index: usize,
+};
+
+pub fn writeLevelDat(allocator: std.mem.Allocator, save_dir: std.fs.Dir, name: []const u8, seed: u64, generator_index: usize, last_played: i64) !void {
+    const payload = .{
+        .name = name,
+        .seed = seed,
+        .last_played = last_played,
+        .generator_index = generator_index,
+    };
+    const json_str = try std.json.Stringify.valueAlloc(allocator, payload, .{ .whitespace = .indent_2 });
+    defer allocator.free(json_str);
+    const file = try save_dir.createFile("level.dat", .{});
+    defer file.close();
+    try file.writeAll(json_str);
+}
+
+pub fn readLevelDat(allocator: std.mem.Allocator, save_dir: std.fs.Dir) ?LevelDat {
+    const content = save_dir.readFileAlloc("level.dat", allocator, @enumFromInt(4096)) catch return null;
+    defer allocator.free(content);
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, content, .{}) catch return null;
+    defer parsed.deinit();
+    const root = parsed.value;
+    if (root != .object) return null;
+    const obj = root.object;
+    const name_val = obj.get("name") orelse return null;
+    const seed_val = obj.get("seed") orelse return null;
+    const gen_val = obj.get("generator_index") orelse return null;
+    const last_val = obj.get("last_played");
+    const name_str = switch (name_val) {
+        .string => |s| s,
+        else => return null,
+    };
+    const name_copy = allocator.dupe(u8, name_str) catch return null;
+    return .{
+        .name = name_copy,
+        .seed = switch (seed_val) {
+            .integer => |i| @intCast(i),
+            else => return null,
+        },
+        .last_played = if (last_val) |lv| switch (lv) {
+            .integer => |i| i,
+            else => 0,
+        } else 0,
+        .generator_index = switch (gen_val) {
+            .integer => |i| @intCast(i),
+            else => 0,
+        },
+    };
+}
+
+pub fn scanWorlds(allocator: std.mem.Allocator) ![]const WorldEntry {
+    const home = std.posix.getenv("HOME") orelse return &[_]WorldEntry{};
+    var home_dir = std.fs.openDirAbsolute(home, .{}) catch return &[_]WorldEntry{};
+    defer home_dir.close();
+    home_dir.makePath(SAVE_DIR) catch {};
+    var saves_dir = home_dir.openDir(SAVE_DIR, .{ .iterate = true }) catch return &[_]WorldEntry{};
+    defer saves_dir.close();
+    var entries = std.ArrayList(WorldEntry).empty;
+    errdefer {
+        for (entries.items) |e| {
+            allocator.free(e.name);
+            allocator.free(e.dir_path);
+        }
+        entries.deinit(allocator);
+    }
+    var iter = saves_dir.iterate();
+    while (try iter.next()) |entry| {
+        if (entry.kind != .directory) continue;
+        const name_alloc = allocator.dupe(u8, entry.name) catch continue;
+        errdefer allocator.free(name_alloc);
+        const level = readLevelDat(allocator, saves_dir);
+        const dir_buf = std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ home, SAVE_DIR, entry.name }) catch continue;
+        if (level) |ld| {
+            try entries.append(allocator, .{
+                .name = ld.name,
+                .seed = ld.seed,
+                .last_played = ld.last_played,
+                .generator_index = ld.generator_index,
+                .dir_path = dir_buf,
+            });
+            allocator.free(name_alloc);
+        } else {
+            try entries.append(allocator, .{
+                .name = name_alloc,
+                .seed = 0,
+                .last_played = 0,
+                .generator_index = 0,
+                .dir_path = dir_buf,
+            });
+        }
+    }
+    std.sort.block(WorldEntry, entries.items, {}, compareWorldsByLastPlayed);
+    return try entries.toOwnedSlice(allocator);
+}
+
+fn compareWorldsByLastPlayed(_: void, a: WorldEntry, b: WorldEntry) bool {
+    return a.last_played > b.last_played;
+}
+
+pub fn deleteWorld(allocator: std.mem.Allocator, dir_path: []const u8) !void {
+    const parent_path = std.fs.path.dirname(dir_path) orelse return;
+    const base = std.fs.path.basename(dir_path);
+    var parent = std.fs.openDirAbsolute(parent_path, .{ .iterate = true }) catch |err| {
+        log.log.err("Failed to open parent dir for deletion: {}", .{err});
+        return err;
+    };
+    defer parent.close();
+    parent.deleteTree(base) catch |err| {
+        log.log.warn("Failed to remove world directory: {}", .{err});
+    };
+    allocator.free(dir_path);
+}
+
+pub const WorldListScreen = struct {
+    context: EngineContext,
+    worlds: []const WorldEntry,
+    selected: ?usize,
+    scroll_offset: f32,
+    confirm_delete: bool,
+
+    pub const vtable = IScreen.VTable{
+        .deinit = deinit,
+        .update = update,
+        .draw = draw,
+        .onEnter = onEnter,
+    };
+
+    pub fn init(allocator: std.mem.Allocator, context: EngineContext) !*WorldListScreen {
+        const self = try allocator.create(WorldListScreen);
+        errdefer allocator.destroy(self);
+        const worlds = scanWorlds(allocator) catch &[_]WorldEntry{};
+        self.* = .{
+            .context = context,
+            .worlds = worlds,
+            .selected = null,
+            .scroll_offset = 0.0,
+            .confirm_delete = false,
+        };
+        return self;
+    }
+
+    pub fn deinit(ptr: *anyopaque) void {
+        const self: *@This() = @ptrCast(@alignCast(ptr));
+        for (self.worlds) |e| {
+            self.context.allocator.free(e.name);
+            if (e.dir_path.len > 0) self.context.allocator.free(e.dir_path);
+        }
+        self.context.allocator.free(self.worlds);
+        self.context.allocator.destroy(self);
+    }
+
+    pub fn update(ptr: *anyopaque, dt: f32) !void {
+        const self: *@This() = @ptrCast(@alignCast(ptr));
+        _ = dt;
+        if (self.context.input_mapper.isActionPressed(self.context.input, .ui_back)) {
+            if (self.confirm_delete) {
+                self.confirm_delete = false;
+            } else {
+                self.context.screen_manager.popScreen();
+            }
+        }
+    }
+
+    pub fn draw(ptr: *anyopaque, ui: *UISystem) !void {
+        const self: *@This() = @ptrCast(@alignCast(ptr));
+        const ctx = self.context;
+        ui.begin();
+        defer ui.end();
+        const mouse_pos = ctx.input.getMousePosition();
+        const mx: f32 = @floatFromInt(mouse_pos.x);
+        const my: f32 = @floatFromInt(mouse_pos.y);
+        const mc = ctx.input.isMouseButtonPressed(.left);
+        const screen_w: f32 = @floatFromInt(ctx.input.getWindowWidth());
+        const screen_h: f32 = @floatFromInt(ctx.input.getWindowHeight());
+        const ui_scale: f32 = @max(1.0, screen_h / 720.0);
+        const title_scale: f32 = 3.5 * ui_scale;
+        const label_scale: f32 = 2.0 * ui_scale;
+        const btn_scale: f32 = 2.0 * ui_scale;
+        const row_scale: f32 = 1.8 * ui_scale;
+        const pw: f32 = @min(screen_w * 0.75, PANEL_WIDTH_MAX * ui_scale);
+        const ph: f32 = PANEL_HEIGHT_BASE * ui_scale;
+        const px: f32 = (screen_w - pw) * 0.5;
+        const py: f32 = screen_h * 0.12;
+        ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = ph }, BG_COLOR);
+        ui.drawRectOutline(.{ .x = px, .y = py, .width = pw, .height = ph }, BORDER_COLOR, 2.0 * ui_scale);
+        Font.drawTextCentered(ui, "LOAD WORLD", screen_w * 0.5, py + 18.0 * ui_scale, title_scale, TITLE_COLOR);
+        const scroll_dy = ctx.input.getScrollDelta().y;
+        self.scroll_offset -= scroll_dy * 30.0 * ui_scale;
+        const list_top: f32 = py + 65.0 * ui_scale;
+        const list_bottom: f32 = py + ph - 90.0 * ui_scale;
+        const row_h: f32 = 55.0 * ui_scale;
+        const max_scroll = @max(0.0, @as(f32, @floatFromInt(self.worlds.len)) * row_h - (list_bottom - list_top));
+        self.scroll_offset = @max(0.0, @min(self.scroll_offset, max_scroll));
+        ui.drawRect(.{ .x = px + 2.0, .y = list_top, .width = pw - 4.0, .height = list_bottom - list_top }, Color.rgba(0.05, 0.06, 0.08, 0.6));
+        if (self.worlds.len == 0) {
+            Font.drawTextCentered(ui, "NO SAVED WORLDS FOUND", screen_w * 0.5, list_top + (list_bottom - list_top) * 0.4, label_scale, LABEL_COLOR);
+            Font.drawTextCentered(ui, "CREATE A NEW WORLD FIRST", screen_w * 0.5, list_top + (list_bottom - list_top) * 0.4 + 25.0 * ui_scale, label_scale * 0.7, Color.rgba(0.5, 0.55, 0.6, 1.0));
+        }
+        const clip_top = list_top;
+        const clip_bottom = list_bottom;
+        _ = clip_top;
+        _ = clip_bottom;
+        var i: usize = 0;
+        while (i < self.worlds.len) : (i += 1) {
+            const ry: f32 = list_top + @as(f32, @floatFromInt(i)) * row_h - self.scroll_offset;
+            if (ry + row_h < list_top or ry > list_bottom) continue;
+            const world = self.worlds[i];
+            const row_rect = Rect{ .x = px + 6.0 * ui_scale, .y = ry, .width = pw - 12.0 * ui_scale, .height = row_h - 4.0 * ui_scale };
+            const row_hovered = row_rect.contains(mx, my);
+            const is_selected = self.selected == i;
+            if (is_selected) {
+                ui.drawRect(row_rect, SELECTED_BG);
+            } else if (row_hovered) {
+                ui.drawRect(row_rect, ROW_HOVER_BG);
+            } else {
+                ui.drawRect(row_rect, ROW_BG);
+            }
+            ui.drawRectOutline(row_rect, if (is_selected) Color.rgba(0.5, 0.7, 0.95, 1.0) else Color.rgba(0.2, 0.25, 0.3, 1.0), 1.0);
+            if (mc and row_hovered and !self.confirm_delete) {
+                self.selected = i;
+            }
+            const text_x: f32 = row_rect.x + 12.0 * ui_scale;
+            const name_y: f32 = ry + 8.0 * ui_scale;
+            Font.drawText(ui, world.name, text_x, name_y, row_scale, TITLE_COLOR);
+            var seed_buf: [64]u8 = undefined;
+            const seed_text = std.fmt.bufPrint(&seed_buf, "SEED: {}", .{world.seed}) catch "SEED: ???";
+            Font.drawText(ui, seed_text, text_x, name_y + 18.0 * ui_scale, row_scale * 0.65, LABEL_COLOR);
+            const last_text = formatTimestamp(world.last_played);
+            const seed_w = Font.measureTextWidth(seed_text, row_scale * 0.65);
+            Font.drawText(ui, last_text, text_x + seed_w + 15.0 * ui_scale, name_y + 18.0 * ui_scale, row_scale * 0.65, Color.rgba(0.5, 0.55, 0.6, 1.0));
+        }
+        const btn_h: f32 = 46.0 * ui_scale;
+        const byy: f32 = py + ph - 70.0 * ui_scale;
+        const btn_w: f32 = (pw - 40.0 * ui_scale) / 3.0;
+        const bx_base: f32 = px + 10.0 * ui_scale;
+        if (Widgets.drawButton(ui, .{ .x = bx_base, .y = byy, .width = btn_w, .height = btn_h }, "BACK", btn_scale, mx, my, mc)) {
+            ctx.screen_manager.popScreen();
+        }
+        const load_enabled = self.selected != null and !self.confirm_delete;
+        if (!load_enabled) {
+            ui.drawRect(.{ .x = bx_base + btn_w + 10.0 * ui_scale, .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.1, 0.12, 0.16, 0.7));
+            ui.drawRectOutline(.{ .x = bx_base + btn_w + 10.0 * ui_scale, .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.2, 0.22, 0.26, 1.0), 2.0);
+            Font.drawTextCentered(ui, "LOAD", bx_base + btn_w + 10.0 * ui_scale + btn_w * 0.5, byy + (btn_h - 7.0 * btn_scale) * 0.5, btn_scale, Color.rgba(0.4, 0.42, 0.46, 1.0));
+        } else {
+            if (Widgets.drawButton(ui, .{ .x = bx_base + btn_w + 10.0 * ui_scale, .y = byy, .width = btn_w, .height = btn_h }, "LOAD", btn_scale, mx, my, mc)) {
+                if (self.selected) |idx| {
+                    try self.loadWorld(idx);
+                }
+            }
+        }
+        const del_enabled = self.selected != null and !self.confirm_delete;
+        if (!del_enabled) {
+            ui.drawRect(.{ .x = bx_base + 2.0 * (btn_w + 10.0 * ui_scale), .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.1, 0.1, 0.12, 0.7));
+            ui.drawRectOutline(.{ .x = bx_base + 2.0 * (btn_w + 10.0 * ui_scale), .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.2, 0.2, 0.22, 1.0), 2.0);
+            Font.drawTextCentered(ui, "DELETE", bx_base + 2.0 * (btn_w + 10.0 * ui_scale) + btn_w * 0.5, byy + (btn_h - 7.0 * btn_scale) * 0.5, btn_scale, Color.rgba(0.4, 0.35, 0.35, 1.0));
+        } else {
+            if (Widgets.drawButton(ui, .{ .x = bx_base + 2.0 * (btn_w + 10.0 * ui_scale), .y = byy, .width = btn_w, .height = btn_h }, "DELETE", btn_scale, mx, my, mc)) {
+                self.confirm_delete = true;
+            }
+        }
+        if (self.confirm_delete) {
+            if (self.selected) |idx| {
+                const cw: f32 = 420.0 * ui_scale;
+                const ch: f32 = 160.0 * ui_scale;
+                const cx: f32 = (screen_w - cw) * 0.5;
+                const cy: f32 = (screen_h - ch) * 0.5;
+                ui.drawRect(.{ .x = 0, .y = 0, .width = screen_w, .height = screen_h }, Color.rgba(0, 0, 0, 0.6));
+                ui.drawRect(.{ .x = cx, .y = cy, .width = cw, .height = ch }, CONFIRM_BG);
+                ui.drawRectOutline(.{ .x = cx, .y = cy, .width = cw, .height = ch }, CONFIRM_BORDER, 2.0);
+                const msg_scale: f32 = 1.8 * ui_scale;
+                Font.drawTextCentered(ui, "DELETE WORLD?", cx + cw * 0.5, cy + 20.0 * ui_scale, msg_scale, DELETE_COLOR);
+                var name_buf: [128]u8 = undefined;
+                const confirm_msg = std.fmt.bufPrint(&name_buf, "'{s}'", .{self.worlds[idx].name}) catch "'?'";
+                Font.drawTextCentered(ui, confirm_msg, cx + cw * 0.5, cy + 50.0 * ui_scale, msg_scale * 0.8, LABEL_COLOR);
+                Font.drawTextCentered(ui, "THIS CANNOT BE UNDONE", cx + cw * 0.5, cy + 72.0 * ui_scale, msg_scale * 0.65, Color.rgba(0.7, 0.5, 0.5, 1.0));
+                const cbw: f32 = (cw - 30.0 * ui_scale) / 2.0;
+                const cby: f32 = cy + ch - 55.0 * ui_scale;
+                if (Widgets.drawButton(ui, .{ .x = cx + 10.0 * ui_scale, .y = cby, .width = cbw, .height = 40.0 * ui_scale }, "CANCEL", btn_scale, mx, my, mc)) {
+                    self.confirm_delete = false;
+                }
+                if (Widgets.drawButton(ui, .{ .x = cx + cbw + 20.0 * ui_scale, .y = cby, .width = cbw, .height = 40.0 * ui_scale }, "CONFIRM", btn_scale, mx, my, mc)) {
+                    self.confirmDelete(idx) catch {};
+                }
+            }
+        }
+    }
+
+    pub fn onEnter(ptr: *anyopaque) void {
+        const self: *@This() = @ptrCast(@alignCast(ptr));
+        self.context.input.setMouseCapture(self.context.window_manager.window, false);
+    }
+
+    pub fn screen(self: *@This()) IScreen {
+        return Screen.makeScreen(@This(), self);
+    }
+
+    fn loadWorld(self: *@This(), idx: usize) !void {
+        const world = self.worlds[idx];
+        const world_screen = try WorldScreen.init(self.context.allocator, self.context, world.seed, world.generator_index);
+        errdefer world_screen.deinit(world_screen);
+        self.context.screen_manager.setScreen(world_screen.screen());
+    }
+
+    fn confirmDelete(self: *@This(), idx: usize) !void {
+        const allocator = self.context.allocator;
+        const entry_name = allocator.dupe(u8, self.worlds[idx].name) catch "<unknown>";
+        defer allocator.free(entry_name);
+        const dir_path = self.worlds[idx].dir_path;
+        deleteWorld(allocator, dir_path) catch {
+            log.log.err("Failed to delete world: {s}", .{entry_name});
+        };
+        for (self.worlds) |e| {
+            allocator.free(e.name);
+        }
+        allocator.free(self.worlds);
+        self.worlds = scanWorlds(allocator) catch &[_]WorldEntry{};
+        self.selected = null;
+        self.confirm_delete = false;
+        self.scroll_offset = 0.0;
+    }
+};
+
+fn formatTimestamp(ts: i64) []const u8 {
+    if (ts <= 0) return "NEVER";
+    const now: i64 = @as(i64, @intCast(c.SDL_GetTicks()));
+    const diff = now - ts;
+    if (diff < 0) return "NEVER";
+    if (diff < 60000) return "JUST NOW";
+    if (diff < 3600000) return "EARLIER";
+    if (diff < 86400000) return "TODAY";
+    if (diff < 172800000) return "YESTERDAY";
+    return "OLDER";
+}

--- a/src/game/screens/world_list.zig
+++ b/src/game/screens/world_list.zig
@@ -364,7 +364,10 @@ pub const WorldListScreen = struct {
 
 fn formatTimestamp(ts: i64) []const u8 {
     if (ts <= 0) return "NEVER";
-    const now: i64 = std.time.milliTimestamp();
+    const now: i64 = blk: {
+        const t = std.posix.clock_gettime(std.posix.CLOCK.REALTIME) catch return "NEVER";
+        break :blk t.sec * 1000 + @divTrunc(t.nsec, 1000000);
+    };
     const diff = now - ts;
     if (diff < 0) return "NEVER";
     if (diff < 60000) return "JUST NOW";

--- a/src/game/screens/world_list.zig
+++ b/src/game/screens/world_list.zig
@@ -72,6 +72,7 @@ pub fn readLevelDat(allocator: std.mem.Allocator, save_dir: std.fs.Dir) ?LevelDa
         else => return null,
     };
     const name_copy = allocator.dupe(u8, name_str) catch return null;
+    errdefer allocator.free(name_copy);
     return .{
         .name = name_copy,
         .seed = switch (seed_val) {
@@ -111,6 +112,7 @@ pub fn scanWorlds(allocator: std.mem.Allocator) ![]const WorldEntry {
         errdefer allocator.free(name_alloc);
         const level = readLevelDat(allocator, saves_dir);
         const dir_buf = std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ home, SAVE_DIR, entry.name }) catch continue;
+        errdefer allocator.free(dir_buf);
         if (level) |ld| {
             try entries.append(allocator, .{
                 .name = ld.name,
@@ -138,12 +140,12 @@ fn compareWorldsByLastPlayed(_: void, a: WorldEntry, b: WorldEntry) bool {
     return a.last_played > b.last_played;
 }
 
-pub fn deleteWorld(allocator: std.mem.Allocator, dir_path: []const u8) !void {
+pub fn deleteWorld(allocator: std.mem.Allocator, dir_path: []const u8) void {
     const parent_path = std.fs.path.dirname(dir_path) orelse return;
     const base = std.fs.path.basename(dir_path);
     var parent = std.fs.openDirAbsolute(parent_path, .{ .iterate = true }) catch |err| {
         log.log.err("Failed to open parent dir for deletion: {}", .{err});
-        return err;
+        return;
     };
     defer parent.close();
     parent.deleteTree(base) catch |err| {
@@ -237,10 +239,6 @@ pub const WorldListScreen = struct {
             Font.drawTextCentered(ui, "NO SAVED WORLDS FOUND", screen_w * 0.5, list_top + (list_bottom - list_top) * 0.4, label_scale, LABEL_COLOR);
             Font.drawTextCentered(ui, "CREATE A NEW WORLD FIRST", screen_w * 0.5, list_top + (list_bottom - list_top) * 0.4 + 25.0 * ui_scale, label_scale * 0.7, Color.rgba(0.5, 0.55, 0.6, 1.0));
         }
-        const clip_top = list_top;
-        const clip_bottom = list_bottom;
-        _ = clip_top;
-        _ = clip_bottom;
         var i: usize = 0;
         while (i < self.worlds.len) : (i += 1) {
             const ry: f32 = list_top + @as(f32, @floatFromInt(i)) * row_h - self.scroll_offset;
@@ -347,9 +345,7 @@ pub const WorldListScreen = struct {
         const entry_name = allocator.dupe(u8, self.worlds[idx].name) catch "<unknown>";
         defer allocator.free(entry_name);
         const dir_path = self.worlds[idx].dir_path;
-        deleteWorld(allocator, dir_path) catch {
-            log.log.err("Failed to delete world: {s}", .{entry_name});
-        };
+        deleteWorld(allocator, dir_path);
         for (self.worlds) |e| {
             allocator.free(e.name);
         }

--- a/src/game/world_list_tests.zig
+++ b/src/game/world_list_tests.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+const testing = std.testing;
+const world_list = @import("screens/world_list.zig");
+
+test "writeLevelDat creates valid JSON" {
+    const allocator = testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try world_list.writeLevelDat(allocator, tmp_dir.dir, "TestWorld", 12345, 0, 100000);
+    const content = try tmp_dir.dir.readFileAlloc("level.dat", allocator, @enumFromInt(4096));
+    defer allocator.free(content);
+    try testing.expect(content.len > 0);
+    try testing.expect(std.mem.indexOf(u8, content, "TestWorld") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "12345") != null);
+}
+
+test "readLevelDat returns correct values" {
+    const allocator = testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try world_list.writeLevelDat(allocator, tmp_dir.dir, "MyWorld", 99887766, 1, 200000);
+    const result = world_list.readLevelDat(allocator, tmp_dir.dir);
+    try testing.expect(result != null);
+    defer allocator.free(result.?.name);
+    try testing.expectEqualStrings("MyWorld", result.?.name);
+    try testing.expectEqual(@as(u64, 99887766), result.?.seed);
+    try testing.expectEqual(@as(usize, 1), result.?.generator_index);
+    try testing.expect(result.?.last_played > 0);
+}
+
+test "readLevelDat returns null for missing file" {
+    const allocator = testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const result = world_list.readLevelDat(allocator, tmp_dir.dir);
+    try testing.expect(result == null);
+}
+
+test "readLevelDat returns null for invalid JSON" {
+    const allocator = testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const file = try tmp_dir.dir.createFile("level.dat", .{});
+    defer file.close();
+    try file.writeAll("not valid json!!!");
+    const result = world_list.readLevelDat(allocator, tmp_dir.dir);
+    try testing.expect(result == null);
+}
+
+test "writeLevelDat overwrites existing" {
+    const allocator = testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try world_list.writeLevelDat(allocator, tmp_dir.dir, "First", 100, 0, 100000);
+    try world_list.writeLevelDat(allocator, tmp_dir.dir, "Second", 200, 1, 200000);
+    const result = world_list.readLevelDat(allocator, tmp_dir.dir);
+    try testing.expect(result != null);
+    defer allocator.free(result.?.name);
+    try testing.expectEqualStrings("Second", result.?.name);
+    try testing.expectEqual(@as(u64, 200), result.?.seed);
+    try testing.expectEqual(@as(usize, 1), result.?.generator_index);
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -89,6 +89,7 @@ test {
     _ = @import("game/inventory_tests.zig");
     _ = @import("game/screen_tests.zig");
     _ = @import("game/session_tests.zig");
+    _ = @import("game/world_list_tests.zig");
     _ = @import("world/persistence/region_file.zig");
     _ = @import("world/persistence/chunk_serializer.zig");
     _ = @import("world/meshing/quadric_simplifier.zig");


### PR DESCRIPTION
## Summary

Closes #382

- **WorldListScreen** (`src/game/screens/world_list.zig`): New screen with scrollable world list, row selection, LOAD and DELETE buttons, and delete confirmation dialog. Scans `~/.local/share/zigcraft/saves/` for world directories.
- **level.dat persistence**: JSON-based world metadata (name, seed, generator_index, last_played timestamp). Written on world creation, read when scanning saves. Worlds sorted by most recently played.
- **SingleplayerScreen**: Added "LOAD WORLD" button that navigates to WorldListScreen. World creation now writes a `level.dat` to a timestamped save directory.
- **Tests** (`src/game/world_list_tests.zig`): Unit tests for `writeLevelDat`, `readLevelDat` (valid/missing/invalid JSON, overwrite behavior).

### Files Created
- `src/game/screens/world_list.zig` — WorldListScreen, WorldEntry, level.dat read/write, save scanning
- `src/game/world_list_tests.zig` — Unit tests

### Files Modified
- `src/game/screens/singleplayer.zig` — LOAD WORLD button, level.dat write on creation
- `src/tests.zig` — Import new test file

### Notes
- The load path currently creates a fresh world using the saved seed/generator. Full chunk-level save/load integration (Step 3 from the issue) requires the SaveManager to be built on top of the existing persistence APIs (#377/#372), which is a follow-up task.
- GameSession `save_dir` parameter support is deferred to that follow-up since it depends on SaveManager.