### PR TITLE
fix: remove erroneous green tint from grass block dirt side face

### DIFF
--- a/src/world/meshing/greedy_mesher.zig
+++ b/src/world/meshing/greedy_mesher.zig
@@ -180,8 +180,8 @@ fn addGreedyFace(
         .south => Face.north,
         else => return error.UnsupportedFace,
     };
-    const base_col = block_def.getFaceColor(face);
-    const col = [3]f32{ base_col[0] * tint[0], base_col[1] * tint[1], base_col[2] * tint[2] };
+    const shade = face.getShade();
+    const col = [3]f32{ shade * tint[0], shade * tint[1], shade * tint[2] };
     const norm = face.getNormal();
     const nf = [3]f32{ @floatFromInt(norm[0]), @floatFromInt(norm[1]), @floatFromInt(norm[2]) };
     const tiles = atlas.getTilesForBlock(@intFromEnum(block_def.id));


### PR DESCRIPTION
## Summary
- Remove erroneous green default_color tint from grass block side faces
- Grass block side texture (grass_side.png) contains both grass and dirt pixels; the dirt portion was incorrectly tinted green
- Dirt blocks are unaffected and render with their correct brown color

## Fix
In `src/world/meshing/greedy_mesher.zig`, stop multiplying textured face colors by `default_color` (which was acting as an unwanted texture tint). Face shading and explicit biome tint are preserved.

## Testing
- `zig fmt` and `zig build test` pass (Vulkan smoke tests fail in this environment but are pre-existing)