### PR TITLE
feat: dedicated transfer queue + ring-buffered staging allocator (issue #384)

### DIFF
--- a/src/engine/graphics/rhi_tests.zig
+++ b/src/engine/graphics/rhi_tests.zig
@@ -484,9 +484,8 @@ test "ResourceManager.registerExternalTexture validation" {
         .next_texture_handle = 1,
         .buffer_deletion_queue = undefined,
         .image_deletion_queue = undefined,
-        .staging_buffers = undefined,
-        .transfer_command_pool = null,
-        .transfer_command_buffers = undefined,
+        .staging_ring = undefined,
+        .transfer = undefined,
         .transfer_fence = null,
     };
     defer manager.textures.deinit();

--- a/src/engine/graphics/rhi_tests.zig
+++ b/src/engine/graphics/rhi_tests.zig
@@ -486,7 +486,6 @@ test "ResourceManager.registerExternalTexture validation" {
         .image_deletion_queue = undefined,
         .staging_ring = undefined,
         .transfer = undefined,
-        .transfer_fence = null,
     };
     defer manager.textures.deinit();
     defer manager.buffers.deinit();

--- a/src/engine/graphics/rhi_vulkan.zig
+++ b/src/engine/graphics/rhi_vulkan.zig
@@ -73,7 +73,7 @@ fn beginFrame(ctx_ptr: *anyopaque) void {
         frame_orchestration.recreateSwapchainInternal(ctx);
     }
 
-    if (ctx.resources.transfer_ready) {
+    if (ctx.resources.transfer.transfer_ready[ctx.resources.transfer.current_frame]) {
         ctx.resources.flushTransfer() catch |err| {
             log.log.errWithTrace("Failed to flush inter-frame transfers: {}", .{err});
         };

--- a/src/engine/graphics/vulkan/frame_manager.zig
+++ b/src/engine/graphics/vulkan/frame_manager.zig
@@ -140,20 +140,27 @@ pub const FrameManager = struct {
         const cb = self.command_buffers[self.current_frame];
         try Utils.checkVk(c.vkEndCommandBuffer(cb));
 
-        // End transfer command buffer if present (for shared-queue case; for dedicated queue, already ended)
-        if (transfer_cb) |tcb| {
-            try Utils.checkVk(c.vkEndCommandBuffer(tcb));
+        // Shared-queue uploads are submitted with graphics, so this CB is ended here.
+        // Dedicated-queue uploads are ended in submitTransfer() before the separate submit.
+        if (transfer_semaphore == null) {
+            if (transfer_cb) |tcb| {
+                try Utils.checkVk(c.vkEndCommandBuffer(tcb));
+            }
         }
 
-        var wait_stages = [_]c.VkPipelineStageFlags{c.VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT};
+        var wait_semaphores: [2]c.VkSemaphore = .{ null, null };
+        var wait_stages: [2]c.VkPipelineStageFlags = .{
+            c.VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+            c.VK_PIPELINE_STAGE_VERTEX_INPUT_BIT,
+        };
+        var wait_count: u32 = 0;
 
         var submit_info = std.mem.zeroes(c.VkSubmitInfo);
         submit_info.sType = c.VK_STRUCTURE_TYPE_SUBMIT_INFO;
 
         if (!swapchain.skip_present) {
-            submit_info.waitSemaphoreCount = 1;
-            submit_info.pWaitSemaphores = &self.image_available_semaphores[self.current_frame];
-            submit_info.pWaitDstStageMask = &wait_stages[0];
+            wait_semaphores[wait_count] = self.image_available_semaphores[self.current_frame];
+            wait_count += 1;
         }
 
         // For dedicated transfer queue, transfer runs on its own queue and signals a semaphore
@@ -173,10 +180,15 @@ pub const FrameManager = struct {
         submit_info.commandBufferCount = cb_count;
         submit_info.pCommandBuffers = &command_buffers[0];
 
-        if (transfer_semaphore != null) {
-            submit_info.waitSemaphoreCount += 1;
-            submit_info.pWaitSemaphores = @ptrCast(&self.image_available_semaphores[self.current_frame]);
-            submit_info.pWaitDstStageMask = @ptrCast(&wait_stages);
+        if (transfer_semaphore) |sem| {
+            wait_semaphores[wait_count] = sem;
+            wait_count += 1;
+        }
+
+        if (wait_count > 0) {
+            submit_info.waitSemaphoreCount = wait_count;
+            submit_info.pWaitSemaphores = &wait_semaphores[0];
+            submit_info.pWaitDstStageMask = &wait_stages[0];
         }
 
         if (!self.dry_run) {

--- a/src/engine/graphics/vulkan/frame_manager.zig
+++ b/src/engine/graphics/vulkan/frame_manager.zig
@@ -133,14 +133,14 @@ pub const FrameManager = struct {
         return true;
     }
 
-    pub fn endFrame(self: *FrameManager, swapchain: *SwapchainPresenter, transfer_cb: ?c.VkCommandBuffer) !void {
+    pub fn endFrame(self: *FrameManager, swapchain: *SwapchainPresenter, transfer_cb: ?c.VkCommandBuffer, transfer_semaphore: ?c.VkSemaphore) !void {
         if (!self.frame_in_progress) return error.InvalidState;
         defer self.frame_in_progress = false;
 
         const cb = self.command_buffers[self.current_frame];
         try Utils.checkVk(c.vkEndCommandBuffer(cb));
 
-        // End transfer command buffer if present
+        // End transfer command buffer if present (for shared-queue case; for dedicated queue, already ended)
         if (transfer_cb) |tcb| {
             try Utils.checkVk(c.vkEndCommandBuffer(tcb));
         }
@@ -156,28 +156,30 @@ pub const FrameManager = struct {
             submit_info.pWaitDstStageMask = &wait_stages[0];
         }
 
-        // Submit transfer buffer first if needed?
-        // Actually, if we submit them in the same batch, we can list multiple command buffers.
-        // Or if we need strict ordering (transfer before graphics), we can submit twice or use barriers.
-        // Since both are on graphics queue, single submit guarantees execution order.
-
+        // For dedicated transfer queue, transfer runs on its own queue and signals a semaphore
+        // that the graphics queue waits on. The transfer CB is NOT included in the graphics submit.
+        // For shared queue, both CBs go in the same submit.
         var command_buffers: [2]c.VkCommandBuffer = undefined;
         var cb_count: u32 = 0;
 
-        if (transfer_cb) |tcb| {
-            command_buffers[cb_count] = tcb;
+        if (transfer_semaphore == null and transfer_cb != null) {
+            command_buffers[cb_count] = transfer_cb.?;
             cb_count += 1;
         }
+
         command_buffers[cb_count] = cb;
         cb_count += 1;
 
         submit_info.commandBufferCount = cb_count;
         submit_info.pCommandBuffers = &command_buffers[0];
 
+        if (transfer_semaphore != null) {
+            submit_info.waitSemaphoreCount += 1;
+            submit_info.pWaitSemaphores = @ptrCast(&self.image_available_semaphores[self.current_frame]);
+            submit_info.pWaitDstStageMask = @ptrCast(&wait_stages);
+        }
+
         if (!self.dry_run) {
-            // Only signal render_finished_semaphore if we're going to present.
-            // If skip_present is true, signaling would leave an orphaned semaphore
-            // that crashes Lavapipe when any wait operation is called.
             if (!swapchain.skip_present) {
                 submit_info.signalSemaphoreCount = 1;
                 submit_info.pSignalSemaphores = &self.render_finished_semaphores[self.current_image_index];

--- a/src/engine/graphics/vulkan/resource_manager.zig
+++ b/src/engine/graphics/vulkan/resource_manager.zig
@@ -65,9 +65,6 @@ pub const ResourceManager = struct {
     current_frame_index: usize = 0,
     textures_enabled: bool = true,
 
-    // Legacy transfer fence for init-time synchronous flushes
-    transfer_fence: c.VkFence = null,
-
     pub fn init(allocator: std.mem.Allocator, vulkan_device: *VulkanDevice) !ResourceManager {
         var self = ResourceManager{
             .allocator = allocator,
@@ -80,7 +77,6 @@ pub const ResourceManager = struct {
             .image_deletion_queue = undefined,
             .staging_ring = undefined,
             .transfer = undefined,
-            .transfer_fence = null,
         };
 
         for (0..rhi.MAX_FRAMES_IN_FLIGHT) |i| {
@@ -99,13 +95,6 @@ pub const ResourceManager = struct {
         } else {
             log.log.info("Transfer queue: SHARED with graphics (family {})", .{tx_family});
         }
-
-        var fence_info = std.mem.zeroes(c.VkFenceCreateInfo);
-        fence_info.sType = c.VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-        Utils.checkVk(c.vkCreateFence(vulkan_device.vk_device, &fence_info, null, &self.transfer_fence)) catch |err| {
-            log.log.err("Failed to create transfer fence: {}", .{err});
-            return err;
-        };
 
         return self;
     }
@@ -152,10 +141,6 @@ pub const ResourceManager = struct {
 
         self.transfer.deinit(device);
         self.staging_ring.deinit(device);
-
-        if (self.transfer_fence != null) {
-            c.vkDestroyFence(device, self.transfer_fence, null);
-        }
     }
 
     pub fn flushTransfer(self: *ResourceManager) !void {
@@ -165,6 +150,10 @@ pub const ResourceManager = struct {
     pub fn setCurrentFrame(self: *ResourceManager, frame_index: usize) void {
         self.current_frame_index = frame_index;
         self.transfer.setCurrentFrame(frame_index);
+
+        if (self.transfer.is_dedicated) {
+            self.transfer.waitForFrameFence(self.vulkan_device.vk_device, frame_index);
+        }
         self.staging_ring.reclaimFrame(frame_index);
         self.staging_ring.beginFrame(frame_index);
 
@@ -224,7 +213,7 @@ pub const ResourceManager = struct {
         submit_info.pSignalSemaphores = &self.transfer.transfer_semaphore;
 
         self.vulkan_device.mutex.lock();
-        const result = c.vkQueueSubmit(self.transfer.queue, 1, &submit_info, null);
+        const result = c.vkQueueSubmit(self.transfer.queue, 1, &submit_info, self.transfer.frame_fences[self.transfer.current_frame]);
         self.vulkan_device.mutex.unlock();
 
         if (result != c.VK_SUCCESS) return error.VulkanError;
@@ -395,8 +384,13 @@ pub const ResourceManager = struct {
         barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
         barrier.oldLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
         barrier.newLayout = c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-        barrier.srcQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
-        barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+        if (self.transfer.is_dedicated) {
+            barrier.srcQueueFamilyIndex = self.vulkan_device.graphics_family;
+            barrier.dstQueueFamilyIndex = self.transfer.family_index;
+        } else {
+            barrier.srcQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+            barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+        }
         barrier.image = tex.image orelse return error.ExtensionNotPresent;
         barrier.subresourceRange.aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT;
         barrier.subresourceRange.baseMipLevel = 0;
@@ -420,6 +414,13 @@ pub const ResourceManager = struct {
         barrier.newLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
         barrier.srcAccessMask = c.VK_ACCESS_TRANSFER_WRITE_BIT;
         barrier.dstAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+        if (self.transfer.is_dedicated) {
+            barrier.srcQueueFamilyIndex = self.transfer.family_index;
+            barrier.dstQueueFamilyIndex = self.vulkan_device.graphics_family;
+        } else {
+            barrier.srcQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+            barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+        }
 
         c.vkCmdPipelineBarrier(transfer_cb, c.VK_PIPELINE_STAGE_TRANSFER_BIT, c.VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, null, 0, null, 1, &barrier);
     }

--- a/src/engine/graphics/vulkan/resource_manager.zig
+++ b/src/engine/graphics/vulkan/resource_manager.zig
@@ -194,8 +194,8 @@ pub const ResourceManager = struct {
 
     pub fn getTransferSemaphore(self: *ResourceManager) ?c.VkSemaphore {
         if (!self.transfer.is_dedicated) return null;
-        if (!self.transfer.transfer_ready[self.transfer.current_frame]) return null;
-        return self.transfer.transfer_semaphore;
+        if (!self.transfer.transfer_submitted[self.transfer.current_frame]) return null;
+        return self.transfer.transfer_semaphores[self.transfer.current_frame];
     }
 
     pub fn submitTransfer(self: *ResourceManager) !void {
@@ -203,6 +203,8 @@ pub const ResourceManager = struct {
         if (!self.transfer.transfer_ready[self.transfer.current_frame]) return;
 
         const cb = self.transfer.command_buffers[self.transfer.current_frame];
+        try self.transfer.endTransferCommandBuffer();
+        try Utils.checkVk(c.vkResetFences(self.vulkan_device.vk_device, 1, &self.transfer.frame_fences[self.transfer.current_frame]));
 
         var submit_info = std.mem.zeroes(c.VkSubmitInfo);
         submit_info.sType = c.VK_STRUCTURE_TYPE_SUBMIT_INFO;
@@ -210,7 +212,7 @@ pub const ResourceManager = struct {
         submit_info.pCommandBuffers = &cb;
 
         submit_info.signalSemaphoreCount = 1;
-        submit_info.pSignalSemaphores = &self.transfer.transfer_semaphore;
+        submit_info.pSignalSemaphores = &self.transfer.transfer_semaphores[self.transfer.current_frame];
 
         self.vulkan_device.mutex.lock();
         const result = c.vkQueueSubmit(self.transfer.queue, 1, &submit_info, self.transfer.frame_fences[self.transfer.current_frame]);
@@ -219,6 +221,7 @@ pub const ResourceManager = struct {
         if (result != c.VK_SUCCESS) return error.VulkanError;
 
         self.transfer.transfer_ready[self.transfer.current_frame] = false;
+        self.transfer.transfer_submitted[self.transfer.current_frame] = true;
     }
 
     pub fn createBuffer(self: *ResourceManager, size: usize, usage: rhi.BufferUsage) rhi.RhiError!rhi.BufferHandle {

--- a/src/engine/graphics/vulkan/resource_manager.zig
+++ b/src/engine/graphics/vulkan/resource_manager.zig
@@ -5,6 +5,10 @@ const log = @import("../../core/log.zig");
 const VulkanDevice = @import("../vulkan_device.zig").VulkanDevice;
 const Utils = @import("utils.zig");
 const resource_texture_ops = @import("resource_texture_ops.zig");
+const transfer_queue = @import("transfer_queue.zig");
+const StagingRing = transfer_queue.StagingRing;
+const StagingSlice = transfer_queue.StagingSlice;
+const TransferQueue = transfer_queue.TransferQueue;
 
 /// Vulkan buffer with backing memory.
 pub const VulkanBuffer = Utils.VulkanBuffer;
@@ -37,54 +41,6 @@ const ZombieImage = struct {
     is_owned: bool,
 };
 
-/// Per-frame linear staging buffer for async uploads.
-const StagingBuffer = struct {
-    buffer: c.VkBuffer,
-    memory: c.VkDeviceMemory,
-    size: u64,
-    current_offset: u64,
-    mapped_ptr: ?*anyopaque,
-
-    fn init(device: *const VulkanDevice, size: u64) !StagingBuffer {
-        const buf = try Utils.createVulkanBuffer(device, size, c.VK_BUFFER_USAGE_TRANSFER_SRC_BIT, c.VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | c.VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-        if (buf.buffer == null) return error.VulkanError;
-
-        return StagingBuffer{
-            .buffer = buf.buffer,
-            .memory = buf.memory,
-            .size = size,
-            .current_offset = 0,
-            .mapped_ptr = buf.mapped_ptr,
-        };
-    }
-
-    fn deinit(self: *StagingBuffer, device: c.VkDevice) void {
-        if (self.mapped_ptr != null) {
-            c.vkUnmapMemory(device, self.memory);
-        }
-        c.vkDestroyBuffer(device, self.buffer, null);
-        c.vkFreeMemory(device, self.memory, null);
-    }
-
-    fn reset(self: *StagingBuffer) void {
-        self.current_offset = 0;
-    }
-
-    /// Allocates space in the staging buffer. Returns offset if successful, null if full.
-    /// Aligns allocation to 256 bytes (common minUniformBufferOffsetAlignment/optimal copy offset).
-    pub fn allocate(self: *StagingBuffer, size: u64) ?u64 {
-        const alignment = 256; // Safe alignment for most GPU copy operations
-        const aligned_offset = std.mem.alignForward(u64, self.current_offset, alignment);
-
-        if (aligned_offset + size > self.size) return null;
-
-        if (self.mapped_ptr == null) return null;
-
-        self.current_offset = aligned_offset + size;
-        return aligned_offset;
-    }
-};
-
 pub const ResourceManager = struct {
     allocator: std.mem.Allocator,
     vulkan_device: *VulkanDevice,
@@ -100,14 +56,17 @@ pub const ResourceManager = struct {
     buffer_deletion_queue: [rhi.MAX_FRAMES_IN_FLIGHT]std.ArrayListUnmanaged(ZombieBuffer),
     image_deletion_queue: [rhi.MAX_FRAMES_IN_FLIGHT]std.ArrayListUnmanaged(ZombieImage),
 
-    // Staging
-    staging_buffers: [rhi.MAX_FRAMES_IN_FLIGHT]StagingBuffer,
-    transfer_command_pool: c.VkCommandPool,
-    transfer_command_buffers: [rhi.MAX_FRAMES_IN_FLIGHT]c.VkCommandBuffer,
-    transfer_fence: c.VkFence,
-    transfer_ready: bool = false,
+    // Staging ring buffer (replaces per-frame StagingBuffer)
+    staging_ring: StagingRing,
+
+    // Transfer queue (dedicated or shared with graphics)
+    transfer: TransferQueue,
+
     current_frame_index: usize = 0,
     textures_enabled: bool = true,
+
+    // Legacy transfer fence for init-time synchronous flushes
+    transfer_fence: c.VkFence = null,
 
     pub fn init(allocator: std.mem.Allocator, vulkan_device: *VulkanDevice) !ResourceManager {
         var self = ResourceManager{
@@ -119,43 +78,32 @@ pub const ResourceManager = struct {
             .next_texture_handle = 1,
             .buffer_deletion_queue = undefined,
             .image_deletion_queue = undefined,
-            .staging_buffers = undefined,
-            .transfer_command_pool = null,
-            .transfer_command_buffers = undefined,
+            .staging_ring = undefined,
+            .transfer = undefined,
             .transfer_fence = null,
         };
 
         for (0..rhi.MAX_FRAMES_IN_FLIGHT) |i| {
             self.buffer_deletion_queue[i] = .{};
             self.image_deletion_queue[i] = .{};
-            self.staging_buffers[i] = try StagingBuffer.init(vulkan_device, 64 * 1024 * 1024); // 64MB staging buffer
         }
 
-        // Create transfer command pool
-        var pool_info = std.mem.zeroes(c.VkCommandPoolCreateInfo);
-        pool_info.sType = c.VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-        pool_info.queueFamilyIndex = vulkan_device.graphics_family;
-        pool_info.flags = c.VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-        try Utils.checkVk(c.vkCreateCommandPool(vulkan_device.vk_device, &pool_info, null, &self.transfer_command_pool));
+        self.staging_ring = try StagingRing.init(vulkan_device, transfer_queue.DEFAULT_STAGING_CAPACITY);
+        log.log.info("Staging ring initialized: {}MB", .{transfer_queue.DEFAULT_STAGING_CAPACITY / (1024 * 1024)});
 
-        // Allocate transfer command buffers
-        var alloc_info = std.mem.zeroes(c.VkCommandBufferAllocateInfo);
-        alloc_info.sType = c.VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-        alloc_info.commandPool = self.transfer_command_pool;
-        alloc_info.level = c.VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-        alloc_info.commandBufferCount = rhi.MAX_FRAMES_IN_FLIGHT;
-        try Utils.checkVk(c.vkAllocateCommandBuffers(vulkan_device.vk_device, &alloc_info, &self.transfer_command_buffers));
+        const tx_family = vulkan_device.transfer_family;
+        const is_dedicated = vulkan_device.has_dedicated_transfer_queue;
+        self.transfer = try TransferQueue.init(vulkan_device, tx_family, is_dedicated);
+        if (is_dedicated) {
+            log.log.info("Transfer queue: DEDICATED (family {})", .{tx_family});
+        } else {
+            log.log.info("Transfer queue: SHARED with graphics (family {})", .{tx_family});
+        }
 
-        // Create transfer fence
         var fence_info = std.mem.zeroes(c.VkFenceCreateInfo);
         fence_info.sType = c.VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-        fence_info.flags = 0; // Not signaled initially
         Utils.checkVk(c.vkCreateFence(vulkan_device.vk_device, &fence_info, null, &self.transfer_fence)) catch |err| {
             log.log.err("Failed to create transfer fence: {}", .{err});
-            // Cleanup command pool and buffers before returning to avoid leaks
-            if (self.transfer_command_pool != null) {
-                c.vkDestroyCommandPool(vulkan_device.vk_device, self.transfer_command_pool, null);
-            }
             return err;
         };
 
@@ -167,7 +115,6 @@ pub const ResourceManager = struct {
         _ = c.vkDeviceWaitIdle(device);
 
         for (0..rhi.MAX_FRAMES_IN_FLIGHT) |i| {
-            self.staging_buffers[i].deinit(device);
             for (self.buffer_deletion_queue[i].items) |b| {
                 c.vkDestroyBuffer(device, b.buffer, null);
                 c.vkFreeMemory(device, b.memory, null);
@@ -203,50 +150,23 @@ pub const ResourceManager = struct {
         }
         self.textures.deinit();
 
-        if (self.transfer_command_pool != null) {
-            c.vkDestroyCommandPool(device, self.transfer_command_pool, null);
-        }
+        self.transfer.deinit(device);
+        self.staging_ring.deinit(device);
+
         if (self.transfer_fence != null) {
             c.vkDestroyFence(device, self.transfer_fence, null);
         }
     }
 
-    /// Flushes any pending transfer commands for the current frame.
-    /// This is useful for initialization-time resource uploads that must complete before rendering begins.
     pub fn flushTransfer(self: *ResourceManager) !void {
-        if (!self.transfer_ready) return;
-
-        const cb = self.transfer_command_buffers[self.current_frame_index];
-        try Utils.checkVk(c.vkEndCommandBuffer(cb));
-
-        var submit_info = std.mem.zeroes(c.VkSubmitInfo);
-        submit_info.sType = c.VK_STRUCTURE_TYPE_SUBMIT_INFO;
-        submit_info.commandBufferCount = 1;
-        submit_info.pCommandBuffers = &cb;
-
-        // Use the transfer fence to wait
-        try Utils.checkVk(c.vkResetFences(self.vulkan_device.vk_device, 1, &self.transfer_fence));
-
-        self.vulkan_device.mutex.lock();
-        const result = c.vkQueueSubmit(self.vulkan_device.queue, 1, &submit_info, self.transfer_fence);
-        self.vulkan_device.mutex.unlock();
-
-        if (result != c.VK_SUCCESS) return error.VulkanError;
-
-        try Utils.checkVk(c.vkWaitForFences(self.vulkan_device.vk_device, 1, &self.transfer_fence, c.VK_TRUE, std.math.maxInt(u64)));
-
-        self.transfer_ready = false;
-
-        // Note: We do NOT reset the staging buffer here because other systems might still rely on it
-        // being valid until the next frame. However, for init-time flush, we can reset it.
-        // Let's reset it to be safe for next usage.
-        self.staging_buffers[self.current_frame_index].reset();
+        try self.transfer.flushSync(self.vulkan_device.vk_device, &self.vulkan_device.mutex);
     }
 
     pub fn setCurrentFrame(self: *ResourceManager, frame_index: usize) void {
         self.current_frame_index = frame_index;
-        self.transfer_ready = false; // Reset for new frame
-        self.staging_buffers[frame_index].reset();
+        self.transfer.setCurrentFrame(frame_index);
+        self.staging_ring.reclaimFrame(frame_index);
+        self.staging_ring.beginFrame(frame_index);
 
         // Process deletion queue for this frame
         const device = self.vulkan_device.vk_device;
@@ -268,27 +188,48 @@ pub const ResourceManager = struct {
     }
 
     pub fn resetTransferState(self: *ResourceManager) void {
-        self.transfer_ready = false;
+        self.transfer.resetTransferState();
     }
 
     pub fn prepareTransfer(self: *ResourceManager) !c.VkCommandBuffer {
-        if (self.transfer_ready) return self.transfer_command_buffers[self.current_frame_index];
-
-        const cb = self.transfer_command_buffers[self.current_frame_index];
-        try Utils.checkVk(c.vkResetCommandBuffer(cb, 0));
-
-        var begin_info = std.mem.zeroes(c.VkCommandBufferBeginInfo);
-        begin_info.sType = c.VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-        begin_info.flags = c.VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-        try Utils.checkVk(c.vkBeginCommandBuffer(cb, &begin_info));
-
-        self.transfer_ready = true;
-        return cb;
+        return self.transfer.prepareTransfer();
     }
 
     pub fn getTransferCommandBuffer(self: *ResourceManager) ?c.VkCommandBuffer {
-        if (!self.transfer_ready) return null;
-        return self.transfer_command_buffers[self.current_frame_index];
+        return self.transfer.getTransferCommandBuffer();
+    }
+
+    pub fn endTransferCommandBuffer(self: *ResourceManager) !void {
+        try self.transfer.endTransferCommandBuffer();
+    }
+
+    pub fn getTransferSemaphore(self: *ResourceManager) ?c.VkSemaphore {
+        if (!self.transfer.is_dedicated) return null;
+        if (!self.transfer.transfer_ready[self.transfer.current_frame]) return null;
+        return self.transfer.transfer_semaphore;
+    }
+
+    pub fn submitTransfer(self: *ResourceManager) !void {
+        if (!self.transfer.is_dedicated) return;
+        if (!self.transfer.transfer_ready[self.transfer.current_frame]) return;
+
+        const cb = self.transfer.command_buffers[self.transfer.current_frame];
+
+        var submit_info = std.mem.zeroes(c.VkSubmitInfo);
+        submit_info.sType = c.VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submit_info.commandBufferCount = 1;
+        submit_info.pCommandBuffers = &cb;
+
+        submit_info.signalSemaphoreCount = 1;
+        submit_info.pSignalSemaphores = &self.transfer.transfer_semaphore;
+
+        self.vulkan_device.mutex.lock();
+        const result = c.vkQueueSubmit(self.transfer.queue, 1, &submit_info, null);
+        self.vulkan_device.mutex.unlock();
+
+        if (result != c.VK_SUCCESS) return error.VulkanError;
+
+        self.transfer.transfer_ready[self.transfer.current_frame] = false;
     }
 
     pub fn createBuffer(self: *ResourceManager, size: usize, usage: rhi.BufferUsage) rhi.RhiError!rhi.BufferHandle {
@@ -329,32 +270,33 @@ pub const ResourceManager = struct {
     pub fn updateBuffer(self: *ResourceManager, handle: rhi.BufferHandle, offset: usize, data: []const u8) rhi.RhiError!void {
         const buf = self.buffers.get(handle) orelse return;
 
-        const staging = &self.staging_buffers[self.current_frame_index];
-        const staging_offset = staging.allocate(data.len) orelse {
-            log.log.err("Staging buffer overflow in updateBuffer! Data dropped.", .{});
+        const slice = self.staging_ring.allocate(data.len, self.current_frame_index) orelse {
+            log.log.err("Staging ring overflow in updateBuffer! Data dropped.", .{});
             return error.OutOfMemory;
         };
 
-        if (staging.mapped_ptr == null) return error.OutOfMemory;
-        const dest = @as([*]u8, @ptrCast(staging.mapped_ptr.?)) + staging_offset;
-        @memcpy(dest[0..data.len], data);
+        @memcpy(slice.ptr[0..data.len], data);
 
         const cmd = try self.prepareTransfer();
 
         var region = std.mem.zeroes(c.VkBufferCopy);
-        region.srcOffset = staging_offset;
+        region.srcOffset = slice.buffer_offset;
         region.dstOffset = offset;
         region.size = data.len;
 
-        c.vkCmdCopyBuffer(cmd, staging.buffer, buf.buffer, 1, &region);
+        c.vkCmdCopyBuffer(cmd, self.staging_ring.buffer, buf.buffer, 1, &region);
 
-        // Ensure visibility for subsequent stages
         var barrier = std.mem.zeroes(c.VkBufferMemoryBarrier);
         barrier.sType = c.VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
         barrier.srcAccessMask = c.VK_ACCESS_TRANSFER_WRITE_BIT;
         barrier.dstAccessMask = c.VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | c.VK_ACCESS_INDEX_READ_BIT | c.VK_ACCESS_SHADER_READ_BIT | c.VK_ACCESS_INDIRECT_COMMAND_READ_BIT;
-        barrier.srcQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
-        barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+        if (self.transfer.is_dedicated) {
+            barrier.srcQueueFamilyIndex = self.transfer.family_index;
+            barrier.dstQueueFamilyIndex = self.vulkan_device.graphics_family;
+        } else {
+            barrier.srcQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+            barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+        }
         barrier.buffer = buf.buffer;
         barrier.offset = offset;
         barrier.size = data.len;
@@ -440,51 +382,46 @@ pub const ResourceManager = struct {
     pub fn updateTexture(self: *ResourceManager, handle: rhi.TextureHandle, data: []const u8) rhi.RhiError!void {
         const tex = self.textures.get(handle) orelse return;
 
-        const staging = &self.staging_buffers[self.current_frame_index];
-        if (staging.allocate(data.len)) |offset| {
-            if (staging.mapped_ptr == null) return error.OutOfMemory;
-            // Async Path
-            const dest = @as([*]u8, @ptrCast(staging.mapped_ptr.?)) + offset;
-            @memcpy(dest[0..data.len], data);
-
-            const transfer_cb = try self.prepareTransfer();
-
-            var barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
-            barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-            barrier.oldLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-            barrier.newLayout = c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-            barrier.srcQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
-            barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
-            barrier.image = tex.image orelse return error.ExtensionNotPresent;
-            barrier.subresourceRange.aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT;
-            barrier.subresourceRange.baseMipLevel = 0;
-            barrier.subresourceRange.levelCount = 1;
-            barrier.subresourceRange.baseArrayLayer = 0;
-            barrier.subresourceRange.layerCount = 1;
-            barrier.srcAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
-            barrier.dstAccessMask = c.VK_ACCESS_TRANSFER_WRITE_BIT;
-
-            c.vkCmdPipelineBarrier(transfer_cb, c.VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, c.VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, null, 0, null, 1, &barrier);
-
-            var region = std.mem.zeroes(c.VkBufferImageCopy);
-            region.bufferOffset = offset;
-            region.imageSubresource.aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT;
-            region.imageSubresource.layerCount = 1;
-            region.imageExtent = .{ .width = tex.width, .height = tex.height, .depth = tex.depth };
-
-            c.vkCmdCopyBufferToImage(transfer_cb, staging.buffer, tex.image.?, c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
-
-            barrier.oldLayout = c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-            barrier.newLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-            barrier.srcAccessMask = c.VK_ACCESS_TRANSFER_WRITE_BIT;
-            barrier.dstAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
-
-            c.vkCmdPipelineBarrier(transfer_cb, c.VK_PIPELINE_STAGE_TRANSFER_BIT, c.VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, null, 0, null, 1, &barrier);
-        } else {
-            // Buffer full, drop update for now (or implement fallback)
-            log.log.err("Staging buffer full during updateTexture! Update dropped.", .{});
+        const slice = self.staging_ring.allocate(data.len, self.current_frame_index) orelse {
+            log.log.err("Staging ring full during updateTexture! Update dropped.", .{});
             return error.OutOfMemory;
-        }
+        };
+
+        @memcpy(slice.ptr[0..data.len], data);
+
+        const transfer_cb = try self.prepareTransfer();
+
+        var barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
+        barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        barrier.oldLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        barrier.newLayout = c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        barrier.srcQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+        barrier.image = tex.image orelse return error.ExtensionNotPresent;
+        barrier.subresourceRange.aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT;
+        barrier.subresourceRange.baseMipLevel = 0;
+        barrier.subresourceRange.levelCount = 1;
+        barrier.subresourceRange.baseArrayLayer = 0;
+        barrier.subresourceRange.layerCount = 1;
+        barrier.srcAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+        barrier.dstAccessMask = c.VK_ACCESS_TRANSFER_WRITE_BIT;
+
+        c.vkCmdPipelineBarrier(transfer_cb, c.VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, c.VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, null, 0, null, 1, &barrier);
+
+        var region = std.mem.zeroes(c.VkBufferImageCopy);
+        region.bufferOffset = slice.buffer_offset;
+        region.imageSubresource.aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT;
+        region.imageSubresource.layerCount = 1;
+        region.imageExtent = .{ .width = tex.width, .height = tex.height, .depth = tex.depth };
+
+        c.vkCmdCopyBufferToImage(transfer_cb, self.staging_ring.buffer, tex.image.?, c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+        barrier.oldLayout = c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        barrier.newLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        barrier.srcAccessMask = c.VK_ACCESS_TRANSFER_WRITE_BIT;
+        barrier.dstAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+
+        c.vkCmdPipelineBarrier(transfer_cb, c.VK_PIPELINE_STAGE_TRANSFER_BIT, c.VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, null, 0, null, 1, &barrier);
     }
 
     pub fn createShader(self: *ResourceManager, vertex_src: [*c]const u8, fragment_src: [*c]const u8) rhi.RhiError!rhi.ShaderHandle {

--- a/src/engine/graphics/vulkan/resource_texture_ops.zig
+++ b/src/engine/graphics/vulkan/resource_texture_ops.zig
@@ -3,6 +3,7 @@ const c = @import("../../../c.zig").c;
 const rhi = @import("../rhi.zig");
 const log = @import("../../core/log.zig");
 const Utils = @import("utils.zig");
+const transfer_queue = @import("transfer_queue.zig");
 
 pub fn createTexture(self: anytype, width: u32, height: u32, format: rhi.TextureFormat, config: rhi.TextureConfig, data_opt: ?[]const u8) rhi.RhiError!rhi.TextureHandle {
     const vk_format: c.VkFormat = switch (format) {
@@ -32,13 +33,14 @@ pub fn createTexture(self: anytype, width: u32, height: u32, format: rhi.Texture
     if (mip_levels > 1) usage_flags |= c.VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     if (config.is_render_target) usage_flags |= c.VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     if (format == .rgba32f) usage_flags |= c.VK_IMAGE_USAGE_STORAGE_BIT;
+    if (config.is_render_target) usage_flags |= c.VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    if (format == .rgba32f) usage_flags |= c.VK_IMAGE_USAGE_STORAGE_BIT;
 
     var staging_offset: u64 = 0;
+    var staging_slice: ?transfer_queue.StagingSlice = null;
     if (data_opt) |data| {
-        const staging = &self.staging_buffers[self.current_frame_index];
-        const offset = staging.allocate(data.len) orelse return error.OutOfMemory;
-        if (staging.mapped_ptr == null) return error.OutOfMemory;
-        staging_offset = offset;
+        staging_slice = self.staging_ring.allocate(data.len, self.current_frame_index) orelse return error.OutOfMemory;
+        staging_offset = staging_slice.?.buffer_offset;
     }
 
     const device = self.vulkan_device.vk_device;
@@ -77,10 +79,9 @@ pub fn createTexture(self: anytype, width: u32, height: u32, format: rhi.Texture
     try Utils.checkVk(c.vkBindImageMemory(device, image, memory, 0));
 
     if (data_opt) |data| {
-        const staging = &self.staging_buffers[self.current_frame_index];
-        if (staging.mapped_ptr == null) return error.OutOfMemory;
-        const dest = @as([*]u8, @ptrCast(staging.mapped_ptr.?)) + staging_offset;
-        @memcpy(dest[0..data.len], data);
+        if (staging_slice == null) return error.OutOfMemory;
+        const slice = staging_slice.?;
+        @memcpy(slice.ptr[0..data.len], data);
 
         const transfer_cb = try self.prepareTransfer();
 
@@ -107,7 +108,7 @@ pub fn createTexture(self: anytype, width: u32, height: u32, format: rhi.Texture
         region.imageSubresource.layerCount = 1;
         region.imageExtent = .{ .width = width, .height = height, .depth = 1 };
 
-        c.vkCmdCopyBufferToImage(transfer_cb, staging.buffer, image, c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+        c.vkCmdCopyBufferToImage(transfer_cb, self.staging_ring.buffer, image, c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
 
         if (mip_levels > 1) {
             var mip_width: i32 = @intCast(width);
@@ -251,11 +252,10 @@ pub fn createTexture3D(self: anytype, width: u32, height: u32, depth: u32, forma
     if (texture_config.is_render_target) usage_flags |= c.VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
     var staging_offset: u64 = 0;
+    var staging_slice_3d: ?transfer_queue.StagingSlice = null;
     if (data_opt) |data| {
-        const staging = &self.staging_buffers[self.current_frame_index];
-        const offset = staging.allocate(data.len) orelse return error.OutOfMemory;
-        if (staging.mapped_ptr == null) return error.OutOfMemory;
-        staging_offset = offset;
+        staging_slice_3d = self.staging_ring.allocate(data.len, self.current_frame_index) orelse return error.OutOfMemory;
+        staging_offset = staging_slice_3d.?.buffer_offset;
     }
 
     const device = self.vulkan_device.vk_device;
@@ -321,17 +321,16 @@ pub fn createTexture3D(self: anytype, width: u32, height: u32, depth: u32, forma
     );
 
     if (data_opt) |data| {
-        const staging = &self.staging_buffers[self.current_frame_index];
-        if (staging.mapped_ptr == null) return error.OutOfMemory;
-        const dest = @as([*]u8, @ptrCast(staging.mapped_ptr.?)) + staging_offset;
-        @memcpy(dest[0..data.len], data);
+        if (staging_slice_3d == null) return error.OutOfMemory;
+        const slice = staging_slice_3d.?;
+        @memcpy(slice.ptr[0..data.len], data);
 
         var region = std.mem.zeroes(c.VkBufferImageCopy);
         region.bufferOffset = staging_offset;
         region.imageSubresource.aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT;
         region.imageSubresource.layerCount = 1;
         region.imageExtent = .{ .width = width, .height = height, .depth = depth };
-        c.vkCmdCopyBufferToImage(transfer_cb, staging.buffer, image, c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+        c.vkCmdCopyBufferToImage(transfer_cb, self.staging_ring.buffer, image, c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
 
         barrier.oldLayout = c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
         barrier.newLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;

--- a/src/engine/graphics/vulkan/resource_texture_ops.zig
+++ b/src/engine/graphics/vulkan/resource_texture_ops.zig
@@ -33,8 +33,6 @@ pub fn createTexture(self: anytype, width: u32, height: u32, format: rhi.Texture
     if (mip_levels > 1) usage_flags |= c.VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     if (config.is_render_target) usage_flags |= c.VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     if (format == .rgba32f) usage_flags |= c.VK_IMAGE_USAGE_STORAGE_BIT;
-    if (config.is_render_target) usage_flags |= c.VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    if (format == .rgba32f) usage_flags |= c.VK_IMAGE_USAGE_STORAGE_BIT;
 
     var staging_offset: u64 = 0;
     var staging_slice: ?transfer_queue.StagingSlice = null;

--- a/src/engine/graphics/vulkan/rhi_context_factory.zig
+++ b/src/engine/graphics/vulkan/rhi_context_factory.zig
@@ -105,8 +105,7 @@ pub fn createRHI(
     }
 
     ctx.frames.command_pool = null;
-    ctx.resources.transfer_command_pool = null;
-    ctx.resources.transfer_ready = false;
+    ctx.resources.transfer_fence = null;
     ctx.swapchain.swapchain.main_render_pass = null;
     ctx.swapchain.swapchain.handle = null;
     ctx.swapchain.swapchain.depth_image = null;
@@ -183,6 +182,7 @@ pub fn createRHI(
         }
         ctx.resources.buffer_deletion_queue[i] = .empty;
         ctx.resources.image_deletion_queue[i] = .empty;
+        ctx.resources.transfer.transfer_ready[i] = false;
     }
 
     for (0..rhi.MAX_SWAPCHAIN_IMAGES) |i| {

--- a/src/engine/graphics/vulkan/rhi_context_factory.zig
+++ b/src/engine/graphics/vulkan/rhi_context_factory.zig
@@ -105,7 +105,6 @@ pub fn createRHI(
     }
 
     ctx.frames.command_pool = null;
-    ctx.resources.transfer_fence = null;
     ctx.swapchain.swapchain.main_render_pass = null;
     ctx.swapchain.swapchain.handle = null;
     ctx.swapchain.swapchain.depth_image = null;

--- a/src/engine/graphics/vulkan/rhi_context_types.zig
+++ b/src/engine/graphics/vulkan/rhi_context_types.zig
@@ -90,7 +90,6 @@ const LegacyResources = struct {
     dummy_shadow_view: c.VkImageView = null,
     model_ubo: VulkanBuffer = .{},
     dummy_instance_buffer: VulkanBuffer = .{},
-    transfer_fence: c.VkFence = null,
 };
 
 const ShadowRuntime = struct {

--- a/src/engine/graphics/vulkan/rhi_pass_orchestration.zig
+++ b/src/engine/graphics/vulkan/rhi_pass_orchestration.zig
@@ -431,8 +431,15 @@ pub fn endFrame(ctx: anytype) void {
     if (ctx.fxaa.pass_active) endFXAAPassInternal(ctx);
 
     const transfer_cb = ctx.resources.getTransferCommandBuffer();
+    const transfer_sem = ctx.resources.getTransferSemaphore();
 
-    ctx.frames.endFrame(&ctx.swapchain, transfer_cb) catch |err| {
+    if (ctx.resources.transfer.is_dedicated and transfer_cb != null) {
+        ctx.resources.submitTransfer() catch |err| {
+            log.log.errWithTrace("Failed to submit transfer: {}", .{err});
+        };
+    }
+
+    ctx.frames.endFrame(&ctx.swapchain, transfer_cb, transfer_sem) catch |err| {
         log.log.errWithTrace("endFrame failed: {}", .{err});
     };
 

--- a/src/engine/graphics/vulkan/rhi_pass_orchestration.zig
+++ b/src/engine/graphics/vulkan/rhi_pass_orchestration.zig
@@ -431,13 +431,14 @@ pub fn endFrame(ctx: anytype) void {
     if (ctx.fxaa.pass_active) endFXAAPassInternal(ctx);
 
     const transfer_cb = ctx.resources.getTransferCommandBuffer();
-    const transfer_sem = ctx.resources.getTransferSemaphore();
 
     if (ctx.resources.transfer.is_dedicated and transfer_cb != null) {
         ctx.resources.submitTransfer() catch |err| {
             log.log.errWithTrace("Failed to submit transfer: {}", .{err});
         };
     }
+
+    const transfer_sem = ctx.resources.getTransferSemaphore();
 
     ctx.frames.endFrame(&ctx.swapchain, transfer_cb, transfer_sem) catch |err| {
         log.log.errWithTrace("endFrame failed: {}", .{err});

--- a/src/engine/graphics/vulkan/transfer_queue.zig
+++ b/src/engine/graphics/vulkan/transfer_queue.zig
@@ -135,6 +135,7 @@ pub const TransferQueue = struct {
     command_pool: c.VkCommandPool = null,
     command_buffers: [rhi.MAX_FRAMES_IN_FLIGHT]c.VkCommandBuffer = undefined,
     fence: c.VkFence = null,
+    frame_fences: [rhi.MAX_FRAMES_IN_FLIGHT]c.VkFence = .{null} ** rhi.MAX_FRAMES_IN_FLIGHT,
     transfer_semaphore: c.VkSemaphore = null,
     transfer_ready: [rhi.MAX_FRAMES_IN_FLIGHT]bool = undefined,
     current_frame: usize = 0,
@@ -165,6 +166,10 @@ pub const TransferQueue = struct {
         fence_info.sType = c.VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
         try Utils.checkVk(c.vkCreateFence(device.vk_device, &fence_info, null, &self.fence));
 
+        for (0..rhi.MAX_FRAMES_IN_FLIGHT) |i| {
+            try Utils.checkVk(c.vkCreateFence(device.vk_device, &fence_info, null, &self.frame_fences[i]));
+        }
+
         var sem_info = std.mem.zeroes(c.VkSemaphoreCreateInfo);
         sem_info.sType = c.VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
         try Utils.checkVk(c.vkCreateSemaphore(device.vk_device, &sem_info, null, &self.transfer_semaphore));
@@ -183,6 +188,12 @@ pub const TransferQueue = struct {
         if (self.fence != null) {
             c.vkDestroyFence(vk_device, self.fence, null);
             self.fence = null;
+        }
+        for (0..rhi.MAX_FRAMES_IN_FLIGHT) |i| {
+            if (self.frame_fences[i] != null) {
+                c.vkDestroyFence(vk_device, self.frame_fences[i], null);
+                self.frame_fences[i] = null;
+            }
         }
         if (self.transfer_semaphore != null) {
             c.vkDestroySemaphore(vk_device, self.transfer_semaphore, null);
@@ -222,6 +233,12 @@ pub const TransferQueue = struct {
         if (!self.transfer_ready[self.current_frame]) return;
         const cb = self.command_buffers[self.current_frame];
         try Utils.checkVk(c.vkEndCommandBuffer(cb));
+    }
+
+    pub fn waitForFrameFence(self: *TransferQueue, vk_device: c.VkDevice, frame_index: usize) void {
+        if (self.frame_fences[frame_index] == null) return;
+        _ = c.vkWaitForFences(vk_device, 1, &self.frame_fences[frame_index], c.VK_TRUE, std.math.maxInt(u64));
+        _ = c.vkResetFences(vk_device, 1, &self.frame_fences[frame_index]);
     }
 
     pub fn submitAndWait(self: *TransferQueue, vk_device: c.VkDevice, queue_mutex: *std.Thread.Mutex) !void {

--- a/src/engine/graphics/vulkan/transfer_queue.zig
+++ b/src/engine/graphics/vulkan/transfer_queue.zig
@@ -1,0 +1,255 @@
+//! Dedicated Vulkan transfer queue with ring-buffered staging allocator.
+//!
+//! Provides async GPU uploads that can overlap with rendering when a dedicated
+//! transfer queue family is available. Falls back to sharing the graphics queue
+//! otherwise — the staging ring still works but without parallelism.
+//!
+//! ## Ring Buffer Lifecycle
+//! Each frame's allocations occupy a contiguous region of the ring. When that
+//! frame's fence completes, the region is reclaimed. With `MAX_FRAMES_IN_FLIGHT=2`
+//! the ring needs at most 2× the per-frame upload budget.
+
+const std = @import("std");
+const c = @import("../../../c.zig").c;
+const rhi = @import("../rhi.zig");
+const log = @import("../../core/log.zig");
+const VulkanDevice = @import("../vulkan_device.zig").VulkanDevice;
+const Utils = @import("utils.zig");
+
+pub const DEFAULT_STAGING_CAPACITY: u64 = 64 * 1024 * 1024;
+const ALIGNMENT: u64 = 256;
+
+pub const StagingRing = struct {
+    buffer: c.VkBuffer = null,
+    memory: c.VkDeviceMemory = null,
+    mapped: [*]u8 = undefined,
+    is_mapped: bool = false,
+    capacity: u64 = 0,
+    head: u64 = 0,
+    tail: u64 = 0,
+    frame_base: [rhi.MAX_FRAMES_IN_FLIGHT]u64,
+    frame_used: [rhi.MAX_FRAMES_IN_FLIGHT]u64,
+
+    pub fn init(device: *const VulkanDevice, capacity: u64) !StagingRing {
+        const buf = try Utils.createVulkanBuffer(
+            device,
+            capacity,
+            c.VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+            c.VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | c.VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+        );
+        if (buf.buffer == null or buf.mapped_ptr == null) return error.VulkanError;
+
+        var ring = StagingRing{
+            .buffer = buf.buffer,
+            .memory = buf.memory,
+            .mapped = @ptrCast(buf.mapped_ptr.?),
+            .is_mapped = true,
+            .capacity = capacity,
+            .head = 0,
+            .tail = 0,
+            .frame_base = undefined,
+            .frame_used = undefined,
+        };
+        @memset(&ring.frame_base, 0);
+        @memset(&ring.frame_used, 0);
+        return ring;
+    }
+
+    pub fn deinit(self: *StagingRing, vk_device: c.VkDevice) void {
+        if (self.is_mapped and self.memory != null) {
+            c.vkUnmapMemory(vk_device, self.memory);
+        }
+        if (self.buffer != null) c.vkDestroyBuffer(vk_device, self.buffer, null);
+        if (self.memory != null) c.vkFreeMemory(vk_device, self.memory, null);
+        self.buffer = null;
+        self.memory = null;
+        self.is_mapped = false;
+        self.capacity = 0;
+        self.head = 0;
+        self.tail = 0;
+        @memset(&self.frame_base, 0);
+        @memset(&self.frame_used, 0);
+    }
+
+    pub fn beginFrame(self: *StagingRing, frame_index: usize) void {
+        self.frame_base[frame_index] = self.head;
+        self.frame_used[frame_index] = 0;
+    }
+
+    pub fn reclaimFrame(self: *StagingRing, frame_index: usize) void {
+        self.tail = self.frame_base[frame_index] + self.frame_used[frame_index];
+        if (self.tail >= self.capacity) self.tail -= self.capacity;
+    }
+
+    pub fn allocated(self: *StagingRing) u64 {
+        if (self.head >= self.tail) return self.head - self.tail;
+        return self.capacity - self.tail + self.head;
+    }
+
+    pub fn available(self: *StagingRing) u64 {
+        return self.capacity - self.allocated();
+    }
+
+    pub fn allocate(self: *StagingRing, size: u64, frame_index: usize) ?StagingSlice {
+        if (size == 0) return null;
+
+        const aligned_head = std.mem.alignForward(u64, self.head, ALIGNMENT);
+        var padded_to_end: u64 = 0;
+
+        const try_offset = blk: {
+            if (aligned_head + size <= self.capacity) {
+                break :blk aligned_head;
+            }
+            padded_to_end = self.capacity - self.head;
+            const wrap = std.mem.alignForward(u64, 0, ALIGNMENT);
+            if (wrap + size > self.capacity) return null;
+            const avail = self.available();
+            if (size + padded_to_end > avail) return null;
+            break :blk wrap;
+        };
+
+        const slice = StagingSlice{
+            .ptr = self.mapped + try_offset,
+            .buffer_offset = try_offset,
+            .size = size,
+        };
+
+        const new_head = try_offset + size;
+        self.head = if (new_head >= self.capacity) 0 else new_head;
+        self.frame_used[frame_index] += size + padded_to_end;
+
+        return slice;
+    }
+};
+
+pub const StagingSlice = struct {
+    ptr: [*]u8,
+    buffer_offset: u64,
+    size: u64,
+};
+
+pub const TransferQueue = struct {
+    queue: c.VkQueue = null,
+    family_index: u32 = 0,
+    is_dedicated: bool = false,
+    command_pool: c.VkCommandPool = null,
+    command_buffers: [rhi.MAX_FRAMES_IN_FLIGHT]c.VkCommandBuffer = undefined,
+    fence: c.VkFence = null,
+    transfer_semaphore: c.VkSemaphore = null,
+    transfer_ready: [rhi.MAX_FRAMES_IN_FLIGHT]bool = undefined,
+    current_frame: usize = 0,
+
+    pub fn init(device: *const VulkanDevice, transfer_family: u32, is_dedicated: bool) !TransferQueue {
+        var self = TransferQueue{
+            .family_index = transfer_family,
+            .is_dedicated = is_dedicated,
+        };
+        @memset(&self.transfer_ready, false);
+
+        c.vkGetDeviceQueue(device.vk_device, transfer_family, 0, &self.queue);
+
+        var pool_info = std.mem.zeroes(c.VkCommandPoolCreateInfo);
+        pool_info.sType = c.VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        pool_info.queueFamilyIndex = transfer_family;
+        pool_info.flags = c.VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | c.VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+        try Utils.checkVk(c.vkCreateCommandPool(device.vk_device, &pool_info, null, &self.command_pool));
+
+        var alloc_info = std.mem.zeroes(c.VkCommandBufferAllocateInfo);
+        alloc_info.sType = c.VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+        alloc_info.commandPool = self.command_pool;
+        alloc_info.level = c.VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        alloc_info.commandBufferCount = rhi.MAX_FRAMES_IN_FLIGHT;
+        try Utils.checkVk(c.vkAllocateCommandBuffers(device.vk_device, &alloc_info, &self.command_buffers));
+
+        var fence_info = std.mem.zeroes(c.VkFenceCreateInfo);
+        fence_info.sType = c.VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+        try Utils.checkVk(c.vkCreateFence(device.vk_device, &fence_info, null, &self.fence));
+
+        var sem_info = std.mem.zeroes(c.VkSemaphoreCreateInfo);
+        sem_info.sType = c.VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+        try Utils.checkVk(c.vkCreateSemaphore(device.vk_device, &sem_info, null, &self.transfer_semaphore));
+
+        return self;
+    }
+
+    pub fn deinit(self: *TransferQueue, vk_device: c.VkDevice) void {
+        if (vk_device == null) return;
+        _ = c.vkDeviceWaitIdle(vk_device);
+
+        if (self.command_pool != null) {
+            c.vkDestroyCommandPool(vk_device, self.command_pool, null);
+            self.command_pool = null;
+        }
+        if (self.fence != null) {
+            c.vkDestroyFence(vk_device, self.fence, null);
+            self.fence = null;
+        }
+        if (self.transfer_semaphore != null) {
+            c.vkDestroySemaphore(vk_device, self.transfer_semaphore, null);
+            self.transfer_semaphore = null;
+        }
+    }
+
+    pub fn setCurrentFrame(self: *TransferQueue, frame_index: usize) void {
+        self.current_frame = frame_index;
+    }
+
+    pub fn prepareTransfer(self: *TransferQueue) !c.VkCommandBuffer {
+        if (self.transfer_ready[self.current_frame]) return self.command_buffers[self.current_frame];
+
+        const cb = self.command_buffers[self.current_frame];
+        try Utils.checkVk(c.vkResetCommandBuffer(cb, 0));
+
+        var begin_info = std.mem.zeroes(c.VkCommandBufferBeginInfo);
+        begin_info.sType = c.VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        begin_info.flags = c.VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        try Utils.checkVk(c.vkBeginCommandBuffer(cb, &begin_info));
+
+        self.transfer_ready[self.current_frame] = true;
+        return cb;
+    }
+
+    pub fn getTransferCommandBuffer(self: *TransferQueue) ?c.VkCommandBuffer {
+        if (!self.transfer_ready[self.current_frame]) return null;
+        return self.command_buffers[self.current_frame];
+    }
+
+    pub fn resetTransferState(self: *TransferQueue) void {
+        self.transfer_ready[self.current_frame] = false;
+    }
+
+    pub fn endTransferCommandBuffer(self: *TransferQueue) !void {
+        if (!self.transfer_ready[self.current_frame]) return;
+        const cb = self.command_buffers[self.current_frame];
+        try Utils.checkVk(c.vkEndCommandBuffer(cb));
+    }
+
+    pub fn submitAndWait(self: *TransferQueue, vk_device: c.VkDevice, queue_mutex: *std.Thread.Mutex) !void {
+        if (!self.transfer_ready[self.current_frame]) return;
+
+        const cb = self.command_buffers[self.current_frame];
+        try Utils.checkVk(c.vkEndCommandBuffer(cb));
+
+        var submit_info = std.mem.zeroes(c.VkSubmitInfo);
+        submit_info.sType = c.VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submit_info.commandBufferCount = 1;
+        submit_info.pCommandBuffers = &cb;
+
+        try Utils.checkVk(c.vkResetFences(vk_device, 1, &self.fence));
+
+        queue_mutex.lock();
+        const result = c.vkQueueSubmit(self.queue, 1, &submit_info, self.fence);
+        queue_mutex.unlock();
+
+        if (result != c.VK_SUCCESS) return error.VulkanError;
+
+        try Utils.checkVk(c.vkWaitForFences(vk_device, 1, &self.fence, c.VK_TRUE, std.math.maxInt(u64)));
+
+        self.transfer_ready[self.current_frame] = false;
+    }
+
+    pub fn flushSync(self: *TransferQueue, vk_device: c.VkDevice, queue_mutex: *std.Thread.Mutex) !void {
+        if (!self.transfer_ready[self.current_frame]) return;
+        try self.submitAndWait(vk_device, queue_mutex);
+    }
+};

--- a/src/engine/graphics/vulkan/transfer_queue.zig
+++ b/src/engine/graphics/vulkan/transfer_queue.zig
@@ -136,8 +136,9 @@ pub const TransferQueue = struct {
     command_buffers: [rhi.MAX_FRAMES_IN_FLIGHT]c.VkCommandBuffer = undefined,
     fence: c.VkFence = null,
     frame_fences: [rhi.MAX_FRAMES_IN_FLIGHT]c.VkFence = .{null} ** rhi.MAX_FRAMES_IN_FLIGHT,
-    transfer_semaphore: c.VkSemaphore = null,
+    transfer_semaphores: [rhi.MAX_FRAMES_IN_FLIGHT]c.VkSemaphore = .{null} ** rhi.MAX_FRAMES_IN_FLIGHT,
     transfer_ready: [rhi.MAX_FRAMES_IN_FLIGHT]bool = undefined,
+    transfer_submitted: [rhi.MAX_FRAMES_IN_FLIGHT]bool = undefined,
     current_frame: usize = 0,
 
     pub fn init(device: *const VulkanDevice, transfer_family: u32, is_dedicated: bool) !TransferQueue {
@@ -146,6 +147,7 @@ pub const TransferQueue = struct {
             .is_dedicated = is_dedicated,
         };
         @memset(&self.transfer_ready, false);
+        @memset(&self.transfer_submitted, false);
 
         c.vkGetDeviceQueue(device.vk_device, transfer_family, 0, &self.queue);
 
@@ -172,7 +174,9 @@ pub const TransferQueue = struct {
 
         var sem_info = std.mem.zeroes(c.VkSemaphoreCreateInfo);
         sem_info.sType = c.VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-        try Utils.checkVk(c.vkCreateSemaphore(device.vk_device, &sem_info, null, &self.transfer_semaphore));
+        for (0..rhi.MAX_FRAMES_IN_FLIGHT) |i| {
+            try Utils.checkVk(c.vkCreateSemaphore(device.vk_device, &sem_info, null, &self.transfer_semaphores[i]));
+        }
 
         return self;
     }
@@ -195,9 +199,11 @@ pub const TransferQueue = struct {
                 self.frame_fences[i] = null;
             }
         }
-        if (self.transfer_semaphore != null) {
-            c.vkDestroySemaphore(vk_device, self.transfer_semaphore, null);
-            self.transfer_semaphore = null;
+        for (0..rhi.MAX_FRAMES_IN_FLIGHT) |i| {
+            if (self.transfer_semaphores[i] != null) {
+                c.vkDestroySemaphore(vk_device, self.transfer_semaphores[i], null);
+                self.transfer_semaphores[i] = null;
+            }
         }
     }
 
@@ -217,6 +223,7 @@ pub const TransferQueue = struct {
         try Utils.checkVk(c.vkBeginCommandBuffer(cb, &begin_info));
 
         self.transfer_ready[self.current_frame] = true;
+        self.transfer_submitted[self.current_frame] = false;
         return cb;
     }
 
@@ -227,6 +234,7 @@ pub const TransferQueue = struct {
 
     pub fn resetTransferState(self: *TransferQueue) void {
         self.transfer_ready[self.current_frame] = false;
+        self.transfer_submitted[self.current_frame] = false;
     }
 
     pub fn endTransferCommandBuffer(self: *TransferQueue) !void {

--- a/src/engine/graphics/vulkan_device.zig
+++ b/src/engine/graphics/vulkan_device.zig
@@ -268,18 +268,14 @@ pub const VulkanDevice = struct {
         }
 
         const queue_priority: f32 = 1.0;
-        var queue_create_infos: [2]c.VkDeviceQueueCreateInfo = undefined;
+        var queue_create_infos: [2]c.VkDeviceQueueCreateInfo = .{std.mem.zeroes(c.VkDeviceQueueCreateInfo)} ** 2;
         var queue_create_count: u32 = 1;
 
-        queue_create_infos[0] = std.mem.zeroes(c.VkDeviceQueueCreateInfo);
-        queue_create_infos[0].sType = c.VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
         queue_create_infos[0].queueFamilyIndex = self.graphics_family;
         queue_create_infos[0].queueCount = 1;
         queue_create_infos[0].pQueuePriorities = &queue_priority;
 
         if (self.has_dedicated_transfer_queue) {
-            queue_create_infos[1] = std.mem.zeroes(c.VkDeviceQueueCreateInfo);
-            queue_create_infos[1].sType = c.VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
             queue_create_infos[1].queueFamilyIndex = self.transfer_family;
             queue_create_infos[1].queueCount = 1;
             queue_create_infos[1].pQueuePriorities = &queue_priority;

--- a/src/engine/graphics/vulkan_device.zig
+++ b/src/engine/graphics/vulkan_device.zig
@@ -50,6 +50,8 @@ pub const VulkanDevice = struct {
     vk_device: c.VkDevice = null,
     queue: c.VkQueue = null,
     graphics_family: u32 = 0,
+    transfer_family: u32 = 0,
+    has_dedicated_transfer_queue: bool = false,
     supports_device_fault: bool = false,
     mutex: std.Thread.Mutex = .{},
 
@@ -238,21 +240,51 @@ pub const VulkanDevice = struct {
         c.vkGetPhysicalDeviceQueueFamilyProperties(self.physical_device, &queue_family_count, queue_families.ptr);
 
         var graphics_family: ?u32 = null;
+        var dedicated_transfer_family: ?u32 = null;
         for (queue_families, 0..) |qf, i| {
-            if ((qf.queueFlags & c.VK_QUEUE_GRAPHICS_BIT) != 0) {
-                graphics_family = @intCast(i);
-                break;
+            const idx: u32 = @intCast(i);
+            if (graphics_family == null and (qf.queueFlags & c.VK_QUEUE_GRAPHICS_BIT) != 0) {
+                graphics_family = idx;
+            }
+            if (dedicated_transfer_family == null and
+                (qf.queueFlags & c.VK_QUEUE_TRANSFER_BIT) != 0 and
+                (qf.queueFlags & c.VK_QUEUE_GRAPHICS_BIT) == 0 and
+                (qf.queueFlags & c.VK_QUEUE_COMPUTE_BIT) == 0)
+            {
+                dedicated_transfer_family = idx;
             }
         }
         if (graphics_family == null) return error.NoGraphicsQueue;
         self.graphics_family = graphics_family.?;
 
+        if (dedicated_transfer_family) |tf| {
+            self.transfer_family = tf;
+            self.has_dedicated_transfer_queue = true;
+            log.log.info("Dedicated transfer queue family found: {}", .{tf});
+        } else {
+            self.transfer_family = self.graphics_family;
+            self.has_dedicated_transfer_queue = false;
+            log.log.info("No dedicated transfer queue — sharing graphics queue family {}", .{self.graphics_family});
+        }
+
         const queue_priority: f32 = 1.0;
-        var queue_create_info = std.mem.zeroes(c.VkDeviceQueueCreateInfo);
-        queue_create_info.sType = c.VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-        queue_create_info.queueFamilyIndex = self.graphics_family;
-        queue_create_info.queueCount = 1;
-        queue_create_info.pQueuePriorities = &queue_priority;
+        var queue_create_infos: [2]c.VkDeviceQueueCreateInfo = undefined;
+        var queue_create_count: u32 = 1;
+
+        queue_create_infos[0] = std.mem.zeroes(c.VkDeviceQueueCreateInfo);
+        queue_create_infos[0].sType = c.VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+        queue_create_infos[0].queueFamilyIndex = self.graphics_family;
+        queue_create_infos[0].queueCount = 1;
+        queue_create_infos[0].pQueuePriorities = &queue_priority;
+
+        if (self.has_dedicated_transfer_queue) {
+            queue_create_infos[1] = std.mem.zeroes(c.VkDeviceQueueCreateInfo);
+            queue_create_infos[1].sType = c.VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+            queue_create_infos[1].queueFamilyIndex = self.transfer_family;
+            queue_create_infos[1].queueCount = 1;
+            queue_create_infos[1].pQueuePriorities = &queue_priority;
+            queue_create_count = 2;
+        }
 
         var ext_count: u32 = 0;
         _ = c.vkEnumerateDeviceExtensionProperties(self.physical_device, null, &ext_count, null);
@@ -318,8 +350,8 @@ pub const VulkanDevice = struct {
 
         var device_create_info = std.mem.zeroes(c.VkDeviceCreateInfo);
         device_create_info.sType = c.VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-        device_create_info.queueCreateInfoCount = 1;
-        device_create_info.pQueueCreateInfos = &queue_create_info;
+        device_create_info.queueCreateInfoCount = queue_create_count;
+        device_create_info.pQueueCreateInfos = &queue_create_infos[0];
         device_create_info.pEnabledFeatures = &device_features;
         if (allow_robustness2) {
             device_create_info.pNext = @ptrCast(&robustness2_features);
@@ -339,6 +371,8 @@ pub const VulkanDevice = struct {
             enabled_extension_count = 1;
             device_create_info.enabledExtensionCount = enabled_extension_count;
             device_create_info.ppEnabledExtensionNames = &enabled_extensions;
+            queue_create_count = 1;
+            device_create_info.queueCreateInfoCount = queue_create_count;
             create_result = c.vkCreateDevice(self.physical_device, &device_create_info, null, &self.vk_device);
         }
 


### PR DESCRIPTION
## Summary

Implements a dedicated Vulkan transfer queue with a ring-buffered staging allocator for chunk mesh uploads (Issue #384).

### Changes

**New file: `transfer_queue.zig`**
- `StagingRing`: persistent 64MB ring buffer with frame-based tail reclamation
- `TransferQueue`: dedicated (or shared-fallback) Vulkan queue + command pool

**Modified: `vulkan_device.zig`**
- Detects dedicated transfer queue family (TRANSFER-only, non-GRAPHICS)
- Falls back to sharing graphics queue when no dedicated queue available
- Creates second queue create info for dedicated transfer queue

**Modified: `resource_manager.zig`**
- Replaces per-frame `StagingBuffer[2]` array with single `StagingRing`
- Transfer command pool now uses dedicated transfer queue family when available
- `prepareTransfer()` delegates to `TransferQueue`
- `submitTransfer()` for dedicated queue submits to separate queue with semaphore

**Modified: `frame_manager.zig`**
- `endFrame()` signature extended with `?VkSemaphore` parameter
- For dedicated queue: transfer CB NOT included in graphics submit; separate submit + semaphore sync
- For shared queue: behavior unchanged (both CBs in same submit)

**Modified: `rhi_pass_orchestration.zig`**
- Calls `submitTransfer()` before `endFrame()` when dedicated queue active
- Passes `getTransferSemaphore()` to `endFrame()`

**Modified: `rhi_vulkan.zig`, `rhi_context_factory.zig`, `rhi_tests.zig`, `resource_texture_ops.zig`**
- Updated to match new ResourceManager struct layout

### Architecture

When a dedicated transfer queue is available:
1. Worker thread builds mesh vertices on CPU
2. Main thread: `staging.allocate()` → get CPU-visible slice
3. Copy vertex data into staging slice
4. Record `vkCmdCopyBuffer(staging → megabuffer)` on transfer queue
5. Submit to transfer queue with fence + signal semaphore
6. Next frame: fence completed → ring space reclaimed
7. Graphics queue waits on transfer semaphore before reading megabuffer

When only shared graphics queue:
- Falls back to original per-frame staging behavior
- No parallelism but staging ring still prevents per-frame buffer overflow

## Testing

- [x] Build passes
- [x] Tests pass
- [x] Code formatted with `zig fmt`