### PR TITLE
feat(world): GPU block data buffer for compute meshing (#389)

### DIFF
--- a/src/world/gpu_block_buffer.zig
+++ b/src/world/gpu_block_buffer.zig
@@ -1,0 +1,161 @@
+//! GPU block data buffer - uploads chunk block data to GPU storage buffer.
+//!
+//! This provides a GPU-visible storage buffer holding block data for all loaded
+//! chunks. A compute meshing shader (future issue) can read blocks directly from
+//! this buffer and output vertices on the GPU.
+//!
+//! ## Layout
+//!
+//! ```
+//! Buffer: [chunk_0_blocks | chunk_1_blocks | ... | chunk_N_blocks]
+//! Each chunk: 16 × 256 × 16 = 65536 bytes (BlockType is u8)
+//! Total: max_chunks × 64KB
+//! ```
+//!
+//! ## Slot Allocation
+//!
+//! Uses a free-list allocator to track which slots are in use.
+//! - `allocate()`: reserves a slot for a chunk
+//! - `free()`: returns a slot to the free list
+//! - `upload()`: copies block data to the GPU buffer at a specific slot offset
+
+const std = @import("std");
+const log = @import("../engine/core/log.zig");
+const rhi_mod = @import("../engine/graphics/rhi.zig");
+const ResourceManager = rhi_mod.ResourceManager;
+const BufferHandle = rhi_mod.BufferHandle;
+const InvalidBufferHandle = rhi_mod.InvalidBufferHandle;
+const BufferUsage = rhi_mod.BufferUsage;
+const CHUNK_SIZE_X = @import("chunk.zig").CHUNK_SIZE_X;
+const CHUNK_SIZE_Y = @import("chunk.zig").CHUNK_SIZE_Y;
+const CHUNK_SIZE_Z = @import("chunk.zig").CHUNK_SIZE_Z;
+const CHUNK_VOLUME = @import("chunk.zig").CHUNK_VOLUME;
+
+pub const MAX_GPU_CHUNKS: usize = 16384;
+pub const SLOT_SIZE: usize = CHUNK_VOLUME;
+
+pub const GpuBlockBuffer = struct {
+    allocator: std.mem.Allocator,
+    rm: ResourceManager,
+    buffer: BufferHandle,
+    capacity: usize,
+    slot_size: usize,
+    free_list: std.ArrayListUnmanaged(usize),
+    slot_to_chunk: std.AutoArrayHashMapUnmanaged(usize, ChunkSlot),
+
+    pub const ChunkSlot = struct {
+        cx: i32,
+        cz: i32,
+    };
+
+    pub fn init(allocator: std.mem.Allocator, rm: ResourceManager, max_chunks: usize) !*GpuBlockBuffer {
+        const buffer = try allocator.create(GpuBlockBuffer);
+
+        const capacity = @min(max_chunks, MAX_GPU_CHUNKS);
+        const total_size = capacity * SLOT_SIZE;
+
+        const buf_handle = try rm.createBuffer(total_size, .storage);
+        errdefer rm.destroyBuffer(buf_handle);
+
+        buffer.* = .{
+            .allocator = allocator,
+            .rm = rm,
+            .buffer = buf_handle,
+            .capacity = capacity,
+            .slot_size = SLOT_SIZE,
+            .free_list = .empty,
+            .slot_to_chunk = .empty,
+        };
+
+        try buffer.free_list.ensureTotalCapacity(allocator, capacity);
+        for (0..capacity) |i| {
+            buffer.free_list.append(allocator, capacity - 1 - i) catch unreachable;
+        }
+
+        return buffer;
+    }
+
+    pub fn deinit(self: *GpuBlockBuffer) void {
+        self.rm.destroyBuffer(self.buffer);
+        self.free_list.deinit(self.allocator);
+        self.slot_to_chunk.deinit(self.allocator);
+        self.allocator.destroy(self);
+    }
+
+    pub fn allocate(self: *GpuBlockBuffer, cx: i32, cz: i32) !usize {
+        if (self.free_list.pop()) |slot| {
+            try self.slot_to_chunk.put(self.allocator, slot, ChunkSlot{ .cx = cx, .cz = cz });
+            return slot;
+        }
+        return error.OutOfMemory;
+    }
+
+    pub fn free(self: *GpuBlockBuffer, slot: usize) void {
+        if (self.slot_to_chunk.swapRemove(slot)) {
+            self.free_list.append(self.allocator, slot) catch {};
+        }
+    }
+
+    pub fn freeByChunk(self: *GpuBlockBuffer, cx: i32, cz: i32) ?usize {
+        var it = self.slot_to_chunk.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.cx == cx and entry.value_ptr.cz == cz) {
+                const slot = entry.key_ptr.*;
+                _ = self.slot_to_chunk.swapRemove(slot);
+                self.free_list.append(self.allocator, slot) catch {};
+                return slot;
+            }
+        }
+        return null;
+    }
+
+    pub fn upload(self: *GpuBlockBuffer, slot: usize, blocks: []const u8) !void {
+        std.debug.assert(blocks.len == SLOT_SIZE);
+        const offset = slot * SLOT_SIZE;
+        try self.rm.updateBuffer(self.buffer, offset, blocks);
+    }
+
+    pub fn update(self: *GpuBlockBuffer, slot: usize, offset: usize, data: []const u8) !void {
+        const slot_offset = slot * SLOT_SIZE + offset;
+        try self.rm.updateBuffer(self.buffer, slot_offset, data);
+    }
+
+    pub fn updateBlock(self: *GpuBlockBuffer, cx: i32, cz: i32, local_x: u32, local_y: u32, local_z: u32, block: u8) !void {
+        if (self.getSlotForChunk(cx, cz)) |slot| {
+            const offset = slot * SLOT_SIZE + local_x + local_z * CHUNK_SIZE_X + local_y * CHUNK_SIZE_X * CHUNK_SIZE_Z;
+            const block_data: [1]u8 = .{block};
+            try self.rm.updateBuffer(self.buffer, offset, &block_data);
+        }
+    }
+
+    pub fn getSlotForChunk(self: *GpuBlockBuffer, cx: i32, cz: i32) ?usize {
+        var it = self.slot_to_chunk.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.cx == cx and entry.value_ptr.cz == cz) {
+                return entry.key_ptr.*;
+            }
+        }
+        return null;
+    }
+
+    pub fn getBufferHandle(self: *GpuBlockBuffer) BufferHandle {
+        return self.buffer;
+    }
+
+    pub fn allocatedCount(self: *GpuBlockBuffer) usize {
+        return self.capacity - self.free_list.items.len;
+    }
+
+    pub fn stats(self: *GpuBlockBuffer) struct {
+        allocated: usize,
+        capacity: usize,
+        used_bytes: usize,
+    } {
+        const allocated = self.allocatedCount();
+        return .{
+            .allocated = allocated,
+            .capacity = self.capacity,
+            .used_bytes = allocated * SLOT_SIZE,
+        };
+    }
+};

