### PR TITLE
refactor: abstract world renderer culling

### DIFF
--- a/src/engine/graphics/culling.zig
+++ b/src/engine/graphics/culling.zig
@@ -1,0 +1,47 @@
+const Mat4 = @import("../math/mat4.zig").Mat4;
+
+pub const ChunkCullData = extern struct {
+    min_point: [4]f32,
+    max_point: [4]f32,
+};
+
+pub const DispatchConfig = struct {
+    view_proj: Mat4,
+    chunk_count: u32,
+    screen_width: f32,
+    screen_height: f32,
+    previous_frame_valid: bool,
+};
+
+pub const ICullingSystem = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        deinit: *const fn (ptr: *anyopaque) void,
+        updateAABBData: *const fn (ptr: *anyopaque, frame_index: usize, chunks: []const ChunkCullData) void,
+        readVisibleCount: *const fn (ptr: *anyopaque, frame_index: usize) u32,
+        readVisibleIndices: *const fn (ptr: *anyopaque, frame_index: usize, count: u32, out: []u32) void,
+        dispatch: *const fn (ptr: *anyopaque, config: DispatchConfig) void,
+    };
+
+    pub fn deinit(self: ICullingSystem) void {
+        self.vtable.deinit(self.ptr);
+    }
+
+    pub fn updateAABBData(self: ICullingSystem, frame_index: usize, chunks: []const ChunkCullData) void {
+        self.vtable.updateAABBData(self.ptr, frame_index, chunks);
+    }
+
+    pub fn readVisibleCount(self: ICullingSystem, frame_index: usize) u32 {
+        return self.vtable.readVisibleCount(self.ptr, frame_index);
+    }
+
+    pub fn readVisibleIndices(self: ICullingSystem, frame_index: usize, count: u32, out: []u32) void {
+        self.vtable.readVisibleIndices(self.ptr, frame_index, count, out);
+    }
+
+    pub fn dispatch(self: ICullingSystem, config: DispatchConfig) void {
+        self.vtable.dispatch(self.ptr, config);
+    }
+};

