### PR TITLE
fix(ci): trigger build and review workflows for bot-created PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,15 @@ on:
     branches: [ dev ]
   pull_request:
     branches: [ dev ]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or ref to build/test'
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.ref }}
   cancel-in-progress: true
 
 env:
@@ -22,12 +28,14 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     outputs:
-      code_changes: ${{ steps.filter.outputs.code_changes }}
+      code_changes: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.code_changes }}
     steps:
     - uses: actions/checkout@v4
+      if: github.event_name != 'workflow_dispatch'
 
     - name: Detect build-relevant changes
       id: filter
+      if: github.event_name != 'workflow_dispatch'
       uses: dorny/paths-filter@v4
       with:
         filters: |
@@ -50,6 +58,8 @@ jobs:
     needs: changes
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
 
     - name: Skip build for workflow-only changes
       if: needs.changes.outputs.code_changes != 'true'
@@ -87,6 +97,8 @@ jobs:
     needs: [changes, build]
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
 
     - name: Skip unit tests for workflow-only changes
       if: needs.changes.outputs.code_changes != 'true'
@@ -112,6 +124,8 @@ jobs:
     needs: [changes, unit-test]
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
 
     - name: Skip integration tests for workflow-only changes
       if: needs.changes.outputs.code_changes != 'true'

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -230,7 +230,8 @@ jobs:
         if: steps.check-existing.outputs.skip != 'true'
         run: |
           sleep 5
-          PR_NUM=$(gh pr list --base dev --label automated-test --state open --json number --jq '.[0].number')
+          BRANCH="${{ steps.select-module.outputs.branch }}"
+          PR_NUM=$(gh pr list --base dev --head "$BRANCH" --label automated-test --state open --json number --jq '.[0].number')
           if [ -n "$PR_NUM" ]; then
             echo "Triggering Build and opencode review for PR #$PR_NUM"
             SHA=$(gh api repos/OpenStaticFish/ZigCraft/pulls/$PR_NUM --jq '.head.sha')

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -230,11 +230,12 @@ jobs:
         if: steps.check-existing.outputs.skip != 'true'
         run: |
           sleep 5
-          PR_NUM=$(gh pr list --base dev --head "opencode/dispatch-" --label automated-test --state open --json number --jq '.[0].number')
+          PR_NUM=$(gh pr list --base dev --label automated-test --state open --json number --jq '.[0].number')
           if [ -n "$PR_NUM" ]; then
             echo "Triggering Build and opencode review for PR #$PR_NUM"
             SHA=$(gh api repos/OpenStaticFish/ZigCraft/pulls/$PR_NUM --jq '.head.sha')
-            gh workflow run build.yml --field ref="opencode/dispatch-" || echo "Build trigger attempted"
+            BRANCH=$(gh api repos/OpenStaticFish/ZigCraft/pulls/$PR_NUM --jq '.head.ref')
+            gh workflow run build.yml --field ref="$BRANCH" || echo "Build trigger attempted"
             gh workflow run opencode-pr.yml --field pr_number="$PR_NUM" --field head_sha="$SHA"
           else
             echo "No PR found to trigger workflows"


### PR DESCRIPTION
## Summary

Bot-created PRs (from `opencode/schedule-*` or `opencode/dispatch-*` branches) never trigger the required `build`, `unit-test`, and `ai-merge-gate` status checks because `GITHUB_TOKEN`-created PRs don't fire `pull_request` events.

This leaves the dev ruleset permanently stuck at "Expected — Waiting for status to be reported" (see #443).

## Changes

### `build.yml`
- Add `workflow_dispatch` trigger with `ref` input for on-demand runs
- Short-circuit the `changes` filter job for dispatch events (test PRs always have code changes)
- Pass `${{ inputs.ref }}` to all `actions/checkout` steps (build, unit-test, integration-test)

### `opencode-test-writer.yml`
- Fix PR search: use `--label automated-test` instead of broken `--head "opencode/dispatch-"` filter
- Fetch actual branch name from the PR and pass it via `--field ref="$BRANCH"` to `build.yml`

## Flow
```
test-writer → creates PR → trigger step
  ├→ gh workflow run build.yml --field ref="opencode/schedule-..."  → build + unit-test
  └→ gh workflow run opencode-pr.yml --field pr_number=N            → AI review + ai-merge-gate
```

All 3 required checks (`build`, `unit-test`, `ai-merge-gate`) will now post against the bot PR's head SHA.

## Testing
- `workflow_dispatch` with `GITHUB_TOKEN` is the one exception that CAN trigger other workflows (no PAT needed)
- Human PRs are unaffected — they still fire `pull_request` events normally
- No duplicate runs: bot PRs never trigger `pull_request`, and dispatch concurrency is keyed separately