### PR TITLE
fix: call cleanup on job when re-add fails in JobQueue.doReprioritize

### DIFF
--- a/src/engine/core/job_system.zig
+++ b/src/engine/core/job_system.zig
@@ -225,6 +225,7 @@ pub const JobQueue = struct {
         for (temp.items) |job| {
             self.jobs.add(job) catch {
                 log.log.warn("Job queue: failed to re-add job after priority update", .{});
+                job.cleanup();
                 continue;
             };
         }


### PR DESCRIPTION
## Summary
- Fixed memory leak in `JobQueue.doReprioritize` where jobs were silently dropped without calling `cleanup_fn` when `self.jobs.add(job)` failed
- Added `job.cleanup()` call before `continue` in the error handler, matching the pattern used earlier in the same function (line 219)

## Testing
- All existing unit tests pass (`zig build test`)

## Fixes
Fixes the memory leak reported in the audit issue where generic jobs with `cleanup_fn` that fail to re-prioritize have their cleanup called.