### PR TITLE
refactor: split screen UI responsibilities

### DIFF
--- a/src/game/screen.zig
+++ b/src/game/screen.zig
@@ -30,10 +30,7 @@ pub const EngineContext = struct {
     benchmark_runner: ?*BenchmarkRunner = null,
 
     pub fn saveSettings(self: EngineContext) void {
-        settings_pkg.persistence.save(self.settings, self.allocator);
-        @import("input_settings.zig").InputSettings.saveFromMapper(self.allocator, self.input_mapper) catch |err| {
-            @import("../engine/core/log.zig").log.err("Failed to save input settings: {}", .{err});
-        };
+        saveSettingsShared(self.allocator, self.settings, self.input_mapper);
     }
 
     pub fn menuContext(self: EngineContext) MenuContext {
@@ -57,6 +54,18 @@ pub const EngineContext = struct {
             .input_mapper = self.input_mapper,
             .screen_manager = self.screen_manager,
             .render_settings = self.render_settings,
+        };
+    }
+
+    pub fn environmentContext(self: EngineContext) EnvironmentContext {
+        return .{
+            .allocator = self.allocator,
+            .window_manager = self.window_manager,
+            .render_system = self.render_system,
+            .settings = self.settings,
+            .input = self.input,
+            .input_mapper = self.input_mapper,
+            .screen_manager = self.screen_manager,
         };
     }
 
@@ -98,10 +107,21 @@ pub const SettingsContext = struct {
     render_settings: IRenderSettings,
 
     pub fn saveSettings(self: SettingsContext) void {
-        settings_pkg.persistence.save(self.settings, self.allocator);
-        @import("input_settings.zig").InputSettings.saveFromMapper(self.allocator, self.input_mapper) catch |err| {
-            @import("../engine/core/log.zig").log.err("Failed to save input settings: {}", .{err});
-        };
+        saveSettingsShared(self.allocator, self.settings, self.input_mapper);
+    }
+};
+
+pub const EnvironmentContext = struct {
+    allocator: std.mem.Allocator,
+    window_manager: *WindowManager,
+    render_system: *RenderSystem,
+    settings: *Settings,
+    input: IRawInputProvider,
+    input_mapper: IInputMapper,
+    screen_manager: *ScreenManager,
+
+    pub fn saveSettings(self: EnvironmentContext) void {
+        saveSettingsShared(self.allocator, self.settings, self.input_mapper);
     }
 };
 
@@ -119,6 +139,13 @@ pub const WorldContext = struct {
     skip_world_update: bool,
     benchmark_runner: ?*BenchmarkRunner = null,
 };
+
+fn saveSettingsShared(allocator: std.mem.Allocator, settings: *Settings, input_mapper: IInputMapper) void {
+    settings_pkg.persistence.save(settings, allocator);
+    @import("input_settings.zig").InputSettings.saveFromMapper(allocator, input_mapper) catch |err| {
+        @import("../engine/core/log.zig").log.err("Failed to save input settings: {}", .{err});
+    };
+}
 
 pub const IScreen = struct {
     ptr: *anyopaque,

--- a/src/game/screen.zig
+++ b/src/game/screen.zig
@@ -35,6 +35,89 @@ pub const EngineContext = struct {
             @import("../engine/core/log.zig").log.err("Failed to save input settings: {}", .{err});
         };
     }
+
+    pub fn menuContext(self: EngineContext) MenuContext {
+        return .{
+            .allocator = self.allocator,
+            .window_manager = self.window_manager,
+            .settings = self.settings,
+            .input = self.input,
+            .input_mapper = self.input_mapper,
+            .time = self.time,
+            .screen_manager = self.screen_manager,
+        };
+    }
+
+    pub fn settingsContext(self: EngineContext) SettingsContext {
+        return .{
+            .allocator = self.allocator,
+            .window_manager = self.window_manager,
+            .settings = self.settings,
+            .input = self.input,
+            .input_mapper = self.input_mapper,
+            .screen_manager = self.screen_manager,
+            .render_settings = self.render_settings,
+        };
+    }
+
+    pub fn worldContext(self: EngineContext) WorldContext {
+        return .{
+            .allocator = self.allocator,
+            .window_manager = self.window_manager,
+            .render_system = self.render_system,
+            .audio_system = self.audio_system,
+            .ui_manager = self.ui_manager,
+            .settings = self.settings,
+            .input = self.input,
+            .input_mapper = self.input_mapper,
+            .time = self.time,
+            .screen_manager = self.screen_manager,
+            .skip_world_update = self.skip_world_update,
+            .benchmark_runner = self.benchmark_runner,
+        };
+    }
+};
+
+pub const MenuContext = struct {
+    allocator: std.mem.Allocator,
+    window_manager: *WindowManager,
+    settings: *Settings,
+    input: IRawInputProvider,
+    input_mapper: IInputMapper,
+    time: *Time,
+    screen_manager: *ScreenManager,
+};
+
+pub const SettingsContext = struct {
+    allocator: std.mem.Allocator,
+    window_manager: *WindowManager,
+    settings: *Settings,
+    input: IRawInputProvider,
+    input_mapper: IInputMapper,
+    screen_manager: *ScreenManager,
+    render_settings: IRenderSettings,
+
+    pub fn saveSettings(self: SettingsContext) void {
+        settings_pkg.persistence.save(self.settings, self.allocator);
+        @import("input_settings.zig").InputSettings.saveFromMapper(self.allocator, self.input_mapper) catch |err| {
+            @import("../engine/core/log.zig").log.err("Failed to save input settings: {}", .{err});
+        };
+    }
+};
+
+pub const WorldContext = struct {
+    allocator: std.mem.Allocator,
+    window_manager: *WindowManager,
+    render_system: *RenderSystem,
+    audio_system: *AudioSystem,
+    ui_manager: *UISystemManager,
+    settings: *Settings,
+    input: IRawInputProvider,
+    input_mapper: IInputMapper,
+    time: *Time,
+    screen_manager: *ScreenManager,
+    skip_world_update: bool,
+    benchmark_runner: ?*BenchmarkRunner = null,
 };
 
 pub const IScreen = struct {

--- a/src/game/screen.zig
+++ b/src/game/screen.zig
@@ -69,6 +69,18 @@ pub const EngineContext = struct {
         };
     }
 
