### PR TITLE
fix(ci): use PAT for audit issue creation to trigger triage workflow

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -90,7 +90,7 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:


### PR DESCRIPTION
## Summary

- Switch `GH_TOKEN` in `opencode-audit.yml` from `github.token` to `secrets.WORKFLOW_PAT` so that `gh issue create` uses a PAT instead of the default `GITHUB_TOKEN`

## Problem

GitHub Actions suppresses events created by `GITHUB_TOKEN` to prevent infinite loops. When `opencode-audit.yml` creates an issue using the default token, the `issues: opened` event never fires, so `opencode-triage.yml` is never triggered.

## Fix

Issues created with a PAT **do** trigger downstream workflow events. By switching the `GH_TOKEN` env var (used by `gh` CLI commands) to a PAT, the triage workflow will correctly fire on audit-created issues.

**Required repo admin action:** Add a `WORKFLOW_PAT` secret containing a fine-grained PAT with `issues` and `pull_requests` permissions.

Related: #439