### PR TITLE


Remove unused isInCoastalNoTreeZone with bad logic

### DIFF
--- a/src/world/worldgen/surface_builder.zig
+++ b/src/world/worldgen/surface_builder.zig
@@ -233,13 +233,6 @@ pub const SurfaceBuilder = struct {
         return block;
     }
 
-    /// Check if position is in coastal no-tree zone
-    pub fn isInCoastalNoTreeZone(self: *const SurfaceBuilder, height: i32) bool {
-        const p = self.params;
-        const diff = height - p.sea_level;
-        return diff >= 0 and diff <= p.coastal_no_tree_max and diff >= p.coastal_no_tree_min;
-    }
-
     /// Get filler depth for a biome
     pub fn getFillerDepth(_: *const SurfaceBuilder, biome_id: BiomeId) i32 {
         const biome_def = biome_mod.getBiomeDefinition(biome_id);

--- a/src/world/worldgen/surface_builder.zig
+++ b/src/world/worldgen/surface_builder.zig
@@ -44,10 +44,6 @@ pub const SurfaceParams = struct {
     // Coastal zone (continentalness thresholds)
     ocean_threshold: f32 = 0.35,
     beach_band: f32 = 0.05, // Width of beach zone in continentalness units
-
-    // Coastal tree restriction zone
-    coastal_no_tree_min: i32 = 8,
-    coastal_no_tree_max: i32 = 18,
 };
 
 // ============================================================================


### PR DESCRIPTION


Removed the dead `isInCoastalNoTreeZone` function from `surface_builder.zig:237-241`. It was never called anywhere in the codebase and had incorrect AND logic that would have produced wrong results if used. The function created an impossible constraint (`diff >= 0 AND diff <= 18 AND diff >= 8` = `diff >= 8 AND diff <= 18`).

Build passes. Changes ready for PR to `dev`.

Closes #477

<a href="https://opencode.ai/s/ZSxtg1fu"><img width="200" alt="New%20session%20-%202026-04-16T02%3A02%3A15.358Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTE2VDAyOjAyOjE1LjM1OFo=.png?model=minimax-coding-plan/MiniMax-M2.7&version=1.4.6&id=ZSxtg1fu" /></a>
[opencode session](https://opencode.ai/s/ZSxtg1fu)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/24488002532)