### PR TITLE
feat: dynamic resolution rendering (Issue #392)

### DIFF
--- a/src/engine/graphics/render_graph.zig
+++ b/src/engine/graphics/render_graph.zig
@@ -80,6 +80,7 @@ pub const SceneContext = struct {
     disable_clouds: bool,
     fxaa_enabled: bool = true,
     bloom_enabled: bool = true,
+    resolution_scale: f32 = 1.0,
     overlay_renderer: ?*const fn (ctx: SceneContext) void = null,
     overlay_ctx: ?*anyopaque = null,
     lpv_texture_handle: rhi_pkg.TextureHandle = 0,

--- a/src/engine/graphics/rhi.zig
+++ b/src/engine/graphics/rhi.zig
@@ -899,6 +899,8 @@ pub const RHI = struct {
         setColorGradingIntensity: *const fn (ctx: *anyopaque, intensity: f32) void,
         setTAABlendFactor: *const fn (ctx: *anyopaque, value: f32) void,
         setTAAVelocityRejection: *const fn (ctx: *anyopaque, value: f32) void,
+        setDynamicResolution: *const fn (ctx: *anyopaque, enabled: bool, min_scale: f32, max_scale: f32, target_fps: u32) void,
+        getResolutionScale: *const fn (ctx: *anyopaque) f32,
         captureFrame: *const fn (ctx: *anyopaque, path: []const u8) bool,
     };
 
@@ -1199,6 +1201,12 @@ pub const RHI = struct {
     }
     pub fn setTAAVelocityRejection(self: RHI, value: f32) void {
         self.vtable.setTAAVelocityRejection(self.ptr, value);
+    }
+    pub fn setDynamicResolution(self: RHI, enabled: bool, min_scale: f32, max_scale: f32, target_fps: u32) void {
+        self.vtable.setDynamicResolution(self.ptr, enabled, min_scale, max_scale, target_fps);
+    }
+    pub fn getResolutionScale(self: RHI) f32 {
+        return self.vtable.getResolutionScale(self.ptr);
     }
     pub fn captureFrame(self: RHI, path: []const u8) bool {
         return self.vtable.captureFrame(self.ptr, path);

--- a/src/engine/graphics/rhi_tests.zig
+++ b/src/engine/graphics/rhi_tests.zig
@@ -12,6 +12,12 @@ const MockContext = struct {
     draw_depth_texture_called: bool = false,
     sky_pipeline_requested: bool = false,
     cloud_pipeline_requested: bool = false,
+    dynamic_resolution_called: bool = false,
+    dynamic_resolution_enabled: bool = false,
+    dynamic_resolution_min_scale: f32 = 0.0,
+    dynamic_resolution_max_scale: f32 = 0.0,
+    dynamic_resolution_target_fps: u32 = 0,
+    resolution_scale: f32 = 1.0,
 
     fn bindShader(ptr: *anyopaque, handle: rhi.ShaderHandle) void {
         const self: *MockContext = @ptrCast(@alignCast(ptr));
@@ -158,6 +164,20 @@ const MockContext = struct {
     fn getTimingResults(ptr: *anyopaque) rhi.GpuTimingResults {
         _ = ptr;
         return std.mem.zeroes(rhi.GpuTimingResults);
+    }
+
+    fn setDynamicResolution(ptr: *anyopaque, enabled: bool, min_scale: f32, max_scale: f32, target_fps: u32) void {
+        const self: *MockContext = @ptrCast(@alignCast(ptr));
+        self.dynamic_resolution_called = true;
+        self.dynamic_resolution_enabled = enabled;
+        self.dynamic_resolution_min_scale = min_scale;
+        self.dynamic_resolution_max_scale = max_scale;
+        self.dynamic_resolution_target_fps = target_fps;
+    }
+
+    fn getResolutionScale(ptr: *anyopaque) f32 {
+        const self: *MockContext = @ptrCast(@alignCast(ptr));
+        return self.resolution_scale;
     }
 
     fn getShadowMapHandle(ptr: *anyopaque, cascade_index: u32) rhi.TextureHandle {
@@ -383,8 +403,8 @@ const MockContext = struct {
         .setColorGradingIntensity = undefined,
         .setTAABlendFactor = undefined,
         .setTAAVelocityRejection = undefined,
-        .setDynamicResolution = undefined,
-        .getResolutionScale = undefined,
+        .setDynamicResolution = MockContext.setDynamicResolution,
+        .getResolutionScale = MockContext.getResolutionScale,
         .captureFrame = undefined,
     };
 
@@ -543,4 +563,18 @@ test "ResourceManager.registerExternalTexture validation" {
 
     // Test null sampler validation
     try testing.expectError(error.InvalidImageView, manager.registerExternalTexture(128, 128, .rgba, dummy_view, null));
+}
+
+test "RHI dynamic resolution passthrough" {
+    var mock = MockContext{};
+    mock.resolution_scale = 0.75;
+    const rhi_instance = rhi.RHI{ .ptr = &mock, .vtable = &MockContext.MOCK_VULKAN_RHI_VTABLE, .device = null };
+
+    rhi_instance.setDynamicResolution(true, 0.5, 0.9, 120);
+    try testing.expect(mock.dynamic_resolution_called);
+    try testing.expect(mock.dynamic_resolution_enabled);
+    try testing.expectEqual(@as(f32, 0.5), mock.dynamic_resolution_min_scale);
+    try testing.expectEqual(@as(f32, 0.9), mock.dynamic_resolution_max_scale);
+    try testing.expectEqual(@as(u32, 120), mock.dynamic_resolution_target_fps);
+    try testing.expectEqual(@as(f32, 0.75), rhi_instance.getResolutionScale());
 }

--- a/src/engine/graphics/rhi_tests.zig
+++ b/src/engine/graphics/rhi_tests.zig
@@ -383,6 +383,8 @@ const MockContext = struct {
         .setColorGradingIntensity = undefined,
         .setTAABlendFactor = undefined,
         .setTAAVelocityRejection = undefined,
+        .setDynamicResolution = undefined,
+        .getResolutionScale = undefined,
         .captureFrame = undefined,
     };
 

--- a/src/engine/graphics/rhi_vulkan.zig
+++ b/src/engine/graphics/rhi_vulkan.zig
@@ -182,6 +182,7 @@ fn computeBloom(ctx_ptr: *anyopaque) void {
     pass_orchestration.ensureNoRenderPassActiveInternal(ctx);
 
     var bloom_source_image = ctx.hdr.hdr_image;
+    // Bloom samples the raw blitted image, while post-process consumes its image view.
     if (ctx.dynamic_resolution.isActive() and ctx.taa.ran_this_frame and ctx.dynamic_resolution.upscale_image != null) {
         bloom_source_image = ctx.dynamic_resolution.upscale_image;
     } else if (ctx.taa.ran_this_frame and ctx.taa.output_texture != 0) {
@@ -241,7 +242,7 @@ fn upscaleDynamicResolution(ctx: *VulkanContext, command_buffer: c.VkCommandBuff
     src_barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
     src_barrier.image = taa_output_image;
     src_barrier.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .baseMipLevel = 0, .levelCount = 1, .baseArrayLayer = 0, .layerCount = 1 };
-    src_barrier.srcAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+    src_barrier.srcAccessMask = c.VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     src_barrier.dstAccessMask = c.VK_ACCESS_TRANSFER_READ_BIT;
 
     var dst_barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
@@ -362,12 +363,17 @@ fn setTAAVelocityRejection(ctx_ptr: *anyopaque, value: f32) void {
 fn setDynamicResolution(ctx_ptr: *anyopaque, enabled: bool, min_scale: f32, max_scale: f32, target_fps: u32) void {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
     ctx.dynamic_resolution.enabled = enabled;
-    ctx.dynamic_resolution.min_scale = min_scale;
-    ctx.dynamic_resolution.max_scale = max_scale;
-    ctx.dynamic_resolution.target_fps = target_fps;
+    ctx.dynamic_resolution.min_scale = std.math.clamp(min_scale, 0.25, 1.0);
+    ctx.dynamic_resolution.max_scale = std.math.clamp(max_scale, 0.25, 1.0);
+    if (ctx.dynamic_resolution.min_scale > ctx.dynamic_resolution.max_scale) {
+        ctx.dynamic_resolution.max_scale = ctx.dynamic_resolution.min_scale;
+    }
+    ctx.dynamic_resolution.target_fps = if (target_fps == 0) 60 else target_fps;
     if (!enabled) {
         ctx.dynamic_resolution.current_scale = 1.0;
         ctx.dynamic_resolution.render_extent = ctx.swapchain.getExtent();
+    } else {
+        ctx.dynamic_resolution.update(ctx.timing.timing_results.total_gpu_ms);
     }
 }
 

--- a/src/engine/graphics/rhi_vulkan.zig
+++ b/src/engine/graphics/rhi_vulkan.zig
@@ -242,7 +242,7 @@ fn upscaleDynamicResolution(ctx: *VulkanContext, command_buffer: c.VkCommandBuff
     src_barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
     src_barrier.image = taa_output_image;
     src_barrier.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .baseMipLevel = 0, .levelCount = 1, .baseArrayLayer = 0, .layerCount = 1 };
-    src_barrier.srcAccessMask = c.VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    src_barrier.srcAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
     src_barrier.dstAccessMask = c.VK_ACCESS_TRANSFER_READ_BIT;
 
     var dst_barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
@@ -253,7 +253,7 @@ fn upscaleDynamicResolution(ctx: *VulkanContext, command_buffer: c.VkCommandBuff
     dst_barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
     dst_barrier.image = ctx.dynamic_resolution.upscale_image;
     dst_barrier.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .baseMipLevel = 0, .levelCount = 1, .baseArrayLayer = 0, .layerCount = 1 };
-    dst_barrier.srcAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+    dst_barrier.srcAccessMask = 0;
     dst_barrier.dstAccessMask = c.VK_ACCESS_TRANSFER_WRITE_BIT;
 
     const barriers = [_]c.VkImageMemoryBarrier{ src_barrier, dst_barrier };

--- a/src/engine/graphics/rhi_vulkan.zig
+++ b/src/engine/graphics/rhi_vulkan.zig
@@ -93,6 +93,10 @@ fn beginFrame(ctx_ptr: *anyopaque) void {
     if (frame_started) {
         processTimingResults(ctx);
 
+        if (ctx.dynamic_resolution.enabled) {
+            ctx.dynamic_resolution.update(ctx.timing.timing_results.total_gpu_ms);
+        }
+
         const current_frame = ctx.frames.current_frame;
         const command_buffer = ctx.frames.command_buffers[current_frame];
         if (ctx.timing.query_pool != null) {
@@ -178,7 +182,9 @@ fn computeBloom(ctx_ptr: *anyopaque) void {
     pass_orchestration.ensureNoRenderPassActiveInternal(ctx);
 
     var bloom_source_image = ctx.hdr.hdr_image;
-    if (ctx.taa.ran_this_frame and ctx.taa.output_texture != 0) {
+    if (ctx.dynamic_resolution.isActive() and ctx.taa.ran_this_frame and ctx.dynamic_resolution.upscale_image != null) {
+        bloom_source_image = ctx.dynamic_resolution.upscale_image;
+    } else if (ctx.taa.ran_this_frame and ctx.taa.output_texture != 0) {
         if (ctx.resources.textures.get(ctx.taa.output_texture)) |tex| {
             if (tex.image) |img| {
                 bloom_source_image = img;
@@ -205,6 +211,8 @@ fn computeTAA(ctx_ptr: *anyopaque) void {
     pass_orchestration.ensureNoRenderPassActiveInternal(ctx);
 
     const command_buffer = ctx.frames.command_buffers[ctx.frames.current_frame];
+    const render_extent = ctx.dynamic_resolution.getRenderExtent();
+
     ctx.taa.compute(
         ctx.vulkan_device.vk_device,
         command_buffer,
@@ -212,9 +220,70 @@ fn computeTAA(ctx_ptr: *anyopaque) void {
         &ctx.resources,
         ctx.hdr.hdr_view,
         ctx.velocity.velocity_view,
-        ctx.swapchain.getExtent(),
+        render_extent,
         &ctx.runtime.draw_call_count,
     );
+
+    if (ctx.dynamic_resolution.isActive() and ctx.taa.ran_this_frame and ctx.dynamic_resolution.upscale_image != null) {
+        upscaleDynamicResolution(ctx, command_buffer, render_extent);
+    }
+}
+
+fn upscaleDynamicResolution(ctx: *VulkanContext, command_buffer: c.VkCommandBuffer, render_extent: c.VkExtent2D) void {
+    const taa_output_tex = ctx.resources.textures.get(ctx.taa.output_texture) orelse return;
+    const taa_output_image = taa_output_tex.image orelse return;
+
+    var src_barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
+    src_barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    src_barrier.oldLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    src_barrier.newLayout = c.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    src_barrier.srcQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+    src_barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+    src_barrier.image = taa_output_image;
+    src_barrier.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .baseMipLevel = 0, .levelCount = 1, .baseArrayLayer = 0, .layerCount = 1 };
+    src_barrier.srcAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+    src_barrier.dstAccessMask = c.VK_ACCESS_TRANSFER_READ_BIT;
+
+    var dst_barrier = std.mem.zeroes(c.VkImageMemoryBarrier);
+    dst_barrier.sType = c.VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    dst_barrier.oldLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    dst_barrier.newLayout = c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    dst_barrier.srcQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+    dst_barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+    dst_barrier.image = ctx.dynamic_resolution.upscale_image;
+    dst_barrier.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .baseMipLevel = 0, .levelCount = 1, .baseArrayLayer = 0, .layerCount = 1 };
+    dst_barrier.srcAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+    dst_barrier.dstAccessMask = c.VK_ACCESS_TRANSFER_WRITE_BIT;
+
+    const barriers = [_]c.VkImageMemoryBarrier{ src_barrier, dst_barrier };
+    c.vkCmdPipelineBarrier(command_buffer, c.VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, c.VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, null, 0, null, barriers.len, &barriers[0]);
+
+    const native_extent = ctx.swapchain.getExtent();
+
+    var blit_info = std.mem.zeroes(c.VkImageBlit);
+    blit_info.srcSubresource = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .mipLevel = 0, .baseArrayLayer = 0, .layerCount = 1 };
+    blit_info.srcOffsets[0] = .{ .x = 0, .y = 0, .z = 0 };
+    blit_info.srcOffsets[1] = .{ .x = @intCast(render_extent.width), .y = @intCast(render_extent.height), .z = 1 };
+    blit_info.dstSubresource = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .mipLevel = 0, .baseArrayLayer = 0, .layerCount = 1 };
+    blit_info.dstOffsets[0] = .{ .x = 0, .y = 0, .z = 0 };
+    blit_info.dstOffsets[1] = .{ .x = @intCast(native_extent.width), .y = @intCast(native_extent.height), .z = 1 };
+
+    c.vkCmdBlitImage(command_buffer, taa_output_image, c.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, ctx.dynamic_resolution.upscale_image, c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit_info, c.VK_FILTER_LINEAR);
+
+    var restore_src = src_barrier;
+    restore_src.oldLayout = c.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    restore_src.newLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    restore_src.srcAccessMask = c.VK_ACCESS_TRANSFER_READ_BIT;
+    restore_src.dstAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+
+    var restore_dst = dst_barrier;
+    restore_dst.oldLayout = c.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    restore_dst.newLayout = c.VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    restore_dst.srcAccessMask = c.VK_ACCESS_TRANSFER_WRITE_BIT;
+    restore_dst.dstAccessMask = c.VK_ACCESS_SHADER_READ_BIT;
+
+    const restore_barriers = [_]c.VkImageMemoryBarrier{ restore_src, restore_dst };
+    c.vkCmdPipelineBarrier(command_buffer, c.VK_PIPELINE_STAGE_TRANSFER_BIT, c.VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, null, 0, null, restore_barriers.len, &restore_barriers[0]);
 }
 
 fn setFXAA(ctx_ptr: *anyopaque, enabled: bool) void {
@@ -288,6 +357,23 @@ fn setTAABlendFactor(ctx_ptr: *anyopaque, value: f32) void {
 fn setTAAVelocityRejection(ctx_ptr: *anyopaque, value: f32) void {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
     ctx.taa.velocity_rejection = std.math.clamp(value, 0.0, 0.25);
+}
+
+fn setDynamicResolution(ctx_ptr: *anyopaque, enabled: bool, min_scale: f32, max_scale: f32, target_fps: u32) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    ctx.dynamic_resolution.enabled = enabled;
+    ctx.dynamic_resolution.min_scale = min_scale;
+    ctx.dynamic_resolution.max_scale = max_scale;
+    ctx.dynamic_resolution.target_fps = target_fps;
+    if (!enabled) {
+        ctx.dynamic_resolution.current_scale = 1.0;
+        ctx.dynamic_resolution.render_extent = ctx.swapchain.getExtent();
+    }
+}
+
+fn getResolutionScale(ctx_ptr: *anyopaque) f32 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return ctx.dynamic_resolution.current_scale;
 }
 
 fn captureFrame(ctx_ptr: *anyopaque, path: []const u8) bool {
@@ -743,7 +829,7 @@ fn computeSSAO(ctx_ptr: *anyopaque, proj: Mat4, inv_proj: Mat4) void {
         ctx.vulkan_device.vk_device,
         ctx.frames.command_buffers[ctx.frames.current_frame],
         ctx.frames.current_frame,
-        ctx.swapchain.getExtent(),
+        ctx.dynamic_resolution.getRenderExtent(),
         proj,
         inv_proj,
     );
@@ -886,6 +972,8 @@ const VULKAN_RHI_VTABLE = rhi.RHI.VTable{
     .setColorGradingIntensity = setColorGradingIntensity,
     .setTAABlendFactor = setTAABlendFactor,
     .setTAAVelocityRejection = setTAAVelocityRejection,
+    .setDynamicResolution = setDynamicResolution,
+    .getResolutionScale = getResolutionScale,
     .captureFrame = captureFrame,
 };
 

--- a/src/engine/graphics/vulkan/dynamic_resolution.zig
+++ b/src/engine/graphics/vulkan/dynamic_resolution.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const c = @import("../../../c.zig").c;
 
 const ROLLING_WINDOW_SIZE = 8;
+const ACTIVE_THRESHOLD = 0.999;
 
 pub const DynamicResolutionState = struct {
     enabled: bool = false,
@@ -29,6 +30,9 @@ pub const DynamicResolutionState = struct {
             return;
         }
 
+        const min_scale = @min(self.min_scale, self.max_scale);
+        const max_scale = @max(self.min_scale, self.max_scale);
+
         self.frame_times[self.frame_time_index] = gpu_time_ms;
         self.frame_time_index = (self.frame_time_index + 1) % ROLLING_WINDOW_SIZE;
         if (self.frame_time_count < ROLLING_WINDOW_SIZE) {
@@ -53,10 +57,12 @@ pub const DynamicResolutionState = struct {
         const target_ms = 1000.0 / @as(f32, @floatFromInt(self.target_fps));
 
         if (self.rolling_avg_ms > target_ms * 1.1) {
-            self.current_scale = @max(self.current_scale - 0.02, self.min_scale);
+            self.current_scale = @max(self.current_scale - 0.02, min_scale);
         } else if (self.rolling_avg_ms < target_ms * 0.8) {
-            self.current_scale = @min(self.current_scale + 0.01, self.max_scale);
+            self.current_scale = @min(self.current_scale + 0.01, max_scale);
         }
+
+        self.current_scale = std.math.clamp(self.current_scale, min_scale, max_scale);
 
         self.computeRenderExtent();
     }
@@ -81,7 +87,7 @@ pub const DynamicResolutionState = struct {
     }
 
     pub fn isActive(self: *const DynamicResolutionState) bool {
-        return self.enabled and self.current_scale < 0.999;
+        return self.enabled and self.current_scale < ACTIVE_THRESHOLD;
     }
 
     pub fn getRenderExtent(self: *const DynamicResolutionState) c.VkExtent2D {
@@ -91,3 +97,38 @@ pub const DynamicResolutionState = struct {
         return self.swapchain_extent;
     }
 };
+
+test "DynamicResolutionState scales smoothly and clamps bounds" {
+    var state = DynamicResolutionState{};
+    state.enabled = true;
+    state.min_scale = 0.5;
+    state.max_scale = 1.0;
+    state.target_fps = 60;
+    state.setSwapchainExtent(.{ .width = 1920, .height = 1080 });
+
+    state.update(25.0);
+    try std.testing.expectEqual(@as(f32, 1.0), state.current_scale);
+    try std.testing.expectEqual(@as(u32, 1920), state.getRenderExtent().width);
+
+    for (0..4) |_| state.update(40.0);
+    try std.testing.expect(state.current_scale < 1.0);
+    try std.testing.expect(state.isActive());
+
+    state.min_scale = 0.9;
+    state.max_scale = 0.6;
+    state.update(100.0);
+    try std.testing.expect(state.current_scale >= 0.6);
+    try std.testing.expect(state.current_scale <= 0.9);
+}
+
+test "DynamicResolutionState disables cleanly" {
+    var state = DynamicResolutionState{};
+    state.enabled = false;
+    state.setSwapchainExtent(.{ .width = 1280, .height = 720 });
+    state.update(50.0);
+
+    try std.testing.expectEqual(@as(f32, 1.0), state.current_scale);
+    try std.testing.expect(!state.isActive());
+    try std.testing.expectEqual(@as(u32, 1280), state.getRenderExtent().width);
+    try std.testing.expectEqual(@as(u32, 720), state.getRenderExtent().height);
+}

--- a/src/engine/graphics/vulkan/dynamic_resolution.zig
+++ b/src/engine/graphics/vulkan/dynamic_resolution.zig
@@ -1,0 +1,93 @@
+const std = @import("std");
+const c = @import("../../../c.zig").c;
+
+const ROLLING_WINDOW_SIZE = 8;
+
+pub const DynamicResolutionState = struct {
+    enabled: bool = false,
+    min_scale: f32 = 0.5,
+    max_scale: f32 = 1.0,
+    target_fps: u32 = 60,
+    current_scale: f32 = 1.0,
+    render_extent: c.VkExtent2D = .{ .width = 0, .height = 0 },
+    swapchain_extent: c.VkExtent2D = .{ .width = 0, .height = 0 },
+
+    frame_times: [ROLLING_WINDOW_SIZE]f32 = .{0.0} ** ROLLING_WINDOW_SIZE,
+    frame_time_index: usize = 0,
+    frame_time_count: usize = 0,
+    rolling_avg_ms: f32 = 0.0,
+
+    upscale_image: c.VkImage = null,
+    upscale_memory: c.VkDeviceMemory = null,
+    upscale_view: c.VkImageView = null,
+    upscale_extent: c.VkExtent2D = .{ .width = 0, .height = 0 },
+
+    pub fn update(self: *DynamicResolutionState, gpu_time_ms: f32) void {
+        if (!self.enabled) {
+            self.current_scale = 1.0;
+            self.render_extent = self.swapchain_extent;
+            return;
+        }
+
+        self.frame_times[self.frame_time_index] = gpu_time_ms;
+        self.frame_time_index = (self.frame_time_index + 1) % ROLLING_WINDOW_SIZE;
+        if (self.frame_time_count < ROLLING_WINDOW_SIZE) {
+            self.frame_time_count += 1;
+        }
+
+        var sum: f32 = 0.0;
+        var count: usize = 0;
+        for (self.frame_times) |t| {
+            if (t > 0.0) {
+                sum += t;
+                count += 1;
+            }
+        }
+        self.rolling_avg_ms = if (count > 0) sum / @as(f32, @floatFromInt(count)) else 0.0;
+
+        if (self.frame_time_count < 4) {
+            self.computeRenderExtent();
+            return;
+        }
+
+        const target_ms = 1000.0 / @as(f32, @floatFromInt(self.target_fps));
+
+        if (self.rolling_avg_ms > target_ms * 1.1) {
+            self.current_scale = @max(self.current_scale - 0.02, self.min_scale);
+        } else if (self.rolling_avg_ms < target_ms * 0.8) {
+            self.current_scale = @min(self.current_scale + 0.01, self.max_scale);
+        }
+
+        self.computeRenderExtent();
+    }
+
+    fn computeRenderExtent(self: *DynamicResolutionState) void {
+        const w = @as(u32, @intFromFloat(@round(@as(f32, @floatFromInt(self.swapchain_extent.width)) * self.current_scale)));
+        const h = @as(u32, @intFromFloat(@round(@as(f32, @floatFromInt(self.swapchain_extent.height)) * self.current_scale)));
+        self.render_extent = .{
+            .width = @max(w, 1),
+            .height = @max(h, 1),
+        };
+    }
+
+    pub fn setSwapchainExtent(self: *DynamicResolutionState, extent: c.VkExtent2D) void {
+        self.swapchain_extent = extent;
+        if (!self.enabled) {
+            self.render_extent = extent;
+            self.current_scale = 1.0;
+        } else {
+            self.computeRenderExtent();
+        }
+    }
+
+    pub fn isActive(self: *const DynamicResolutionState) bool {
+        return self.enabled and self.current_scale < 0.999;
+    }
+
+    pub fn getRenderExtent(self: *const DynamicResolutionState) c.VkExtent2D {
+        if (self.enabled) {
+            return self.render_extent;
+        }
+        return self.swapchain_extent;
+    }
+};

--- a/src/engine/graphics/vulkan/resource_texture_ops.zig
+++ b/src/engine/graphics/vulkan/resource_texture_ops.zig
@@ -31,7 +31,7 @@ pub fn createTexture(self: anytype, width: u32, height: u32, format: rhi.Texture
         c.VK_IMAGE_USAGE_TRANSFER_DST_BIT | c.VK_IMAGE_USAGE_SAMPLED_BIT;
 
     if (mip_levels > 1) usage_flags |= c.VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    if (config.is_render_target) usage_flags |= c.VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    if (config.is_render_target) usage_flags |= c.VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | c.VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     if (format == .rgba32f) usage_flags |= c.VK_IMAGE_USAGE_STORAGE_BIT;
 
     var staging_offset: u64 = 0;
@@ -247,7 +247,7 @@ pub fn createTexture3D(self: anytype, width: u32, height: u32, depth: u32, forma
 
     var usage_flags: c.VkImageUsageFlags = c.VK_IMAGE_USAGE_TRANSFER_DST_BIT | c.VK_IMAGE_USAGE_SAMPLED_BIT;
     if (format == .rgba32f) usage_flags |= c.VK_IMAGE_USAGE_STORAGE_BIT;
-    if (texture_config.is_render_target) usage_flags |= c.VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    if (texture_config.is_render_target) usage_flags |= c.VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | c.VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
     var staging_offset: u64 = 0;
     var staging_slice_3d: ?transfer_queue.StagingSlice = null;

--- a/src/engine/graphics/vulkan/rhi_context_types.zig
+++ b/src/engine/graphics/vulkan/rhi_context_types.zig
@@ -22,6 +22,7 @@ const TAASystem = @import("taa_system.zig").TAASystem;
 const DepthPyramidSystem = @import("depth_pyramid.zig").DepthPyramidSystem;
 const WaterSystem = @import("water_system.zig").WaterSystem;
 const VulkanDevice = @import("device.zig").VulkanDevice;
+const DynamicResolutionState = @import("dynamic_resolution.zig").DynamicResolutionState;
 
 const MAX_FRAMES_IN_FLIGHT = rhi.MAX_FRAMES_IN_FLIGHT;
 
@@ -221,4 +222,5 @@ pub const VulkanContext = struct {
     water_system: WaterSystem = .{},
 
     timing: TimingState = .{},
+    dynamic_resolution: DynamicResolutionState = .{},
 };

--- a/src/engine/graphics/vulkan/rhi_frame_orchestration.zig
+++ b/src/engine/graphics/vulkan/rhi_frame_orchestration.zig
@@ -22,6 +22,7 @@ pub fn recreateSwapchainInternal(ctx: anytype) void {
     lifecycle.destroyBloomResources(ctx);
     lifecycle.destroyPostProcessResources(ctx);
     lifecycle.destroyGPassResources(ctx);
+    lifecycle.destroyUpscaleResources(ctx);
 
     ctx.runtime.main_pass_active = false;
     ctx.shadow_system.pass_active = false;
@@ -90,6 +91,13 @@ pub fn recreateSwapchainInternal(ctx: anytype) void {
         return;
     };
     setup.updatePostProcessDescriptorsWithBloom(ctx);
+
+    setup.createUpscaleResources(ctx) catch |err| {
+        log.log.errWithTrace("Failed to recreate upscale resources: {}", .{err});
+        return;
+    };
+
+    ctx.dynamic_resolution.setSwapchainExtent(ctx.swapchain.getExtent());
 
     {
         var list: [32]c.VkImage = undefined;

--- a/src/engine/graphics/vulkan/rhi_pass_orchestration.zig
+++ b/src/engine/graphics/vulkan/rhi_pass_orchestration.zig
@@ -39,12 +39,14 @@ pub fn beginGPassInternal(ctx: anytype) void {
         return;
     }
 
+    const g_extent = ctx.dynamic_resolution.getRenderExtent();
+
     var render_pass_info = std.mem.zeroes(c.VkRenderPassBeginInfo);
     render_pass_info.sType = c.VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
     render_pass_info.renderPass = ctx.render_pass_manager.g_render_pass;
     render_pass_info.framebuffer = ctx.render_pass_manager.g_framebuffer;
     render_pass_info.renderArea.offset = .{ .x = 0, .y = 0 };
-    render_pass_info.renderArea.extent = ctx.swapchain.getExtent();
+    render_pass_info.renderArea.extent = g_extent;
 
     var clear_values: [3]c.VkClearValue = undefined;
     clear_values[0] = std.mem.zeroes(c.VkClearValue);
@@ -59,9 +61,9 @@ pub fn beginGPassInternal(ctx: anytype) void {
     c.vkCmdBeginRenderPass(command_buffer, &render_pass_info, c.VK_SUBPASS_CONTENTS_INLINE);
     c.vkCmdBindPipeline(command_buffer, c.VK_PIPELINE_BIND_POINT_GRAPHICS, ctx.pipeline_manager.g_pipeline);
 
-    const viewport = c.VkViewport{ .x = 0, .y = 0, .width = @floatFromInt(ctx.swapchain.getExtent().width), .height = @floatFromInt(ctx.swapchain.getExtent().height), .minDepth = 0, .maxDepth = 1 };
+    const viewport = c.VkViewport{ .x = 0, .y = 0, .width = @floatFromInt(g_extent.width), .height = @floatFromInt(g_extent.height), .minDepth = 0, .maxDepth = 1 };
     c.vkCmdSetViewport(command_buffer, 0, 1, &viewport);
-    const scissor = c.VkRect2D{ .offset = .{ .x = 0, .y = 0 }, .extent = ctx.swapchain.getExtent() };
+    const scissor = c.VkRect2D{ .offset = .{ .x = 0, .y = 0 }, .extent = g_extent };
     c.vkCmdSetScissor(command_buffer, 0, 1, &scissor);
 
     const ds = ctx.descriptors.descriptor_sets[ctx.frames.current_frame];
@@ -263,7 +265,7 @@ pub fn beginMainPassInternal(ctx: anytype) void {
         render_pass_info.renderPass = ctx.render_pass_manager.hdr_render_pass;
         render_pass_info.framebuffer = ctx.render_pass_manager.main_framebuffer;
         render_pass_info.renderArea.offset = .{ .x = 0, .y = 0 };
-        render_pass_info.renderArea.extent = ctx.swapchain.getExtent();
+        render_pass_info.renderArea.extent = ctx.dynamic_resolution.getRenderExtent();
 
         var clear_values: [2]c.VkClearValue = undefined;
         clear_values[0] = std.mem.zeroes(c.VkClearValue);
@@ -278,18 +280,20 @@ pub fn beginMainPassInternal(ctx: anytype) void {
         ctx.draw.lod_mode = false;
     }
 
+    const main_extent = ctx.dynamic_resolution.getRenderExtent();
+
     var viewport = std.mem.zeroes(c.VkViewport);
     viewport.x = 0.0;
     viewport.y = 0.0;
-    viewport.width = @floatFromInt(ctx.swapchain.getExtent().width);
-    viewport.height = @floatFromInt(ctx.swapchain.getExtent().height);
+    viewport.width = @floatFromInt(main_extent.width);
+    viewport.height = @floatFromInt(main_extent.height);
     viewport.minDepth = 0.0;
     viewport.maxDepth = 1.0;
     c.vkCmdSetViewport(command_buffer, 0, 1, &viewport);
 
     var scissor = std.mem.zeroes(c.VkRect2D);
     scissor.offset = .{ .x = 0, .y = 0 };
-    scissor.extent = ctx.swapchain.getExtent();
+    scissor.extent = main_extent;
     c.vkCmdSetScissor(command_buffer, 0, 1, &scissor);
 }
 
@@ -353,7 +357,9 @@ pub fn beginPostProcessPassInternal(ctx: anytype) void {
 
         var source_view = ctx.hdr.hdr_view;
         var source_sampler = ctx.post_process.sampler;
-        if (ctx.taa.ran_this_frame and ctx.taa.output_texture != 0) {
+        if (ctx.dynamic_resolution.isActive() and ctx.taa.ran_this_frame and ctx.dynamic_resolution.upscale_view != null) {
+            source_view = ctx.dynamic_resolution.upscale_view;
+        } else if (ctx.taa.ran_this_frame and ctx.taa.output_texture != 0) {
             if (ctx.resources.textures.get(ctx.taa.output_texture)) |tex| {
                 source_view = tex.view;
                 source_sampler = tex.sampler;

--- a/src/engine/graphics/vulkan/rhi_resource_lifecycle.zig
+++ b/src/engine/graphics/vulkan/rhi_resource_lifecycle.zig
@@ -31,6 +31,25 @@ pub fn destroyHDRResources(ctx: anytype) void {
     }
 }
 
+pub fn destroyUpscaleResources(ctx: anytype) void {
+    const vk = ctx.vulkan_device.vk_device;
+    if (vk == null) return;
+    const dr = &ctx.dynamic_resolution;
+    if (dr.upscale_view != null) {
+        c.vkDestroyImageView(vk, dr.upscale_view, null);
+        dr.upscale_view = null;
+    }
+    if (dr.upscale_image != null) {
+        c.vkDestroyImage(vk, dr.upscale_image, null);
+        dr.upscale_image = null;
+    }
+    if (dr.upscale_memory != null) {
+        c.vkFreeMemory(vk, dr.upscale_memory, null);
+        dr.upscale_memory = null;
+    }
+    dr.upscale_extent = .{ .width = 0, .height = 0 };
+}
+
 pub fn destroyPostProcessResources(ctx: anytype) void {
     const vk = ctx.vulkan_device.vk_device;
 

--- a/src/engine/graphics/vulkan/rhi_resource_setup.zig
+++ b/src/engine/graphics/vulkan/rhi_resource_setup.zig
@@ -444,13 +444,59 @@ pub fn createPostProcessResources(ctx: anytype) !void {
         global_uniform_size,
     );
 
-    // Create neutral (identity) 3D LUT for color grading and bind it
     if (ctx.post_process.lut_texture == 0) {
         ctx.post_process.lut_texture = try createNeutralLUT3D(ctx);
     }
     updatePostProcessLUTDescriptor(ctx);
 
     try ctx.render_pass_manager.createPostProcessFramebuffers(vk, ctx.allocator, ctx.swapchain.getExtent(), ctx.swapchain.getImageViews());
+}
+
+pub fn createUpscaleResources(ctx: anytype) !void {
+    const vk = ctx.vulkan_device.vk_device;
+    const extent = ctx.swapchain.getExtent();
+    if (extent.width == 0 or extent.height == 0) return;
+
+    lifecycle.destroyUpscaleResources(ctx);
+
+    const format = c.VK_FORMAT_R32G32B32A32_SFLOAT;
+    const dr = &ctx.dynamic_resolution;
+
+    var image_info = std.mem.zeroes(c.VkImageCreateInfo);
+    image_info.sType = c.VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    image_info.imageType = c.VK_IMAGE_TYPE_2D;
+    image_info.extent = .{ .width = extent.width, .height = extent.height, .depth = 1 };
+    image_info.mipLevels = 1;
+    image_info.arrayLayers = 1;
+    image_info.format = format;
+    image_info.tiling = c.VK_IMAGE_TILING_OPTIMAL;
+    image_info.initialLayout = c.VK_IMAGE_LAYOUT_UNDEFINED;
+    image_info.usage = c.VK_IMAGE_USAGE_TRANSFER_DST_BIT | c.VK_IMAGE_USAGE_SAMPLED_BIT;
+    image_info.samples = c.VK_SAMPLE_COUNT_1_BIT;
+    image_info.sharingMode = c.VK_SHARING_MODE_EXCLUSIVE;
+    try Utils.checkVk(c.vkCreateImage(vk, &image_info, null, &dr.upscale_image));
+
+    var mem_reqs: c.VkMemoryRequirements = undefined;
+    c.vkGetImageMemoryRequirements(vk, dr.upscale_image, &mem_reqs);
+    var alloc_info = std.mem.zeroes(c.VkMemoryAllocateInfo);
+    alloc_info.sType = c.VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    alloc_info.allocationSize = mem_reqs.size;
+    alloc_info.memoryTypeIndex = try Utils.findMemoryType(ctx.vulkan_device.physical_device, mem_reqs.memoryTypeBits, c.VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    try Utils.checkVk(c.vkAllocateMemory(vk, &alloc_info, null, &dr.upscale_memory));
+    try Utils.checkVk(c.vkBindImageMemory(vk, dr.upscale_image, dr.upscale_memory, 0));
+
+    var view_info = std.mem.zeroes(c.VkImageViewCreateInfo);
+    view_info.sType = c.VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    view_info.image = dr.upscale_image;
+    view_info.viewType = c.VK_IMAGE_VIEW_TYPE_2D;
+    view_info.format = format;
+    view_info.subresourceRange = .{ .aspectMask = c.VK_IMAGE_ASPECT_COLOR_BIT, .baseMipLevel = 0, .levelCount = 1, .baseArrayLayer = 0, .layerCount = 1 };
+    try Utils.checkVk(c.vkCreateImageView(vk, &view_info, null, &dr.upscale_view));
+
+    dr.upscale_extent = extent;
+
+    const images = [_]c.VkImage{dr.upscale_image};
+    try lifecycle.transitionImagesToShaderRead(ctx, &images, false);
 }
 
 /// Generate a 32x32x32 identity LUT where each texel maps to itself: color(r,g,b) = (r,g,b).

--- a/src/engine/ui/timing_overlay.zig
+++ b/src/engine/ui/timing_overlay.zig
@@ -42,6 +42,12 @@ pub const TimingOverlay = struct {
             font.drawText(ui, cpu_str, x + 10, y, scale, Color.white);
             y += line_height + 3;
         }
+        if (data.resolution_scale < 0.999) {
+            var scale_buf: [32]u8 = undefined;
+            const scale_str = std.fmt.bufPrint(&scale_buf, "RES SCALE: {d:.0}%", .{data.resolution_scale * 100.0}) catch "";
+            font.drawText(ui, scale_str, x + 10, y, scale, Color.rgba(1.0, 0.7, 0.3, 1.0));
+            y += line_height + 3;
+        }
 
         drawSectionHeader(ui, "GPU PASSES (MS)", label_x, &y, scale, Color.gray);
         drawGpuLine(ui, "SHADOW 0:", data.gpu.shadow_pass_ms[0], label_x, value_x, &y, scale, Color.gray);
@@ -137,6 +143,7 @@ pub const PerformanceData = struct {
     gpu: rhi.GpuTimingResults,
     cpu_frame_ms: f32,
     fps: f32,
+    resolution_scale: f32 = 1.0,
     world: ?WorldStats,
     gpu_stats: RenderDeviceStats,
 };

--- a/src/engine/ui/ui_system_manager.zig
+++ b/src/engine/ui/ui_system_manager.zig
@@ -60,6 +60,7 @@ pub const UISystemManager = struct {
                     .gpu = gpu_timing,
                     .cpu_frame_ms = cpu_frame_ms,
                     .fps = fps,
+                    .resolution_scale = rhi_ptr.getResolutionScale(),
                     .world = world_stats,
                     .gpu_stats = gpu_stats,
                 };

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -279,6 +279,10 @@ pub const WorldScreen = struct {
 
             var frame_cascades: ?@import("../../engine/graphics/csm.zig").ShadowCascades = null;
 
+            const resolution_scale = rhi.getResolutionScale();
+            const render_w = screen_w * resolution_scale;
+            const render_h = screen_h * resolution_scale;
+
             const render_ctx = render_graph_pkg.SceneContext{
                 .render_ctx = rhi.renderContext(),
                 .shadow_ctx = rhi.shadowSystem(),
@@ -292,8 +296,8 @@ pub const WorldScreen = struct {
                 .material_system = render_system.getMaterialSystem(),
                 .aspect = aspect,
                 .taa_enabled = taa_enabled,
-                .viewport_width = screen_w,
-                .viewport_height = screen_h,
+                .viewport_width = render_w,
+                .viewport_height = render_h,
                 .sky_params = sky_params,
                 .cloud_params = cloud_params,
                 .main_shader = render_system.getShader(),
@@ -306,6 +310,7 @@ pub const WorldScreen = struct {
                 .disable_clouds = render_system.getDisableClouds(),
                 .fxaa_enabled = ctx.settings.fxaa_enabled and !ctx.settings.taa_enabled,
                 .bloom_enabled = ctx.settings.bloom_enabled,
+                .resolution_scale = resolution_scale,
                 .overlay_renderer = renderOverlay,
                 .overlay_ctx = self,
                 .cached_cascades = &frame_cascades,

--- a/src/game/settings/apply.zig
+++ b/src/game/settings/apply.zig
@@ -45,6 +45,7 @@ pub fn applyToRHI(settings: *const Settings, rhi: *RHI) void {
     rhi.setMSAA(settings.msaa_samples);
     rhi.setTAABlendFactor(settings.taa_blend_factor);
     rhi.setTAAVelocityRejection(settings.taa_velocity_rejection);
+    rhi.setDynamicResolution(settings.dynamic_resolution_enabled, settings.dynamic_resolution_min_scale, settings.dynamic_resolution_max_scale, settings.target_fps);
 }
 
 pub fn applyToRenderSettings(settings: *const Settings, rs: IRenderSettings) void {

--- a/src/game/settings/data.zig
+++ b/src/game/settings/data.zig
@@ -123,6 +123,12 @@ pub const Settings = struct {
     // Water Settings (Issue #390)
     water_quality: u8 = 2, // 0=Low, 1=Medium, 2=High
 
+    // Dynamic Resolution Settings (Issue #392)
+    dynamic_resolution_enabled: bool = false,
+    dynamic_resolution_min_scale: f32 = 0.5,
+    dynamic_resolution_max_scale: f32 = 1.0,
+    target_fps: u32 = 60,
+
     pub const SettingMetadata = struct {
         label: []const u8,
         description: []const u8 = "",
@@ -312,6 +318,29 @@ pub const Settings = struct {
             .kind = .{ .choice = .{
                 .labels = &[_][]const u8{ "LOW", "MEDIUM", "HIGH" },
                 .values = &[_]u32{ 0, 1, 2 },
+            } },
+        };
+        pub const dynamic_resolution_enabled = SettingMetadata{
+            .label = "DYNAMIC RES",
+            .description = "Adjusts render resolution to maintain target frame rate",
+            .kind = .toggle,
+        };
+        pub const dynamic_resolution_min_scale = SettingMetadata{
+            .label = "MIN RES SCALE",
+            .description = "Minimum resolution scale when under heavy load",
+            .kind = .{ .slider = .{ .min = 0.25, .max = 1.0, .step = 0.05 } },
+        };
+        pub const dynamic_resolution_max_scale = SettingMetadata{
+            .label = "MAX RES SCALE",
+            .description = "Maximum resolution scale when GPU has headroom",
+            .kind = .{ .slider = .{ .min = 0.5, .max = 1.0, .step = 0.05 } },
+        };
+        pub const target_fps = SettingMetadata{
+            .label = "TARGET FPS",
+            .description = "Frame rate budget for dynamic resolution",
+            .kind = .{ .choice = .{
+                .labels = &[_][]const u8{ "30 FPS", "60 FPS", "120 FPS", "144 FPS" },
+                .values = &[_]u32{ 30, 60, 120, 144 },
             } },
         };
     };


### PR DESCRIPTION
## Summary

- Implements dynamic resolution rendering that adjusts render resolution based on GPU frame time budget (Issue #392)
- Scene rendering (G-Pass, Main Pass, SSAO, TAA) uses a dynamically scaled viewport; UI always renders at native resolution
- After TAA resolve, a `vkCmdBlitImage` upscale blit expands the lower-resolution output to native swapchain extent for bloom/post-process/FXAA
- Rolling average GPU time tracking (8-frame window) with smooth scale transitions (±0.01–0.02 per frame) prevents popping
- Adds settings: `dynamic_resolution_enabled`, `dynamic_resolution_min_scale`, `dynamic_resolution_max_scale`, `target_fps`
- Timing overlay shows current resolution scale percentage when active

## Implementation Details

| Component | Change |
|-----------|--------|
| `dynamic_resolution.zig` | New module: `DynamicResolutionState` with frame time rolling average and scale adjustment logic |
| `rhi_pass_orchestration.zig` | G-Pass and Main Pass use `getRenderExtent()` for viewport/scissor |
| `rhi_vulkan.zig` | `computeTAA` passes render extent + upscale blit; `computeBloom`/`computeSSAO` use render extent; post-process uses upscale view |
| `rhi_resource_setup.zig` | Creates dedicated RGBA32F upscale image at native resolution |
| `rhi_frame_orchestration.zig` | Updates dynamic resolution state each frame; creates/destroys upscale resources on swapchain recreate |
| `rhi.zig` | New vtable entries: `setDynamicResolution`, `getResolutionScale` |
| `settings/data.zig` | New fields + metadata for dynamic resolution toggle, min/max scale, target FPS |
| `settings/apply.zig` | Wires dynamic resolution settings to RHI |
| `render_graph.zig` | `resolution_scale` added to `SceneContext` |
| `timing_overlay.zig` | Shows "RES SCALE: XX%" when scale < 100% |
| `world.zig` | Passes scaled viewport dimensions for correct projection jittering |

## Architecture

```
Scene (render extent = swapchain × scale)
  G-Pass → SSAO → Main Pass → TAA
                                    ↓
                        Upscale blit (LINEAR)
                                    ↓
Post (native swapchain extent)
  Bloom → Post-Process → FXAA → UI
```

All intermediate render targets (G-Pass, HDR, TAA history) are pre-allocated at native resolution. Dynamic scaling uses viewport/scissor only — no resource recreation on scale change.

## Testing

- [x] `zig build` — compiles clean
- [x] `zig build test` — all unit tests pass (including shader validation)
- [x] Code formatted with `zig fmt`

Closes #392