### PR TITLE
fix(ci): find PR by author instead of branch name for downstream triggers

### DIFF
--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -230,20 +230,27 @@ jobs:
         if: steps.check-existing.outputs.skip != 'true'
         id: find-pr
         run: |
-          sleep 5
           PAT_USER=$(gh api user --jq '.login')
-          PR_NUM=$(gh pr list \
-            --base dev \
-            --state open \
-            --limit 10 \
-            --json number,createdAt,author \
-            --jq "[.[] | select(.author.login == \"${PAT_USER}\")] | sort_by(.createdAt) | reverse | .[0].number")
+          PR_NUM=""
+          for i in 1 2 3 4 5; do
+            sleep $((i * 3))
+            echo "Attempt $i: searching for PR by ${PAT_USER}..."
+            PR_NUM=$(gh pr list \
+              --base dev \
+              --state open \
+              --limit 10 \
+              --json number,createdAt,author \
+              --jq "[.[] | select(.author.login == \"${PAT_USER}\")] | sort_by(.createdAt) | reverse | .[0].number")
+            if [ -n "$PR_NUM" ]; then
+              break
+            fi
+          done
           if [ -n "$PR_NUM" ]; then
             echo "Found newly created PR #$PR_NUM (author: ${PAT_USER})"
             gh pr edit "$PR_NUM" --add-label "automated-test"
             echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
           else
-            echo "No PR found authored by ${PAT_USER}"
+            echo "No PR found authored by ${PAT_USER} after 5 attempts"
           fi
         env:
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -226,20 +226,36 @@ jobs:
             5. Commit your changes: `git add` and `git commit` with message `test: add {area} tests for ${{ steps.select-module.outputs.module }}`
             6. STOP. Do not push or create a PR.
 
-      - name: Trigger downstream workflows
+      - name: Find and label created PR
         if: steps.check-existing.outputs.skip != 'true'
+        id: find-pr
         run: |
           sleep 5
-          BRANCH="${{ steps.select-module.outputs.branch }}"
-          PR_NUM=$(gh pr list --base dev --head "$BRANCH" --label automated-test --state open --json number --jq '.[0].number')
+          PAT_USER=$(gh api user --jq '.login')
+          PR_NUM=$(gh pr list \
+            --base dev \
+            --state open \
+            --limit 10 \
+            --json number,createdAt,author \
+            --jq "[.[] | select(.author.login == \"${PAT_USER}\")] | sort_by(.createdAt) | reverse | .[0].number")
           if [ -n "$PR_NUM" ]; then
-            echo "Triggering Build and opencode review for PR #$PR_NUM"
-            SHA=$(gh api repos/OpenStaticFish/ZigCraft/pulls/$PR_NUM --jq '.head.sha')
-            BRANCH=$(gh api repos/OpenStaticFish/ZigCraft/pulls/$PR_NUM --jq '.head.ref')
-            gh workflow run build.yml --field ref="$BRANCH" || echo "Build trigger attempted"
-            gh workflow run opencode-pr.yml --field pr_number="$PR_NUM" --field head_sha="$SHA"
+            echo "Found newly created PR #$PR_NUM (author: ${PAT_USER})"
+            gh pr edit "$PR_NUM" --add-label "automated-test"
+            echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
           else
-            echo "No PR found to trigger workflows"
+            echo "No PR found authored by ${PAT_USER}"
           fi
+        env:
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+
+      - name: Trigger downstream workflows
+        if: steps.find-pr.outputs.pr_number != ''
+        run: |
+          PR_NUM="${{ steps.find-pr.outputs.pr_number }}"
+          echo "Triggering Build and opencode review for PR #$PR_NUM"
+          SHA=$(gh api repos/OpenStaticFish/ZigCraft/pulls/$PR_NUM --jq '.head.sha')
+          BRANCH=$(gh api repos/OpenStaticFish/ZigCraft/pulls/$PR_NUM --jq '.head.ref')
+          gh workflow run build.yml --field ref="$BRANCH" || echo "Build trigger attempted"
+          gh workflow run opencode-pr.yml --field pr_number="$PR_NUM" --field head_sha="$SHA"
         env:
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -77,6 +77,7 @@ jobs:
           BRANCH_NAME="test/$(echo "${SELECTED}" | tr '/' '-')"
           echo "module=${SELECTED}" >> "$GITHUB_OUTPUT"
           echo "branch=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
