### PR TITLE
fix: harden world scanning and render no-ops

### DIFF
--- a/src/engine/graphics/shadow_system.zig
+++ b/src/engine/graphics/shadow_system.zig
@@ -85,6 +85,10 @@ pub const ShadowSystem = struct {
             @import("../core/log.zig").log.err("ShadowSystem: framebuffer for cascade {} is null", .{cascade_index});
             return;
         }
+        if (command_buffer == null) {
+            @import("../core/log.zig").log.err("ShadowSystem: cannot begin pass, command_buffer is null", .{});
+            return;
+        }
 
         self.pass_active = true;
         self.pass_index = cascade_index;
@@ -93,8 +97,6 @@ pub const ShadowSystem = struct {
 
         // Render pass handles transition from UNDEFINED to DEPTH_STENCIL_ATTACHMENT_OPTIMAL
         self.shadow_image_layouts[cascade_index] = c.VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-
-        if (command_buffer == null) return;
 
         var render_pass_info: c.VkRenderPassBeginInfo = undefined;
         @memset(std.mem.asBytes(&render_pass_info), 0);
@@ -161,4 +163,17 @@ test "ShadowSystem initialization and state" {
     sys.pass_index = 1;
     try testing.expect(sys.pass_active);
     try testing.expectEqual(@as(u32, 1), sys.pass_index);
+}
+
+test "ShadowSystem beginPass leaves state inactive for null command buffer" {
+    const testing = std.testing;
+    var sys = try ShadowSystem.init(testing.allocator, 1024);
+    sys.shadow_render_pass = @ptrFromInt(1);
+    sys.shadow_framebuffers[0] = @ptrFromInt(1);
+
+    sys.beginPass(null, 0, Mat4.identity);
+
+    try testing.expect(!sys.pass_active);
+    try testing.expectEqual(@as(u32, 0), sys.pass_index);
+    try testing.expect(!sys.pipeline_bound);
 }

--- a/src/engine/graphics/shadow_system_tests.zig
+++ b/src/engine/graphics/shadow_system_tests.zig
@@ -43,7 +43,7 @@ test "ShadowSystem beginPass rejects null framebuffer" {
     try testing.expectEqual(@as(bool, false), sys.pass_active);
 }
 
-test "ShadowSystem beginPass sets correct pass state" {
+test "ShadowSystem beginPass rejects null command buffer before setting pass state" {
     var sys = try ShadowSystem.init(testing.allocator, 1024);
     defer sys.deinit(null);
 
@@ -58,13 +58,13 @@ test "ShadowSystem beginPass sets correct pass state" {
 
     sys.beginPass(null, 2, light_matrix);
 
-    try testing.expect(sys.pass_active);
-    try testing.expectEqual(@as(u32, 2), sys.pass_index);
-    try testing.expectEqual(@as(f32, 5.0), sys.pass_matrix.data[0][0]);
+    try testing.expect(!sys.pass_active);
+    try testing.expectEqual(@as(u32, 0), sys.pass_index);
+    try testing.expectEqual(@as(f32, 1.0), sys.pass_matrix.data[0][0]);
     try testing.expect(!sys.pipeline_bound);
 }
 
-test "ShadowSystem beginPass updates image layout to depth stencil" {
+test "ShadowSystem beginPass leaves image layout unchanged for null command buffer" {
     var sys = try ShadowSystem.init(testing.allocator, 1024);
     defer sys.deinit(null);
 
@@ -78,7 +78,7 @@ test "ShadowSystem beginPass updates image layout to depth stencil" {
 
     sys.beginPass(null, 1, Mat4.identity);
 
-    try testing.expectEqual(@as(u32, c.VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL), sys.shadow_image_layouts[1]);
+    try testing.expectEqual(@as(u32, c.VK_IMAGE_LAYOUT_UNDEFINED), sys.shadow_image_layouts[1]);
 }
 
 test "ShadowConfig default field values" {
@@ -381,7 +381,8 @@ test "ShadowSystem endPass resets pass_active to false" {
     sys.shadow_framebuffers[2] = @ptrFromInt(3);
     sys.shadow_framebuffers[3] = @ptrFromInt(4);
 
-    sys.beginPass(null, 1, Mat4.identity);
+    sys.pass_active = true;
+    sys.pass_index = 1;
     try testing.expect(sys.pass_active);
 
     sys.endPass(null);
@@ -398,7 +399,8 @@ test "ShadowSystem endPass does not modify pass_index" {
     sys.shadow_framebuffers[2] = @ptrFromInt(3);
     sys.shadow_framebuffers[3] = @ptrFromInt(4);
 
-    sys.beginPass(null, 2, Mat4.identity);
+    sys.pass_active = true;
+    sys.pass_index = 2;
     try testing.expectEqual(@as(u32, 2), sys.pass_index);
 
     sys.endPass(null);
@@ -415,7 +417,9 @@ test "ShadowSystem endPass updates image layout to depth stencil read only optim
     sys.shadow_framebuffers[2] = @ptrFromInt(3);
     sys.shadow_framebuffers[3] = @ptrFromInt(4);
 
-    sys.beginPass(null, 3, Mat4.identity);
+    sys.pass_active = true;
+    sys.pass_index = 3;
+    sys.shadow_image_layouts[3] = c.VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     try testing.expectEqual(@as(u32, c.VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL), sys.shadow_image_layouts[3]);
 
     sys.endPass(null);

--- a/src/engine/graphics/vulkan/rhi_draw_submission.zig
+++ b/src/engine/graphics/vulkan/rhi_draw_submission.zig
@@ -21,7 +21,10 @@ pub fn drawIndexed(ctx: anytype, vbo_handle: rhi.BufferHandle, ebo_handle: rhi.B
 
     if (!ctx.runtime.main_pass_active and !ctx.shadow_system.pass_active and !ctx.runtime.g_pass_active and !ctx.water_system.pass_active) pass_orchestration.beginMainPassInternal(ctx);
 
-    if (!ctx.runtime.main_pass_active and !ctx.shadow_system.pass_active and !ctx.runtime.g_pass_active and !ctx.water_system.pass_active) return;
+    if (!ctx.runtime.main_pass_active and !ctx.shadow_system.pass_active and !ctx.runtime.g_pass_active and !ctx.water_system.pass_active) {
+        log.log.warn("drawIndexed: no active render pass after implicit main pass begin", .{});
+        return;
+    }
 
     const vbo_opt = ctx.resources.buffers.get(vbo_handle);
     const ebo_opt = ctx.resources.buffers.get(ebo_handle);
@@ -41,7 +44,10 @@ pub fn drawIndexed(ctx: anytype, vbo_handle: rhi.BufferHandle, ebo_handle: rhi.B
                     ctx.pipeline_manager.wireframe_pipeline
                 else
                     ctx.pipeline_manager.terrain_pipeline;
-                if (selected_pipeline == null) return;
+                if (selected_pipeline == null) {
+                    log.log.warn("drawIndexed: selected terrain pipeline is null", .{});
+                    return;
+                }
                 c.vkCmdBindPipeline(command_buffer, c.VK_PIPELINE_BIND_POINT_GRAPHICS, selected_pipeline);
                 ctx.draw.terrain_pipeline_bound = !ctx.water_system.pass_active;
             }
@@ -62,7 +68,10 @@ pub fn drawIndirect(ctx: anytype, handle: rhi.BufferHandle, command_buffer: rhi.
 
     if (!ctx.runtime.main_pass_active and !ctx.shadow_system.pass_active and !ctx.runtime.g_pass_active and !ctx.water_system.pass_active) pass_orchestration.beginMainPassInternal(ctx);
 
-    if (!ctx.runtime.main_pass_active and !ctx.shadow_system.pass_active and !ctx.runtime.g_pass_active and !ctx.water_system.pass_active) return;
+    if (!ctx.runtime.main_pass_active and !ctx.shadow_system.pass_active and !ctx.runtime.g_pass_active and !ctx.water_system.pass_active) {
+        log.log.warn("drawIndirect: no active render pass after implicit main pass begin", .{});
+        return;
+    }
 
     const use_shadow = ctx.shadow_system.pass_active;
     const use_g_pass = ctx.runtime.g_pass_active;
@@ -77,12 +86,18 @@ pub fn drawIndirect(ctx: anytype, handle: rhi.BufferHandle, command_buffer: rhi.
 
             if (use_shadow) {
                 if (!ctx.shadow_system.pipeline_bound) {
-                    if (ctx.shadow_system.shadow_pipeline == null) return;
+                    if (ctx.shadow_system.shadow_pipeline == null) {
+                        log.log.warn("drawIndirect: shadow pipeline is null", .{});
+                        return;
+                    }
                     c.vkCmdBindPipeline(cb, c.VK_PIPELINE_BIND_POINT_GRAPHICS, ctx.shadow_system.shadow_pipeline);
                     ctx.shadow_system.pipeline_bound = true;
                 }
             } else if (use_g_pass) {
-                if (ctx.pipeline_manager.g_pipeline == null) return;
+                if (ctx.pipeline_manager.g_pipeline == null) {
+                    log.log.warn("drawIndirect: g-pass pipeline is null", .{});
+                    return;
+                }
                 c.vkCmdBindPipeline(cb, c.VK_PIPELINE_BIND_POINT_GRAPHICS, ctx.pipeline_manager.g_pipeline);
             } else {
                 if (!ctx.draw.terrain_pipeline_bound) {

--- a/src/game/screens/world_list.zig
+++ b/src/game/screens/world_list.zig
@@ -100,6 +100,10 @@ pub fn readLevelDat(allocator: std.mem.Allocator, save_dir: fs.Dir) ?LevelDat {
 
 pub fn scanWorlds(allocator: std.mem.Allocator) ![]const WorldEntry {
     const home = getenv("HOME") orelse return &[_]WorldEntry{};
+    return scanWorldsInHome(allocator, home);
+}
+
+pub fn scanWorldsInHome(allocator: std.mem.Allocator, home: []const u8) ![]const WorldEntry {
     var home_dir = fs.openDirAbsolute(home, .{}) catch return &[_]WorldEntry{};
     defer home_dir.close();
     home_dir.makePath(SAVE_DIR) catch {};
@@ -118,7 +122,11 @@ pub fn scanWorlds(allocator: std.mem.Allocator) ![]const WorldEntry {
         if (entry.kind != .directory) continue;
         const name_alloc = allocator.dupe(u8, entry.name) catch continue;
         errdefer allocator.free(name_alloc);
-        const level = readLevelDat(allocator, saves_dir);
+        const level = blk: {
+            var world_dir = saves_dir.openDir(entry.name, .{}) catch break :blk null;
+            defer world_dir.close();
+            break :blk readLevelDat(allocator, world_dir);
+        };
         const dir_buf = std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ home, SAVE_DIR, entry.name }) catch {
             allocator.free(name_alloc);
             continue;

--- a/src/game/world_list_tests.zig
+++ b/src/game/world_list_tests.zig
@@ -66,3 +66,67 @@ test "writeLevelDat overwrites existing" {
     try testing.expectEqual(@as(u64, 200), result.?.seed);
     try testing.expectEqual(@as(usize, 1), result.?.generator_index);
 }
+
+test "scanWorlds reads level.dat from each world directory" {
+    const allocator = testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+
+    var home_path_buf: [fs.max_path_bytes]u8 = undefined;
+    const home_path = try dir.realpath(".", &home_path_buf);
+
+    try dir.makePath(world_list.SAVE_DIR ++ "/world_a");
+    try dir.makePath(world_list.SAVE_DIR ++ "/world_b");
+
+    var world_a = try dir.openDir(world_list.SAVE_DIR ++ "/world_a", .{});
+    defer world_a.close();
+    var world_b = try dir.openDir(world_list.SAVE_DIR ++ "/world_b", .{});
+    defer world_b.close();
+
+    try world_list.writeLevelDat(allocator, world_a, "Alpha", 111, 1, 1000);
+    try world_list.writeLevelDat(allocator, world_b, "Beta", 222, 2, 2000);
+
+    const worlds = try world_list.scanWorldsInHome(allocator, home_path);
+    defer {
+        for (worlds) |entry| {
+            allocator.free(entry.name);
+            allocator.free(entry.dir_path);
+        }
+        allocator.free(worlds);
+    }
+
+    try testing.expectEqual(@as(usize, 2), worlds.len);
+    try testing.expectEqualStrings("Beta", worlds[0].name);
+    try testing.expectEqual(@as(u64, 222), worlds[0].seed);
+    try testing.expectEqual(@as(usize, 2), worlds[0].generator_index);
+    try testing.expectEqualStrings("Alpha", worlds[1].name);
+    try testing.expectEqual(@as(u64, 111), worlds[1].seed);
+    try testing.expectEqual(@as(usize, 1), worlds[1].generator_index);
+}
+
+test "scanWorlds keeps directory fallback when level.dat is missing" {
+    const allocator = testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+
+    var home_path_buf: [fs.max_path_bytes]u8 = undefined;
+    const home_path = try dir.realpath(".", &home_path_buf);
+
+    try dir.makePath(world_list.SAVE_DIR ++ "/missing_level");
+
+    const worlds = try world_list.scanWorldsInHome(allocator, home_path);
+    defer {
+        for (worlds) |entry| {
+            allocator.free(entry.name);
+            allocator.free(entry.dir_path);
+        }
+        allocator.free(worlds);
+    }
+
+    try testing.expectEqual(@as(usize, 1), worlds.len);
+    try testing.expectEqualStrings("missing_level", worlds[0].name);
+    try testing.expectEqual(@as(u64, 0), worlds[0].seed);
+    try testing.expectEqual(@as(usize, 0), worlds[0].generator_index);
+}


### PR DESCRIPTION
## Summary
- Fix world-list scanning so each save directory's own level.dat is read.
- Add warnings for render draw paths that previously returned silently after failed implicit pass/pipeline setup.
- Validate shadow pass command buffers before mutating active pass state.

## Tests
- nix develop --command zig fmt src/
- nix develop --command zig build test

Closes #538
Closes #539