### PR TITLE
refactor: move LPV ownership into render graph

### DIFF
--- a/src/engine/graphics/render_graph.zig
+++ b/src/engine/graphics/render_graph.zig
@@ -52,6 +52,29 @@ const log = @import("../core/log.zig");
 const CSM = @import("csm.zig");
 const AtmosphereSystem = @import("atmosphere_system.zig").AtmosphereSystem;
 const MaterialSystem = @import("material_system.zig").MaterialSystem;
+pub const LPVSystem = @import("lpv_system.zig").LPVSystem;
+
+pub const LPVConfig = struct {
+    grid_size: u32,
+    cell_size: f32,
+    intensity: f32,
+    propagation_iterations: u32,
+    enabled: bool,
+};
+
+pub const LPVTextureHandles = struct {
+    red: rhi_pkg.TextureHandle = 0,
+    green: rhi_pkg.TextureHandle = 0,
+    blue: rhi_pkg.TextureHandle = 0,
+
+    pub fn fromSystem(lpv_system: *LPVSystem) LPVTextureHandles {
+        return .{
+            .red = lpv_system.getTextureHandle(),
+            .green = lpv_system.getTextureHandleG(),
+            .blue = lpv_system.getTextureHandleB(),
+        };
+    }
+};
 
 pub const SceneContext = struct {
     render_ctx: RenderContext,
@@ -82,9 +105,7 @@ pub const SceneContext = struct {
     resolution_scale: f32 = 1.0,
     overlay_renderer: ?*const fn (ctx: SceneContext) void = null,
     overlay_ctx: ?*anyopaque = null,
-    lpv_texture_handle: rhi_pkg.TextureHandle = 0,
-    lpv_texture_handle_g: rhi_pkg.TextureHandle = 0,
-    lpv_texture_handle_b: rhi_pkg.TextureHandle = 0,
+    lpv_textures: LPVTextureHandles = .{},
     cached_cascades: *?CSM.ShadowCascades,
     gpu_mesh_dispatch_fn: ?*const fn (*anyopaque) void = null,
     gpu_mesh_dispatch_ctx: ?*anyopaque = null,
@@ -116,16 +137,33 @@ pub const IRenderPass = struct {
 pub const RenderGraph = struct {
     passes: std.ArrayListUnmanaged(IRenderPass),
     allocator: std.mem.Allocator,
+    lpv_system: *LPVSystem,
 
-    pub fn init(allocator: std.mem.Allocator) RenderGraph {
+    pub fn init(allocator: std.mem.Allocator, rhi: rhi_pkg.RHI, lpv_config: LPVConfig) !RenderGraph {
+        const lpv_system = try LPVSystem.init(
+            allocator,
+            rhi,
+            lpv_config.grid_size,
+            lpv_config.cell_size,
+            lpv_config.intensity,
+            lpv_config.propagation_iterations,
+            lpv_config.enabled,
+        );
+
         return .{
             .passes = .empty,
             .allocator = allocator,
+            .lpv_system = lpv_system,
         };
     }
 
     pub fn deinit(self: *RenderGraph) void {
         self.passes.deinit(self.allocator);
+        self.lpv_system.deinit();
+    }
+
+    pub fn getLPVSystem(self: *RenderGraph) *LPVSystem {
+        return self.lpv_system;
     }
 
     pub fn addPass(self: *RenderGraph, pass: IRenderPass) !void {
@@ -354,9 +392,9 @@ pub const OpaquePass = struct {
         _ = ptr;
         ctx.render_ctx.bindShader(ctx.main_shader);
         ctx.material_system.bindTerrainMaterial(ctx.render_ctx, ctx.env_map_handle);
-        ctx.render_ctx.bindTexture(ctx.lpv_texture_handle, 11);
-        ctx.render_ctx.bindTexture(ctx.lpv_texture_handle_g, 12);
-        ctx.render_ctx.bindTexture(ctx.lpv_texture_handle_b, 13);
+        ctx.render_ctx.bindTexture(ctx.lpv_textures.red, 11);
+        ctx.render_ctx.bindTexture(ctx.lpv_textures.green, 12);
+        ctx.render_ctx.bindTexture(ctx.lpv_textures.blue, 13);
         const view_proj = ctx.camera.getJitteredProjectionMatrixReverseZ(ctx.aspect, ctx.viewport_width, ctx.viewport_height, ctx.taa_enabled).multiply(ctx.camera.getViewMatrixOriginCentered());
         ctx.world.render(view_proj, ctx.camera.position, true);
     }
@@ -495,9 +533,9 @@ pub const WaterReflectionPass = struct {
 
         ctx.render_ctx.bindShader(ctx.main_shader);
         ctx.material_system.bindTerrainMaterial(ctx.render_ctx, ctx.env_map_handle);
-        ctx.render_ctx.bindTexture(ctx.lpv_texture_handle, 11);
-        ctx.render_ctx.bindTexture(ctx.lpv_texture_handle_g, 12);
-        ctx.render_ctx.bindTexture(ctx.lpv_texture_handle_b, 13);
+        ctx.render_ctx.bindTexture(ctx.lpv_textures.red, 11);
+        ctx.render_ctx.bindTexture(ctx.lpv_textures.green, 12);
+        ctx.render_ctx.bindTexture(ctx.lpv_textures.blue, 13);
 
         ctx.world.renderOpaque(reflected_vp, ctx.camera.position, true);
     }

--- a/src/engine/graphics/render_system.zig
+++ b/src/engine/graphics/render_system.zig
@@ -13,7 +13,6 @@ const render_graph_pkg = @import("render_graph.zig");
 const RenderGraph = render_graph_pkg.RenderGraph;
 const AtmosphereSystem = @import("atmosphere_system.zig").AtmosphereSystem;
 const MaterialSystem = @import("material_system.zig").MaterialSystem;
-const LPVSystem = @import("lpv_system.zig").LPVSystem;
 const ResourcePackManager = @import("resource_pack.zig").ResourcePackManager;
 const Mat4 = @import("../math/mat4.zig").Mat4;
 const Vec3 = @import("../math/vec3.zig").Vec3;
@@ -37,7 +36,6 @@ pub const RenderSystem = struct {
     render_graph: RenderGraph,
     atmosphere_system: *AtmosphereSystem,
     material_system: *MaterialSystem,
-    lpv_system: *LPVSystem,
     shadow_passes: [4]render_graph_pkg.ShadowPass,
     g_pass: render_graph_pkg.GPass,
     ssao_pass: render_graph_pkg.SSAOPass,
@@ -198,7 +196,14 @@ pub const RenderSystem = struct {
         const atmosphere_system = try AtmosphereSystem.init(allocator, rhi.resourceManager());
         errdefer atmosphere_system.deinit();
 
-        var render_graph = RenderGraph.init(allocator);
+        log.log.info("RenderSystem.init: initializing graph LPVSystem (grid_size={}, cell_size={})", .{ settings.lpv_grid_size, settings.lpv_cell_size });
+        var render_graph = try RenderGraph.init(allocator, rhi, .{
+            .grid_size = settings.lpv_grid_size,
+            .cell_size = settings.lpv_cell_size,
+            .intensity = settings.lpv_intensity,
+            .propagation_iterations = settings.lpv_propagation_iterations,
+            .enabled = settings.lpv_enabled,
+        });
         errdefer render_graph.deinit();
 
         const self = try allocator.create(RenderSystem);
@@ -214,7 +219,6 @@ pub const RenderSystem = struct {
             .render_graph = render_graph,
             .atmosphere_system = atmosphere_system,
             .material_system = undefined,
-            .lpv_system = undefined,
             .shadow_passes = .{
                 render_graph_pkg.ShadowPass.init(0),
                 render_graph_pkg.ShadowPass.init(1),
@@ -248,17 +252,6 @@ pub const RenderSystem = struct {
         log.log.info("RenderSystem.init: initializing MaterialSystem", .{});
         self.material_system = try MaterialSystem.init(allocator, &self.atlas);
         errdefer self.material_system.deinit();
-        log.log.info("RenderSystem.init: initializing LPVSystem (grid_size={}, cell_size={})", .{ settings.lpv_grid_size, settings.lpv_cell_size });
-        self.lpv_system = try LPVSystem.init(
-            allocator,
-            rhi,
-            settings.lpv_grid_size,
-            settings.lpv_cell_size,
-            settings.lpv_intensity,
-            settings.lpv_propagation_iterations,
-            settings.lpv_enabled,
-        );
-        errdefer self.lpv_system.deinit();
 
         self.rhi.setFXAA((settings.fxaa_enabled and !settings.taa_enabled) and !disable_fxaa);
         self.rhi.setBloom(settings.bloom_enabled and !disable_bloom);
@@ -308,7 +301,6 @@ pub const RenderSystem = struct {
         self.render_graph.deinit();
         self.atmosphere_system.deinit();
         self.material_system.deinit();
-        self.lpv_system.deinit();
         self.atlas.deinit();
         if (self.env_map) |*t| t.deinit();
         self.resource_pack_manager.deinit();
@@ -375,8 +367,8 @@ pub const RenderSystem = struct {
         return self.material_system;
     }
 
-    pub fn getLPVSystem(self: *RenderSystem) *LPVSystem {
-        return self.lpv_system;
+    pub fn getLPVSystem(self: *RenderSystem) *render_graph_pkg.LPVSystem {
+        return self.render_graph.getLPVSystem();
     }
 
     pub fn getAtlas(self: *RenderSystem) *TextureAtlas {

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -420,9 +420,7 @@ pub const WorldScreen = struct {
                 .overlay_renderer = if (clean_capture) null else renderOverlay,
                 .overlay_ctx = if (clean_capture) null else self,
                 .cached_cascades = &frame_cascades,
-                .lpv_texture_handle = lpv_system.getTextureHandle(),
-                .lpv_texture_handle_g = lpv_system.getTextureHandleG(),
-                .lpv_texture_handle_b = lpv_system.getTextureHandleB(),
+                .lpv_textures = render_graph_pkg.LPVTextureHandles.fromSystem(lpv_system),
                 .gpu_mesh_dispatch_fn = if (self.session.world.renderer.getGpuMesher() != null) WorldRenderer.processGpuMeshing else null,
                 .gpu_mesh_dispatch_ctx = @ptrCast(self.session.world.renderer),
             };


### PR DESCRIPTION
## Summary
- Move LPVSystem allocation and teardown from RenderSystem into RenderGraph.
- Replace loose SceneContext LPV texture fields with an explicit LPV texture handle set.
- Keep RenderSystem accessors routing through RenderGraph so existing call sites retain behavior.

## Verification
- `nix develop --command zig fmt src/`
- `nix develop --command zig build`
- `nix develop --command zig build test` currently fails at runtime in existing Vulkan test setup with unmapped memory/null shadow resources after shader validation.

Closes #463