### PR TITLE
fix(opencode-test-writer): use github.token instead of OPENCODE_PAT

### DIFF
--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
-          token: ${{ secrets.OPENCODE_PAT }}
+          token: ${{ github.token }}
 
       - name: Ensure test label exists
         run: |
@@ -147,7 +147,7 @@ jobs:
               --color "0E8A16"
           fi
         env:
-          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Check for existing PR
         id: check-existing
@@ -167,7 +167,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Validate scan paths exist
         if: steps.check-existing.outputs.skip != 'true'
@@ -192,8 +192,8 @@ jobs:
         if: steps.check-existing.outputs.skip != 'true'
         uses: anomalyco/opencode/github@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
-          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:


### PR DESCRIPTION
## Summary
- Replace `secrets.OPENCODE_PAT` with `github.token` throughout the opencode-test-writer workflow
- The OPENCODE_PAT secret belongs to a separate account (MichaelFisher1997) that lacks write permissions to this repo
- Since the workflow already declares `permissions: contents: write`, the built-in github.token is the correct token to use

## Changes
- `.github/workflows/opencode-test-writer.yml`: 5 replacements of `secrets.OPENCODE_PAT` → `github.token`

## Testing
- Workflow permissions are now correctly applied via the workflow's `permissions:` block