--- a/src/engine/graphics/culling.zig
+++ b/src/engine/graphics/culling.zig
@@ -19,9 +19,9 @@ pub const ICullingSystem = struct {
 
     pub const VTable = struct {
         deinit: *const fn (ptr: *anyopaque) void,
-        updateAABBData: *const fn (ptr: *anyopaque, frame_index: usize, chunks: []const ChunkCullData) void,
-        readVisibleCount: *const fn (ptr: *anyopaque, frame_index: usize) u32,
-        readVisibleIndices: *const fn (ptr: *anyopaque, frame_index: usize, count: u32, out: []u32) void,
+        update_aabb_data: *const fn (ptr: *anyopaque, frame_index: usize, chunks: []const ChunkCullData) void,
+        read_visible_count: *const fn (ptr: *anyopaque, frame_index: usize) u32,
+        read_visible_indices: *const fn (ptr: *anyopaque, frame_index: usize, count: u32, out: []u32) void,
         dispatch: *const fn (ptr: *anyopaque, config: DispatchConfig) void,
     };
 
@@ -29,16 +29,16 @@ pub const ICullingSystem = struct {
         self.vtable.deinit(self.ptr);
     }
 
-    pub fn updateAABBData(self: ICullingSystem, frame_index: usize, chunks: []const ChunkCullData) void {
-        self.vtable.updateAABBData(self.ptr, frame_index, chunks);
+    pub fn update_aabb_data(self: ICullingSystem, frame_index: usize, chunks: []const ChunkCullData) void {
+        self.vtable.update_aabb_data(self.ptr, frame_index, chunks);
     }
 
-    pub fn readVisibleCount(self: ICullingSystem, frame_index: usize) u32 {
-        return self.vtable.readVisibleCount(self.ptr, frame_index);
+    pub fn read_visible_count(self: ICullingSystem, frame_index: usize) u32 {
+        return self.vtable.read_visible_count(self.ptr, frame_index);
     }
 
-    pub fn readVisibleIndices(self: ICullingSystem, frame_index: usize, count: u32, out: []u32) void {
-        self.vtable.readVisibleIndices(self.ptr, frame_index, count, out);
+    pub fn read_visible_indices(self: ICullingSystem, frame_index: usize, count: u32, out: []u32) void {
+        self.vtable.read_visible_indices(self.ptr, frame_index, count, out);
     }
 
     pub fn dispatch(self: ICullingSystem, config: DispatchConfig) void {

--- a/src/engine/graphics/rhi.zig
+++ b/src/engine/graphics/rhi.zig
@@ -57,6 +57,7 @@ const Allocator = std.mem.Allocator;
 const Mat4 = @import("../math/mat4.zig").Mat4;
 const Vec3 = @import("../math/vec3.zig").Vec3;
 const RenderDevice = @import("render_device.zig").RenderDevice;
+const culling = @import("culling.zig");
 
 const rhi_types = @import("rhi_types.zig");
 
@@ -93,6 +94,12 @@ pub const ShadowParams = rhi_types.ShadowParams;
 pub const Color = rhi_types.Color;
 pub const Rect = rhi_types.Rect;
 pub const GpuTimingResults = rhi_types.GpuTimingResults;
+pub const ICullingSystem = culling.ICullingSystem;
+
+pub const RenderResolution = struct {
+    width: u32,
+    height: u32,
+};
 
 // --- Segregated Interfaces ---
 
@@ -787,6 +794,7 @@ pub const IDeviceQuery = struct {
         getValidationErrorCount: *const fn (ptr: *anyopaque) u32,
         getDrawCallCount: *const fn (ptr: *anyopaque) u32,
         getDeviceLocalVramBytes: *const fn (ptr: *anyopaque) u64,
+        getRenderResolution: *const fn (ptr: *anyopaque) RenderResolution,
         waitIdle: *const fn (ptr: *anyopaque) void,
     };
 
@@ -809,6 +817,10 @@ pub const IDeviceQuery = struct {
 
     pub fn getDeviceLocalVramBytes(self: IDeviceQuery) u64 {
         return self.vtable.getDeviceLocalVramBytes(self.ptr);
+    }
+
+    pub fn getRenderResolution(self: IDeviceQuery) RenderResolution {
+        return self.vtable.getRenderResolution(self.ptr);
     }
 };
 
@@ -896,6 +908,7 @@ pub const RHI = struct {
         setTAAVelocityRejection: *const fn (ctx: *anyopaque, value: f32) void,
         setDynamicResolution: *const fn (ctx: *anyopaque, enabled: bool, min_scale: f32, max_scale: f32, target_fps: u32) void,
         getResolutionScale: *const fn (ctx: *anyopaque) f32,
+        createCullingSystem: *const fn (ctx: *anyopaque, allocator: Allocator, max_chunks: usize) anyerror!?ICullingSystem,
         captureFrame: *const fn (ctx: *anyopaque, path: []const u8) bool,
     };
 
@@ -951,6 +964,9 @@ pub const RHI = struct {
     }
     pub fn timing(self: RHI) IDeviceTiming {
         return .{ .ptr = self.ptr, .vtable = &self.vtable.timing };
+    }
+    pub fn createCullingSystem(self: RHI, allocator: Allocator, max_chunks: usize) anyerror!?ICullingSystem {
+        return self.vtable.createCullingSystem(self.ptr, allocator, max_chunks);
     }
 
     // -------------------------------------------------------------------------
@@ -1209,6 +1225,10 @@ pub const RHI = struct {
     }
     pub fn getResolutionScale(self: RHI) f32 {
         return self.vtable.getResolutionScale(self.ptr);
+    }
+
+    pub fn getRenderResolution(self: RHI) RenderResolution {
+        return self.vtable.query.getRenderResolution(self.ptr);
     }
     pub fn captureFrame(self: RHI, path: []const u8) bool {
         return self.vtable.captureFrame(self.ptr, path);

--- a/src/engine/graphics/rhi_tests.zig
+++ b/src/engine/graphics/rhi_tests.zig
@@ -170,6 +170,18 @@ const MockContext = struct {
         return self.resolution_scale;
     }
 
+    fn createCullingSystem(ptr: *anyopaque, allocator: std.mem.Allocator, max_chunks: usize) anyerror!?rhi.ICullingSystem {
+        _ = ptr;
+        _ = allocator;
+        _ = max_chunks;
+        return null;
+    }
+
+    fn getRenderResolution(ptr: *anyopaque) rhi.RenderResolution {
+        _ = ptr;
+        return .{ .width = 1920, .height = 1080 };
+    }
+
     fn getShadowMapHandle(ptr: *anyopaque, cascade_index: u32) rhi.TextureHandle {
         _ = ptr;
         _ = cascade_index;
@@ -339,6 +351,7 @@ const MockContext = struct {
         .getValidationErrorCount = undefined,
         .getDrawCallCount = undefined,
         .getDeviceLocalVramBytes = undefined,
+        .getRenderResolution = getRenderResolution,
         .waitIdle = undefined,
     };
 
@@ -398,6 +411,7 @@ const MockContext = struct {
         .setTAAVelocityRejection = undefined,
         .setDynamicResolution = MockContext.setDynamicResolution,
         .getResolutionScale = MockContext.getResolutionScale,
+        .createCullingSystem = MockContext.createCullingSystem,
         .captureFrame = undefined,
     };
 

--- a/src/engine/graphics/rhi_vulkan.zig
+++ b/src/engine/graphics/rhi_vulkan.zig
@@ -19,6 +19,7 @@ const render_state = @import("vulkan/rhi_render_state.zig");
 const init_deinit = @import("vulkan/rhi_init_deinit.zig");
 const rhi_timing = @import("vulkan/rhi_timing.zig");
 const screenshot = @import("vulkan/screenshot.zig");
+const CullingSystem = @import("vulkan/culling_system.zig").CullingSystem;
 
 const QUERY_COUNT_PER_FRAME = rhi_timing.QUERY_COUNT_PER_FRAME;
 
@@ -387,6 +388,12 @@ fn getResolutionScale(ctx_ptr: *anyopaque) f32 {
     return ctx.dynamic_resolution.current_scale;
 }
 
+fn createCullingSystem(ctx_ptr: *anyopaque, allocator: std.mem.Allocator, max_chunks: usize) anyerror!?rhi.ICullingSystem {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const system = try CullingSystem.init(allocator, ctx, max_chunks);
+    return system.interface();
+}
+
 fn captureFrame(ctx_ptr: *anyopaque, path: []const u8) bool {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
     return screenshot.captureScreenshot(ctx, path);
@@ -634,6 +641,14 @@ fn getValidationErrorCount(ctx_ptr: *anyopaque) u32 {
 fn getDeviceLocalVramBytes(ctx_ptr: *anyopaque) u64 {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
     return ctx.vulkan_device.getDeviceLocalVramBytes();
+}
+
+fn getRenderResolution(ctx_ptr: *anyopaque) rhi.RenderResolution {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return .{
+        .width = ctx.gpass.g_pass_extent.width,
+        .height = ctx.gpass.g_pass_extent.height,
+    };
 }
 
 fn getDrawCallCount(ctx_ptr: *anyopaque) u32 {
@@ -965,6 +980,7 @@ const VULKAN_RHI_VTABLE = rhi.RHI.VTable{
         .getValidationErrorCount = getValidationErrorCount,
         .getDrawCallCount = getDrawCallCount,
         .getDeviceLocalVramBytes = getDeviceLocalVramBytes,
+        .getRenderResolution = getRenderResolution,
         .waitIdle = waitIdle,
     },
     .timing = .{
@@ -996,6 +1012,7 @@ const VULKAN_RHI_VTABLE = rhi.RHI.VTable{
     .setTAAVelocityRejection = setTAAVelocityRejection,
     .setDynamicResolution = setDynamicResolution,
     .getResolutionScale = getResolutionScale,
+    .createCullingSystem = createCullingSystem,
     .captureFrame = captureFrame,
 };
 

--- a/src/engine/graphics/vulkan/culling_system.zig
+++ b/src/engine/graphics/vulkan/culling_system.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const fs = @import("fs");
 const c = @import("../../../c.zig").c;
 const rhi_pkg = @import("../rhi.zig");
+const culling = @import("../culling.zig");
 const log = @import("../../core/log.zig");
 const Mat4 = @import("../../math/mat4.zig").Mat4;
 const VulkanContext = @import("rhi_context_types.zig").VulkanContext;
@@ -12,10 +13,7 @@ pub const MAX_CULLABLE_CHUNKS: usize = 16384;
 pub const WORKGROUP_SIZE: u32 = 64;
 const MAX_FRAMES_IN_FLIGHT = rhi_pkg.MAX_FRAMES_IN_FLIGHT;
 
-pub const ChunkCullData = extern struct {
-    min_point: [4]f32,
-    max_point: [4]f32,
-};
+pub const ChunkCullData = culling.ChunkCullData;
 
 const CullingPushConstants = extern struct {
     planes: [6][4]f32,
@@ -117,6 +115,13 @@ pub const CullingSystem = struct {
         self.deinitComputeResources();
         self.destroyAllBuffers();
         self.allocator.destroy(self);
+    }
+
+    pub fn interface(self: *CullingSystem) culling.ICullingSystem {
+        return .{
+            .ptr = self,
+            .vtable = &interface_vtable,
+        };
     }
 
     pub fn updateAABBData(self: *CullingSystem, frame_index: usize, chunks: []const ChunkCullData) void {
@@ -457,6 +462,39 @@ pub const CullingSystem = struct {
         self.counter_readback_buffers = std.mem.zeroes([MAX_FRAMES_IN_FLIGHT]Utils.VulkanBuffer);
     }
 };
+
+const interface_vtable = culling.ICullingSystem.VTable{
+    .deinit = interfaceDeinit,
+    .updateAABBData = interfaceUpdateAABBData,
+    .readVisibleCount = interfaceReadVisibleCount,
+    .readVisibleIndices = interfaceReadVisibleIndices,
+    .dispatch = interfaceDispatch,
+};
+
+fn interfaceDeinit(ptr: *anyopaque) void {
+    const self: *CullingSystem = @ptrCast(@alignCast(ptr));
+    self.deinit();
+}
+
+fn interfaceUpdateAABBData(ptr: *anyopaque, frame_index: usize, chunks: []const ChunkCullData) void {
+    const self: *CullingSystem = @ptrCast(@alignCast(ptr));
+    self.updateAABBData(frame_index, chunks);
+}
+
+fn interfaceReadVisibleCount(ptr: *anyopaque, frame_index: usize) u32 {
+    const self: *CullingSystem = @ptrCast(@alignCast(ptr));
+    return self.readVisibleCount(frame_index);
+}
+
+fn interfaceReadVisibleIndices(ptr: *anyopaque, frame_index: usize, count: u32, out: []u32) void {
+    const self: *CullingSystem = @ptrCast(@alignCast(ptr));
+    self.readVisibleIndices(frame_index, count, out);
+}
+
+fn interfaceDispatch(ptr: *anyopaque, config: culling.DispatchConfig) void {
+    const self: *CullingSystem = @ptrCast(@alignCast(ptr));
+    self.dispatch(config.view_proj, config.chunk_count, config.screen_width, config.screen_height, config.previous_frame_valid);
+}
 
 fn mat4Equal(a: Mat4, b: Mat4) bool {
     for (0..4) |col| {

--- a/src/engine/graphics/vulkan/culling_system.zig
+++ b/src/engine/graphics/vulkan/culling_system.zig
@@ -25,7 +25,6 @@ const CullingPushConstants = extern struct {
 
 pub const CullingSystem = struct {
     allocator: std.mem.Allocator,
-    rhi: rhi_pkg.RHI,
     vk_ctx: *VulkanContext,
 
     aabb_buffers: [MAX_FRAMES_IN_FLIGHT]Utils.VulkanBuffer,
@@ -47,18 +46,16 @@ pub const CullingSystem = struct {
 
     pub fn init(
         allocator: std.mem.Allocator,
-        rhi: rhi_pkg.RHI,
+        vk_ctx: *VulkanContext,
         max_chunks: usize,
     ) !*CullingSystem {
         const self = try allocator.create(CullingSystem);
         errdefer allocator.destroy(self);
 
-        const vk_ctx: *VulkanContext = @ptrCast(@alignCast(rhi.ptr));
         const clamped_max = std.math.clamp(max_chunks, 1, MAX_CULLABLE_CHUNKS);
 
         self.* = .{
             .allocator = allocator,
-            .rhi = rhi,
             .vk_ctx = vk_ctx,
             .max_chunks = clamped_max,
             .aabb_buffers = std.mem.zeroes([MAX_FRAMES_IN_FLIGHT]Utils.VulkanBuffer),
@@ -124,7 +121,7 @@ pub const CullingSystem = struct {
         };
     }
 
-    pub fn updateAABBData(self: *CullingSystem, frame_index: usize, chunks: []const ChunkCullData) void {
+    pub fn update_aabb_data(self: *CullingSystem, frame_index: usize, chunks: []const ChunkCullData) void {
         const buf = &self.aabb_buffers[frame_index];
         if (buf.mapped_ptr == null) return;
         const copy_len = @min(chunks.len, self.max_chunks) * @sizeOf(ChunkCullData);
@@ -223,14 +220,14 @@ pub const CullingSystem = struct {
         self.copyCounterToReadback(cmd, fi);
     }
 
-    pub fn readVisibleCount(self: *CullingSystem, frame_index: usize) u32 {
+    pub fn read_visible_count(self: *CullingSystem, frame_index: usize) u32 {
         const buf = &self.counter_readback_buffers[frame_index];
         if (buf.mapped_ptr == null) return 0;
         const ptr: *align(1) u32 = @ptrCast(@alignCast(buf.mapped_ptr.?));
         return ptr.*;
     }
 
-    pub fn readVisibleIndices(self: *CullingSystem, frame_index: usize, count: u32, out: []u32) void {
+    pub fn read_visible_indices(self: *CullingSystem, frame_index: usize, count: u32, out: []u32) void {
         if (count == 0) return;
         const buf = &self.visible_index_buffers[frame_index];
         if (buf.mapped_ptr == null) return;
@@ -465,9 +462,9 @@ pub const CullingSystem = struct {
 
 const interface_vtable = culling.ICullingSystem.VTable{
     .deinit = interfaceDeinit,
-    .updateAABBData = interfaceUpdateAABBData,
-    .readVisibleCount = interfaceReadVisibleCount,
-    .readVisibleIndices = interfaceReadVisibleIndices,
+    .update_aabb_data = interfaceUpdateAabbData,
+    .read_visible_count = interfaceReadVisibleCount,
+    .read_visible_indices = interfaceReadVisibleIndices,
     .dispatch = interfaceDispatch,
 };
 
@@ -476,19 +473,19 @@ fn interfaceDeinit(ptr: *anyopaque) void {
     self.deinit();
 }
 
-fn interfaceUpdateAABBData(ptr: *anyopaque, frame_index: usize, chunks: []const ChunkCullData) void {
+fn interfaceUpdateAabbData(ptr: *anyopaque, frame_index: usize, chunks: []const ChunkCullData) void {
     const self: *CullingSystem = @ptrCast(@alignCast(ptr));
-    self.updateAABBData(frame_index, chunks);
+    self.update_aabb_data(frame_index, chunks);
 }
 
 fn interfaceReadVisibleCount(ptr: *anyopaque, frame_index: usize) u32 {
     const self: *CullingSystem = @ptrCast(@alignCast(ptr));
-    return self.readVisibleCount(frame_index);
+    return self.read_visible_count(frame_index);
 }
 
 fn interfaceReadVisibleIndices(ptr: *anyopaque, frame_index: usize, count: u32, out: []u32) void {
     const self: *CullingSystem = @ptrCast(@alignCast(ptr));
-    self.readVisibleIndices(frame_index, count, out);
+    self.read_visible_indices(frame_index, count, out);
 }
 
 fn interfaceDispatch(ptr: *anyopaque, config: culling.DispatchConfig) void {

--- a/src/world/world.zig
+++ b/src/world/world.zig
@@ -18,6 +18,8 @@ const registry = @import("worldgen/registry.zig");
 const LightingComputer = @import("worldgen/lighting_computer.zig").LightingComputer;
 const rhi_mod = @import("../engine/graphics/rhi.zig");
 const RHI = rhi_mod.RHI;
+const CullingSystem = @import("../engine/graphics/vulkan/culling_system.zig").CullingSystem;
+const VulkanContext = @import("../engine/graphics/vulkan/rhi_context_types.zig").VulkanContext;
 const WorldLOD = @import("world_lod.zig").WorldLOD(RHI);
 
 fn getenv(name: [:0]const u8) ?[]const u8 {
@@ -32,6 +34,8 @@ const ShadowConfig = @import("../engine/graphics/rhi_types.zig").ShadowConfig;
 const WorldStreamer = @import("world_streamer.zig").WorldStreamer;
 const TextureAtlas = @import("../engine/graphics/texture_atlas.zig").TextureAtlas;
 const WorldRenderer = @import("world_renderer.zig").WorldRenderer;
+const MAX_MDI_CHUNKS = @import("world_renderer.zig").MAX_MDI_CHUNKS;
+const CullingScreenSize = @import("world_renderer.zig").CullingScreenSize;
 const RenderStats = @import("world_renderer.zig").RenderStats;
 const RenderLayer = @import("world_renderer.zig").RenderLayer;
 const ShadowStats = @import("world_renderer.zig").ShadowStats;
@@ -185,7 +189,22 @@ pub const World = struct {
         };
 
         log.log.info("World.initGen: initializing WorldRenderer", .{});
-        world.renderer = try WorldRenderer.init(allocator, rhi.resourceManager(), rhi.renderContext(), rhi.query(), &world.storage, atlas, rhi);
+        const vk_ctx: *VulkanContext = @ptrCast(@alignCast(rhi.ptr));
+        const culling_size = CullingScreenSize{
+            .width = vk_ctx.gpass.g_pass_extent.width,
+            .height = vk_ctx.gpass.g_pass_extent.height,
+        };
+        var culling_system = if (!safe_mode) blk: {
+            const system = CullingSystem.init(allocator, rhi, MAX_MDI_CHUNKS) catch |err| {
+                log.log.warn("GPU culling init failed ({}), falling back to CPU culling", .{err});
+                break :blk null;
+            };
+            break :blk system.interface();
+        } else null;
+        errdefer if (culling_system) |system| system.deinit();
+
+        world.renderer = try WorldRenderer.init(allocator, rhi.resourceManager(), rhi.renderContext(), rhi.query(), &world.storage, atlas, rhi, culling_system, culling_size, safe_mode);
+        culling_system = null;
         errdefer _ = world.renderer;
 
         world.gpu_block_buffer = world.renderer.getGpuBlockBuffer();

--- a/src/world/world.zig
+++ b/src/world/world.zig
@@ -18,8 +18,6 @@ const registry = @import("worldgen/registry.zig");
 const LightingComputer = @import("worldgen/lighting_computer.zig").LightingComputer;
 const rhi_mod = @import("../engine/graphics/rhi.zig");
 const RHI = rhi_mod.RHI;
-const CullingSystem = @import("../engine/graphics/vulkan/culling_system.zig").CullingSystem;
-const VulkanContext = @import("../engine/graphics/vulkan/rhi_context_types.zig").VulkanContext;
 const WorldLOD = @import("world_lod.zig").WorldLOD(RHI);
 
 fn getenv(name: [:0]const u8) ?[]const u8 {
@@ -35,7 +33,6 @@ const WorldStreamer = @import("world_streamer.zig").WorldStreamer;
 const TextureAtlas = @import("../engine/graphics/texture_atlas.zig").TextureAtlas;
 const WorldRenderer = @import("world_renderer.zig").WorldRenderer;
 const MAX_MDI_CHUNKS = @import("world_renderer.zig").MAX_MDI_CHUNKS;
-const CullingScreenSize = @import("world_renderer.zig").CullingScreenSize;
 const RenderStats = @import("world_renderer.zig").RenderStats;
 const RenderLayer = @import("world_renderer.zig").RenderLayer;
 const ShadowStats = @import("world_renderer.zig").ShadowStats;
@@ -189,22 +186,16 @@ pub const World = struct {
         };
 
         log.log.info("World.initGen: initializing WorldRenderer", .{});
-        const vk_ctx: *VulkanContext = @ptrCast(@alignCast(rhi.ptr));
-        const culling_size = CullingScreenSize{
-            .width = vk_ctx.gpass.g_pass_extent.width,
-            .height = vk_ctx.gpass.g_pass_extent.height,
-        };
+        const culling_size = rhi.getRenderResolution();
         var culling_system = if (!safe_mode) blk: {
-            const system = CullingSystem.init(allocator, rhi, MAX_MDI_CHUNKS) catch |err| {
+            break :blk rhi.createCullingSystem(allocator, MAX_MDI_CHUNKS) catch |err| {
                 log.log.warn("GPU culling init failed ({}), falling back to CPU culling", .{err});
                 break :blk null;
             };
-            break :blk system.interface();
         } else null;
         errdefer if (culling_system) |system| system.deinit();
 
-        world.renderer = try WorldRenderer.init(allocator, rhi.resourceManager(), rhi.renderContext(), rhi.query(), &world.storage, atlas, rhi, culling_system, culling_size, safe_mode);
-        culling_system = null;
+        world.renderer = try WorldRenderer.init(allocator, rhi.resourceManager(), rhi.renderContext(), rhi.query(), &world.storage, atlas, rhi, &culling_system, culling_size, safe_mode);
         errdefer _ = world.renderer;
 
         world.gpu_block_buffer = world.renderer.getGpuBlockBuffer();

--- a/src/world/world_renderer.zig
+++ b/src/world/world_renderer.zig
@@ -15,16 +15,16 @@ const LODManager = @import("lod_manager.zig").LODManager;
 const Vec3 = @import("../engine/math/vec3.zig").Vec3;
 const Mat4 = @import("../engine/math/mat4.zig").Mat4;
 const Frustum = @import("../engine/math/frustum.zig").Frustum;
-const CullingSystem = @import("../engine/graphics/vulkan/culling_system.zig").CullingSystem;
-const ChunkCullData = @import("../engine/graphics/vulkan/culling_system.zig").ChunkCullData;
-const VulkanContext = @import("../engine/graphics/vulkan/rhi_context_types.zig").VulkanContext;
+const culling = @import("../engine/graphics/culling.zig");
+const ICullingSystem = culling.ICullingSystem;
+const ChunkCullData = culling.ChunkCullData;
 const TextureAtlas = @import("../engine/graphics/texture_atlas.zig").TextureAtlas;
 const GpuBlockBuffer = @import("gpu_block_buffer.zig").GpuBlockBuffer;
 const GpuMesher = @import("gpu_mesher.zig").GpuMesher;
 const build_options = @import("build_options");
 const runtime_env = @import("../engine/core/runtime_env.zig");
 
-const MAX_MDI_CHUNKS: usize = 16384;
+pub const MAX_MDI_CHUNKS: usize = 16384;
 
 fn getenv(name: [:0]const u8) ?[]const u8 {
     return runtime_env.getenv(name);
@@ -49,13 +49,18 @@ pub const RenderLayer = enum {
     fluid,
 };
 
+pub const CullingScreenSize = struct {
+    width: u32,
+    height: u32,
+};
+
 pub const WorldRenderer = struct {
     allocator: std.mem.Allocator,
     storage: *ChunkStorage,
     rm: ResourceManager,
     render_ctx: RenderContext,
     query: IDeviceQuery,
-    vk_ctx: *VulkanContext,
+    culling_screen_size: CullingScreenSize,
 
     vertex_allocator: *GlobalVertexAllocator,
     visible_chunks: std.ArrayListUnmanaged(*ChunkData),
@@ -70,7 +75,7 @@ pub const WorldRenderer = struct {
     force_mdi_fallback: bool,
 
     // GPU Culling
-    culling_system: ?*CullingSystem,
+    culling_system: ?ICullingSystem,
     aabb_data: std.ArrayListUnmanaged(ChunkCullData),
     chunk_lookup: [rhi_mod.MAX_FRAMES_IN_FLIGHT]std.ArrayListUnmanaged(*ChunkData),
     gpu_visible_indices: std.ArrayListUnmanaged(u32),
@@ -85,7 +90,7 @@ pub const WorldRenderer = struct {
     // Diagnostic frame counter
     render_frame_count: u64 = 0,
 
-    pub fn init(allocator: std.mem.Allocator, rm: ResourceManager, render_ctx: RenderContext, query: IDeviceQuery, storage: *ChunkStorage, atlas: *const TextureAtlas, rhi: rhi_mod.RHI) !*WorldRenderer {
+    pub fn init(allocator: std.mem.Allocator, rm: ResourceManager, render_ctx: RenderContext, query: IDeviceQuery, storage: *ChunkStorage, atlas: *const TextureAtlas, rhi: rhi_mod.RHI, culling_system: ?ICullingSystem, culling_screen_size: CullingScreenSize, safe_mode_enabled: bool) !*WorldRenderer {
         const renderer = try allocator.create(WorldRenderer);
 
         const safe_mode = runtime_env.safeModeEnabled();
@@ -121,9 +126,6 @@ pub const WorldRenderer = struct {
         const vertex_allocator = try allocator.create(GlobalVertexAllocator);
         vertex_allocator.* = try GlobalVertexAllocator.init(allocator, rm, query, vertex_capacity_mb);
 
-        const vk_ctx: *VulkanContext = @ptrCast(@alignCast(rhi.ptr));
-
-        const safe_mode_enabled = vk_ctx.options.safe_mode;
         const gpu_meshing_env = getenv("ZIGCRAFT_ENABLE_GPU_MESHING");
         const gpu_meshing_enabled = if (gpu_meshing_env) |val|
             !(std.mem.eql(u8, val, "0") or std.mem.eql(u8, val, "false"))
@@ -138,16 +140,10 @@ pub const WorldRenderer = struct {
             indirect_buffers[i] = try rm.createBuffer(max_chunks * @sizeOf(rhi_mod.DrawIndirectCommand) * 3, .indirect);
         }
 
-        var culling_system: ?*CullingSystem = null;
         const use_gpu = false;
-        if (!safe_mode_enabled) {
-            if (CullingSystem.init(allocator, rhi, max_chunks)) |cs| {
-                culling_system = cs;
-                log.log.info("GPU chunk culling initialized but kept disabled due unstable visibility", .{});
-            } else |err| {
-                log.log.warn("GPU culling init failed ({}), falling back to CPU culling", .{err});
-            }
-        } else {
+        if (!safe_mode_enabled and culling_system != null) {
+            log.log.info("GPU chunk culling initialized but kept disabled due unstable visibility", .{});
+        } else if (safe_mode_enabled) {
             log.log.info("Safe mode: GPU frustum culling disabled, using CPU culling", .{});
         }
 
@@ -190,7 +186,7 @@ pub const WorldRenderer = struct {
             .rm = rm,
             .render_ctx = render_ctx,
             .query = query,
-            .vk_ctx = vk_ctx,
+            .culling_screen_size = culling_screen_size,
             .vertex_allocator = vertex_allocator,
             .visible_chunks = .empty,
             .last_render_stats = .{},
@@ -703,12 +699,16 @@ pub const WorldRenderer = struct {
         }
 
         cs.updateAABBData(fi, self.aabb_data.items);
-        const screen_w = @as(f32, @floatFromInt(self.vk_ctx.gpass.g_pass_extent.width));
-        const screen_h = @as(f32, @floatFromInt(self.vk_ctx.gpass.g_pass_extent.height));
         // The previous-frame depth pyramid is currently too unstable during camera
         // rotation and causes chunks to be wrongly occluded. Keep GPU frustum
         // culling, but disable temporal occlusion until the reprojection path is fixed.
-        cs.dispatch(view_proj, chunk_count, screen_w, screen_h, false);
+        cs.dispatch(.{
+            .view_proj = view_proj,
+            .chunk_count = chunk_count,
+            .screen_width = @floatFromInt(self.culling_screen_size.width),
+            .screen_height = @floatFromInt(self.culling_screen_size.height),
+            .previous_frame_valid = false,
+        });
     }
 
     pub fn renderShadowPass(self: *WorldRenderer, light_space_matrix: Mat4, camera_pos: Vec3, shadow_caster_distance: f32) void {

--- a/src/world/world_renderer.zig
+++ b/src/world/world_renderer.zig
@@ -49,18 +49,13 @@ pub const RenderLayer = enum {
     fluid,
 };
 
-pub const CullingScreenSize = struct {
-    width: u32,
-    height: u32,
-};
-
 pub const WorldRenderer = struct {
     allocator: std.mem.Allocator,
     storage: *ChunkStorage,
     rm: ResourceManager,
     render_ctx: RenderContext,
     query: IDeviceQuery,
-    culling_screen_size: CullingScreenSize,
+    culling_screen_size: rhi_mod.RenderResolution,
 
     vertex_allocator: *GlobalVertexAllocator,
     visible_chunks: std.ArrayListUnmanaged(*ChunkData),
@@ -90,10 +85,9 @@ pub const WorldRenderer = struct {
     // Diagnostic frame counter
     render_frame_count: u64 = 0,
 
-    pub fn init(allocator: std.mem.Allocator, rm: ResourceManager, render_ctx: RenderContext, query: IDeviceQuery, storage: *ChunkStorage, atlas: *const TextureAtlas, rhi: rhi_mod.RHI, culling_system: ?ICullingSystem, culling_screen_size: CullingScreenSize, safe_mode_enabled: bool) !*WorldRenderer {
+    pub fn init(allocator: std.mem.Allocator, rm: ResourceManager, render_ctx: RenderContext, query: IDeviceQuery, storage: *ChunkStorage, atlas: *const TextureAtlas, rhi: rhi_mod.RHI, culling_system: *?ICullingSystem, culling_screen_size: rhi_mod.RenderResolution, safe_mode_enabled: bool) !*WorldRenderer {
         const renderer = try allocator.create(WorldRenderer);
 
-        const safe_mode = runtime_env.safeModeEnabled();
         const strict_safe_mode = runtime_env.strictSafeModeEnabled();
 
         const vram_bytes = query.getDeviceLocalVramBytes();
@@ -119,7 +113,7 @@ pub const WorldRenderer = struct {
 
         if (strict_safe_mode) {
             log.log.warn("ZIGCRAFT_SAFE_MODE enabled: reduced GPU buffer sizes", .{});
-        } else if (safe_mode) {
+        } else if (safe_mode_enabled) {
             log.log.warn("Wayland stability profile active: keeping normal GPU buffer budgets while using CPU chunk path", .{});
         }
 
@@ -141,7 +135,8 @@ pub const WorldRenderer = struct {
         }
 
         const use_gpu = false;
-        if (!safe_mode_enabled and culling_system != null) {
+        const owned_culling_system = culling_system.*;
+        if (!safe_mode_enabled and owned_culling_system != null) {
             log.log.info("GPU chunk culling initialized but kept disabled due unstable visibility", .{});
         } else if (safe_mode_enabled) {
             log.log.info("Safe mode: GPU frustum culling disabled, using CPU culling", .{});
@@ -196,7 +191,7 @@ pub const WorldRenderer = struct {
             .instance_buffers = instance_buffers,
             .indirect_buffers = indirect_buffers,
             .force_mdi_fallback = force_mdi_fallback,
-            .culling_system = culling_system,
+            .culling_system = owned_culling_system,
             .aabb_data = .empty,
             .chunk_lookup = undefined,
             .gpu_visible_indices = .empty,
@@ -204,6 +199,7 @@ pub const WorldRenderer = struct {
             .gpu_block_buffer = gpu_block_buffer,
             .gpu_mesher = gpu_mesher,
         };
+        culling_system.* = null;
 
         for (&renderer.chunk_lookup) |*lookup| lookup.* = .empty;
 
@@ -659,11 +655,11 @@ pub const WorldRenderer = struct {
         const fi = self.query.getFrameIndex();
         const prev_fi = (fi + rhi_mod.MAX_FRAMES_IN_FLIGHT - 1) % rhi_mod.MAX_FRAMES_IN_FLIGHT;
 
-        const prev_visible_count = cs.readVisibleCount(prev_fi);
+        const prev_visible_count = cs.read_visible_count(prev_fi);
         self.gpu_visible_indices.clearRetainingCapacity();
         if (prev_visible_count > 0) {
             self.gpu_visible_indices.resize(self.allocator, prev_visible_count) catch return;
-            cs.readVisibleIndices(prev_fi, prev_visible_count, self.gpu_visible_indices.items);
+            cs.read_visible_indices(prev_fi, prev_visible_count, self.gpu_visible_indices.items);
 
             const limit = @min(@as(usize, @intCast(prev_visible_count)), self.gpu_visible_indices.items.len);
             for (self.gpu_visible_indices.items[0..limit]) |idx| {
@@ -698,7 +694,7 @@ pub const WorldRenderer = struct {
             self.last_render_stats.chunks_culled += chunk_count - @min(prev_rendered, chunk_count);
         }
 
-        cs.updateAABBData(fi, self.aabb_data.items);
+        cs.update_aabb_data(fi, self.aabb_data.items);
         // The previous-frame depth pyramid is currently too unstable during camera
         // rotation and causes chunks to be wrongly occluded. Keep GPU frustum
         // culling, but disable temporal occlusion until the reprojection path is fixed.


### PR DESCRIPTION
## Summary
- Add a backend-neutral `ICullingSystem` interface and shared chunk cull data type.
- Adapt the current Vulkan culling system behind the interface without changing frame-indexed read/write behavior.
- Remove direct `VulkanContext` and Vulkan culling implementation coupling from `WorldRenderer`.

## Issues
- Resolves https://github.com/OpenStaticFish/ZigCraft/issues/467
- Resolves https://github.com/OpenStaticFish/ZigCraft/issues/468
- Resolves https://github.com/OpenStaticFish/ZigCraft/issues/469

## Verification
- `nix develop --command zig fmt src/engine/graphics/culling.zig src/engine/graphics/vulkan/culling_system.zig src/world/world_renderer.zig src/world/world.zig`
- `nix develop --command zig build`
- `nix develop --command zig build test` fails during existing graphics/shadow test execution after shader validation with `memory not mapped`, null shadow render pass, cascade bounds, and null framebuffer errors.