--- a/src/world/world.zig
+++ b/src/world/world.zig
@@ -43,6 +43,7 @@ const ILODConfig = @import("lod_chunk.zig").ILODConfig;
 const CHUNK_UNLOAD_BUFFER = @import("chunk.zig").CHUNK_UNLOAD_BUFFER;
 const SaveManager = @import("persistence/save_manager.zig").SaveManager;
 const LoadResult = @import("persistence/save_manager.zig").LoadResult;
+const GpuBlockBuffer = @import("gpu_block_buffer.zig").GpuBlockBuffer;
 
 /// Buffer distance beyond render_distance for chunk unloading.
 /// Prevents thrashing when player moves near chunk boundaries.
@@ -136,6 +137,9 @@ pub const World = struct {
     // Save system (Issue #380)
     save_manager: ?*SaveManager,
 
+    // GPU Block Buffer (Batch 5 - Issue #389)
+    gpu_block_buffer: ?*GpuBlockBuffer,
+
     pub fn init(allocator: std.mem.Allocator, render_distance: i32, seed: u64, rhi: RHI, atlas: *const TextureAtlas) !*World {
         return initGen(0, allocator, render_distance, seed, rhi, atlas);
     }
@@ -172,14 +176,17 @@ pub const World = struct {
             .lod = null,
             .lod_enabled = false,
             .save_manager = null,
+            .gpu_block_buffer = null,
         };
 
         log.log.info("World.initGen: initializing WorldRenderer", .{});
         world.renderer = try WorldRenderer.init(allocator, rhi.resourceManager(), rhi.renderContext(), rhi.query(), &world.storage, rhi);
         errdefer _ = world.renderer;
 
+        world.gpu_block_buffer = world.renderer.getGpuBlockBuffer();
+
         log.log.info("World.initGen: initializing WorldStreamer (render_distance={})", .{safe_render_distance});
-        world.streamer = try WorldStreamer.init(allocator, &world.storage, world.generator, atlas, world.render_distance, world.renderer.vertex_allocator, max_uploads);
+        world.streamer = try WorldStreamer.init(allocator, &world.storage, world.generator, atlas, world.render_distance, world.renderer.vertex_allocator, max_uploads, world.gpu_block_buffer);
         errdefer world.streamer.deinit();
 
         return world;
@@ -355,7 +362,12 @@ pub const World = struct {
         const local = worldToLocal(world_x, world_z);
         data.chunk.setBlock(local.x, @intCast(world_y), local.z, block);
 
-        // Update skylight for this column
+        if (self.gpu_block_buffer) |buf| {
+            buf.updateBlock(cp.chunk_x, cp.chunk_z, local.x, @intCast(world_y), local.z, @intFromEnum(block)) catch |err| {
+                log.log.debug("GPU block buffer update failed: {}", .{err});
+            };
+        }
+
         data.chunk.updateSkylightColumn(local.x, local.z);
 
         // Mark neighbor chunks dirty if block is on chunk boundary

--- a/src/world/world_renderer.zig
+++ b/src/world/world_renderer.zig
@@ -20,6 +20,7 @@ const Mat4 = @import("../engine/math/mat4.zig").Mat4;
 const Frustum = @import("../engine/math/frustum.zig").Frustum;
 const CullingSystem = @import("../engine/graphics/vulkan/culling_system.zig").CullingSystem;
 const ChunkCullData = @import("../engine/graphics/vulkan/culling_system.zig").ChunkCullData;
+const GpuBlockBuffer = @import("gpu_block_buffer.zig").GpuBlockBuffer;
 
 const MAX_MDI_CHUNKS: usize = 16384;
 
@@ -67,6 +68,9 @@ pub const WorldRenderer = struct {
     gpu_visible_indices: std.ArrayListUnmanaged(u32),
     use_gpu_culling: bool,
 
+    // GPU Block Buffer (Batch 5 - Issue #389)
+    gpu_block_buffer: ?*GpuBlockBuffer,
+
     pub fn init(allocator: std.mem.Allocator, rm: ResourceManager, render_ctx: RenderContext, query: IDeviceQuery, storage: *ChunkStorage, rhi: rhi_mod.RHI) !*WorldRenderer {
         const renderer = try allocator.create(WorldRenderer);
 
@@ -102,6 +106,11 @@ pub const WorldRenderer = struct {
             log.log.warn("GPU culling init failed ({}), falling back to CPU culling", .{err});
         }
 
+        var gpu_block_buffer: ?*GpuBlockBuffer = null;
+        errdefer if (gpu_block_buffer) |buf| buf.deinit();
+        gpu_block_buffer = try GpuBlockBuffer.init(allocator, rm, max_chunks);
+        log.log.info("GpuBlockBuffer initialized (capacity={})", .{max_chunks});
+
         renderer.* = .{
             .allocator = allocator,
             .storage = storage,
@@ -121,6 +130,7 @@ pub const WorldRenderer = struct {
             .chunk_lookup = undefined,
             .gpu_visible_indices = .empty,
             .use_gpu_culling = use_gpu,
+            .gpu_block_buffer = gpu_block_buffer,
         };
 
         for (&renderer.chunk_lookup) |*lookup| lookup.* = .empty;
@@ -134,7 +144,11 @@ pub const WorldRenderer = struct {
     }
 
     pub fn resetShadowStats(self: *WorldRenderer) void {
-        self.last_shadow_stats = .{};
+        self.last_shadow_stats = .{ .chunks_rendered = 0, .chunks_culled = 0 };
+    }
+
+    pub fn getGpuBlockBuffer(self: *WorldRenderer) ?*GpuBlockBuffer {
+        return self.gpu_block_buffer;
     }
 
     pub fn deinit(self: *WorldRenderer) void {
@@ -151,6 +165,8 @@ pub const WorldRenderer = struct {
         self.draw_commands.deinit(self.allocator);
 
         if (self.culling_system) |cs| cs.deinit();
+
+        if (self.gpu_block_buffer) |buf| buf.deinit();
 
         self.vertex_allocator.deinit();
         self.allocator.destroy(self.vertex_allocator);

--- a/src/world/world_streamer.zig
+++ b/src/world/world_streamer.zig
@@ -63,6 +63,7 @@ const TextureAtlas = @import("../engine/graphics/texture_atlas.zig").TextureAtla
 const log = @import("../engine/core/log.zig");
 const SaveManager = @import("persistence/save_manager.zig").SaveManager;
 const LoadResult = @import("persistence/save_manager.zig").LoadResult;
+const GpuBlockBuffer = @import("gpu_block_buffer.zig").GpuBlockBuffer;
 
 /// Buffer distance beyond render_distance for chunk unloading.
 /// Prevents thrashing when player moves near chunk boundaries.
@@ -150,10 +151,13 @@ pub const WorldStreamer = struct {
     paused: bool = false,
     save_manager: ?*SaveManager = null,
 
+    // GPU Block Buffer for compute meshing (Batch 5 - Issue #389)
+    gpu_block_buffer: ?*GpuBlockBuffer,
+
     const GEN_WORKERS = 4;
     const MESH_WORKERS = 3;
 
-    pub fn init(allocator: std.mem.Allocator, storage: *ChunkStorage, generator: Generator, atlas: *const TextureAtlas, render_distance: i32, vertex_allocator: *GlobalVertexAllocator, max_uploads_per_frame: usize) !*WorldStreamer {
+    pub fn init(allocator: std.mem.Allocator, storage: *ChunkStorage, generator: Generator, atlas: *const TextureAtlas, render_distance: i32, vertex_allocator: *GlobalVertexAllocator, max_uploads_per_frame: usize, gpu_block_buffer: ?*GpuBlockBuffer) !*WorldStreamer {
         const streamer = try allocator.create(WorldStreamer);
 
         const gen_queue = try allocator.create(JobQueue);
@@ -178,6 +182,7 @@ pub const WorldStreamer = struct {
             .vertex_allocator = vertex_allocator,
             .lod_manager = null,
             .max_uploads_per_frame = max_uploads_per_frame,
+            .gpu_block_buffer = gpu_block_buffer,
         };
 
         streamer.gen_pool = try WorkerPool.init(allocator, GEN_WORKERS, gen_queue, streamer, processGenJob);
@@ -358,7 +363,20 @@ pub const WorldStreamer = struct {
                 if (data.chunk.state != .uploading) continue;
 
                 data.mesh.upload(self.vertex_allocator);
+
                 if (data.mesh.ready) {
+                    if (self.gpu_block_buffer) |buf| {
+                        const slot = buf.allocate(data.chunk.chunk_x, data.chunk.chunk_z) catch |err| {
+                            log.log.err("GpuBlockBuffer allocation failed for chunk ({}, {}): {}", .{ data.chunk.chunk_x, data.chunk.chunk_z, err });
+                            return;
+                        };
+                        const blocks_slice: []const u8 = @as([]const u8, @ptrCast(&data.chunk.blocks));
+                        buf.upload(slot, blocks_slice) catch |upload_err| {
+                            log.log.err("GpuBlockBuffer upload failed for chunk ({}, {}): {}", .{ data.chunk.chunk_x, data.chunk.chunk_z, upload_err });
+                            buf.free(slot);
+                            return;
+                        };
+                    }
                     data.chunk.state = .renderable;
                 } else {
                     data.chunk.state = .mesh_ready;
@@ -402,6 +420,9 @@ pub const WorldStreamer = struct {
                         data.chunk.unpin();
                     }
                 }
+            }
+            if (self.gpu_block_buffer) |buf| {
+                _ = buf.freeByChunk(key.x, key.z);
             }
             _ = self.storage.removeUnlocked(key.x, key.z, self.vertex_allocator);
         }


### PR DESCRIPTION
## Summary
- Add `GpuBlockBuffer` for uploading chunk block data to GPU storage buffer (foundation for GPU-driven mesh generation)
- Each chunk uses 65536 bytes (16x256x16 BlockType as u8)
- Free-list allocator tracks slot usage for chunk data
- Integrate into `WorldRenderer`, `WorldStreamer`, and `World`

## Changes

### New file: `src/world/gpu_block_buffer.zig`
- `GpuBlockBuffer` struct with free-list slot allocation
- `allocate()` / `free()` / `freeByChunk()` for slot management
- `upload()` for full chunk block data upload
- `updateBlock()` for single block updates (player modifications)

### Modified: `src/world/world_renderer.zig`
- Owns and initializes `GpuBlockBuffer`
- Exposes `getGpuBlockBuffer()` to streamer

### Modified: `src/world/world_streamer.zig`
- After chunk mesh upload: allocate slot and upload block data to GPU
- On chunk unload: free the GPU buffer slot

### Modified: `src/world/world.zig`
- `setBlock()` updates GPU buffer when player places/breaks blocks

## Testing
- [x] Build succeeds (`zig build`)
- [x] Tests pass (`zig build test`)