### PR TITLE


fix: use ShaderCreationNotSupported error

### DIFF
--- a/src/engine/graphics/rhi_types.zig
+++ b/src/engine/graphics/rhi_types.zig
@@ -13,6 +13,7 @@ pub const RhiError = error{
     InitializationFailed,
     ExtensionNotPresent,
     FeatureNotPresent,
+    ShaderCreationNotSupported,
     TooManyObjects,
     FormatNotSupported,
     InvalidImageView,

--- a/src/engine/graphics/vulkan/resource_manager.zig
+++ b/src/engine/graphics/vulkan/resource_manager.zig
@@ -432,10 +432,7 @@ pub const ResourceManager = struct {
         _ = self;
         _ = vertex_src;
         _ = fragment_src;
-        // TODO: Implement actual shader creation when ready.
-        // For now, return error to avoid silent failure.
-        // NOTE: If engine code calls this, it will now fail loudly, which is better than silent failure.
-        return error.ExtensionNotPresent; // Or proper NotImpl error
+        return error.ShaderCreationNotSupported;
     }
 
     pub fn destroyShader(self: *ResourceManager, handle: rhi.ShaderHandle) void {


### PR DESCRIPTION


The fix is complete. Changes made:

1. **Added new error type** `ShaderCreationNotSupported` to `RhiError` in `rhi_types.zig` - accurately reflects that shader creation via GLSL source is not supported (SPIR-V compilation happens elsewhere at build time)

2. **Updated `createShader`** in `resource_manager.zig` - replaced misleading `ExtensionNotPresent` error with the new accurate error type, removed TODO comments

The `ResourceManager.createShader()` stub was never called in production - all shader creation goes through `Utils.createShaderModule()` with pre-compiled SPIR-V bytecode. The fix ensures any future caller gets a meaningful error if they accidentally use this path.

Closes #484

<a href="https://opencode.ai/s/wTC2CeMB"><img width="200" alt="New%20session%20-%202026-04-16T02%3A02%3A14.428Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTE2VDAyOjAyOjE0LjQyOFo=.png?model=minimax-coding-plan/MiniMax-M2.7&version=1.4.6&id=wTC2CeMB" /></a>
[opencode session](https://opencode.ai/s/wTC2CeMB)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/24488000873)