### PR TITLE
feat: GPU depth pyramid generation shader (#383)

### DIFF
--- a/assets/shaders/vulkan/depth_pyramid.comp
+++ b/assets/shaders/vulkan/depth_pyramid.comp
@@ -1,0 +1,27 @@
+#version 450
+
+layout(local_size_x = 8, local_size_y = 8) in;
+
+layout(binding = 0) uniform sampler2D src_depth;
+layout(binding = 1, r32f) uniform writeonly image2D dst_depth;
+
+layout(push_constant) uniform PushConstants {
+    uint mip_level;
+    vec2 inv_src_size;
+} pc;
+
+void main() {
+    ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 dst_size = imageSize(dst_depth);
+    if (coord.x >= dst_size.x || coord.y >= dst_size.y) return;
+
+    vec2 uv = (vec2(coord * 2) + 1.0) * pc.inv_src_size * 0.5;
+
+    float d00 = textureLod(src_depth, uv, pc.mip_level).r;
+    float d10 = textureLodOffset(src_depth, uv, pc.mip_level, ivec2(1, 0)).r;
+    float d01 = textureLodOffset(src_depth, uv, pc.mip_level, ivec2(0, 1)).r;
+    float d11 = textureLodOffset(src_depth, uv, pc.mip_level, ivec2(1, 1)).r;
+
+    float max_depth = max(max(d00, d10), max(d01, d11));
+    imageStore(dst_depth, coord, vec4(max_depth, 0.0, 0.0, 0.0));
+}

--- a/build.zig
+++ b/build.zig
@@ -184,6 +184,7 @@ pub fn build(b: *std.Build) void {
     const validate_vulkan_lpv_inject_comp = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/lpv_inject.comp" });
     const validate_vulkan_lpv_propagate_comp = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/lpv_propagate.comp" });
     const validate_vulkan_culling_comp = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/culling.comp" });
+    const validate_vulkan_depth_pyramid_comp = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/depth_pyramid.comp" });
 
     test_step.dependOn(&validate_vulkan_terrain_vert.step);
     test_step.dependOn(&validate_vulkan_terrain_frag.step);
@@ -208,4 +209,5 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&validate_vulkan_lpv_inject_comp.step);
     test_step.dependOn(&validate_vulkan_lpv_propagate_comp.step);
     test_step.dependOn(&validate_vulkan_culling_comp.step);
+    test_step.dependOn(&validate_vulkan_depth_pyramid_comp.step);
 }

--- a/src/engine/graphics/render_graph.zig
+++ b/src/engine/graphics/render_graph.zig
@@ -284,6 +284,25 @@ pub const SSAOPass = struct {
     }
 };
 
