### PR TITLE
fix: move material ownership into render graph

### DIFF
--- a/src/engine/graphics/render_graph.zig
+++ b/src/engine/graphics/render_graph.zig
@@ -52,6 +52,7 @@ const log = @import("../core/log.zig");
 const CSM = @import("csm.zig");
 const AtmosphereSystem = @import("atmosphere_system.zig").AtmosphereSystem;
 const MaterialSystem = @import("material_system.zig").MaterialSystem;
+const TextureAtlas = @import("texture_atlas.zig").TextureAtlas;
 
 pub const SceneContext = struct {
     render_ctx: RenderContext,
@@ -63,7 +64,6 @@ pub const SceneContext = struct {
     shadow_scene: shadow_scene.IShadowScene,
     camera: *Camera,
     atmosphere_system: *AtmosphereSystem,
-    material_system: *MaterialSystem,
     aspect: f32,
     sky_params: rhi_pkg.SkyParams,
     shadow_sun_dir: Vec3,
@@ -116,16 +116,27 @@ pub const IRenderPass = struct {
 pub const RenderGraph = struct {
     passes: std.ArrayListUnmanaged(IRenderPass),
     allocator: std.mem.Allocator,
+    material_system: ?*MaterialSystem,
 
     pub fn init(allocator: std.mem.Allocator) RenderGraph {
         return .{
             .passes = .empty,
             .allocator = allocator,
+            .material_system = null,
         };
     }
 
     pub fn deinit(self: *RenderGraph) void {
         self.passes.deinit(self.allocator);
+        if (self.material_system) |material_system| material_system.deinit();
+    }
+
+    pub fn initMaterials(self: *RenderGraph, atlas: *TextureAtlas) !void {
+        self.material_system = try MaterialSystem.init(self.allocator, atlas);
+    }
+
+    pub fn materials(self: *RenderGraph) *MaterialSystem {
+        return self.material_system.?;
     }
 
     pub fn addPass(self: *RenderGraph, pass: IRenderPass) !void {
@@ -169,9 +180,10 @@ const SHADOW_PASS_NAMES = [_][]const u8{ "ShadowPass0", "ShadowPass1", "ShadowPa
 
 pub const ShadowPass = struct {
     cascade_index: u32,
+    material_system: *MaterialSystem,
 
-    pub fn init(cascade_index: u32) ShadowPass {
-        return .{ .cascade_index = cascade_index };
+    pub fn init(cascade_index: u32, material_system: *MaterialSystem) ShadowPass {
+        return .{ .cascade_index = cascade_index, .material_system = material_system };
     }
 
     const VTABLES = [_]IRenderPass.VTable{
@@ -234,7 +246,7 @@ pub const ShadowPass = struct {
 
         // Keep cutout casters sampling the terrain atlas during the shadow pass.
         // Without this, shadow.frag can alpha-clip against whatever texture was last bound.
-        ctx.material_system.bindTerrainMaterial(ctx.render_ctx, ctx.env_map_handle);
+        self.material_system.bindTerrainMaterial(ctx.render_ctx, ctx.env_map_handle);
 
         ctx.shadow_ctx.beginPass(cascade_idx, light_space_matrix);
         errdefer ctx.shadow_ctx.endPass();
@@ -244,6 +256,12 @@ pub const ShadowPass = struct {
 };
 
 pub const GPass = struct {
+    material_system: *MaterialSystem,
+
+    pub fn init(material_system: *MaterialSystem) GPass {
+        return .{ .material_system = material_system };
+    }
+
     const VTABLE = IRenderPass.VTable{
         .name = "GPass",
         .needs_main_pass = false,
@@ -257,11 +275,11 @@ pub const GPass = struct {
     }
 
     fn execute(ptr: *anyopaque, ctx: SceneContext) anyerror!void {
-        _ = ptr;
+        const self: *GPass = @ptrCast(@alignCast(ptr));
         if (!ctx.ssao_enabled or ctx.disable_gpass_draw) return;
 
         ctx.render_ctx.beginGPass();
-        const atlas = ctx.material_system.getAtlasHandles(ctx.env_map_handle);
+        const atlas = self.material_system.getAtlasHandles(ctx.env_map_handle);
         ctx.render_ctx.bindTexture(atlas.diffuse, 1);
         const view_proj = ctx.camera.getJitteredProjectionMatrixReverseZ(ctx.aspect, ctx.viewport_width, ctx.viewport_height, ctx.taa_enabled).multiply(ctx.camera.getViewMatrixOriginCentered());
         ctx.world.render(view_proj, ctx.camera.position, false);
@@ -338,6 +356,12 @@ pub const SkyPass = struct {
 };
 
 pub const OpaquePass = struct {
+    material_system: *MaterialSystem,
+
+    pub fn init(material_system: *MaterialSystem) OpaquePass {
+        return .{ .material_system = material_system };
+    }
+
     const VTABLE = IRenderPass.VTable{
         .name = "OpaquePass",
         .needs_main_pass = true,
@@ -351,9 +375,9 @@ pub const OpaquePass = struct {
     }
 
     fn execute(ptr: *anyopaque, ctx: SceneContext) anyerror!void {
-        _ = ptr;
+        const self: *OpaquePass = @ptrCast(@alignCast(ptr));
         ctx.render_ctx.bindShader(ctx.main_shader);
-        ctx.material_system.bindTerrainMaterial(ctx.render_ctx, ctx.env_map_handle);
+        self.material_system.bindTerrainMaterial(ctx.render_ctx, ctx.env_map_handle);
         ctx.render_ctx.bindTexture(ctx.lpv_texture_handle, 11);
         ctx.render_ctx.bindTexture(ctx.lpv_texture_handle_g, 12);
         ctx.render_ctx.bindTexture(ctx.lpv_texture_handle_b, 13);
@@ -472,6 +496,12 @@ pub const FXAAPass = struct {
 };
 
 pub const WaterReflectionPass = struct {
+    material_system: *MaterialSystem,
+
+    pub fn init(material_system: *MaterialSystem) WaterReflectionPass {
+        return .{ .material_system = material_system };
+    }
+
     const VTABLE = IRenderPass.VTable{
         .name = "WaterReflectionPass",
         .needs_main_pass = false,
@@ -485,7 +515,7 @@ pub const WaterReflectionPass = struct {
     }
 
     fn execute(ptr: *anyopaque, ctx: SceneContext) anyerror!void {
-        _ = ptr;
+        const self: *WaterReflectionPass = @ptrCast(@alignCast(ptr));
         ctx.water_ctx.beginReflectionPass();
         defer ctx.water_ctx.endReflectionPass();
 
@@ -494,7 +524,7 @@ pub const WaterReflectionPass = struct {
         const reflected_vp = ctx.water_ctx.computeReflectedViewProj(view, proj, ctx.camera.position);
 
         ctx.render_ctx.bindShader(ctx.main_shader);
-        ctx.material_system.bindTerrainMaterial(ctx.render_ctx, ctx.env_map_handle);
+        self.material_system.bindTerrainMaterial(ctx.render_ctx, ctx.env_map_handle);
         ctx.render_ctx.bindTexture(ctx.lpv_texture_handle, 11);
         ctx.render_ctx.bindTexture(ctx.lpv_texture_handle_g, 12);
         ctx.render_ctx.bindTexture(ctx.lpv_texture_handle_b, 13);

--- a/src/engine/graphics/render_system.zig
+++ b/src/engine/graphics/render_system.zig
@@ -12,7 +12,6 @@ const Texture = @import("texture.zig").Texture;
 const render_graph_pkg = @import("render_graph.zig");
 const RenderGraph = render_graph_pkg.RenderGraph;
 const AtmosphereSystem = @import("atmosphere_system.zig").AtmosphereSystem;
-const MaterialSystem = @import("material_system.zig").MaterialSystem;
 const LPVSystem = @import("lpv_system.zig").LPVSystem;
 const ResourcePackManager = @import("resource_pack.zig").ResourcePackManager;
 const Mat4 = @import("../math/mat4.zig").Mat4;
@@ -36,7 +35,6 @@ pub const RenderSystem = struct {
     env_map: ?Texture,
     render_graph: RenderGraph,
     atmosphere_system: *AtmosphereSystem,
-    material_system: *MaterialSystem,
     lpv_system: *LPVSystem,
     shadow_passes: [4]render_graph_pkg.ShadowPass,
     g_pass: render_graph_pkg.GPass,
@@ -213,26 +211,20 @@ pub const RenderSystem = struct {
             .env_map = env_map,
             .render_graph = render_graph,
             .atmosphere_system = atmosphere_system,
-            .material_system = undefined,
             .lpv_system = undefined,
-            .shadow_passes = .{
-                render_graph_pkg.ShadowPass.init(0),
-                render_graph_pkg.ShadowPass.init(1),
-                render_graph_pkg.ShadowPass.init(2),
-                render_graph_pkg.ShadowPass.init(3),
-            },
-            .g_pass = .{},
+            .shadow_passes = undefined,
+            .g_pass = undefined,
             .ssao_pass = .{},
             .depth_pyramid_pass = .{},
             .mesh_build_pass = .{},
             .sky_pass = .{},
-            .opaque_pass = .{},
+            .opaque_pass = undefined,
             .entity_pass = .{},
             .taa_pass = .{ .enabled = !disable_taa and settings.taa_enabled },
             .bloom_pass = .{ .enabled = !disable_bloom and settings.bloom_enabled },
             .post_process_pass = .{},
             .fxaa_pass = .{ .enabled = !disable_fxaa and settings.fxaa_enabled },
-            .water_reflection_pass = .{},
+            .water_reflection_pass = undefined,
             .water_pass = .{ .enabled = true },
             .safe_mode = safe_mode,
             .safe_render_mode = safe_render_mode,
@@ -244,10 +236,21 @@ pub const RenderSystem = struct {
             .disable_fxaa = disable_fxaa,
             .disable_bloom = disable_bloom,
         };
+        errdefer self.render_graph.deinit();
 
-        log.log.info("RenderSystem.init: initializing MaterialSystem", .{});
-        self.material_system = try MaterialSystem.init(allocator, &self.atlas);
-        errdefer self.material_system.deinit();
+        log.log.info("RenderSystem.init: initializing render graph materials", .{});
+        try self.render_graph.initMaterials(&self.atlas);
+        const material_system = self.render_graph.materials();
+        self.shadow_passes = .{
+            render_graph_pkg.ShadowPass.init(0, material_system),
+            render_graph_pkg.ShadowPass.init(1, material_system),
+            render_graph_pkg.ShadowPass.init(2, material_system),
+            render_graph_pkg.ShadowPass.init(3, material_system),
+        };
+        self.g_pass = render_graph_pkg.GPass.init(material_system);
+        self.opaque_pass = render_graph_pkg.OpaquePass.init(material_system);
+        self.water_reflection_pass = render_graph_pkg.WaterReflectionPass.init(material_system);
+
         log.log.info("RenderSystem.init: initializing LPVSystem (grid_size={}, cell_size={})", .{ settings.lpv_grid_size, settings.lpv_cell_size });
         self.lpv_system = try LPVSystem.init(
             allocator,
@@ -307,7 +310,6 @@ pub const RenderSystem = struct {
 
         self.render_graph.deinit();
         self.atmosphere_system.deinit();
-        self.material_system.deinit();
         self.lpv_system.deinit();
         self.atlas.deinit();
         if (self.env_map) |*t| t.deinit();
@@ -369,10 +371,6 @@ pub const RenderSystem = struct {
 
     pub fn getAtmosphereSystem(self: *RenderSystem) *AtmosphereSystem {
         return self.atmosphere_system;
-    }
-
-    pub fn getMaterialSystem(self: *RenderSystem) *MaterialSystem {
-        return self.material_system;
     }
 
     pub fn getLPVSystem(self: *RenderSystem) *LPVSystem {

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -400,7 +400,6 @@ pub const WorldScreen = struct {
                 .shadow_scene = self.world.shadowScene(),
                 .camera = camera,
                 .atmosphere_system = render_system.getAtmosphereSystem(),
-                .material_system = render_system.getMaterialSystem(),
                 .aspect = aspect,
                 .taa_enabled = taa_enabled,
                 .viewport_width = render_w,


### PR DESCRIPTION
## Summary
- Move `MaterialSystem` ownership from `RenderSystem` into `RenderGraph`.
- Pass material binding dependencies directly to shadow, G-pass, opaque, and water reflection passes.
- Remove material plumbing from `SceneContext` and `WorldScreen` frame setup.

## Testing
- `nix develop --command zig fmt src/`
- `nix develop --command zig build test --summary all`

Closes #462