### PR TITLE
fix(ci): revert GLM-5.1 to MiniMax-M2.7 in failing workflows

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -4,7 +4,7 @@ name: opencode-audit
 # - OPENCODE_PAT: Classic PAT with `repo` scope OR fine-grained PAT with:
 #     Contents: Read, Issues: Read & Write, Pull requests: Read & Write
 #   Without proper scopes, gh issue create and label operations will fail.
-# - ZHIPU_API_KEY: API key for the Zhipu AI GLM-5.1 model
+# - MINIMAX_API_KEY: API key for the MiniMax M2.7 model
 
 on:
   schedule:
@@ -20,7 +20,7 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     permissions:
       id-token: write
       contents: write
@@ -115,10 +115,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
-          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:
-          model: zhipuai-coding-plan/glm-5.1
+          model: minimax-coding-plan/MiniMax-M2.7
           use_github_token: true
           prompt: |
             You are a senior Zig systems programming auditor performing a deep code audit.

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -4,7 +4,7 @@ name: opencode-test-writer
 # - OPENCODE_PAT: Classic PAT with `repo` scope OR fine-grained PAT with:
 #     Contents: Read & Write, Pull requests: Read & Write, Metadata: Read
 #   Without `repo` scope, git push will fail with 403 permission denied.
-# - ZHIPU_API_KEY: API key for the Zhipu AI GLM-5.1 model
+# - MINIMAX_API_KEY: API key for the MiniMax M2.7 model
 
 on:
   schedule:
@@ -221,10 +221,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
-          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:
-          model: zhipuai-coding-plan/glm-5.1
+          model: minimax-coding-plan/MiniMax-M2.7
           use_github_token: true
           prompt: |
             Load the `test-writer` skill first — it contains the full codebase context, testing patterns, and workflow rules.

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
-          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         with:
-          model: zhipuai-coding-plan/glm-5.1
+          model: minimax-coding-plan/MiniMax-M2.7
           use_github_token: true


### PR DESCRIPTION
## Summary
- Revert `opencode-audit`, `opencode-test-writer`, and `opencode` workflows from `zhipuai-coding-plan/glm-5.1` back to `minimax-coding-plan/MiniMax-M2.7`
- Reduce `opencode-audit` timeout from 20min to 10min to fail faster on hangs

The GLM-5.1 model was causing all three workflows to hang indefinitely with no response from the API, timing out every run since April 26.