### PR TITLE
fix: route SSAO through dedicated context

### DIFF
--- a/src/engine/graphics/rhi.zig
+++ b/src/engine/graphics/rhi.zig
@@ -277,9 +277,6 @@ pub const RenderContext = struct {
     pub fn setClearColor(self: RenderContext, color: Vec3) void {
         self.render.vtable.setClearColor(self.render.ptr, color);
     }
-    pub fn computeSSAO(self: RenderContext, proj: Mat4, inv_proj: Mat4) void {
-        self.render.vtable.computeSSAO(self.render.ptr, proj, inv_proj);
-    }
     pub fn drawDebugShadowMap(self: RenderContext, cascade_index: usize, depth_map_handle: TextureHandle) void {
         self.render.vtable.drawDebugShadowMap(self.render.ptr, cascade_index, depth_map_handle);
     }
@@ -683,8 +680,6 @@ pub const IRenderContext = struct {
         setClearColor: *const fn (ptr: *anyopaque, color: Vec3) void,
 
         // Specific rendering passes/techniques (Tracked for refactoring)
-        // TODO (#225): Relocate computeSSAO to dedicated SSAOSystem
-        computeSSAO: *const fn (ptr: *anyopaque, proj: Mat4, inv_proj: Mat4) void,
         /// @deprecated TODO (#226): Relocate drawDebugShadowMap to a debug overlay system.
         drawDebugShadowMap: *const fn (ptr: *anyopaque, cascade_index: usize, depth_map_handle: TextureHandle) void,
 

--- a/src/engine/graphics/rhi_tests.zig
+++ b/src/engine/graphics/rhi_tests.zig
@@ -115,7 +115,7 @@ const MockContext = struct {
         return 0;
     }
 
-    fn computeSSAO(ptr: *anyopaque, proj: Mat4, inv_proj: Mat4) void {
+    fn computeSsao(ptr: *anyopaque, proj: Mat4, inv_proj: Mat4) void {
         _ = ptr;
         _ = proj;
         _ = inv_proj;
@@ -228,12 +228,11 @@ const MockContext = struct {
         .getNativeCommandBuffer = getNativeCommandBuffer,
         .getNativeSwapchainExtent = getNativeSwapchainExtent,
         .getNativeDevice = getNativeDevice,
-        .computeSSAO = computeSSAO,
         .drawDebugShadowMap = drawDebugShadowMap,
     };
 
     const MOCK_SSAO_VTABLE = rhi.ISSAOContext.VTable{
-        .compute = computeSSAO,
+        .compute = computeSsao,
     };
 
     const MOCK_WATER_VTABLE = rhi.IWaterContext.VTable{

--- a/src/engine/graphics/rhi_vulkan.zig
+++ b/src/engine/graphics/rhi_vulkan.zig
@@ -841,7 +841,7 @@ fn getNativeDevice(ctx_ptr: *anyopaque) u64 {
     return native_access.getNativeDevice(ctx);
 }
 
-fn computeSSAO(ctx_ptr: *anyopaque, proj: Mat4, inv_proj: Mat4) void {
+fn computeSsao(ctx_ptr: *anyopaque, proj: Mat4, inv_proj: Mat4) void {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
     ctx.ssao_system.compute(
         ctx.vulkan_device.vk_device,
@@ -859,7 +859,7 @@ fn drawDebugShadowMap(ctx_ptr: *anyopaque, cascade_index: usize, depth_map_handl
 }
 
 const VULKAN_SSAO_VTABLE = rhi.ISSAOContext.VTable{
-    .compute = computeSSAO,
+    .compute = computeSsao,
 };
 
 const VULKAN_UI_CONTEXT_VTABLE = rhi.IUIContext.VTable{
@@ -946,7 +946,6 @@ const VULKAN_RHI_VTABLE = rhi.RHI.VTable{
         .getNativeSwapchainExtent = getNativeSwapchainExtent,
         .getNativeDevice = getNativeDevice,
         .setClearColor = setClearColor,
-        .computeSSAO = computeSSAO,
         .drawDebugShadowMap = drawDebugShadowMap,
     },
     .ssao = VULKAN_SSAO_VTABLE,


### PR DESCRIPTION
## Summary

- Remove the SSAO compute hook from the render context vtable and wrapper.
- Keep Vulkan and tests routing SSAO computation through `ISSAOContext` only.

## Verification
- `nix develop --command zig build test --summary all`
- `nix develop --command zig build -Doptimize=ReleaseFast`


Closes #460