### PR TITLE
fix(ci): replace OPENCODE_PAT with github.token in audit workflow

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -65,15 +65,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Ensure audit label exists
+      - name: Validate token permissions
         run: |
+          echo "Checking token permissions for issue creation..."
+          if ! gh api repos/{owner}/{repo} --jq '.permissions.issues' 2>/dev/null | grep -q 'true'; then
+            echo "::error::Token lacks 'issues' write permission. Ensure the token has repo scope (classic PAT) or Issues: Read & Write (fine-grained PAT)."
+            exit 1
+          fi
+          echo "Token has required permissions."
           if ! gh label list --json name --jq '.[].name' | grep -q '^automated-audit$'; then
+            echo "Creating automated-audit label..."
             gh label create "automated-audit" \
               --description "Issues found by automated opencode audit scans" \
               --color "1D76DB"
+          else
+            echo "Label 'automated-audit' already exists."
           fi
         env:
-          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
@@ -87,8 +96,8 @@ jobs:
       - name: Run opencode audit
         uses: anomalyco/opencode/github@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
-          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:
@@ -261,7 +270,7 @@ jobs:
         run: |
           echo "=== Checking for audit compliance violations ==="
 
-          BOT_LOGIN="opencode-agent[bot]"
+          BOT_LOGIN="github-actions[bot]"
 
           VIOLATIONS=0
 
@@ -321,4 +330,4 @@ jobs:
             echo "✅ No compliance violations detected."
           fi
         env:
-          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Replaces all `secrets.OPENCODE_PAT` references with `github.token` in the audit workflow — the job already declares `issues: write` and `pull-requests: write` in its permissions block, so the automatic token has the required access
- Adds an early token permission validation step that fails fast with a clear error message if the token can't create issues, instead of failing deep in the audit run
- Updates the compliance guard bot login from `opencode-agent[bot]` to `github-actions[bot]` to match the automatic token identity

## Why

The `OPENCODE_PAT` secret lacked issue creation permissions, causing `Resource not accessible by personal access token` failures (seen in [run #24208848153](https://github.com/OpenStaticFish/ZigCraft/actions/runs/24208848153/job/70671843789)). Using `github.token` with the job's existing `permissions` block resolves this without requiring PAT configuration.

## Test plan

- [ ] Workflow dispatch runs successfully and creates an issue
- [ ] Token validation step passes when permissions are correct
- [ ] Token validation step fails with a clear error when permissions are insufficient
- [ ] Compliance guard correctly identifies `github-actions[bot]` as the agent