### PR TITLE
refactor: split world screen and renderer responsibilities

### DIFF
--- a/src/game/screens/world.zig
+++ b/src/game/screens/world.zig
@@ -110,101 +110,12 @@ pub const WorldScreen = struct {
         const self: *@This() = @ptrCast(@alignCast(ptr));
         const ctx = self.context;
         const render_system = ctx.render_system;
-        const rhi = render_system.getRHI();
         const now = ctx.time.elapsed;
-        const can_toggle_debug = now - self.last_debug_toggle_time > 0.2;
         const benchmark_mode = ctx.benchmark_runner != null;
         const automated_capture = build_options.shadow_test_scene and build_options.screenshot_path.len > 0;
 
         if (!benchmark_mode and !automated_capture) {
-            if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_debug_menu)) {
-                self.debug_menu.toggle();
-                if (self.debug_menu.enabled) {
-                    ctx.input.setMouseCapture(@ptrCast(@alignCast(ctx.window_manager.window)), false);
-                } else {
-                    ctx.input.setMouseCapture(@ptrCast(@alignCast(ctx.window_manager.window)), true);
-                }
-                self.last_debug_toggle_time = now;
-            }
-
-            if (ctx.input_mapper.isActionPressed(ctx.input, .ui_back)) {
-                const paused_screen = try PausedScreen.init(ctx.allocator, self.parent_context);
-                errdefer paused_screen.deinit(paused_screen);
-                ctx.screen_manager.pushScreen(paused_screen.screen());
-                return;
-            }
-
-            if (ctx.input_mapper.isActionPressed(ctx.input, .tab_menu)) {
-                ctx.input.setMouseCapture(@ptrCast(@alignCast(ctx.window_manager.window)), !ctx.input.isMouseCaptured());
-            }
-            if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_wireframe)) {
-                ctx.settings.wireframe_enabled = !ctx.settings.wireframe_enabled;
-                rhi.setWireframe(ctx.settings.wireframe_enabled);
-                self.last_debug_toggle_time = now;
-            }
-            if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_textures)) {
-                ctx.settings.textures_enabled = !ctx.settings.textures_enabled;
-                rhi.setTexturesEnabled(ctx.settings.textures_enabled);
-                self.last_debug_toggle_time = now;
-            }
-            if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_vsync)) {
-                ctx.settings.vsync = !ctx.settings.vsync;
-                rhi.setVSync(ctx.settings.vsync);
-                self.last_debug_toggle_time = now;
-            }
-            if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_shadow_debug_vis)) {
-                log.log.info("Toggling shadow debug visualization (G pressed)", .{});
-                const enable = !ctx.settings.debug_shadows_active;
-                if (enable and !render_system.getDisableShadowDraw()) {
-                    ctx.settings.shadow_sandbox_enabled = true;
-                }
-                settings_data.clearTerrainDebugViews(ctx.settings);
-                ctx.settings.debug_shadows_active = enable;
-                rhi.setDebugShadowView(settings_data.anyTerrainDebugActive(ctx.settings));
-                rhi.setShadowDebugChannel(resolveShadowDebugChannel(ctx.settings));
-                self.last_debug_toggle_time = now;
-            }
-            if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_lod_render)) {
-                if (!self.world.isLODEnabled()) {
-                    log.log.warn("LOD toggle requested but LOD system is not initialized", .{});
-                } else {
-                    self.session.world.lod_enabled = !self.session.world.lod_enabled;
-                    log.log.info("LOD rendering {s}", .{if (self.session.world.lod_enabled) "enabled" else "disabled"});
-                }
-                self.last_debug_toggle_time = now;
-            }
-            if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_gpass_render)) {
-                const new_val = !render_system.getDisableGPassDraw();
-                render_system.setDisableGPassDraw(new_val);
-                log.log.info("G-pass rendering {s}", .{if (new_val) "disabled" else "enabled"});
-                self.last_debug_toggle_time = now;
-            }
-            if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_ssao)) {
-                const new_val = !render_system.getDisableSSAO();
-                render_system.setDisableSSAO(new_val);
-                log.log.info("SSAO {s}", .{if (new_val) "disabled" else "enabled"});
-                self.last_debug_toggle_time = now;
-            }
-            if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_fog)) {
-                self.session.atmosphere.fog_enabled = !self.session.atmosphere.fog_enabled;
-                log.log.info("Fog {s}", .{if (self.session.atmosphere.fog_enabled) "enabled" else "disabled"});
-                self.last_debug_toggle_time = now;
-            }
-            if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_lpv_overlay)) {
-                ctx.settings.debug_lpv_overlay_active = !ctx.settings.debug_lpv_overlay_active;
-                log.log.info("LPV overlay {s}", .{if (ctx.settings.debug_lpv_overlay_active) "enabled" else "disabled"});
-                self.last_debug_toggle_time = now;
-            }
-            if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_frustum_debug)) {
-                ctx.settings.debug_frustum_active = !ctx.settings.debug_frustum_active;
-                log.log.info("Frustum debug {s}", .{if (ctx.settings.debug_frustum_active) "enabled" else "disabled"});
-                self.last_debug_toggle_time = now;
-            }
-            if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_chunk_inspector)) {
-                self.chunk_inspector_overlay.toggle();
-                log.log.info("Chunk inspector {s}", .{if (self.chunk_inspector_overlay.enabled) "enabled" else "disabled"});
-                self.last_debug_toggle_time = now;
-            }
+            if (try self.processControls(now)) return;
         }
 
         if (benchmark_mode) {
@@ -223,6 +134,100 @@ pub const WorldScreen = struct {
         }
 
         self.maybeLogStartupDiagnostic(now);
+    }
+
+    fn processControls(self: *@This(), now: f32) !bool {
+        const ctx = self.context;
+        const render_system = ctx.render_system;
+        const rhi = render_system.getRHI();
+        const can_toggle_debug = now - self.last_debug_toggle_time > 0.2;
+
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_debug_menu)) {
+            self.debug_menu.toggle();
+            ctx.input.setMouseCapture(@ptrCast(@alignCast(ctx.window_manager.window)), !self.debug_menu.enabled);
+            self.last_debug_toggle_time = now;
+        }
+
+        if (ctx.input_mapper.isActionPressed(ctx.input, .ui_back)) {
+            const paused_screen = try PausedScreen.init(ctx.allocator, self.parent_context);
+            errdefer paused_screen.deinit(paused_screen);
+            ctx.screen_manager.pushScreen(paused_screen.screen());
+            return true;
+        }
+
+        if (ctx.input_mapper.isActionPressed(ctx.input, .tab_menu)) {
+            ctx.input.setMouseCapture(@ptrCast(@alignCast(ctx.window_manager.window)), !ctx.input.isMouseCaptured());
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_wireframe)) {
+            ctx.settings.wireframe_enabled = !ctx.settings.wireframe_enabled;
+            rhi.setWireframe(ctx.settings.wireframe_enabled);
+            self.last_debug_toggle_time = now;
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_textures)) {
+            ctx.settings.textures_enabled = !ctx.settings.textures_enabled;
+            rhi.setTexturesEnabled(ctx.settings.textures_enabled);
+            self.last_debug_toggle_time = now;
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_vsync)) {
+            ctx.settings.vsync = !ctx.settings.vsync;
+            rhi.setVSync(ctx.settings.vsync);
+            self.last_debug_toggle_time = now;
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_shadow_debug_vis)) {
+            log.log.info("Toggling shadow debug visualization (G pressed)", .{});
+            const enable = !ctx.settings.debug_shadows_active;
+            if (enable and !render_system.getDisableShadowDraw()) {
+                ctx.settings.shadow_sandbox_enabled = true;
+            }
+            settings_data.clearTerrainDebugViews(ctx.settings);
+            ctx.settings.debug_shadows_active = enable;
+            rhi.setDebugShadowView(settings_data.anyTerrainDebugActive(ctx.settings));
+            rhi.setShadowDebugChannel(resolveShadowDebugChannel(ctx.settings));
+            self.last_debug_toggle_time = now;
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_lod_render)) {
+            if (!self.world.isLODEnabled()) {
+                log.log.warn("LOD toggle requested but LOD system is not initialized", .{});
+            } else {
+                self.session.world.lod_enabled = !self.session.world.lod_enabled;
+                log.log.info("LOD rendering {s}", .{if (self.session.world.lod_enabled) "enabled" else "disabled"});
+            }
+            self.last_debug_toggle_time = now;
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_gpass_render)) {
+            const new_val = !render_system.getDisableGPassDraw();
+            render_system.setDisableGPassDraw(new_val);
+            log.log.info("G-pass rendering {s}", .{if (new_val) "disabled" else "enabled"});
+            self.last_debug_toggle_time = now;
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_ssao)) {
+            const new_val = !render_system.getDisableSSAO();
+            render_system.setDisableSSAO(new_val);
+            log.log.info("SSAO {s}", .{if (new_val) "disabled" else "enabled"});
+            self.last_debug_toggle_time = now;
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_fog)) {
+            self.session.atmosphere.fog_enabled = !self.session.atmosphere.fog_enabled;
+            log.log.info("Fog {s}", .{if (self.session.atmosphere.fog_enabled) "enabled" else "disabled"});
+            self.last_debug_toggle_time = now;
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_lpv_overlay)) {
+            ctx.settings.debug_lpv_overlay_active = !ctx.settings.debug_lpv_overlay_active;
+            log.log.info("LPV overlay {s}", .{if (ctx.settings.debug_lpv_overlay_active) "enabled" else "disabled"});
+            self.last_debug_toggle_time = now;
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_frustum_debug)) {
+            ctx.settings.debug_frustum_active = !ctx.settings.debug_frustum_active;
+            log.log.info("Frustum debug {s}", .{if (ctx.settings.debug_frustum_active) "enabled" else "disabled"});
+            self.last_debug_toggle_time = now;
+        }
+        if (can_toggle_debug and ctx.input_mapper.isActionPressed(ctx.input, .toggle_chunk_inspector)) {
+            self.chunk_inspector_overlay.toggle();
+            log.log.info("Chunk inspector {s}", .{if (self.chunk_inspector_overlay.enabled) "enabled" else "disabled"});
+            self.last_debug_toggle_time = now;
+        }
+
+        return false;
     }
 
     fn maybeLogStartupDiagnostic(self: *@This(), now: f32) void {

--- a/src/game/session.zig
+++ b/src/game/session.zig
@@ -31,12 +31,7 @@ const GameAction = input_mapper_pkg.GameAction;
 
 const CSM = @import("../engine/graphics/csm.zig");
 const UISystem = @import("../engine/ui/ui_system.zig").UISystem;
-const Color = @import("../engine/ui/ui_system.zig").Color;
-const Font = @import("../engine/ui/font.zig");
-const Widgets = @import("../engine/ui/widgets.zig");
-const region_pkg = @import("../world/worldgen/region.zig");
-const hotbar = @import("ui/hotbar.zig");
-const worldToChunkFromFloat = @import("../world/chunk.zig").worldToChunkFromFloat;
+const session_hud = @import("ui/session_hud.zig");
 
 fn getenv(name: [:0]const u8) ?[]const u8 {
     const value = std.c.getenv(name) orelse return null;
@@ -317,108 +312,7 @@ pub const GameSession = struct {
     }
 
     pub fn drawHUD(self: *GameSession, ui: *UISystem, atlas: *const TextureAtlas, active_pack: ?[]const u8, fps: f32, screen_w: f32, screen_h: f32, mouse_x: f32, mouse_y: f32, mouse_clicked: bool) !void {
-        if (self.map_controller.show_map) {
-            try self.map_controller.draw(ui, screen_w, screen_h, &self.world_map, self.world.generator, self.camera.position, self.allocator);
-            return;
-        }
-
-        if (self.debug_show_fps) {
-            ui.drawRect(.{ .x = 10, .y = 10, .width = 80, .height = 30 }, Color.rgba(0, 0, 0, 0.7));
-            Font.drawNumber(ui, @intFromFloat(fps), 15, 15, Color.white);
-        }
-
-        const stats = self.world.getStats();
-        const rs = self.world.getRenderStats();
-        const pc = worldToChunkFromFloat(self.camera.position.x, self.camera.position.z);
-        const hy: f32 = 50.0;
-        const fault_count = self.rhi.query().getFaultCount();
-        const hud_h: f32 = if (fault_count > 0) 230 else 210;
-        ui.drawRect(.{ .x = 10, .y = hy, .width = 220, .height = hud_h }, Color.rgba(0, 0, 0, 0.6));
-        Font.drawText(ui, "POS:", 15, hy + 5, 1.5, Color.white);
-        Font.drawNumber(ui, pc.chunk_x, 120, hy + 5, Color.white);
-        Font.drawNumber(ui, pc.chunk_z, 170, hy + 5, Color.white);
-        Font.drawText(ui, "CHUNKS:", 15, hy + 25, 1.5, Color.white);
-        Font.drawNumber(ui, @intCast(stats.chunks_loaded), 140, hy + 25, Color.white);
-        Font.drawText(ui, "VISIBLE:", 15, hy + 45, 1.5, Color.white);
-        Font.drawNumber(ui, @intCast(rs.chunks_rendered), 140, hy + 45, Color.white);
-
-        if (self.world.getLODStats()) |ls| {
-            Font.drawText(ui, "LODS:", 15, hy + 65, 1.5, Color.rgba(0.5, 0.8, 1.0, 1.0));
-            Font.drawNumber(ui, @intCast(ls.totalLoaded()), 140, hy + 65, Color.rgba(0.5, 0.8, 1.0, 1.0));
-        }
-
-        Font.drawText(ui, "QUEUED GEN:", 15, hy + 85, 1.5, Color.white);
-        Font.drawNumber(ui, @intCast(stats.gen_queue), 140, hy + 85, Color.white);
-        Font.drawText(ui, "QUEUED MESH:", 15, hy + 105, 1.5, Color.white);
-        Font.drawNumber(ui, @intCast(stats.mesh_queue), 140, hy + 105, Color.white);
-        Font.drawText(ui, "PENDING UP:", 15, hy + 125, 1.5, Color.white);
-        Font.drawNumber(ui, @intCast(stats.upload_queue), 140, hy + 125, Color.white);
-        const h = self.atmosphere.getHours();
-        const hr = @as(i32, @intFromFloat(h));
-        const mn = @as(i32, @intFromFloat((h - @as(f32, @floatFromInt(hr))) * 60.0));
-        Font.drawText(ui, "TIME:", 15, hy + 145, 1.5, Color.white);
-        Font.drawNumber(ui, hr, 100, hy + 145, Color.white);
-        Font.drawText(ui, ":", 125, hy + 145, 1.5, Color.white);
-        Font.drawNumber(ui, mn, 140, hy + 145, Color.white);
-        Font.drawText(ui, "SUN:", 15, hy + 165, 1.5, Color.white);
-        Font.drawNumber(ui, @intFromFloat(self.atmosphere.sun_intensity * 100.0), 100, hy + 165, Color.white);
-
-        const px_i: i32 = @intFromFloat(self.camera.position.x);
-        const pz_i: i32 = @intFromFloat(self.camera.position.z);
-        const region = self.world.generator.getRegionInfo(px_i, pz_i);
-        const c3 = region_pkg.getRoleColor(region.role);
-        Font.drawText(ui, "ROLE:", 15, hy + 185, 1.5, Color.rgba(c3[0], c3[1], c3[2], 1.0));
-        var buf: [32]u8 = undefined;
-        const label = std.fmt.bufPrint(&buf, "{s}", .{@tagName(region.role)}) catch "???";
-        Font.drawText(ui, label, 100, hy + 165, 1.5, Color.white);
-
-        if (fault_count > 0) {
-            var buf_f: [32]u8 = undefined;
-            const fault_text = std.fmt.bufPrint(&buf_f, "GPU FAULTS: {d}", .{fault_count}) catch "GPU FAULTS: ???";
-            Font.drawText(ui, fault_text, 15, hy + 185, 1.5, Color.red);
-        }
-
-        if (self.debug_show_block_info) {
-            if (self.player.target_block) |target| {
-                const block_type = self.world.getBlock(target.x, target.y, target.z);
-                const tiles = atlas.getTilesForBlock(@intFromEnum(block_type));
-                const ux = screen_w - 350;
-                var uy: f32 = 10;
-                ui.drawRect(.{ .x = ux - 10, .y = uy, .width = 350, .height = 80 }, Color.rgba(0, 0, 0, 0.7));
-                var buf2: [128]u8 = undefined;
-                const pos_text = std.fmt.bufPrint(&buf2, "BLOCK: {s} ({}, {}, {})", .{ @tagName(block_type), target.x, target.y, target.z }) catch "BLOCK: ???";
-                Font.drawText(ui, pos_text, ux, uy + 5, 1.5, Color.white);
-                uy += 25;
-                const tiles_text = std.fmt.bufPrint(&buf2, "TILES: T:{} B:{} S:{}", .{ tiles.top, tiles.bottom, tiles.side }) catch "TILES: ???";
-                Font.drawText(ui, tiles_text, ux, uy + 5, 1.5, Color.white);
-                uy += 25;
-                const pack_name = if (active_pack) |ap| ap else "Default";
-                const pack_text = std.fmt.bufPrint(&buf2, "PACK: {s}", .{pack_name}) catch "PACK: ???";
-                Font.drawText(ui, pack_text, ux, uy + 5, 1.5, Color.white);
-            }
-        }
-
-        if (!self.inventory_ui_state.visible) {
-            const cx = screen_w / 2.0;
-            const cy = screen_h / 2.0;
-            ui.drawRect(.{ .x = cx - 10, .y = cy - 1, .width = 20, .height = 2 }, Color.white);
-            ui.drawRect(.{ .x = cx - 1, .y = cy - 10, .width = 2, .height = 20 }, Color.white);
-        }
-
-        if (!self.inventory_ui_state.visible) hotbar.drawDefault(ui, &self.inventory, screen_w, screen_h);
-
-        if (self.inventory_ui_state.visible) {
-            const time_action = self.inventory_ui_state.draw(ui, &self.inventory, mouse_x, mouse_y, mouse_clicked, screen_w, screen_h);
-            if (time_action) |time_idx| {
-                const times = [_]f32{ 0.0, 0.25, 0.5, 0.75 };
-                if (time_idx < 4) self.atmosphere.setTimeOfDay(times[time_idx]);
-            }
-        }
-
-        if (self.creative_mode) {
-            Font.drawText(ui, "CREATIVE", screen_w - 100, 10, 1.5, Color.rgba(100, 200, 255, 200));
-            if (self.player.fly_mode) Font.drawText(ui, "FLYING", screen_w - 80, 25, 1.5, Color.rgba(150, 255, 150, 200));
-        }
+        try session_hud.draw(self, ui, atlas, active_pack, fps, screen_w, screen_h, mouse_x, mouse_y, mouse_clicked);
     }
 };
 

--- a/src/game/ui/session_hud.zig
+++ b/src/game/ui/session_hud.zig
@@ -1,0 +1,114 @@
+const std = @import("std");
+
+const UISystem = @import("../../engine/ui/ui_system.zig").UISystem;
+const Color = @import("../../engine/ui/ui_system.zig").Color;
+const Font = @import("../../engine/ui/font.zig");
+const TextureAtlas = @import("../../engine/graphics/texture_atlas.zig").TextureAtlas;
+const hotbar = @import("hotbar.zig");
+const region_pkg = @import("../../world/worldgen/region.zig");
+const worldToChunkFromFloat = @import("../../world/chunk.zig").worldToChunkFromFloat;
+
+pub fn draw(session: anytype, ui: *UISystem, atlas: *const TextureAtlas, active_pack: ?[]const u8, fps: f32, screen_w: f32, screen_h: f32, mouse_x: f32, mouse_y: f32, mouse_clicked: bool) !void {
+    if (session.map_controller.show_map) {
+        try session.map_controller.draw(ui, screen_w, screen_h, &session.world_map, session.world.generator, session.camera.position, session.allocator);
+        return;
+    }
+
+    if (session.debug_show_fps) {
+        ui.drawRect(.{ .x = 10, .y = 10, .width = 80, .height = 30 }, Color.rgba(0, 0, 0, 0.7));
+        Font.drawNumber(ui, @intFromFloat(fps), 15, 15, Color.white);
+    }
+
+    const stats = session.world.getStats();
+    const rs = session.world.getRenderStats();
+    const pc = worldToChunkFromFloat(session.camera.position.x, session.camera.position.z);
+    const hy: f32 = 50.0;
+    const fault_count = session.rhi.query().getFaultCount();
+    const hud_h: f32 = if (fault_count > 0) 230 else 210;
+    ui.drawRect(.{ .x = 10, .y = hy, .width = 220, .height = hud_h }, Color.rgba(0, 0, 0, 0.6));
+    Font.drawText(ui, "POS:", 15, hy + 5, 1.5, Color.white);
+    Font.drawNumber(ui, pc.chunk_x, 120, hy + 5, Color.white);
+    Font.drawNumber(ui, pc.chunk_z, 170, hy + 5, Color.white);
+    Font.drawText(ui, "CHUNKS:", 15, hy + 25, 1.5, Color.white);
+    Font.drawNumber(ui, @intCast(stats.chunks_loaded), 140, hy + 25, Color.white);
+    Font.drawText(ui, "VISIBLE:", 15, hy + 45, 1.5, Color.white);
+    Font.drawNumber(ui, @intCast(rs.chunks_rendered), 140, hy + 45, Color.white);
+
+    if (session.world.getLODStats()) |ls| {
+        Font.drawText(ui, "LODS:", 15, hy + 65, 1.5, Color.rgba(0.5, 0.8, 1.0, 1.0));
+        Font.drawNumber(ui, @intCast(ls.totalLoaded()), 140, hy + 65, Color.rgba(0.5, 0.8, 1.0, 1.0));
+    }
+
+    Font.drawText(ui, "QUEUED GEN:", 15, hy + 85, 1.5, Color.white);
+    Font.drawNumber(ui, @intCast(stats.gen_queue), 140, hy + 85, Color.white);
+    Font.drawText(ui, "QUEUED MESH:", 15, hy + 105, 1.5, Color.white);
+    Font.drawNumber(ui, @intCast(stats.mesh_queue), 140, hy + 105, Color.white);
+    Font.drawText(ui, "PENDING UP:", 15, hy + 125, 1.5, Color.white);
+    Font.drawNumber(ui, @intCast(stats.upload_queue), 140, hy + 125, Color.white);
+    const h = session.atmosphere.getHours();
+    const hr = @as(i32, @intFromFloat(h));
+    const mn = @as(i32, @intFromFloat((h - @as(f32, @floatFromInt(hr))) * 60.0));
+    Font.drawText(ui, "TIME:", 15, hy + 145, 1.5, Color.white);
+    Font.drawNumber(ui, hr, 100, hy + 145, Color.white);
+    Font.drawText(ui, ":", 125, hy + 145, 1.5, Color.white);
+    Font.drawNumber(ui, mn, 140, hy + 145, Color.white);
+    Font.drawText(ui, "SUN:", 15, hy + 165, 1.5, Color.white);
+    Font.drawNumber(ui, @intFromFloat(session.atmosphere.sun_intensity * 100.0), 100, hy + 165, Color.white);
+
+    const px_i: i32 = @intFromFloat(session.camera.position.x);
+    const pz_i: i32 = @intFromFloat(session.camera.position.z);
+    const region = session.world.generator.getRegionInfo(px_i, pz_i);
+    const c3 = region_pkg.getRoleColor(region.role);
+    Font.drawText(ui, "ROLE:", 15, hy + 185, 1.5, Color.rgba(c3[0], c3[1], c3[2], 1.0));
+    var buf: [32]u8 = undefined;
+    const label = std.fmt.bufPrint(&buf, "{s}", .{@tagName(region.role)}) catch "???";
+    Font.drawText(ui, label, 100, hy + 165, 1.5, Color.white);
+
+    if (fault_count > 0) {
+        var buf_f: [32]u8 = undefined;
+        const fault_text = std.fmt.bufPrint(&buf_f, "GPU FAULTS: {d}", .{fault_count}) catch "GPU FAULTS: ???";
+        Font.drawText(ui, fault_text, 15, hy + 185, 1.5, Color.red);
+    }
+
+    if (session.debug_show_block_info) {
+        if (session.player.target_block) |target| {
+            const block_type = session.world.getBlock(target.x, target.y, target.z);
+            const tiles = atlas.getTilesForBlock(@intFromEnum(block_type));
+            const ux = screen_w - 350;
+            var uy: f32 = 10;
+            ui.drawRect(.{ .x = ux - 10, .y = uy, .width = 350, .height = 80 }, Color.rgba(0, 0, 0, 0.7));
+            var buf2: [128]u8 = undefined;
+            const pos_text = std.fmt.bufPrint(&buf2, "BLOCK: {s} ({}, {}, {})", .{ @tagName(block_type), target.x, target.y, target.z }) catch "BLOCK: ???";
+            Font.drawText(ui, pos_text, ux, uy + 5, 1.5, Color.white);
+            uy += 25;
+            const tiles_text = std.fmt.bufPrint(&buf2, "TILES: T:{} B:{} S:{}", .{ tiles.top, tiles.bottom, tiles.side }) catch "TILES: ???";
+            Font.drawText(ui, tiles_text, ux, uy + 5, 1.5, Color.white);
+            uy += 25;
+            const pack_name = if (active_pack) |ap| ap else "Default";
+            const pack_text = std.fmt.bufPrint(&buf2, "PACK: {s}", .{pack_name}) catch "PACK: ???";
+            Font.drawText(ui, pack_text, ux, uy + 5, 1.5, Color.white);
+        }
+    }
+
+    if (!session.inventory_ui_state.visible) {
+        const cx = screen_w / 2.0;
+        const cy = screen_h / 2.0;
+        ui.drawRect(.{ .x = cx - 10, .y = cy - 1, .width = 20, .height = 2 }, Color.white);
+        ui.drawRect(.{ .x = cx - 1, .y = cy - 10, .width = 2, .height = 20 }, Color.white);
+    }
+
+    if (!session.inventory_ui_state.visible) hotbar.drawDefault(ui, &session.inventory, screen_w, screen_h);
+
+    if (session.inventory_ui_state.visible) {
+        const time_action = session.inventory_ui_state.draw(ui, &session.inventory, mouse_x, mouse_y, mouse_clicked, screen_w, screen_h);
+        if (time_action) |time_idx| {
+            const times = [_]f32{ 0.0, 0.25, 0.5, 0.75 };
+            if (time_idx < 4) session.atmosphere.setTimeOfDay(times[time_idx]);
+        }
+    }
+
+    if (session.creative_mode) {
+        Font.drawText(ui, "CREATIVE", screen_w - 100, 10, 1.5, Color.rgba(100, 200, 255, 200));
+        if (session.player.fly_mode) Font.drawText(ui, "FLYING", screen_w - 80, 25, 1.5, Color.rgba(150, 255, 150, 200));
+    }
+}

--- a/src/world/world_renderer.zig
+++ b/src/world/world_renderer.zig
@@ -25,9 +25,30 @@ const build_options = @import("build_options");
 const runtime_env = @import("../engine/core/runtime_env.zig");
 
 pub const MAX_MDI_CHUNKS: usize = 16384;
+const MB: usize = 1024 * 1024;
+const GPU_BLOCK_SLOT_SIZE: usize = 16 * 16 * 256;
 
 fn getenv(name: [:0]const u8) ?[]const u8 {
     return runtime_env.getenv(name);
+}
+
+fn parseEnabledEnv(value: ?[]const u8, default_enabled: bool) bool {
+    const val = value orelse return default_enabled;
+    return !(std.mem.eql(u8, val, "0") or std.mem.eql(u8, val, "false"));
+}
+
+pub fn chooseVertexCapacityMb(vram_mb: usize, strict_safe_mode: bool) usize {
+    if (strict_safe_mode) return @min(@as(usize, 256), @max(@as(usize, 128), @divFloor(vram_mb, 8)));
+    if (vram_mb >= 8192) return 512;
+    if (vram_mb >= 6144) return 384;
+    if (vram_mb >= 4096) return 256;
+    return 128;
+}
+
+pub fn chooseGpuBlockCapacity(vram_mb: usize) usize {
+    const block_budget_mb: usize = if (vram_mb >= 8192) 512 else if (vram_mb >= 6144) 384 else if (vram_mb >= 4096) 256 else 128;
+    const max_by_budget = (block_budget_mb * MB) / GPU_BLOCK_SLOT_SIZE;
+    return @min(MAX_MDI_CHUNKS, max_by_budget);
 }
 
 pub const RenderStats = struct {
@@ -42,6 +63,28 @@ pub const ShadowStats = struct {
     chunks_rendered: u32 = 0,
     chunks_culled: u32 = 0,
 };
+
+test "WorldRenderer chooses vertex capacity from VRAM tier" {
+    try std.testing.expectEqual(@as(usize, 128), chooseVertexCapacityMb(2048, false));
+    try std.testing.expectEqual(@as(usize, 256), chooseVertexCapacityMb(4096, false));
+    try std.testing.expectEqual(@as(usize, 384), chooseVertexCapacityMb(6144, false));
+    try std.testing.expectEqual(@as(usize, 512), chooseVertexCapacityMb(8192, false));
+}
+
+test "WorldRenderer clamps strict safe vertex capacity" {
+    try std.testing.expectEqual(@as(usize, 128), chooseVertexCapacityMb(512, true));
+    try std.testing.expectEqual(@as(usize, 128), chooseVertexCapacityMb(1024, true));
+    try std.testing.expectEqual(@as(usize, 256), chooseVertexCapacityMb(4096, true));
+    try std.testing.expectEqual(@as(usize, 256), chooseVertexCapacityMb(8192, true));
+}
+
+test "WorldRenderer parses boolean feature env" {
+    try std.testing.expect(!parseEnabledEnv("0", true));
+    try std.testing.expect(!parseEnabledEnv("false", true));
+    try std.testing.expect(parseEnabledEnv("1", false));
+    try std.testing.expect(parseEnabledEnv(null, true));
+    try std.testing.expect(!parseEnabledEnv(null, false));
+}
 
 pub const RenderLayer = enum {
     all,
@@ -92,22 +135,8 @@ pub const WorldRenderer = struct {
 
         const vram_bytes = query.getDeviceLocalVramBytes();
         const vram_mb = vram_bytes / (1024 * 1024);
-        const MB: usize = 1024 * 1024;
-
-        const vertex_capacity_mb: usize = if (strict_safe_mode)
-            @min(@as(usize, 256), @max(@as(usize, 128), @divFloor(vram_mb, 8)))
-        else blk: {
-            const budget_mb = if (vram_mb >= 8192) @as(usize, 512) else if (vram_mb >= 6144) @as(usize, 384) else if (vram_mb >= 4096) @as(usize, 256) else @as(usize, 128);
-            break :blk budget_mb;
-        };
-
-        const gpu_block_capacity: usize = blk: {
-            const slot_size = 16 * 16 * 256;
-            const block_budget_mb = if (vram_mb >= 8192) @as(usize, 512) else if (vram_mb >= 6144) @as(usize, 384) else if (vram_mb >= 4096) @as(usize, 256) else @as(usize, 128);
-            const budget_bytes = block_budget_mb * MB;
-            const max_by_budget = budget_bytes / slot_size;
-            break :blk @min(MAX_MDI_CHUNKS, max_by_budget);
-        };
+        const vertex_capacity_mb = chooseVertexCapacityMb(vram_mb, strict_safe_mode);
+        const gpu_block_capacity = chooseGpuBlockCapacity(vram_mb);
 
         log.log.info("VRAM budget: {}MB | vertex_allocator: {}MB | gpu_block_buffer: {} slots", .{ vram_mb, vertex_capacity_mb, gpu_block_capacity });
 
@@ -120,11 +149,7 @@ pub const WorldRenderer = struct {
         const vertex_allocator = try allocator.create(GlobalVertexAllocator);
         vertex_allocator.* = try GlobalVertexAllocator.init(allocator, rm, query, vertex_capacity_mb);
 
-        const gpu_meshing_env = getenv("ZIGCRAFT_ENABLE_GPU_MESHING");
-        const gpu_meshing_enabled = if (gpu_meshing_env) |val|
-            !(std.mem.eql(u8, val, "0") or std.mem.eql(u8, val, "false"))
-        else
-            false;
+        const gpu_meshing_enabled = parseEnabledEnv(getenv("ZIGCRAFT_ENABLE_GPU_MESHING"), false);
 
         const max_chunks = MAX_MDI_CHUNKS;
         var instance_buffers: [rhi_mod.MAX_FRAMES_IN_FLIGHT]rhi_mod.BufferHandle = undefined;
@@ -164,13 +189,7 @@ pub const WorldRenderer = struct {
             log.log.info("Safe mode: GPU meshing disabled, using CPU meshing fallback", .{});
         }
 
-        const force_mdi_fallback = blk: {
-            const env_val = getenv("ZIGCRAFT_FORCE_MDI_FALLBACK");
-            break :blk if (env_val) |val|
-                !(std.mem.eql(u8, val, "0") or std.mem.eql(u8, val, "false"))
-            else
-                true;
-        };
+        const force_mdi_fallback = parseEnabledEnv(getenv("ZIGCRAFT_FORCE_MDI_FALLBACK"), true);
         if (force_mdi_fallback) {
             log.log.info("MDI chunk rendering disabled by default due missing-near-chunk artifacts; set ZIGCRAFT_FORCE_MDI_FALLBACK=0 to test indirect draws", .{});
         }


### PR DESCRIPTION
## Summary
- Extract world-screen control handling out of the main update flow.
- Move gameplay HUD rendering into a dedicated UI module.
- Isolate renderer budget/feature policy helpers and add focused tests.

## Verification
- `nix develop --command zig fmt src/`
- `nix develop --command zig build`
- `nix develop --command zig build test` currently reaches existing Vulkan/shadow runtime failures (`memory not mapped`, swapchain `OutOfMemory`, null shadow pass), not compile errors from this change.