### PR TITLE
fix(ci): increase opencode workflow timeouts and pin action to @latest

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: write
@@ -85,7 +85,7 @@ jobs:
           mkdir -p /tmp/opencode-cache ~/.local/share/opencode
 
       - name: Run opencode audit
-        uses: anomalyco/opencode/github@v1.3.3
+        uses: anomalyco/opencode/github@latest
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   write-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       id-token: write
       contents: write
@@ -190,7 +190,7 @@ jobs:
       # XDG_CACHE_HOME=/tmp — non-persistent but avoids permission issues (see opencode-audit.yml)
       - name: Run opencode test writer
         if: steps.check-existing.outputs.skip != 'true'
-        uses: anomalyco/opencode/github@v1.3.3
+        uses: anomalyco/opencode/github@latest
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}


### PR DESCRIPTION
## Summary

The `opencode-test-writer` and `opencode-audit` workflows have been failing due to timeouts and auth issues:
- **test-writer**: Last 4 consecutive runs all hit the 30-min timeout. The agent writes tests, enters a slow test-fix loop (each `nix develop --command zig build test` takes several minutes), and gets killed before it can push/PR.
- **audit**: Recent runs hit the 15-min ceiling during deep code analysis, and one run found a real bug (ECS memory leak) but couldn't create the issue due to the action version's token handling.

## Changes
- `opencode-test-writer.yml`: `timeout-minutes: 30` → `60`
- `opencode-audit.yml`: `timeout-minutes: 15` → `30`
- Both: `anomalyco/opencode/github@v1.3.3` → `@latest` (matches the working `opencode.yml`)

## Verification
- [x] YAML syntax valid
- [x] No other workflow files modified