+    pub fn resourcePacksContext(self: EngineContext) ResourcePacksContext {
+        return .{
+            .allocator = self.allocator,
+            .window_manager = self.window_manager,
+            .render_system = self.render_system,
+            .settings = self.settings,
+            .input = self.input,
+            .input_mapper = self.input_mapper,
+            .screen_manager = self.screen_manager,
+        };
+    }
+
     pub fn worldContext(self: EngineContext) WorldContext {
         return .{
             .allocator = self.allocator,
@@ -121,6 +133,20 @@ pub const EnvironmentContext = struct {
     screen_manager: *ScreenManager,
 
     pub fn saveSettings(self: EnvironmentContext) void {
+        saveSettingsShared(self.allocator, self.settings, self.input_mapper);
+    }
+};
+
+pub const ResourcePacksContext = struct {
+    allocator: std.mem.Allocator,
+    window_manager: *WindowManager,
+    render_system: *RenderSystem,
+    settings: *Settings,
+    input: IRawInputProvider,
+    input_mapper: IInputMapper,
+    screen_manager: *ScreenManager,
+
+    pub fn saveSettings(self: ResourcePacksContext) void {
         saveSettingsShared(self.allocator, self.settings, self.input_mapper);
     }
 };

--- a/src/game/screens/environment.zig
+++ b/src/game/screens/environment.zig
@@ -19,6 +19,7 @@ const BORDER_COLOR = Color.rgba(0.28, 0.33, 0.42, 1.0);
 
 pub const EnvironmentScreen = struct {
     context: EngineContext,
+    environment_maps: std.ArrayListUnmanaged([]const u8),
 
     pub const vtable = IScreen.VTable{
         .deinit = deinit,
@@ -29,14 +30,18 @@ pub const EnvironmentScreen = struct {
 
     pub fn init(allocator: std.mem.Allocator, context: EngineContext) !*EnvironmentScreen {
         const self = try allocator.create(EnvironmentScreen);
+        errdefer allocator.destroy(self);
         self.* = .{
             .context = context,
+            .environment_maps = .empty,
         };
+        try self.refreshEnvironmentMaps();
         return self;
     }
 
     pub fn deinit(ptr: *anyopaque) void {
         const self: *@This() = @ptrCast(@alignCast(ptr));
+        self.clearEnvironmentMaps();
         self.context.allocator.destroy(self);
     }
 
@@ -100,27 +105,15 @@ pub const EnvironmentScreen = struct {
         }
         sy += btn_height + 10.0 * ui_scale;
 
-        // Scan for files
-        var dir = fs.cwd().openDir(".", .{ .iterate = true }) catch return;
-        defer dir.close();
-
-        var iterator = dir.iterate();
         var buffer: [128]u8 = undefined;
 
-        while (try iterator.next()) |entry| {
-            if (entry.kind != .file) continue;
-            const is_exr = std.mem.endsWith(u8, entry.name, ".exr");
-            const is_hdr = std.mem.endsWith(u8, entry.name, ".hdr");
-            if (!is_exr and !is_hdr) continue;
-
-            if (is_hdr and std.mem.endsWith(u8, entry.name, ".exr.hdr")) continue;
-
-            const is_selected = std.mem.eql(u8, settings.environment_map, entry.name);
-            const label = try std.fmt.bufPrint(&buffer, "{s}{s}", .{ entry.name, if (is_selected) " [SELECTED]" else "" });
+        for (self.environment_maps.items) |environment_map| {
+            const is_selected = std.mem.eql(u8, settings.environment_map, environment_map);
+            const label = try std.fmt.bufPrint(&buffer, "{s}{s}", .{ environment_map, if (is_selected) " [SELECTED]" else "" });
 
             if (Widgets.drawButton(ui, .{ .x = btn_x, .y = sy, .width = btn_width, .height = btn_height }, label, btn_scale, mouse_x, mouse_y, mouse_clicked)) {
                 if (!is_selected) {
-                    try settings_pkg.persistence.setEnvironmentMap(settings, ctx.allocator, entry.name);
+                    try settings_pkg.persistence.setEnvironmentMap(settings, ctx.allocator, environment_map);
                     try self.reloadEnvMap();
                 }
             }
@@ -139,6 +132,28 @@ pub const EnvironmentScreen = struct {
     pub fn onEnter(ptr: *anyopaque) void {
         const self: *@This() = @ptrCast(@alignCast(ptr));
         self.context.input.setMouseCapture(self.context.window_manager.window, false);
+        self.refreshEnvironmentMaps() catch |err| log.log.warn("Failed to refresh environment map list: {}", .{err});
+    }
+
+    fn clearEnvironmentMaps(self: *@This()) void {
+        for (self.environment_maps.items) |name| self.context.allocator.free(name);
+        self.environment_maps.clearRetainingCapacity();
+    }
+
+    fn refreshEnvironmentMaps(self: *@This()) !void {
+        self.clearEnvironmentMaps();
+        var dir = fs.cwd().openDir(".", .{ .iterate = true }) catch return;
+        defer dir.close();
+
+        var iterator = dir.iterate();
+        while (try iterator.next()) |entry| {
+            if (entry.kind != .file) continue;
+            const is_exr = std.mem.endsWith(u8, entry.name, ".exr");
+            const is_hdr = std.mem.endsWith(u8, entry.name, ".hdr");
+            if (!is_exr and !is_hdr) continue;
+            if (is_hdr and std.mem.endsWith(u8, entry.name, ".exr.hdr")) continue;
+            try self.environment_maps.append(self.context.allocator, try self.context.allocator.dupe(u8, entry.name));
+        }
     }
 
     fn reloadEnvMap(self: *@This()) !void {

--- a/src/game/screens/environment.zig
+++ b/src/game/screens/environment.zig
@@ -7,6 +7,7 @@ const Widgets = @import("../../engine/ui/widgets.zig");
 const Screen = @import("../screen.zig");
 const IScreen = Screen.IScreen;
 const EngineContext = Screen.EngineContext;
+const EnvironmentContext = Screen.EnvironmentContext;
 const settings_pkg = @import("../settings.zig");
 const Settings = settings_pkg.Settings;
 const Texture = @import("../../engine/graphics/texture.zig").Texture;
@@ -18,7 +19,7 @@ const BG_COLOR = Color.rgba(0.12, 0.14, 0.18, 0.95);
 const BORDER_COLOR = Color.rgba(0.28, 0.33, 0.42, 1.0);
 
 pub const EnvironmentScreen = struct {
-    context: EngineContext,
+    context: EnvironmentContext,
     environment_maps: std.ArrayListUnmanaged([]const u8),
 
     pub const vtable = IScreen.VTable{
@@ -30,9 +31,13 @@ pub const EnvironmentScreen = struct {
 
     pub fn init(allocator: std.mem.Allocator, context: EngineContext) !*EnvironmentScreen {
         const self = try allocator.create(EnvironmentScreen);
-        errdefer allocator.destroy(self);
+        errdefer {
+            self.clearEnvironmentMaps();
+            self.environment_maps.deinit(allocator);
+            allocator.destroy(self);
+        }
         self.* = .{
-            .context = context,
+            .context = context.environmentContext(),
             .environment_maps = .empty,
         };
         try self.refreshEnvironmentMaps();
@@ -42,6 +47,7 @@ pub const EnvironmentScreen = struct {
     pub fn deinit(ptr: *anyopaque) void {
         const self: *@This() = @ptrCast(@alignCast(ptr));
         self.clearEnvironmentMaps();
+        self.environment_maps.deinit(self.context.allocator);
         self.context.allocator.destroy(self);
     }
 
@@ -152,7 +158,9 @@ pub const EnvironmentScreen = struct {
             const is_hdr = std.mem.endsWith(u8, entry.name, ".hdr");
             if (!is_exr and !is_hdr) continue;
             if (is_hdr and std.mem.endsWith(u8, entry.name, ".exr.hdr")) continue;
-            try self.environment_maps.append(self.context.allocator, try self.context.allocator.dupe(u8, entry.name));
+            const name = try self.context.allocator.dupe(u8, entry.name);
+            errdefer self.context.allocator.free(name);
+            try self.environment_maps.append(self.context.allocator, name);
         }
     }
 

--- a/src/game/screens/resource_packs.zig
+++ b/src/game/screens/resource_packs.zig
@@ -6,6 +6,7 @@ const Widgets = @import("../../engine/ui/widgets.zig");
 const Screen = @import("../screen.zig");
 const IScreen = Screen.IScreen;
 const EngineContext = Screen.EngineContext;
+const ResourcePacksContext = Screen.ResourcePacksContext;
 const settings_pkg = @import("../settings.zig");
 const Settings = settings_pkg.Settings;
 const TextureAtlas = @import("../../engine/graphics/texture_atlas.zig").TextureAtlas;
@@ -16,7 +17,7 @@ const BG_COLOR = Color.rgba(0.12, 0.14, 0.18, 0.95);
 const BORDER_COLOR = Color.rgba(0.28, 0.33, 0.42, 1.0);
 
 pub const ResourcePacksScreen = struct {
-    context: EngineContext,
+    context: ResourcePacksContext,
     reload_status: ?[]const u8,
 
     pub const vtable = IScreen.VTable{
@@ -29,7 +30,7 @@ pub const ResourcePacksScreen = struct {
     pub fn init(allocator: std.mem.Allocator, context: EngineContext) !*ResourcePacksScreen {
         const self = try allocator.create(ResourcePacksScreen);
         self.* = .{
-            .context = context,
+            .context = context.resourcePacksContext(),
             .reload_status = null,
         };
         return self;

--- a/src/game/screens/resource_packs.zig
+++ b/src/game/screens/resource_packs.zig
@@ -17,6 +17,7 @@ const BORDER_COLOR = Color.rgba(0.28, 0.33, 0.42, 1.0);
 
 pub const ResourcePacksScreen = struct {
     context: EngineContext,
+    reload_status: ?[]const u8,
 
     pub const vtable = IScreen.VTable{
         .deinit = deinit,
@@ -29,6 +30,7 @@ pub const ResourcePacksScreen = struct {
         const self = try allocator.create(ResourcePacksScreen);
         self.* = .{
             .context = context,
+            .reload_status = null,
         };
         return self;
     }
@@ -97,7 +99,9 @@ pub const ResourcePacksScreen = struct {
             if (!std.mem.eql(u8, prev_pack, "default")) {
                 try settings_pkg.persistence.setTexturePack(settings, ctx.allocator, "default");
                 try manager.setActivePack("default");
+                self.reload_status = "Reloading textures; rendering may pause briefly...";
                 try self.reloadAtlas();
+                self.reload_status = "Texture pack reloaded.";
             }
         }
         sy += btn_height + 10.0 * ui_scale;
@@ -113,10 +117,16 @@ pub const ResourcePacksScreen = struct {
                 if (!is_selected) {
                     try settings_pkg.persistence.setTexturePack(settings, ctx.allocator, pack.name);
                     try manager.setActivePack(pack.name);
+                    self.reload_status = "Reloading textures; rendering may pause briefly...";
                     try self.reloadAtlas();
+                    self.reload_status = "Texture pack reloaded.";
                 }
             }
             sy += btn_height + 10.0 * ui_scale;
+        }
+
+        if (self.reload_status) |status| {
+            Font.drawTextCentered(ui, status, screen_w * 0.5, py + ph - 105.0 * ui_scale, 1.5 * ui_scale, Color.rgba(0.75, 0.82, 0.92, 1.0));
         }
 
         // Back button

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -28,6 +28,8 @@ const CSM = @import("../../engine/graphics/csm.zig");
 const WorldRenderer = @import("../../world/world_renderer.zig").WorldRenderer;
 const settings_data = @import("../settings/data.zig");
 const build_options = @import("build_options");
+const world_debug = @import("world_debug.zig");
+const world_frame_params = @import("world_frame_params.zig");
 
 const ShadowProbeInfo = struct {
     block_x: i32,
@@ -282,11 +284,6 @@ pub const WorldScreen = struct {
 
         const screen_w: f32 = @floatFromInt(ctx.input.getWindowWidth());
         const screen_h: f32 = @floatFromInt(ctx.input.getWindowHeight());
-        const aspect = screen_w / screen_h;
-
-        const taa_enabled = ctx.settings.taa_enabled;
-        const view_proj_render = camera.getJitteredProjectionMatrixReverseZ(aspect, screen_w, screen_h, taa_enabled).multiply(camera.getViewMatrixOriginCentered());
-
         const safe_mode = render_system.getSafeMode();
         const startup_busy = self.session.world.isStartupBusy();
         const startup_loading = build_options.auto_world.len > 0 and startup_busy;
@@ -300,24 +297,8 @@ pub const WorldScreen = struct {
         const shadow_sun_dir = if (shadow_sandbox_active) self.resolveStableShadowSunDir(render_sun_dir) else render_sun_dir;
         if (!shadow_sandbox_active) self.stable_shadow_sun_initialized = false;
 
-        const sky_params = rhi_pkg.SkyParams{
-            .cam_pos = camera.position,
-            .cam_forward = camera.forward,
-            .cam_right = camera.right,
-            .cam_up = camera.up,
-            .aspect = aspect,
-            .tan_half_fov = @tan(camera.fov / 2.0),
-            .sun_dir = render_sun_dir,
-            .sky_color = self.session.atmosphere.sky_color,
-            .horizon_color = self.session.atmosphere.horizon_color,
-            .sun_intensity = self.session.atmosphere.sun_intensity,
-            .moon_intensity = self.session.atmosphere.moon_intensity,
-            .time = self.session.atmosphere.time.time_of_day,
-        };
-
         // TODO: Replace this stabilization toggle with a user-facing simple lighting setting.
         const simple_lighting_mode = true;
-        const ssao_enabled = ctx.settings.ssao_enabled and !render_system.getDisableSSAO() and !render_system.getDisableGPassDraw() and !safe_mode and !startup_light_render and !simple_lighting_mode;
         const lpv_quality = resolveLPVQuality(ctx.settings.lpv_quality_preset);
         const lpv_system = render_system.getLPVSystem();
         try lpv_system.setSettings(
@@ -335,40 +316,36 @@ pub const WorldScreen = struct {
         }
 
         const lpv_origin = lpv_system.getOrigin();
-        const frame_params = rhi_pkg.FrameRenderParams{
-            .cam_pos = camera.position,
-            .view_proj = view_proj_render,
-            .sun_dir = render_sun_dir,
+        const built_params = world_frame_params.build(.{
+            .camera = camera,
+            .settings = ctx.settings,
+            .render_system = render_system,
+            .screen_w = screen_w,
+            .screen_h = screen_h,
+            .render_sun_dir = render_sun_dir,
+            .sky_color = self.session.atmosphere.sky_color,
+            .horizon_color = self.session.atmosphere.horizon_color,
             .sun_intensity = self.session.atmosphere.sun_intensity,
+            .moon_intensity = self.session.atmosphere.moon_intensity,
+            .time_of_day = self.session.atmosphere.time.time_of_day,
             .fog_color = self.session.atmosphere.fog_color,
             .fog_density = self.session.atmosphere.fog_density,
-            .pbr_enabled = ctx.settings.pbr_enabled and render_system.getAtlas().has_pbr and !safe_mode and !simple_lighting_mode,
-            .simple_lighting_enabled = simple_lighting_mode,
-            .shadow_apply_to_beauty = shadow_beauty_active,
-            .shadow = .{
-                .distance = shadow_distance_active,
-                .resolution = ctx.settings.getShadowResolution(),
-                .pcf_samples = if (shadow_sandbox_active) @as(u8, 1) else ctx.settings.shadow_pcf_samples,
-                .cascade_blend = false,
-                .caster_distance = shadow_caster_distance_active,
-                .strength = if (safe_mode or !shadow_sandbox_active) 0.0 else 0.35,
-            },
-            .pbr_quality = ctx.settings.pbr_quality,
-            .exposure = ctx.settings.exposure,
-            .saturation = ctx.settings.saturation,
-            .volumetric_enabled = ctx.settings.volumetric_lighting_enabled and !safe_mode and !startup_light_render and !simple_lighting_mode,
-            .sun_shafts_enabled = ctx.settings.sun_shafts_enabled and shadow_sandbox_active and !safe_mode,
-            .sun_shafts_intensity = ctx.settings.sun_shafts_intensity,
-            .volumetric_density = ctx.settings.volumetric_density,
-            .volumetric_steps = ctx.settings.volumetric_steps,
-            .volumetric_scattering = ctx.settings.volumetric_scattering,
-            .ssao_enabled = ssao_enabled,
-            .lpv_enabled = ctx.settings.lpv_enabled and !startup_light_render and !simple_lighting_mode,
-            .lpv_intensity = ctx.settings.lpv_intensity,
+            .safe_mode = safe_mode,
+            .startup_light_render = startup_light_render,
+            .shadow_sandbox_active = shadow_sandbox_active,
+            .shadow_beauty_active = shadow_beauty_active,
+            .shadow_distance_active = shadow_distance_active,
+            .shadow_caster_distance_active = shadow_caster_distance_active,
+            .simple_lighting_mode = simple_lighting_mode,
             .lpv_cell_size = lpv_system.getCellSize(),
             .lpv_grid_size = lpv_system.getGridSize(),
             .lpv_origin = lpv_origin,
-        };
+        });
+        const aspect = built_params.aspect;
+        const taa_enabled = built_params.taa_enabled;
+        const view_proj_render = built_params.view_proj_render;
+        const frame_params = built_params.frame;
+        const ssao_enabled = built_params.ssao_enabled;
 
         const skip_world_render = render_system.getSafeRenderMode();
         if (!skip_world_render and !startup_loading) {
@@ -404,7 +381,7 @@ pub const WorldScreen = struct {
                 .taa_enabled = taa_enabled,
                 .viewport_width = render_w,
                 .viewport_height = render_h,
-                .sky_params = sky_params,
+                .sky_params = built_params.sky,
                 .shadow_sun_dir = shadow_sun_dir,
                 .main_shader = render_system.getShader(),
                 .env_map_handle = env_map_handle,
@@ -539,10 +516,10 @@ pub const WorldScreen = struct {
         }
 
         if (self.debug_menu.enabled) {
-            const feature_states = self.collectDebugStates(ctx, render_system);
+            const feature_states = world_debug.collectStates(self, ctx, render_system);
             const scroll_delta = ctx.input.getScrollDelta();
             if (self.debug_menu.draw(ui, feature_states, mouse_x, mouse_y, mouse_clicked, ctx.settings.ui_scale, scroll_delta.y)) |click| {
-                self.applyDebugFeatureToggle(click.feature, ctx, render_system, rhi, ctx.time.elapsed);
+                world_debug.applyToggle(self, click.feature, ctx, render_system, rhi, ctx.time.elapsed);
             }
         }
     }

--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -3,6 +3,7 @@ const UISystem = @import("../../engine/ui/ui_system.zig").UISystem;
 const Screen = @import("../screen.zig");
 const IScreen = Screen.IScreen;
 const EngineContext = Screen.EngineContext;
+const WorldContext = Screen.WorldContext;
 const GameSession = @import("../session.zig").GameSession;
 const IWorld = @import("../../world/world.zig").IWorld;
 const Vec3 = @import("../../engine/math/vec3.zig").Vec3;
@@ -51,7 +52,8 @@ const ShadowProbeInfo = struct {
 };
 
 pub const WorldScreen = struct {
-    context: EngineContext,
+    context: WorldContext,
+    parent_context: EngineContext,
     session: *GameSession,
     world: IWorld,
     last_debug_toggle_time: f32 = 0,
@@ -80,7 +82,8 @@ pub const WorldScreen = struct {
 
         const self = try allocator.create(WorldScreen);
         self.* = .{
-            .context = context,
+            .context = context.worldContext(),
+            .parent_context = context,
             .session = session,
             .world = world,
             .last_debug_toggle_time = 0,
@@ -125,7 +128,7 @@ pub const WorldScreen = struct {
             }
 
             if (ctx.input_mapper.isActionPressed(ctx.input, .ui_back)) {
-                const paused_screen = try PausedScreen.init(ctx.allocator, ctx);
+                const paused_screen = try PausedScreen.init(ctx.allocator, self.parent_context);
                 errdefer paused_screen.deinit(paused_screen);
                 ctx.screen_manager.pushScreen(paused_screen.screen());
                 return;
@@ -516,10 +519,15 @@ pub const WorldScreen = struct {
         }
 
         if (self.debug_menu.enabled) {
-            const feature_states = world_debug.collectStates(self, ctx, render_system);
+            const debug_state = world_debug.ScreenDebugState{
+                .session = self.session,
+                .last_debug_toggle_time = &self.last_debug_toggle_time,
+                .chunk_inspector_overlay = &self.chunk_inspector_overlay,
+            };
+            const feature_states = world_debug.collectStates(debug_state, ctx, render_system);
             const scroll_delta = ctx.input.getScrollDelta();
             if (self.debug_menu.draw(ui, feature_states, mouse_x, mouse_y, mouse_clicked, ctx.settings.ui_scale, scroll_delta.y)) |click| {
-                world_debug.applyToggle(self, click.feature, ctx, render_system, rhi, ctx.time.elapsed);
+                world_debug.applyToggle(debug_state, click.feature, ctx, render_system, rhi, ctx.time.elapsed);
             }
         }
     }

--- a/src/game/screens/world_debug.zig
+++ b/src/game/screens/world_debug.zig
@@ -1,0 +1,141 @@
+const DebugFeature = @import("../../engine/ui/debug_menu.zig").DebugFeature;
+const RenderSystem = @import("../../engine/graphics/render_system.zig").RenderSystem;
+const rhi_pkg = @import("../../engine/graphics/rhi.zig");
+const settings_data = @import("../settings/data.zig");
+const log = @import("../../engine/core/log.zig");
+
+pub fn collectStates(screen: anytype, ctx: anytype, render_system: *RenderSystem) [DebugFeature.count]bool {
+    var states: [DebugFeature.count]bool = @splat(false);
+    states[@intFromEnum(DebugFeature.wireframe)] = ctx.settings.wireframe_enabled;
+    states[@intFromEnum(DebugFeature.textures)] = ctx.settings.textures_enabled;
+    states[@intFromEnum(DebugFeature.vsync)] = ctx.settings.vsync;
+    states[@intFromEnum(DebugFeature.fps_counter)] = screen.session.debug_show_fps;
+    states[@intFromEnum(DebugFeature.block_info)] = screen.session.debug_show_block_info;
+    states[@intFromEnum(DebugFeature.shadow_sandbox)] = ctx.settings.shadow_sandbox_enabled;
+    states[@intFromEnum(DebugFeature.shadow_beauty)] = ctx.settings.shadow_beauty_enabled;
+    states[@intFromEnum(DebugFeature.shadow_probe)] = ctx.settings.shadow_probe_enabled;
+    states[@intFromEnum(DebugFeature.shadow_debug)] = ctx.settings.debug_shadows_active;
+    states[@intFromEnum(DebugFeature.shadow_cascade_index)] = ctx.settings.debug_shadow_cascade_index;
+    states[@intFromEnum(DebugFeature.shadow_caster_coverage)] = ctx.settings.debug_shadow_caster_coverage;
+    states[@intFromEnum(DebugFeature.shadow_seam_diag)] = ctx.settings.debug_shadow_seam_diag;
+    states[@intFromEnum(DebugFeature.direct_key_debug)] = ctx.settings.debug_direct_key_active;
+    states[@intFromEnum(DebugFeature.sky_fill_debug)] = ctx.settings.debug_sky_fill_active;
+    states[@intFromEnum(DebugFeature.block_light_debug)] = ctx.settings.debug_block_light_active;
+    states[@intFromEnum(DebugFeature.outdoor_factor_debug)] = ctx.settings.debug_outdoor_factor_active;
+    states[@intFromEnum(DebugFeature.timing_overlay)] = ctx.ui_manager.timing_overlay.enabled;
+    states[@intFromEnum(DebugFeature.lod_render)] = screen.session.world.lod_enabled;
+    states[@intFromEnum(DebugFeature.gpass_render)] = !render_system.getDisableGPassDraw();
+    states[@intFromEnum(DebugFeature.ssao)] = !render_system.getDisableSSAO();
+    states[@intFromEnum(DebugFeature.fog)] = screen.session.atmosphere.fog_enabled;
+    states[@intFromEnum(DebugFeature.lpv_overlay)] = ctx.settings.debug_lpv_overlay_active;
+    states[@intFromEnum(DebugFeature.frustum_debug)] = ctx.settings.debug_frustum_active;
+    states[@intFromEnum(DebugFeature.occlusion_debug)] = ctx.settings.debug_occlusion_active;
+    states[@intFromEnum(DebugFeature.creative_mode)] = screen.session.creative_mode;
+    states[@intFromEnum(DebugFeature.time_pause)] = screen.session.atmosphere.time.time_scale == 0.0;
+    states[@intFromEnum(DebugFeature.chunk_inspector)] = screen.chunk_inspector_overlay.enabled;
+    return states;
+}
+
+pub fn applyToggle(screen: anytype, feature: DebugFeature, ctx: anytype, render_system: *RenderSystem, rhi: *rhi_pkg.RHI, now: f32) void {
+    screen.last_debug_toggle_time = now;
+    switch (feature) {
+        .wireframe => {
+            ctx.settings.wireframe_enabled = !ctx.settings.wireframe_enabled;
+            rhi.setWireframe(ctx.settings.wireframe_enabled);
+        },
+        .textures => {
+            ctx.settings.textures_enabled = !ctx.settings.textures_enabled;
+            rhi.setTexturesEnabled(ctx.settings.textures_enabled);
+        },
+        .vsync => {
+            ctx.settings.vsync = !ctx.settings.vsync;
+            rhi.setVSync(ctx.settings.vsync);
+        },
+        .fps_counter => screen.session.debug_show_fps = !screen.session.debug_show_fps,
+        .block_info => screen.session.debug_show_block_info = !screen.session.debug_show_block_info,
+        .shadow_sandbox => {
+            ctx.settings.shadow_sandbox_enabled = !ctx.settings.shadow_sandbox_enabled;
+            if (!ctx.settings.shadow_sandbox_enabled) {
+                ctx.settings.shadow_beauty_enabled = false;
+                ctx.settings.shadow_probe_enabled = false;
+                settings_data.clearTerrainDebugViews(ctx.settings);
+                rhi.setDebugShadowView(false);
+                rhi.setShadowDebugChannel(resolveShadowDebugChannel(ctx.settings));
+            }
+        },
+        .shadow_beauty => {
+            ctx.settings.shadow_beauty_enabled = !ctx.settings.shadow_beauty_enabled;
+            if (ctx.settings.shadow_beauty_enabled and !render_system.getDisableShadowDraw()) ctx.settings.shadow_sandbox_enabled = true;
+        },
+        .shadow_probe => {
+            ctx.settings.shadow_probe_enabled = !ctx.settings.shadow_probe_enabled;
+            if (ctx.settings.shadow_probe_enabled and !render_system.getDisableShadowDraw()) ctx.settings.shadow_sandbox_enabled = true;
+        },
+        .shadow_debug, .shadow_cascade_index, .shadow_caster_coverage, .shadow_seam_diag => applyShadowDebugToggle(feature, ctx, render_system, rhi),
+        .direct_key_debug, .sky_fill_debug, .block_light_debug, .outdoor_factor_debug => applyTerrainDebugToggle(feature, ctx, rhi),
+        .timing_overlay => {
+            ctx.ui_manager.timing_overlay.toggle();
+            rhi.timing().setTimingEnabled(ctx.ui_manager.timing_overlay.enabled);
+        },
+        .lod_render => {
+            if (screen.session.world.lod == null) log.log.warn("LOD toggle requested but LOD system is not initialized", .{}) else screen.session.world.lod_enabled = !screen.session.world.lod_enabled;
+        },
+        .gpass_render => render_system.setDisableGPassDraw(!render_system.getDisableGPassDraw()),
+        .ssao => render_system.setDisableSSAO(!render_system.getDisableSSAO()),
+        .fog => screen.session.atmosphere.fog_enabled = !screen.session.atmosphere.fog_enabled,
+        .lpv_overlay => ctx.settings.debug_lpv_overlay_active = !ctx.settings.debug_lpv_overlay_active,
+        .frustum_debug => ctx.settings.debug_frustum_active = !ctx.settings.debug_frustum_active,
+        .occlusion_debug => ctx.settings.debug_occlusion_active = !ctx.settings.debug_occlusion_active,
+        .creative_mode => {
+            screen.session.creative_mode = !screen.session.creative_mode;
+            screen.session.player.setCreativeMode(screen.session.creative_mode);
+        },
+        .time_pause => screen.session.atmosphere.time.time_scale = if (screen.session.atmosphere.time.time_scale > 0) @as(f32, 0.0) else @as(f32, 1.0),
+        .chunk_inspector => screen.chunk_inspector_overlay.toggle(),
+    }
+}
+
+fn applyShadowDebugToggle(feature: DebugFeature, ctx: anytype, render_system: *RenderSystem, rhi: *rhi_pkg.RHI) void {
+    const enable = switch (feature) {
+        .shadow_debug => !ctx.settings.debug_shadows_active,
+        .shadow_cascade_index => !ctx.settings.debug_shadow_cascade_index,
+        .shadow_caster_coverage => !ctx.settings.debug_shadow_caster_coverage,
+        .shadow_seam_diag => !ctx.settings.debug_shadow_seam_diag,
+        else => unreachable,
+    };
+    if (enable and !render_system.getDisableShadowDraw()) ctx.settings.shadow_sandbox_enabled = true;
+    settings_data.clearTerrainDebugViews(ctx.settings);
+    switch (feature) {
+        .shadow_debug => ctx.settings.debug_shadows_active = enable,
+        .shadow_cascade_index => ctx.settings.debug_shadow_cascade_index = enable,
+        .shadow_caster_coverage => ctx.settings.debug_shadow_caster_coverage = enable,
+        .shadow_seam_diag => ctx.settings.debug_shadow_seam_diag = enable,
+        else => unreachable,
+    }
+    rhi.setDebugShadowView(settings_data.anyTerrainDebugActive(ctx.settings));
+    rhi.setShadowDebugChannel(resolveShadowDebugChannel(ctx.settings));
+}
+
+fn applyTerrainDebugToggle(feature: DebugFeature, ctx: anytype, rhi: *rhi_pkg.RHI) void {
+    const enable = switch (feature) {
+        .direct_key_debug => !ctx.settings.debug_direct_key_active,
+        .sky_fill_debug => !ctx.settings.debug_sky_fill_active,
+        .block_light_debug => !ctx.settings.debug_block_light_active,
+        .outdoor_factor_debug => !ctx.settings.debug_outdoor_factor_active,
+        else => unreachable,
+    };
+    settings_data.clearTerrainDebugViews(ctx.settings);
+    switch (feature) {
+        .direct_key_debug => ctx.settings.debug_direct_key_active = enable,
+        .sky_fill_debug => ctx.settings.debug_sky_fill_active = enable,
+        .block_light_debug => ctx.settings.debug_block_light_active = enable,
+        .outdoor_factor_debug => ctx.settings.debug_outdoor_factor_active = enable,
+        else => unreachable,
+    }
+    rhi.setDebugShadowView(settings_data.anyTerrainDebugActive(ctx.settings));
+    rhi.setShadowDebugChannel(resolveShadowDebugChannel(ctx.settings));
+}
+
+fn resolveShadowDebugChannel(settings: *const settings_data.Settings) u32 {
+    return @intFromEnum(settings_data.resolveShadowDebugChannel(settings));
+}

--- a/src/game/screens/world_debug.zig
+++ b/src/game/screens/world_debug.zig
@@ -3,8 +3,17 @@ const RenderSystem = @import("../../engine/graphics/render_system.zig").RenderSy
 const rhi_pkg = @import("../../engine/graphics/rhi.zig");
 const settings_data = @import("../settings/data.zig");
 const log = @import("../../engine/core/log.zig");
+const GameSession = @import("../session.zig").GameSession;
+const ChunkInspectorOverlay = @import("../../engine/ui/chunk_inspector_overlay.zig").ChunkInspectorOverlay;
+const WorldContext = @import("../screen.zig").WorldContext;
 
-pub fn collectStates(screen: anytype, ctx: anytype, render_system: *RenderSystem) [DebugFeature.count]bool {
+pub const ScreenDebugState = struct {
+    session: *GameSession,
+    last_debug_toggle_time: *f32,
+    chunk_inspector_overlay: *ChunkInspectorOverlay,
+};
+
+pub fn collectStates(screen: ScreenDebugState, ctx: WorldContext, render_system: *RenderSystem) [DebugFeature.count]bool {
     var states: [DebugFeature.count]bool = @splat(false);
     states[@intFromEnum(DebugFeature.wireframe)] = ctx.settings.wireframe_enabled;
     states[@intFromEnum(DebugFeature.textures)] = ctx.settings.textures_enabled;
@@ -36,8 +45,8 @@ pub fn collectStates(screen: anytype, ctx: anytype, render_system: *RenderSystem
     return states;
 }
 
-pub fn applyToggle(screen: anytype, feature: DebugFeature, ctx: anytype, render_system: *RenderSystem, rhi: *rhi_pkg.RHI, now: f32) void {
-    screen.last_debug_toggle_time = now;
+pub fn applyToggle(screen: ScreenDebugState, feature: DebugFeature, ctx: WorldContext, render_system: *RenderSystem, rhi: *rhi_pkg.RHI, now: f32) void {
+    screen.last_debug_toggle_time.* = now;
     switch (feature) {
         .wireframe => {
             ctx.settings.wireframe_enabled = !ctx.settings.wireframe_enabled;
@@ -95,7 +104,7 @@ pub fn applyToggle(screen: anytype, feature: DebugFeature, ctx: anytype, render_
     }
 }
 
-fn applyShadowDebugToggle(feature: DebugFeature, ctx: anytype, render_system: *RenderSystem, rhi: *rhi_pkg.RHI) void {
+fn applyShadowDebugToggle(feature: DebugFeature, ctx: WorldContext, render_system: *RenderSystem, rhi: *rhi_pkg.RHI) void {
     const enable = switch (feature) {
         .shadow_debug => !ctx.settings.debug_shadows_active,
         .shadow_cascade_index => !ctx.settings.debug_shadow_cascade_index,
@@ -116,7 +125,7 @@ fn applyShadowDebugToggle(feature: DebugFeature, ctx: anytype, render_system: *R
     rhi.setShadowDebugChannel(resolveShadowDebugChannel(ctx.settings));
 }
 
-fn applyTerrainDebugToggle(feature: DebugFeature, ctx: anytype, rhi: *rhi_pkg.RHI) void {
+fn applyTerrainDebugToggle(feature: DebugFeature, ctx: WorldContext, rhi: *rhi_pkg.RHI) void {
     const enable = switch (feature) {
         .direct_key_debug => !ctx.settings.debug_direct_key_active,
         .sky_fill_debug => !ctx.settings.debug_sky_fill_active,

--- a/src/game/screens/world_frame_params.zig
+++ b/src/game/screens/world_frame_params.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+
+const rhi_pkg = @import("../../engine/graphics/rhi.zig");
+const Vec3 = @import("../../engine/math/vec3.zig").Vec3;
+const Camera = @import("../../engine/graphics/camera.zig").Camera;
+const RenderSystem = @import("../../engine/graphics/render_system.zig").RenderSystem;
+const Settings = @import("../settings/data.zig").Settings;
+
+pub const BuildInput = struct {
+    camera: *Camera,
+    settings: *Settings,
+    render_system: *RenderSystem,
+    screen_w: f32,
+    screen_h: f32,
+    render_sun_dir: Vec3,
+    sky_color: Vec3,
+    horizon_color: Vec3,
+    sun_intensity: f32,
+    moon_intensity: f32,
+    time_of_day: f32,
+    fog_color: Vec3,
+    fog_density: f32,
+    safe_mode: bool,
+    startup_light_render: bool,
+    shadow_sandbox_active: bool,
+    shadow_beauty_active: bool,
+    shadow_distance_active: f32,
+    shadow_caster_distance_active: f32,
+    simple_lighting_mode: bool,
+    lpv_cell_size: f32,
+    lpv_grid_size: u32,
+    lpv_origin: Vec3,
+};
+
+pub const BuiltParams = struct {
+    aspect: f32,
+    taa_enabled: bool,
+    view_proj_render: @import("../../engine/math/mat4.zig").Mat4,
+    sky: rhi_pkg.SkyParams,
+    frame: rhi_pkg.FrameRenderParams,
+    ssao_enabled: bool,
+};
+
+pub fn build(input: BuildInput) BuiltParams {
+    const aspect = input.screen_w / input.screen_h;
+    const taa_enabled = input.settings.taa_enabled;
+    const view_proj_render = input.camera.getJitteredProjectionMatrixReverseZ(aspect, input.screen_w, input.screen_h, taa_enabled).multiply(input.camera.getViewMatrixOriginCentered());
+    const ssao_enabled = input.settings.ssao_enabled and !input.render_system.getDisableSSAO() and !input.render_system.getDisableGPassDraw() and !input.safe_mode and !input.startup_light_render and !input.simple_lighting_mode;
+
+    return .{
+        .aspect = aspect,
+        .taa_enabled = taa_enabled,
+        .view_proj_render = view_proj_render,
+        .sky = .{
+            .cam_pos = input.camera.position,
+            .cam_forward = input.camera.forward,
+            .cam_right = input.camera.right,
+            .cam_up = input.camera.up,
+            .aspect = aspect,
+            .tan_half_fov = @tan(input.camera.fov / 2.0),
+            .sun_dir = input.render_sun_dir,
+            .sky_color = input.sky_color,
+            .horizon_color = input.horizon_color,
+            .sun_intensity = input.sun_intensity,
+            .moon_intensity = input.moon_intensity,
+            .time = input.time_of_day,
+        },
+        .frame = .{
+            .cam_pos = input.camera.position,
+            .view_proj = view_proj_render,
+            .sun_dir = input.render_sun_dir,
+            .sun_intensity = input.sun_intensity,
+            .fog_color = input.fog_color,
+            .fog_density = input.fog_density,
+            .pbr_enabled = input.settings.pbr_enabled and input.render_system.getAtlas().has_pbr and !input.safe_mode and !input.simple_lighting_mode,
+            .simple_lighting_enabled = input.simple_lighting_mode,
+            .shadow_apply_to_beauty = input.shadow_beauty_active,
+            .shadow = .{
+                .distance = input.shadow_distance_active,
+                .resolution = input.settings.getShadowResolution(),
+                .pcf_samples = if (input.shadow_sandbox_active) @as(u8, 1) else input.settings.shadow_pcf_samples,
+                .cascade_blend = false,
+                .caster_distance = input.shadow_caster_distance_active,
+                .strength = if (input.safe_mode or !input.shadow_sandbox_active) 0.0 else 0.35,
+            },
+            .pbr_quality = input.settings.pbr_quality,
+            .exposure = input.settings.exposure,
+            .saturation = input.settings.saturation,
+            .volumetric_enabled = input.settings.volumetric_lighting_enabled and !input.safe_mode and !input.startup_light_render and !input.simple_lighting_mode,
+            .sun_shafts_enabled = input.settings.sun_shafts_enabled and input.shadow_sandbox_active and !input.safe_mode,
+            .sun_shafts_intensity = input.settings.sun_shafts_intensity,
+            .volumetric_density = input.settings.volumetric_density,
+            .volumetric_steps = input.settings.volumetric_steps,
+            .volumetric_scattering = input.settings.volumetric_scattering,
+            .ssao_enabled = ssao_enabled,
+            .lpv_enabled = input.settings.lpv_enabled and !input.startup_light_render and !input.simple_lighting_mode,
+            .lpv_intensity = input.settings.lpv_intensity,
+            .lpv_cell_size = input.lpv_cell_size,
+            .lpv_grid_size = input.lpv_grid_size,
+            .lpv_origin = input.lpv_origin,
+        },
+        .ssao_enabled = ssao_enabled,
+    };
+}

--- a/src/game/screens/world_frame_params.zig
+++ b/src/game/screens/world_frame_params.zig
@@ -1,5 +1,3 @@
-const std = @import("std");
-
 const rhi_pkg = @import("../../engine/graphics/rhi.zig");
 const Vec3 = @import("../../engine/math/vec3.zig").Vec3;
 const Camera = @import("../../engine/graphics/camera.zig").Camera;


### PR DESCRIPTION
## Summary
- Adds narrower screen context types for menu, settings, and world screen dependency boundaries.
- Extracts WorldScreen frame parameter construction and debug feature handling into focused modules.
- Caches environment map discovery outside draw and makes blocking resource pack reload feedback explicit.

## Verification
- `nix develop --command zig fmt src/`
- `nix develop --command zig build test` currently exits after shader validation on existing RHI/shadow test errors: memory not mapped, null shadow render pass/framebuffer.

Closes #542
Closes #543
Closes #544
Closes #545