### PR TITLE
refactor: move AtmosphereSystem ownership into render graph

### DIFF
--- a/src/engine/graphics/render_graph.zig
+++ b/src/engine/graphics/render_graph.zig
@@ -50,7 +50,7 @@ const IDeviceTiming = rhi_pkg.IDeviceTiming;
 const Vec3 = @import("../math/vec3.zig").Vec3;
 const log = @import("../core/log.zig");
 const CSM = @import("csm.zig");
-const AtmosphereSystem = @import("atmosphere_system.zig").AtmosphereSystem;
+pub const AtmosphereSystem = @import("atmosphere_system.zig").AtmosphereSystem;
 const MaterialSystem = @import("material_system.zig").MaterialSystem;
 pub const LPVSystem = @import("lpv_system.zig").LPVSystem;
 const TextureAtlas = @import("texture_atlas.zig").TextureAtlas;
@@ -136,11 +136,15 @@ pub const IRenderPass = struct {
 
 pub const RenderGraph = struct {
     passes: std.ArrayListUnmanaged(IRenderPass),
+    atmosphere_system: *AtmosphereSystem,
     allocator: std.mem.Allocator,
     lpv_system: *LPVSystem,
     material_system: ?*MaterialSystem,
 
     pub fn init(allocator: std.mem.Allocator, rhi: rhi_pkg.RHI, lpv_config: LPVConfig) !RenderGraph {
+        const atmosphere_system = try AtmosphereSystem.init(allocator, rhi.resourceManager());
+        errdefer atmosphere_system.deinit();
+
         const lpv_system = try LPVSystem.init(
             allocator,
             rhi,
@@ -150,9 +154,11 @@ pub const RenderGraph = struct {
             lpv_config.propagation_iterations,
             lpv_config.enabled,
         );
+        errdefer lpv_system.deinit();
 
         return .{
             .passes = .empty,
+            .atmosphere_system = atmosphere_system,
             .allocator = allocator,
             .lpv_system = lpv_system,
             .material_system = null,
@@ -161,6 +167,7 @@ pub const RenderGraph = struct {
 
     pub fn deinit(self: *RenderGraph) void {
         self.passes.deinit(self.allocator);
+        self.atmosphere_system.deinit();
         self.lpv_system.deinit();
         if (self.material_system) |material_system| material_system.deinit();
     }
@@ -175,6 +182,10 @@ pub const RenderGraph = struct {
 
     pub fn materials(self: *RenderGraph) *MaterialSystem {
         return self.material_system.?;
+    }
+
+    pub fn getAtmosphereSystem(self: *RenderGraph) *AtmosphereSystem {
+        return self.atmosphere_system;
     }
 
     pub fn addPass(self: *RenderGraph, pass: IRenderPass) !void {

--- a/src/engine/graphics/render_system.zig
+++ b/src/engine/graphics/render_system.zig
@@ -11,7 +11,6 @@ const TextureAtlas = @import("texture_atlas.zig").TextureAtlas;
 const Texture = @import("texture.zig").Texture;
 const render_graph_pkg = @import("render_graph.zig");
 const RenderGraph = render_graph_pkg.RenderGraph;
-const AtmosphereSystem = @import("atmosphere_system.zig").AtmosphereSystem;
 const ResourcePackManager = @import("resource_pack.zig").ResourcePackManager;
 const Mat4 = @import("../math/mat4.zig").Mat4;
 const Vec3 = @import("../math/vec3.zig").Vec3;
@@ -33,7 +32,6 @@ pub const RenderSystem = struct {
     atlas: TextureAtlas,
     env_map: ?Texture,
     render_graph: RenderGraph,
-    atmosphere_system: *AtmosphereSystem,
     shadow_passes: [4]render_graph_pkg.ShadowPass,
     g_pass: render_graph_pkg.GPass,
     ssao_pass: render_graph_pkg.SSAOPass,
@@ -190,11 +188,7 @@ pub const RenderSystem = struct {
         }
         errdefer if (env_map) |*t| t.deinit();
 
-        log.log.info("RenderSystem.init: initializing AtmosphereSystem", .{});
-        const atmosphere_system = try AtmosphereSystem.init(allocator, rhi.resourceManager());
-        errdefer atmosphere_system.deinit();
-
-        log.log.info("RenderSystem.init: initializing graph LPVSystem (grid_size={}, cell_size={})", .{ settings.lpv_grid_size, settings.lpv_cell_size });
+        log.log.info("RenderSystem.init: initializing graph systems (LPV grid_size={}, cell_size={})", .{ settings.lpv_grid_size, settings.lpv_cell_size });
         var render_graph = try RenderGraph.init(allocator, rhi, .{
             .grid_size = settings.lpv_grid_size,
             .cell_size = settings.lpv_cell_size,
@@ -216,7 +210,6 @@ pub const RenderSystem = struct {
             .atlas = atlas,
             .env_map = env_map,
             .render_graph = render_graph,
-            .atmosphere_system = atmosphere_system,
             .shadow_passes = undefined,
             .g_pass = undefined,
             .ssao_pass = .{},
@@ -303,7 +296,6 @@ pub const RenderSystem = struct {
         self.rhi.waitIdle();
 
         self.render_graph.deinit();
-        self.atmosphere_system.deinit();
         self.atlas.deinit();
         if (self.env_map) |*t| t.deinit();
         self.resource_pack_manager.deinit();
@@ -362,8 +354,8 @@ pub const RenderSystem = struct {
         return &self.render_graph;
     }
 
-    pub fn getAtmosphereSystem(self: *RenderSystem) *AtmosphereSystem {
-        return self.atmosphere_system;
+    pub fn getAtmosphereSystem(self: *RenderSystem) *render_graph_pkg.AtmosphereSystem {
+        return self.render_graph.getAtmosphereSystem();
     }
 
     pub fn getLPVSystem(self: *RenderSystem) *render_graph_pkg.LPVSystem {


### PR DESCRIPTION
## Summary
- Moves `AtmosphereSystem` ownership from `RenderSystem` into `RenderGraph`, where it is actually consumed
- `RenderSystem` now delegates `getAtmosphereSystem()` through the render graph instead of owning it directly
- Sky rendering continues to work unchanged via `SceneContext.atmosphere_system`

Closes #461