+          echo "base_branch=${{ github.event.repository.default_branch }}" >> "$GITHUB_OUTPUT"
 
           case "$SELECTED" in
             graphics/vulkan-device)
@@ -135,7 +136,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ steps.select-module.outputs.base_branch }}
           fetch-depth: 0
           token: ${{ secrets.OPENCODE_PAT }}
 
@@ -154,7 +155,7 @@ jobs:
         run: |
           MODULE="${{ steps.select-module.outputs.module }}"
           EXISTING=$(gh pr list \
-            --base ${{ github.event.repository.default_branch }} \
+            --base ${{ steps.select-module.outputs.base_branch }} \
             --label "automated-test" \
             --state open \
             --limit 20 \
@@ -230,15 +231,15 @@ jobs:
         if: steps.check-existing.outputs.skip != 'true'
         id: find-pr
         run: |
-          # Retry budget: 8 attempts, 3s/6s/9s/12s/15s/18s/21s/24s = ~108s max wait.
-          # Increase max attempts if GitHub API latency during incidents exceeds this window.
+          BASE="${{ steps.select-module.outputs.base_branch }}"
+          MAX_RETRIES=8
           PAT_USER=$(gh api user --jq '.login')
           PR_NUM=""
-          for i in 1 2 3 4 5 6 7 8; do
+          for i in $(seq 1 "$MAX_RETRIES"); do
             sleep $((i * 3))
-            echo "Attempt $i: searching for PR by ${PAT_USER}..."
+            echo "Attempt $i/$MAX_RETRIES: searching for PR by ${PAT_USER} targeting ${BASE}..."
             PR_NUM=$(gh pr list \
-              --base dev \
+              --base "$BASE" \
               --state open \
               --limit 10 \
               --json number,createdAt,author \
@@ -249,10 +250,12 @@ jobs:
           done
           if [ -n "$PR_NUM" ]; then
             echo "Found newly created PR #$PR_NUM (author: ${PAT_USER})"
-            gh pr edit "$PR_NUM" --add-label "automated-test"
+            if ! gh pr edit "$PR_NUM" --add-label "automated-test" 2>/dev/null; then
+              echo "::warning::Failed to add automated-test label to PR #$PR_NUM"
+            fi
             echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
           else
-            echo "No PR found authored by ${PAT_USER} after 8 attempts"
+            echo "No PR found authored by ${PAT_USER} after $MAX_RETRIES attempts"
           fi
         env:
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -230,9 +230,11 @@ jobs:
         if: steps.check-existing.outputs.skip != 'true'
         id: find-pr
         run: |
+          # Retry budget: 8 attempts, 3s/6s/9s/12s/15s/18s/21s/24s = ~108s max wait.
+          # Increase max attempts if GitHub API latency during incidents exceeds this window.
           PAT_USER=$(gh api user --jq '.login')
           PR_NUM=""
-          for i in 1 2 3 4 5; do
+          for i in 1 2 3 4 5 6 7 8; do
             sleep $((i * 3))
             echo "Attempt $i: searching for PR by ${PAT_USER}..."
             PR_NUM=$(gh pr list \
@@ -250,7 +252,7 @@ jobs:
             gh pr edit "$PR_NUM" --add-label "automated-test"
             echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
           else
-            echo "No PR found authored by ${PAT_USER} after 5 attempts"
+            echo "No PR found authored by ${PAT_USER} after 8 attempts"
           fi
         env:
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}


### PR DESCRIPTION
## Problem

The `Trigger downstream workflows` step in `opencode-test-writer.yml` was searching for PRs by exact branch name (`test/MODULE`), but the opencode action auto-creates branches with names like `opencode/schedule-XXX`. This caused the lookup to always return "No PR found" and downstream build/review workflows were never triggered.

Additionally, the opencode action doesn't add the `automated-test` label to PRs it creates, so label-based filtering also failed.

## Fix

Splits the trigger step into two:
1. **Find and label created PR** — queries for the most recent open PR authored by the PAT user, then adds the `automated-test` label
2. **Trigger downstream workflows** — uses the discovered PR number to trigger `build.yml` and `opencode-pr.yml`

This was the root cause of PR #450 getting no build or review triggered.