### PR TITLE
fix(ci): use OPENCODE_PAT in test-writer to trigger downstream workflows

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 20
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
-          token: ${{ github.token }}
+          token: ${{ secrets.OPENCODE_PAT }}
 
       - name: Ensure test label exists
         run: |
@@ -147,7 +147,7 @@ jobs:
               --color "0E8A16"
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
 
       - name: Check for existing PR
         id: check-existing
@@ -167,7 +167,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
 
       - name: Validate scan paths exist
         if: steps.check-existing.outputs.skip != 'true'
@@ -192,8 +192,8 @@ jobs:
         if: steps.check-existing.outputs.skip != 'true'
         uses: anomalyco/opencode/github@latest
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:
@@ -242,4 +242,4 @@ jobs:
             echo "No PR found to trigger workflows"
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}


### PR DESCRIPTION
## Summary
- Replace all `github.token` references in `opencode-test-writer.yml` with `secrets.OPENCODE_PAT` so that PRs created by the bot actually trigger `build.yml` and `opencode-pr.yml`
- Reduce `opencode-audit.yml` timeout from 60 → 20 minutes

## Why
GitHub's `GITHUB_TOKEN` cannot trigger other workflows — this is a deliberate security restriction. PR #447 was created but neither `build.yml` nor `opencode-pr.yml` fired. The audit and visual-test workflows already use `OPENCODE_PAT` for the same reason.