### PR TITLE
fix(ci): resolve opencode workflow failures — PAT permissions, git identity, validation

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -1,5 +1,11 @@
 name: opencode-audit
 
+# Required repository secrets:
+# - OPENCODE_PAT: Classic PAT with `repo` scope OR fine-grained PAT with:
+#     Contents: Read, Issues: Read & Write, Pull requests: Read & Write
+#   Without proper scopes, gh issue create and label operations will fail.
+# - MINIMAX_API_KEY: API key for the MiniMax M2.7 model
+
 on:
   schedule:
     - cron: '0 6 * * *'
@@ -65,7 +71,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.OPENCODE_PAT }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "opencode[bot]"
+          git config user.email "opencode[bot]@users.noreply.github.com"
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
@@ -78,7 +89,21 @@ jobs:
               --color "1D76DB" || true
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+
+      - name: Validate module directory exists
+        run: |
+          MODULE_PATH="${{ steps.select-module.outputs.module_path }}"
+          if [ ! -d "$MODULE_PATH" ]; then
+            echo "::warning::Module directory '$MODULE_PATH' does not exist — audit may be limited to partial or no source files"
+            echo "Listing parent directory:"
+            PARENT=$(dirname "$MODULE_PATH")
+            ls -la "$PARENT" 2>/dev/null || echo "Parent directory '$PARENT' also missing"
+          else
+            echo "Module directory confirmed: $MODULE_PATH"
+            echo "Files in module:"
+            find "$MODULE_PATH" -name '*.zig' | head -20
+          fi
 
       - name: Ensure opencode cache dir exists
         run: |
@@ -323,4 +348,4 @@ jobs:
             echo "✅ No compliance violations detected."
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -1,5 +1,11 @@
 name: opencode-test-writer
 
+# Required repository secrets:
+# - OPENCODE_PAT: Classic PAT with `repo` scope OR fine-grained PAT with:
+#     Contents: Read & Write, Pull requests: Read & Write, Metadata: Read
+#   Without `repo` scope, git push will fail with 403 permission denied.
+# - MINIMAX_API_KEY: API key for the MiniMax M2.7 model
+
 on:
   schedule:
     - cron: '0 4 * * *'
@@ -133,12 +139,20 @@ jobs:
               ;;
           esac
 
+      # OPENCODE_PAT must be a classic PAT with `repo` scope (full control of private repositories)
+      # or a fine-grained PAT with Contents: Read & Write on this repository.
+      # Without write permission, git push will fail with 403.
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.select-module.outputs.base_branch }}
           fetch-depth: 0
           token: ${{ secrets.OPENCODE_PAT }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "opencode[bot]"
+          git config user.email "opencode[bot]@users.noreply.github.com"
 
       - name: Ensure test label exists
         run: |
@@ -183,6 +197,15 @@ jobs:
           if [ "$MISSING" -gt 0 ]; then
             echo "::warning::$MISSING scan path(s) missing — the scan_paths case statement in this workflow may need updating"
           fi
+
+      - name: Verify PAT push permissions
+        if: steps.check-existing.outputs.skip != 'true'
+        run: |
+          if ! git push --dry-run origin HEAD:${{ steps.select-module.outputs.base_branch }} 2>/dev/null; then
+            echo "::error::OPENCODE_PAT cannot push to repository. Ensure the PAT has 'repo' scope (classic) or Contents: Read & Write (fine-grained)."
+            exit 1
+          fi
+          echo "PAT has push permissions."
 
       - name: Setup Nix
         if: steps.check-existing.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

- **Switch audit workflow to OPENCODE_PAT** — `github.token` is read-only for scheduled runs, causing 403 permission denied on both `git push` and `gh issue create`
- **Add `git config user.name/email`** before opencode steps in both workflows — prevents `fatal: empty ident name` / `Author identity unknown` crash
- **Add PAT push permission pre-check** in test-writer — fails fast with a clear error message instead of wasting 6+ minutes
- **Add module directory validation** in audit workflow — warns if the scheduled module path doesn't exist before running the expensive audit step
- **Document required PAT scopes** in both workflow headers

## Root causes identified

| Failure | Workflow | Cause | Fix |
|---------|----------|-------|-----|
| `Permission denied (403)` on `git push` | test-writer | `OPENCODE_PAT` lacks `repo` scope for push | Document required scopes + pre-check |
| `Author identity unknown` | audit | No git identity configured for the bot | Added `git config user.name/email` |
| `Token lacks 'issues' write permission` | audit (earlier) | `github.token` used for `gh` operations | Switched to `OPENCODE_PAT` |
| `Failed to get summary from agent` | audit | Transient opencode action failure | No code fix; module validation helps |

## Test plan

- [x] Reviewed all recent failed workflow runs to identify root causes
- [ ] Verify audit workflow triggers correctly on next schedule
- [ ] Verify test-writer PAT push pre-check passes with properly scoped PAT