+pub const DepthPyramidPass = struct {
+    const VTABLE = IRenderPass.VTable{
+        .name = "DepthPyramidPass",
+        .needs_main_pass = false,
+        .execute = execute,
+    };
+    pub fn pass(self: *DepthPyramidPass) IRenderPass {
+        return .{
+            .ptr = self,
+            .vtable = &VTABLE,
+        };
+    }
+
+    fn execute(ptr: *anyopaque, ctx: SceneContext) anyerror!void {
+        _ = ptr;
+        ctx.render_ctx.computeDepthPyramid();
+    }
+};
+
 pub const SkyPass = struct {
     const VTABLE = IRenderPass.VTable{
         .name = "SkyPass",

--- a/src/engine/graphics/render_system.zig
+++ b/src/engine/graphics/render_system.zig
@@ -34,6 +34,7 @@ pub const RenderSystem = struct {
     shadow_passes: [4]render_graph_pkg.ShadowPass,
     g_pass: render_graph_pkg.GPass,
     ssao_pass: render_graph_pkg.SSAOPass,
+    depth_pyramid_pass: render_graph_pkg.DepthPyramidPass,
     sky_pass: render_graph_pkg.SkyPass,
     opaque_pass: render_graph_pkg.OpaquePass,
     cloud_pass: render_graph_pkg.CloudPass,
@@ -166,6 +167,7 @@ pub const RenderSystem = struct {
             },
             .g_pass = .{},
             .ssao_pass = .{},
+            .depth_pyramid_pass = .{},
             .sky_pass = .{},
             .opaque_pass = .{},
             .cloud_pass = .{},
@@ -209,6 +211,7 @@ pub const RenderSystem = struct {
             try self.render_graph.addPass(self.shadow_passes[3].pass());
             try self.render_graph.addPass(self.g_pass.pass());
             try self.render_graph.addPass(self.ssao_pass.pass());
+            try self.render_graph.addPass(self.depth_pyramid_pass.pass());
             try self.render_graph.addPass(self.sky_pass.pass());
             try self.render_graph.addPass(self.opaque_pass.pass());
             try self.render_graph.addPass(self.cloud_pass.pass());

--- a/src/engine/graphics/rhi.zig
+++ b/src/engine/graphics/rhi.zig
@@ -269,6 +269,9 @@ pub const RenderContext = struct {
     pub fn computeTAA(self: RenderContext) void {
         self.render.computeTAA();
     }
+    pub fn computeDepthPyramid(self: RenderContext) void {
+        self.render.computeDepthPyramid();
+    }
     pub fn requestSwapchainRecreate(self: RenderContext) void {
         self.render.requestSwapchainRecreate();
     }
@@ -616,6 +619,8 @@ pub const IRenderContext = struct {
         computeBloom: *const fn (ptr: *anyopaque) void,
         // TAA pass
         computeTAA: *const fn (ptr: *anyopaque) void,
+        // Depth pyramid
+        computeDepthPyramid: *const fn (ptr: *anyopaque) void,
         getEncoder: *const fn (ptr: *anyopaque) IGraphicsCommandEncoder,
         getStateContext: *const fn (ptr: *anyopaque) IRenderStateContext,
 
@@ -679,6 +684,9 @@ pub const IRenderContext = struct {
     }
     pub fn computeTAA(self: IRenderContext) void {
         self.vtable.computeTAA(self.ptr);
+    }
+    pub fn computeDepthPyramid(self: IRenderContext) void {
+        self.vtable.computeDepthPyramid(self.ptr);
     }
     pub fn requestSwapchainRecreate(self: IRenderContext) void {
         self.vtable.requestSwapchainRecreate(self.ptr);
@@ -1051,6 +1059,9 @@ pub const RHI = struct {
     }
     pub fn computeTAA(self: RHI) void {
         self.vtable.render.computeTAA(self.ptr);
+    }
+    pub fn computeDepthPyramid(self: RHI) void {
+        self.vtable.render.computeDepthPyramid(self.ptr);
     }
     pub fn setTextureUniforms(self: RHI, enabled: bool, handles: [SHADOW_CASCADE_COUNT]TextureHandle) void {
         self.vtable.render.setTextureUniforms(self.ptr, enabled, handles);

--- a/src/engine/graphics/rhi_tests.zig
+++ b/src/engine/graphics/rhi_tests.zig
@@ -180,6 +180,7 @@ const MockContext = struct {
         .requestSwapchainRecreate = undefined,
         .computeBloom = undefined,
         .computeTAA = undefined,
+        .computeDepthPyramid = undefined,
         .getEncoder = MockContext.getEncoder,
         .getStateContext = MockContext.getStateContext,
         .setClearColor = undefined,

--- a/src/engine/graphics/rhi_vulkan.zig
+++ b/src/engine/graphics/rhi_vulkan.zig
@@ -231,6 +231,24 @@ fn setBloomIntensity(ctx_ptr: *anyopaque, intensity: f32) void {
     ctx.bloom.intensity = intensity;
 }
 
+fn computeDepthPyramid(ctx_ptr: *anyopaque) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    ctx.mutex.lock();
+    defer ctx.mutex.unlock();
+    if (!ctx.frames.frame_in_progress) return;
+    if (ctx.depth_pyramid.pipeline == null) return;
+    pass_orchestration.ensureNoRenderPassActiveInternal(ctx);
+
+    const command_buffer = ctx.frames.command_buffers[ctx.frames.current_frame];
+    ctx.depth_pyramid.compute(
+        command_buffer,
+        ctx.frames.current_frame,
+        ctx.gpass.g_depth_image,
+        ctx.gpass.g_pass_extent.width,
+        ctx.gpass.g_pass_extent.height,
+    );
+}
+
 fn setVignetteEnabled(ctx_ptr: *anyopaque, enabled: bool) void {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
     ctx.post_process_state.vignette_enabled = enabled;
@@ -765,6 +783,7 @@ const VULKAN_RHI_VTABLE = rhi.RHI.VTable{
         .requestSwapchainRecreate = requestSwapchainRecreate,
         .computeBloom = computeBloom,
         .computeTAA = computeTAA,
+        .computeDepthPyramid = computeDepthPyramid,
         .getEncoder = getEncoder,
         .getStateContext = getStateContext,
         .getNativeSkyPipeline = getNativeSkyPipeline,

--- a/src/engine/graphics/vulkan/depth_pyramid.zig
+++ b/src/engine/graphics/vulkan/depth_pyramid.zig
@@ -1,0 +1,480 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const c = @import("../../../c.zig").c;
+const rhi = @import("../rhi.zig");
+const log = @import("../../core/log.zig");
+const Utils = @import("utils.zig");
+const VulkanDevice = @import("device.zig").VulkanDevice;
+
+pub const DEPTH_PYRAMID_SHADER_PATH = "assets/shaders/vulkan/depth_pyramid.comp.spv";
+pub const DEPTH_PYRAMID_WORKGROUP_SIZE: u32 = 8;
+const MAX_MIP_LEVELS: u32 = 16;
+const MAX_FRAMES_IN_FLIGHT = rhi.MAX_FRAMES_IN_FLIGHT;
+
+const PushConstants = extern struct {
+    mip_level: u32,
+    inv_src_size: [2]f32,
+};
+
+pub const DepthPyramidSystem = struct {
+    pyramid_image: c.VkImage = null,
+    pyramid_memory: c.VkDeviceMemory = null,
+    pyramid_view: c.VkImageView = null,
+    pyramid_sampler: c.VkSampler = null,
+    mip_count: u32 = 0,
+    mip_widths: [MAX_MIP_LEVELS]u32 = .{0} ** MAX_MIP_LEVELS,
+    mip_heights: [MAX_MIP_LEVELS]u32 = .{0} ** MAX_MIP_LEVELS,
+
+    per_mip_views: [MAX_MIP_LEVELS]c.VkImageView = .{null} ** MAX_MIP_LEVELS,
+
+    descriptor_pool: c.VkDescriptorPool = null,
+    descriptor_set_layout: c.VkDescriptorSetLayout = null,
+    descriptor_sets: [MAX_FRAMES_IN_FLIGHT][MAX_MIP_LEVELS]c.VkDescriptorSet = .{.{null} ** MAX_MIP_LEVELS} ** MAX_FRAMES_IN_FLIGHT,
+    pipeline_layout: c.VkPipelineLayout = null,
+    pipeline: c.VkPipeline = null,
+
+    width: u32 = 0,
+    height: u32 = 0,
+
+    pub fn init(
+        self: *DepthPyramidSystem,
+        device: *const VulkanDevice,
+        allocator: Allocator,
+        descriptor_pool: c.VkDescriptorPool,
+        depth_view: c.VkImageView,
+        width: u32,
+        height: u32,
+    ) !void {
+        self.deinit(device.vk_device, allocator, descriptor_pool);
+        const vk = device.vk_device;
+
+        errdefer self.deinit(vk, allocator, descriptor_pool);
+
+        self.width = width;
+        self.height = height;
+
+        const max_dim = @max(width, height);
+        self.mip_count = if (max_dim > 0) std.math.log2_int(u32, max_dim) + 1 else 1;
+        if (self.mip_count > MAX_MIP_LEVELS) self.mip_count = MAX_MIP_LEVELS;
+
+        for (0..self.mip_count) |i| {
+            const div = @as(u32, 1) << @intCast(i);
+            self.mip_widths[i] = @max(1, @divFloor(width, div));
+            self.mip_heights[i] = @max(1, @divFloor(height, div));
+        }
+
+        var img_info = std.mem.zeroes(c.VkImageCreateInfo);
+        img_info.sType = c.VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        img_info.imageType = c.VK_IMAGE_TYPE_2D;
+        img_info.format = c.VK_FORMAT_R32_SFLOAT;
+        img_info.extent = .{ .width = width, .height = height, .depth = 1 };
+        img_info.mipLevels = self.mip_count;
+        img_info.arrayLayers = 1;
+        img_info.samples = c.VK_SAMPLE_COUNT_1_BIT;
+        img_info.tiling = c.VK_IMAGE_TILING_OPTIMAL;
+        img_info.usage = c.VK_IMAGE_USAGE_SAMPLED_BIT | c.VK_IMAGE_USAGE_STORAGE_BIT | c.VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+        img_info.initialLayout = c.VK_IMAGE_LAYOUT_UNDEFINED;
+        try Utils.checkVk(c.vkCreateImage(vk, &img_info, null, &self.pyramid_image));
+
+        var mem_reqs: c.VkMemoryRequirements = undefined;
+        c.vkGetImageMemoryRequirements(vk, self.pyramid_image, &mem_reqs);
+        var alloc_info = std.mem.zeroes(c.VkMemoryAllocateInfo);
+        alloc_info.sType = c.VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        alloc_info.allocationSize = mem_reqs.size;
+        alloc_info.memoryTypeIndex = try Utils.findMemoryType(device.physical_device, mem_reqs.memoryTypeBits, c.VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+        try Utils.checkVk(c.vkAllocateMemory(vk, &alloc_info, null, &self.pyramid_memory));
+        try Utils.checkVk(c.vkBindImageMemory(vk, self.pyramid_image, self.pyramid_memory, 0));
+
+        var view_info = std.mem.zeroes(c.VkImageViewCreateInfo);
+        view_info.sType = c.VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        view_info.image = self.pyramid_image;
+        view_info.viewType = c.VK_IMAGE_VIEW_TYPE_2D;
+        view_info.format = c.VK_FORMAT_R32_SFLOAT;
+        view_info.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .baseMipLevel = 0, .levelCount = self.mip_count, .baseArrayLayer = 0, .layerCount = 1 };
+        try Utils.checkVk(c.vkCreateImageView(vk, &view_info, null, &self.pyramid_view));
+
+        for (0..self.mip_count) |i| {
+            var mip_view_info = std.mem.zeroes(c.VkImageViewCreateInfo);
+            mip_view_info.sType = c.VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            mip_view_info.image = self.pyramid_image;
+            mip_view_info.viewType = c.VK_IMAGE_VIEW_TYPE_2D;
+            mip_view_info.format = c.VK_FORMAT_R32_SFLOAT;
+            mip_view_info.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .baseMipLevel = @intCast(i), .levelCount = 1, .baseArrayLayer = 0, .layerCount = 1 };
+            try Utils.checkVk(c.vkCreateImageView(vk, &mip_view_info, null, &self.per_mip_views[i]));
+        }
+
+        var sampler_info = std.mem.zeroes(c.VkSamplerCreateInfo);
+        sampler_info.sType = c.VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+        sampler_info.magFilter = c.VK_FILTER_NEAREST;
+        sampler_info.minFilter = c.VK_FILTER_NEAREST;
+        sampler_info.addressModeU = c.VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampler_info.addressModeV = c.VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampler_info.addressModeW = c.VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampler_info.anisotropyEnable = c.VK_FALSE;
+        sampler_info.maxAnisotropy = 1.0;
+        sampler_info.mipmapMode = c.VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        try Utils.checkVk(c.vkCreateSampler(vk, &sampler_info, null, &self.pyramid_sampler));
+
+        var pool_sizes = [_]c.VkDescriptorPoolSize{
+            .{ .type = c.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, .descriptorCount = self.mip_count * MAX_FRAMES_IN_FLIGHT },
+            .{ .type = c.VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, .descriptorCount = self.mip_count * MAX_FRAMES_IN_FLIGHT },
+        };
+
+        var pool_info = std.mem.zeroes(c.VkDescriptorPoolCreateInfo);
+        pool_info.sType = c.VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+        pool_info.maxSets = self.mip_count * MAX_FRAMES_IN_FLIGHT;
+        pool_info.poolSizeCount = pool_sizes.len;
+        pool_info.pPoolSizes = &pool_sizes;
+        try Utils.checkVk(c.vkCreateDescriptorPool(vk, &pool_info, null, &self.descriptor_pool));
+
+        const bindings = [_]c.VkDescriptorSetLayoutBinding{
+            .{ .binding = 0, .descriptorType = c.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, .descriptorCount = 1, .stageFlags = c.VK_SHADER_STAGE_COMPUTE_BIT, .pImmutableSamplers = null },
+            .{ .binding = 1, .descriptorType = c.VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, .descriptorCount = 1, .stageFlags = c.VK_SHADER_STAGE_COMPUTE_BIT, .pImmutableSamplers = null },
+        };
+
+        var layout_info = std.mem.zeroes(c.VkDescriptorSetLayoutCreateInfo);
+        layout_info.sType = c.VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        layout_info.bindingCount = bindings.len;
+        layout_info.pBindings = &bindings;
+        try Utils.checkVk(c.vkCreateDescriptorSetLayout(vk, &layout_info, null, &self.descriptor_set_layout));
+
+        const total_sets = self.mip_count * MAX_FRAMES_IN_FLIGHT;
+        var layouts: [MAX_MIP_LEVELS * MAX_FRAMES_IN_FLIGHT]c.VkDescriptorSetLayout = undefined;
+        for (0..total_sets) |i| layouts[i] = self.descriptor_set_layout;
+
+        var ds_alloc_info = std.mem.zeroes(c.VkDescriptorSetAllocateInfo);
+        ds_alloc_info.sType = c.VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+        ds_alloc_info.descriptorPool = self.descriptor_pool;
+        ds_alloc_info.descriptorSetCount = total_sets;
+        ds_alloc_info.pSetLayouts = &layouts;
+
+        var flat_sets: [MAX_MIP_LEVELS * MAX_FRAMES_IN_FLIGHT]c.VkDescriptorSet = undefined;
+        try Utils.checkVk(c.vkAllocateDescriptorSets(vk, &ds_alloc_info, &flat_sets));
+
+        for (0..MAX_FRAMES_IN_FLIGHT) |frame| {
+            for (0..self.mip_count) |mip| {
+                self.descriptor_sets[frame][mip] = flat_sets[frame * self.mip_count + mip];
+            }
+        }
+
+        self.updateDescriptorSets(vk, depth_view);
+
+        var pc_range = std.mem.zeroes(c.VkPushConstantRange);
+        pc_range.stageFlags = c.VK_SHADER_STAGE_COMPUTE_BIT;
+        pc_range.offset = 0;
+        pc_range.size = @sizeOf(PushConstants);
+
+        var pipeline_layout_info = std.mem.zeroes(c.VkPipelineLayoutCreateInfo);
+        pipeline_layout_info.sType = c.VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+        pipeline_layout_info.setLayoutCount = 1;
+        pipeline_layout_info.pSetLayouts = &self.descriptor_set_layout;
+        pipeline_layout_info.pushConstantRangeCount = 1;
+        pipeline_layout_info.pPushConstantRanges = &pc_range;
+        try Utils.checkVk(c.vkCreatePipelineLayout(vk, &pipeline_layout_info, null, &self.pipeline_layout));
+
+        const shader_module = try loadShaderModule(vk, DEPTH_PYRAMID_SHADER_PATH, allocator);
+        defer c.vkDestroyShaderModule(vk, shader_module, null);
+
+        var stage = std.mem.zeroes(c.VkPipelineShaderStageCreateInfo);
+        stage.sType = c.VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stage.stage = c.VK_SHADER_STAGE_COMPUTE_BIT;
+        stage.module = shader_module;
+        stage.pName = "main";
+
+        var pipeline_info = std.mem.zeroes(c.VkComputePipelineCreateInfo);
+        pipeline_info.sType = c.VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+        pipeline_info.stage = stage;
+        pipeline_info.layout = self.pipeline_layout;
+        try Utils.checkVk(c.vkCreateComputePipelines(vk, null, 1, &pipeline_info, null, &self.pipeline));
+
+        log.log.info("DepthPyramidSystem initialized: {}x{}, {} mip levels", .{ width, height, self.mip_count });
+    }
+
+    fn updateDescriptorSets(self: *DepthPyramidSystem, vk: c.VkDevice, depth_view: c.VkImageView) void {
+        for (0..MAX_FRAMES_IN_FLIGHT) |frame| {
+            {
+                var src_info = c.VkDescriptorImageInfo{
+                    .sampler = self.pyramid_sampler,
+                    .imageView = depth_view,
+                    .imageLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                };
+                var dst_info = c.VkDescriptorImageInfo{
+                    .sampler = null,
+                    .imageView = self.per_mip_views[0],
+                    .imageLayout = c.VK_IMAGE_LAYOUT_GENERAL,
+                };
+                var writes = [_]c.VkWriteDescriptorSet{
+                    .{
+                        .sType = c.VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                        .dstSet = self.descriptor_sets[frame][0],
+                        .dstBinding = 0,
+                        .dstArrayElement = 0,
+                        .descriptorType = c.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                        .descriptorCount = 1,
+                        .pImageInfo = &src_info,
+                    },
+                    .{
+                        .sType = c.VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                        .dstSet = self.descriptor_sets[frame][0],
+                        .dstBinding = 1,
+                        .dstArrayElement = 0,
+                        .descriptorType = c.VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                        .descriptorCount = 1,
+                        .pImageInfo = &dst_info,
+                    },
+                };
+                c.vkUpdateDescriptorSets(vk, writes.len, &writes[0], 0, null);
+            }
+
+            for (1..self.mip_count) |mip| {
+                var src_info = c.VkDescriptorImageInfo{
+                    .sampler = self.pyramid_sampler,
+                    .imageView = self.pyramid_view,
+                    .imageLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                };
+                var dst_info = c.VkDescriptorImageInfo{
+                    .sampler = null,
+                    .imageView = self.per_mip_views[mip],
+                    .imageLayout = c.VK_IMAGE_LAYOUT_GENERAL,
+                };
+                var writes = [_]c.VkWriteDescriptorSet{
+                    .{
+                        .sType = c.VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                        .dstSet = self.descriptor_sets[frame][mip],
+                        .dstBinding = 0,
+                        .dstArrayElement = 0,
+                        .descriptorType = c.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                        .descriptorCount = 1,
+                        .pImageInfo = &src_info,
+                    },
+                    .{
+                        .sType = c.VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                        .dstSet = self.descriptor_sets[frame][mip],
+                        .dstBinding = 1,
+                        .dstArrayElement = 0,
+                        .descriptorType = c.VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                        .descriptorCount = 1,
+                        .pImageInfo = &dst_info,
+                    },
+                };
+                c.vkUpdateDescriptorSets(vk, writes.len, &writes[0], 0, null);
+            }
+        }
+    }
+
+    pub fn compute(
+        self: *const DepthPyramidSystem,
+        command_buffer: c.VkCommandBuffer,
+        frame: usize,
+        depth_image: c.VkImage,
+        depth_width: u32,
+        depth_height: u32,
+    ) void {
+        if (self.pipeline == null) return;
+        if (self.mip_count == 0) return;
+        if (command_buffer == null) return;
+
+        if (depth_image != null) {
+            var depth_barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
+            depth_barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            depth_barrier.srcAccessMask = c.VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+            depth_barrier.dstAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+            depth_barrier.oldLayout = c.VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+            depth_barrier.newLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            depth_barrier.image = depth_image;
+            depth_barrier.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_DEPTH_BIT, .baseMipLevel = 0, .levelCount = 1, .baseArrayLayer = 0, .layerCount = 1 };
+            c.vkCmdPipelineBarrier(
+                command_buffer,
+                c.VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                0,
+                0,
+                null,
+                0,
+                null,
+                1,
+                &depth_barrier,
+            );
+        }
+
+        {
+            var pyramid_barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
+            pyramid_barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            pyramid_barrier.dstAccessMask = c.VK_ACCESS_SHADER_WRITE_BIT;
+            pyramid_barrier.oldLayout = c.VK_IMAGE_LAYOUT_UNDEFINED;
+            pyramid_barrier.newLayout = c.VK_IMAGE_LAYOUT_GENERAL;
+            pyramid_barrier.image = self.pyramid_image;
+            pyramid_barrier.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .baseMipLevel = 0, .levelCount = self.mip_count, .baseArrayLayer = 0, .layerCount = 1 };
+            c.vkCmdPipelineBarrier(
+                command_buffer,
+                c.VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                0,
+                0,
+                null,
+                0,
+                null,
+                1,
+                &pyramid_barrier,
+            );
+        }
+
+        c.vkCmdBindPipeline(command_buffer, c.VK_PIPELINE_BIND_POINT_COMPUTE, self.pipeline);
+
+        for (0..self.mip_count) |mip| {
+            const mip_w = self.mip_widths[mip];
+            const mip_h = self.mip_heights[mip];
+
+            c.vkCmdBindDescriptorSets(command_buffer, c.VK_PIPELINE_BIND_POINT_COMPUTE, self.pipeline_layout, 0, 1, &self.descriptor_sets[frame][mip], 0, null);
+
+            const src_w: f32 = if (mip == 0) @floatFromInt(depth_width) else @floatFromInt(self.mip_widths[mip - 1]);
+            const src_h: f32 = if (mip == 0) @floatFromInt(depth_height) else @floatFromInt(self.mip_heights[mip - 1]);
+
+            const push = PushConstants{
+                .mip_level = @intCast(mip),
+                .inv_src_size = .{ 1.0 / src_w, 1.0 / src_h },
+            };
+            c.vkCmdPushConstants(command_buffer, self.pipeline_layout, c.VK_SHADER_STAGE_COMPUTE_BIT, 0, @sizeOf(PushConstants), &push);
+
+            const groups_x = divCeil(mip_w, DEPTH_PYRAMID_WORKGROUP_SIZE);
+            const groups_y = divCeil(mip_h, DEPTH_PYRAMID_WORKGROUP_SIZE);
+            c.vkCmdDispatch(command_buffer, groups_x, groups_y, 1);
+
+            if (mip < self.mip_count - 1) {
+                var barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
+                barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+                barrier.srcAccessMask = c.VK_ACCESS_SHADER_WRITE_BIT;
+                barrier.dstAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+                barrier.oldLayout = c.VK_IMAGE_LAYOUT_GENERAL;
+                barrier.newLayout = c.VK_IMAGE_LAYOUT_GENERAL;
+                barrier.image = self.pyramid_image;
+                barrier.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .baseMipLevel = @intCast(mip), .levelCount = 1, .baseArrayLayer = 0, .layerCount = 1 };
+                c.vkCmdPipelineBarrier(
+                    command_buffer,
+                    c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                    c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                    0,
+                    0,
+                    null,
+                    0,
+                    null,
+                    1,
+                    &barrier,
+                );
+            }
+        }
+
+        {
+            var final_barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
+            final_barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            final_barrier.srcAccessMask = c.VK_ACCESS_SHADER_WRITE_BIT;
+            final_barrier.dstAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+            final_barrier.oldLayout = c.VK_IMAGE_LAYOUT_GENERAL;
+            final_barrier.newLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            final_barrier.image = self.pyramid_image;
+            final_barrier.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .baseMipLevel = 0, .levelCount = self.mip_count, .baseArrayLayer = 0, .layerCount = 1 };
+            c.vkCmdPipelineBarrier(
+                command_buffer,
+                c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                c.VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                0,
+                0,
+                null,
+                0,
+                null,
+                1,
+                &final_barrier,
+            );
+        }
+
+        if (depth_image != null) {
+            var restore_barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
+            restore_barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            restore_barrier.srcAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+            restore_barrier.dstAccessMask = c.VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT | c.VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
+            restore_barrier.oldLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            restore_barrier.newLayout = c.VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+            restore_barrier.image = depth_image;
+            restore_barrier.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_DEPTH_BIT, .baseMipLevel = 0, .levelCount = 1, .baseArrayLayer = 0, .layerCount = 1 };
+            c.vkCmdPipelineBarrier(
+                command_buffer,
+                c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                c.VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | c.VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                0,
+                0,
+                null,
+                0,
+                null,
+                1,
+                &restore_barrier,
+            );
+        }
+    }
+
+    pub fn deinit(self: *DepthPyramidSystem, device: c.VkDevice, _: Allocator, _: c.VkDescriptorPool) void {
+        if (self.pipeline != null) {
+            c.vkDestroyPipeline(device, self.pipeline, null);
+            self.pipeline = null;
+        }
+        if (self.pipeline_layout != null) {
+            c.vkDestroyPipelineLayout(device, self.pipeline_layout, null);
+            self.pipeline_layout = null;
+        }
+        if (self.descriptor_set_layout != null) {
+            c.vkDestroyDescriptorSetLayout(device, self.descriptor_set_layout, null);
+            self.descriptor_set_layout = null;
+        }
+        if (self.descriptor_pool != null) {
+            c.vkDestroyDescriptorPool(device, self.descriptor_pool, null);
+            self.descriptor_pool = null;
+        }
+        self.descriptor_sets = .{.{null} ** MAX_MIP_LEVELS} ** MAX_FRAMES_IN_FLIGHT;
+
+        for (&self.per_mip_views) |*view| {
+            if (view.* != null) {
+                c.vkDestroyImageView(device, view.*, null);
+                view.* = null;
+            }
+        }
+
+        if (self.pyramid_sampler != null) {
+            c.vkDestroySampler(device, self.pyramid_sampler, null);
+            self.pyramid_sampler = null;
+        }
+        if (self.pyramid_view != null) {
+            c.vkDestroyImageView(device, self.pyramid_view, null);
+            self.pyramid_view = null;
+        }
+        if (self.pyramid_image != null) {
+            c.vkDestroyImage(device, self.pyramid_image, null);
+            self.pyramid_image = null;
+        }
+        if (self.pyramid_memory != null) {
+            c.vkFreeMemory(device, self.pyramid_memory, null);
+            self.pyramid_memory = null;
+        }
+
+        self.mip_count = 0;
+        self.width = 0;
+        self.height = 0;
+    }
+};
+
+fn loadShaderModule(vk: c.VkDevice, path: []const u8, allocator: Allocator) !c.VkShaderModule {
+    const bytes = try std.fs.cwd().readFileAlloc(path, allocator, @enumFromInt(16 * 1024 * 1024));
+    defer allocator.free(bytes);
+    if (bytes.len % 4 != 0) return error.InvalidShader;
+
+    var info = std.mem.zeroes(c.VkShaderModuleCreateInfo);
+    info.sType = c.VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    info.codeSize = bytes.len;
+    info.pCode = @ptrCast(@alignCast(bytes.ptr));
+
+    var module: c.VkShaderModule = null;
+    try Utils.checkVk(c.vkCreateShaderModule(vk, &info, null, &module));
+    return module;
+}
+
+fn divCeil(v: u32, d: u32) u32 {
+    return @divFloor(v + d - 1, d);
+}

--- a/src/engine/graphics/vulkan/depth_pyramid.zig
+++ b/src/engine/graphics/vulkan/depth_pyramid.zig
@@ -40,15 +40,15 @@ pub const DepthPyramidSystem = struct {
         self: *DepthPyramidSystem,
         device: *const VulkanDevice,
         allocator: Allocator,
-        descriptor_pool: c.VkDescriptorPool,
+        _: c.VkDescriptorPool,
         depth_view: c.VkImageView,
         width: u32,
         height: u32,
     ) !void {
-        self.deinit(device.vk_device, allocator, descriptor_pool);
+        self.deinit(device.vk_device);
         const vk = device.vk_device;
 
-        errdefer self.deinit(vk, allocator, descriptor_pool);
+        errdefer self.deinit(vk);
 
         self.width = width;
         self.height = height;
@@ -411,7 +411,7 @@ pub const DepthPyramidSystem = struct {
         }
     }
 
-    pub fn deinit(self: *DepthPyramidSystem, device: c.VkDevice, _: Allocator, _: c.VkDescriptorPool) void {
+    pub fn deinit(self: *DepthPyramidSystem, device: c.VkDevice) void {
         if (self.pipeline != null) {
             c.vkDestroyPipeline(device, self.pipeline, null);
             self.pipeline = null;

--- a/src/engine/graphics/vulkan/depth_pyramid.zig
+++ b/src/engine/graphics/vulkan/depth_pyramid.zig
@@ -9,6 +9,7 @@ const VulkanDevice = @import("device.zig").VulkanDevice;
 pub const DEPTH_PYRAMID_SHADER_PATH = "assets/shaders/vulkan/depth_pyramid.comp.spv";
 pub const DEPTH_PYRAMID_WORKGROUP_SIZE: u32 = 8;
 const MAX_MIP_LEVELS: u32 = 16;
+// Descriptor set arrays sized by MAX_FRAMES_IN_FLIGHT; must match RHI frame count.
 const MAX_FRAMES_IN_FLIGHT = rhi.MAX_FRAMES_IN_FLIGHT;
 
 const PushConstants = extern struct {
@@ -40,7 +41,6 @@ pub const DepthPyramidSystem = struct {
         self: *DepthPyramidSystem,
         device: *const VulkanDevice,
         allocator: Allocator,
-        _: c.VkDescriptorPool,
         depth_view: c.VkImageView,
         width: u32,
         height: u32,

--- a/src/engine/graphics/vulkan/rhi_context_types.zig
+++ b/src/engine/graphics/vulkan/rhi_context_types.zig
@@ -19,6 +19,7 @@ const PostProcessSystem = @import("post_process_system.zig").PostProcessSystem;
 const FXAASystem = @import("fxaa_system.zig").FXAASystem;
 const BloomSystem = @import("bloom_system.zig").BloomSystem;
 const TAASystem = @import("taa_system.zig").TAASystem;
+const DepthPyramidSystem = @import("depth_pyramid.zig").DepthPyramidSystem;
 const VulkanDevice = @import("device.zig").VulkanDevice;
 
 const MAX_FRAMES_IN_FLIGHT = rhi.MAX_FRAMES_IN_FLIGHT;
@@ -212,6 +213,7 @@ pub const VulkanContext = struct {
     fxaa: FXAASystem = .{},
     taa: TAASystem = .{},
     bloom: BloomSystem = .{},
+    depth_pyramid: DepthPyramidSystem = .{},
     post_process_state: PostProcessState = .{},
     velocity: VelocityResources = .{},
 

--- a/src/engine/graphics/vulkan/rhi_init_deinit.zig
+++ b/src/engine/graphics/vulkan/rhi_init_deinit.zig
@@ -103,6 +103,19 @@ pub fn initContext(ctx: anytype, allocator: std.mem.Allocator, render_device: ?*
     try ctx.pipeline_manager.createSwapchainUIPipelines(ctx.allocator, ctx.vulkan_device.vk_device, ctx.render_pass_manager.ui_swapchain_render_pass);
     try ctx.bloom.init(&ctx.vulkan_device, ctx.allocator, ctx.descriptors.descriptor_pool, ctx.hdr.hdr_view, ctx.swapchain.getExtent().width, ctx.swapchain.getExtent().height, c.VK_FORMAT_R16G16B16A16_SFLOAT);
 
+    if (ctx.gpass.g_depth_view != null) {
+        ctx.depth_pyramid.init(
+            &ctx.vulkan_device,
+            ctx.allocator,
+            ctx.descriptors.descriptor_pool,
+            ctx.gpass.g_depth_view,
+            ctx.swapchain.getExtent().width,
+            ctx.swapchain.getExtent().height,
+        ) catch |err| {
+            log.log.warn("DepthPyramidSystem init failed (non-fatal): {}", .{err});
+        };
+    }
+
     setup.updatePostProcessDescriptorsWithBloom(ctx);
 
     ctx.draw.dummy_texture = ctx.descriptors.dummy_texture;
@@ -177,6 +190,10 @@ pub fn initContext(ctx: anytype, allocator: std.mem.Allocator, render_device: ?*
                 count += 1;
             }
         }
+        if (ctx.depth_pyramid.pyramid_image != null) {
+            list[count] = ctx.depth_pyramid.pyramid_image;
+            count += 1;
+        }
 
         if (count > 0) {
             lifecycle.transitionImagesToShaderRead(ctx, list[0..count], false) catch |err| log.log.err("Failed to transition images during init: {}", .{err});
@@ -213,6 +230,7 @@ pub fn deinit(ctx: anytype) void {
         lifecycle.destroyTAAResources(ctx);
         lifecycle.destroyBloomResources(ctx);
         lifecycle.destroyVelocityResources(ctx);
+        ctx.depth_pyramid.deinit(vk_device, ctx.allocator, ctx.descriptors.descriptor_pool);
         lifecycle.destroyPostProcessResources(ctx);
         lifecycle.destroyGPassResources(ctx);
 

--- a/src/engine/graphics/vulkan/rhi_init_deinit.zig
+++ b/src/engine/graphics/vulkan/rhi_init_deinit.zig
@@ -107,7 +107,6 @@ pub fn initContext(ctx: anytype, allocator: std.mem.Allocator, render_device: ?*
         ctx.depth_pyramid.init(
             &ctx.vulkan_device,
             ctx.allocator,
-            ctx.descriptors.descriptor_pool,
             ctx.gpass.g_depth_view,
             ctx.swapchain.getExtent().width,
             ctx.swapchain.getExtent().height,

--- a/src/engine/graphics/vulkan/rhi_init_deinit.zig
+++ b/src/engine/graphics/vulkan/rhi_init_deinit.zig
@@ -230,7 +230,7 @@ pub fn deinit(ctx: anytype) void {
         lifecycle.destroyTAAResources(ctx);
         lifecycle.destroyBloomResources(ctx);
         lifecycle.destroyVelocityResources(ctx);
-        ctx.depth_pyramid.deinit(vk_device, ctx.allocator, ctx.descriptors.descriptor_pool);
+        ctx.depth_pyramid.deinit(vk_device);
         lifecycle.destroyPostProcessResources(ctx);
         lifecycle.destroyGPassResources(ctx);
 


### PR DESCRIPTION
## Summary

- Implements a GPU compute-based depth pyramid (hierarchical Z-buffer) for occlusion culling support
- Adds `depth_pyramid.comp` compute shader that generates a mip chain from the G-pass depth buffer, where each level stores the **max depth** for 2×2 texel blocks (conservative occlusion test with reverse-Z)
- Adds `DepthPyramidSystem` as a self-contained Vulkan compute pipeline (follows `CullingSystem` / `BloomSystem` patterns)
- Integrates as a new `DepthPyramidPass` in the render graph, executed after SSAO pass

## Implementation Details

### Files Created
- `assets/shaders/vulkan/depth_pyramid.comp` — GLSL 450 compute shader (8×8 workgroups, `sampler2D` input + `r32f` storage image output)
- `src/engine/graphics/vulkan/depth_pyramid.zig` — `DepthPyramidSystem` struct managing the R32_SFLOAT pyramid texture, per-mip image views, descriptor pool/layout, compute pipeline, and per-frame dispatch with correct barriers

### Files Modified
- `build.zig` — Added `glslangValidator` check for `depth_pyramid.comp`
- `src/engine/graphics/rhi.zig` — Added `computeDepthPyramid` to `IRenderContext.VTable`, `RenderContext`, and `RHI`
- `src/engine/graphics/rhi_vulkan.zig` — Vulkan implementation of `computeDepthPyramid`
- `src/engine/graphics/rhi_tests.zig` — Updated mock vtable
- `src/engine/graphics/vulkan/rhi_context_types.zig` — Added `depth_pyramid: DepthPyramidSystem` to `VulkanContext`
- `src/engine/graphics/vulkan/rhi_init_deinit.zig` — Init (after bloom, non-fatal) and deinit lifecycle
- `src/engine/graphics/render_graph.zig` — Added `DepthPyramidPass` (needs_main_pass=false)
- `src/engine/graphics/render_system.zig` — Wired `DepthPyramidPass` into render graph after SSAO

### Render Graph Order (updated)
```
ShadowPass[0-3] → GPass → SSAOPass → DepthPyramidPass → SkyPass → OpaquePass → ...
```

### Pipeline Barriers
- `LATE_FRAGMENT_TESTS → COMPUTE_SHADER` to transition G-pass depth to shader-read
- `COMPUTE_SHADER → COMPUTE_SHADER` between mip levels
- `COMPUTE_SHADER → FRAGMENT_SHADER|COMPUTE_SHADER` final transition to shader-read-only
- Depth image restored to `DEPTH_STENCIL_ATTACHMENT_OPTIMAL` after pyramid generation

## Testing

- [x] `zig build` compiles without errors
- [x] `zig build test` passes (shader validation + unit tests)
- [x] `zig fmt src/` passes

Closes #383