### PR TITLE
Add mock infrastructure for recover() testing

### DIFF
--- a/src/engine/graphics/vulkan/rhi_state_control_tests.zig
+++ b/src/engine/graphics/vulkan/rhi_state_control_tests.zig
@@ -21,6 +21,7 @@ const MockOptions = struct {
 const MockDraw = struct {
     descriptors_updated: bool = true,
     terrain_pipeline_bound: bool = true,
+    bound_texture: u32 = 0,
 };
 
 const MockFrames = struct {
@@ -28,12 +29,24 @@ const MockFrames = struct {
     frame_in_progress: bool = false,
     dry_run: bool = true,
     command_buffers: [3]c.VkCommandBuffer = .{ null, null, null },
+
+    pub fn abortFrame(_: *MockFrames) void {
+        // No-op for testing
+    }
 };
 
 const MockRuntime = struct {
     gpu_fault_detected: bool = false,
     framebuffer_resized: bool = false,
     pipeline_rebuild_needed: bool = false,
+    main_pass_active: bool = false,
+    g_pass_active: bool = false,
+    ssao_pass_active: bool = false,
+    recovering: bool = false,
+};
+
+const MockShadowSystem = struct {
+    pass_active: bool = false,
 };
 
 const MockSwapchain = struct {
@@ -70,6 +83,7 @@ const MockSimpleContext = struct {
     runtime: MockRuntime = .{},
     swapchain: MockSwapchain = .{},
     vulkan_device: MockVulkanDevice = .{},
+    shadow_system: MockShadowSystem = .{},
     mutex: sync.Mutex = .{},
     window: ?*c.SDL_Window = null,
 };
@@ -338,3 +352,13 @@ test "rhi_state_control.setVSync no-op when unchanged" {
 
 // Note: setVSync when changed cannot be tested without a real GPU
 // because it calls vkGetPhysicalDeviceSurfacePresentModesKHR
+
+// ============================================================================
+// Recovery State Machine Tests
+// ============================================================================
+// Note: recover() cannot be tested without a real GPU because it calls
+// vkDeviceWaitIdle and frame_orchestration.recreateSwapchainInternal which
+// require valid Vulkan device and swapchain objects. The mock structures
+// (MockFrames.abortFrame, MockDraw.bound_texture, MockRuntime pass flags,
+// MockShadowSystem.pass_active) are in place to support future testing
+// when a full mock context is available.


### PR DESCRIPTION
Add mock structures to `src/engine/graphics/vulkan/rhi_state_control_tests.zig` to support future recover() testing:

**Added mocks and fields:**
- `MockFrames.abortFrame()` - needed by `recover()` path
- `MockDraw.bound_texture` - needed by `recover()` clearing  
- `MockRuntime.main_pass_active`, `g_pass_active`, `ssao_pass_active`, `recovering` - needed by `recover()` state management
- `MockShadowSystem` and added to context - needed by `recover()` to reset pass flags

**Why actual recover() tests were not added:** The `recover()` function calls `vkDeviceWaitIdle` and `frame_orchestration.recreateSwapchainInternal` which require valid Vulkan device and swapchain objects. These cannot be tested without a GPU. The mock structures are infrastructure for future testing when a full mock context is available.

**Tests pass:** 1080 pass.

Triggered by scheduled workflow