### PR TITLE
fix: align ClassificationCache.recenter to CELL_SIZE boundary

### DIFF
--- a/src/world/worldgen/gen_region.zig
+++ b/src/world/worldgen/gen_region.zig
@@ -312,8 +312,10 @@ pub const ClimateCache = struct {
     /// Invalidates all cells.
     pub fn recenter(self: *ClimateCache, center_x: i32, center_z: i32) void {
         const half_size: i32 = @intCast((GRID_SIZE * CELL_SIZE) / 2);
-        self.origin_x = center_x - half_size;
-        self.origin_z = center_z - half_size;
+        const aligned_center_x = @divFloor(center_x, @as(i32, @intCast(CELL_SIZE))) * @as(i32, @intCast(CELL_SIZE));
+        const aligned_center_z = @divFloor(center_z, @as(i32, @intCast(CELL_SIZE))) * @as(i32, @intCast(CELL_SIZE));
+        self.origin_x = aligned_center_x - half_size;
+        self.origin_z = aligned_center_z - half_size;
 
         // Invalidate all cells
         for (&self.cells) |*cell| {

--- a/src/world/worldgen/gen_region.zig
+++ b/src/world/worldgen/gen_region.zig
@@ -417,8 +417,10 @@ pub const ClassificationCache = struct {
     /// Invalidates all cells.
     pub fn recenter(self: *ClassificationCache, center_x: i32, center_z: i32) void {
         const half_size: i32 = @intCast((GRID_SIZE * CELL_SIZE) / 2);
-        self.origin_x = center_x - half_size;
-        self.origin_z = center_z - half_size;
+        const aligned_center_x = @divFloor(center_x, @as(i32, @intCast(CELL_SIZE))) * @as(i32, @intCast(CELL_SIZE));
+        const aligned_center_z = @divFloor(center_z, @as(i32, @intCast(CELL_SIZE))) * @as(i32, @intCast(CELL_SIZE));
+        self.origin_x = aligned_center_x - half_size;
+        self.origin_z = aligned_center_z - half_size;
 
         // Invalidate all cells
         for (&self.cells) |*cell| {


### PR DESCRIPTION
## Summary
Fixes `ClassificationCache.recenter` not aligning center coordinates to `CELL_SIZE` (8 blocks), which caused `contains()` to return true for positions mapping to out-of-bounds cell indices in `getCellIndex()`.

solves issue #475 475

## Fix
Align `center_x` and `center_z` to `CELL_SIZE` using `@divFloor` before computing the origin in `gen_region.zig:418-421`.

## Testing
- `zig build test` passes
- All existing tests continue to work

Fixes issue where misaligned centers caused cache corruption and incorrect terrain at LOD chunk boundaries.