### PR TITLE
fix(ci): use existing OPENCODE_PAT secret instead of WORKFLOW_PAT

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -90,7 +90,7 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:


### PR DESCRIPTION
## Summary

- Rename `WORKFLOW_PAT` → `OPENCODE_PAT` in `opencode-audit.yml` to use the existing repo secret

## Problem

PR #442 introduced `secrets.WORKFLOW_PAT` but the repo already has `secrets.OPENCODE_PAT` configured (used by `visual-test.yml`). The non-existent secret would cause the audit workflow to fail silently with an empty token.

## Fix

Use `secrets.OPENCODE_PAT` which already exists and has the necessary permissions.