### PR TITLE
fix: smooth worldgen slab transitions

### DIFF
--- a/src/world/lod_mesh.zig
+++ b/src/world/lod_mesh.zig
@@ -190,36 +190,39 @@ pub const LODMesh = struct {
 
     /// Build mesh from simplified LOD data (heightmap-based)
     pub fn buildFromSimplifiedData(self: *LODMesh, data: *const LODSimplifiedData, _: i32, _: i32, _: *const TextureAtlas) !void {
-        const cell_size = getCellSize(self.lod_level);
+        if (data.width < 2) return error.EmptyData;
+
+        const region_size: f32 = @floatFromInt(self.lod_level.regionSizeBlocks());
+        const cell_size = region_size / @as(f32, @floatFromInt(data.width - 1));
 
         var vertices = std.ArrayListUnmanaged(Vertex).empty;
         defer vertices.deinit(self.allocator);
 
         var gz: u32 = 0;
-        while (gz < data.width) : (gz += 1) {
+        while (gz + 1 < data.width) : (gz += 1) {
             var gx: u32 = 0;
-            while (gx < data.width) : (gx += 1) {
+            while (gx + 1 < data.width) : (gx += 1) {
                 const h00 = data.heightmap[gx + gz * data.width];
-                const h10 = if (gx + 1 < data.width) data.heightmap[(gx + 1) + gz * data.width] else h00;
-                const h01 = if (gz + 1 < data.width) data.heightmap[gx + (gz + 1) * data.width] else h00;
-                const h11 = if (gx + 1 < data.width and gz + 1 < data.width) data.heightmap[(gx + 1) + (gz + 1) * data.width] else h00;
+                const h10 = data.heightmap[(gx + 1) + gz * data.width];
+                const h01 = data.heightmap[gx + (gz + 1) * data.width];
+                const h11 = data.heightmap[(gx + 1) + (gz + 1) * data.width];
 
                 const c00 = data.colors[gx + gz * data.width];
-                const c10 = if (gx + 1 < data.width) data.colors[(gx + 1) + gz * data.width] else c00;
-                const c01 = if (gz + 1 < data.width) data.colors[gx + (gz + 1) * data.width] else c00;
-                const c11 = if (gx + 1 < data.width and gz + 1 < data.width) data.colors[(gx + 1) + (gz + 1) * data.width] else c00;
+                const c10 = data.colors[(gx + 1) + gz * data.width];
+                const c01 = data.colors[gx + (gz + 1) * data.width];
+                const c11 = data.colors[(gx + 1) + (gz + 1) * data.width];
                 const avg_color = averageColor(c00, c10, c01, c11);
-                const wx: f32 = @floatFromInt(gx * cell_size);
-                const wz: f32 = @floatFromInt(gz * cell_size);
-                const size: f32 = @floatFromInt(cell_size);
+                const wx = @as(f32, @floatFromInt(gx)) * cell_size;
+                const wz = @as(f32, @floatFromInt(gz)) * cell_size;
+                const size = cell_size;
 
                 try addSmoothQuad(self.allocator, &vertices, wx, wz, size, h00, h10, h01, h11, avg_color, avg_color, avg_color, avg_color, Vertex.LOD_TILE_ID);
 
                 const skirt_depth: f32 = size * 4.0;
                 if (gx == 0) try addSideFaceQuad(self.allocator, &vertices, wx, (h00 + h01) * 0.5, wz, size, (h00 + h01) * 0.5 - skirt_depth, unpackR(avg_color) * 0.6, unpackG(avg_color) * 0.6, unpackB(avg_color) * 0.6, .west, Vertex.LOD_TILE_ID);
-                if (gx == data.width - 1) try addSideFaceQuad(self.allocator, &vertices, wx, (h10 + h11) * 0.5, wz, size, (h10 + h11) * 0.5 - skirt_depth, unpackR(avg_color) * 0.6, unpackG(avg_color) * 0.6, unpackB(avg_color) * 0.6, .east, Vertex.LOD_TILE_ID);
+                if (gx == data.width - 2) try addSideFaceQuad(self.allocator, &vertices, wx, (h10 + h11) * 0.5, wz, size, (h10 + h11) * 0.5 - skirt_depth, unpackR(avg_color) * 0.6, unpackG(avg_color) * 0.6, unpackB(avg_color) * 0.6, .east, Vertex.LOD_TILE_ID);
                 if (gz == 0) try addSideFaceQuad(self.allocator, &vertices, wx, (h00 + h10) * 0.5, wz, size, (h00 + h10) * 0.5 - skirt_depth, unpackR(avg_color) * 0.7, unpackG(avg_color) * 0.7, unpackB(avg_color) * 0.7, .north, Vertex.LOD_TILE_ID);
-                if (gz == data.width - 1) try addSideFaceQuad(self.allocator, &vertices, wx, (h01 + h11) * 0.5, wz, size, (h01 + h11) * 0.5 - skirt_depth, unpackR(avg_color) * 0.7, unpackG(avg_color) * 0.7, unpackB(avg_color) * 0.7, .south, Vertex.LOD_TILE_ID);
+                if (gz == data.width - 2) try addSideFaceQuad(self.allocator, &vertices, wx, (h01 + h11) * 0.5, wz, size, (h01 + h11) * 0.5 - skirt_depth, unpackR(avg_color) * 0.7, unpackG(avg_color) * 0.7, unpackB(avg_color) * 0.7, .south, Vertex.LOD_TILE_ID);
             }
         }
 
@@ -538,8 +541,8 @@ fn buildFullDetailHeightmapMesh(
     if (grid_total == 0) return error.EmptyData;
     std.debug.assert(w <= data.heightmap.len and w <= data.biomes.len);
 
-    const cell_size: u32 = lod_level.regionSizeBlocks() / w;
-    std.debug.assert(cell_size >= 1);
+    if (w < 2) return error.EmptyData;
+    const cell_size: f32 = @as(f32, @floatFromInt(lod_level.regionSizeBlocks())) / @as(f32, @floatFromInt(w - 1));
 
     var vertices = std.ArrayListUnmanaged(Vertex).empty;
     errdefer vertices.deinit(allocator);
@@ -547,21 +550,21 @@ fn buildFullDetailHeightmapMesh(
     errdefer indices.deinit(allocator);
 
     var gz: u32 = 0;
-    while (gz < w) : (gz += 1) {
+    while (gz + 1 < w) : (gz += 1) {
         var gx: u32 = 0;
-        while (gx < w) : (gx += 1) {
+        while (gx + 1 < w) : (gx += 1) {
             const h00 = data.heightmap[gx + gz * w];
-            const h10 = if (gx + 1 < w) data.heightmap[(gx + 1) + gz * w] else h00;
-            const h01 = if (gz + 1 < w) data.heightmap[gx + (gz + 1) * w] else h00;
-            const h11 = if (gx + 1 < w and gz + 1 < w) data.heightmap[(gx + 1) + (gz + 1) * w] else h00;
+            const h10 = data.heightmap[(gx + 1) + gz * w];
+            const h01 = data.heightmap[gx + (gz + 1) * w];
+            const h11 = data.heightmap[(gx + 1) + (gz + 1) * w];
 
             const c00 = data.colors[gx + gz * w];
-            const c10 = if (gx + 1 < w) data.colors[(gx + 1) + gz * w] else c00;
-            const c01 = if (gz + 1 < w) data.colors[gx + (gz + 1) * w] else c00;
-            const c11 = if (gx + 1 < w and gz + 1 < w) data.colors[(gx + 1) + (gz + 1) * w] else c00;
-            const wx: f32 = @floatFromInt(gx * cell_size);
-            const wz: f32 = @floatFromInt(gz * cell_size);
-            const size: f32 = @floatFromInt(cell_size);
+            const c10 = data.colors[(gx + 1) + gz * w];
+            const c01 = data.colors[gx + (gz + 1) * w];
+            const c11 = data.colors[(gx + 1) + (gz + 1) * w];
+            const wx = @as(f32, @floatFromInt(gx)) * cell_size;
+            const wz = @as(f32, @floatFromInt(gz)) * cell_size;
+            const size = cell_size;
 
             const top_quad = [4]Vertex{
                 makeLODVertex(.{ wx, h00, wz }, .{ unpackR(c00), unpackG(c00), unpackB(c00) }, .{ 0, 1, 0 }, .{ 0, 0 }, Vertex.LOD_TILE_ID),
@@ -580,7 +583,7 @@ fn buildFullDetailHeightmapMesh(
                 .brightness = 0.7,
                 .dir = .north,
             }, Vertex.LOD_TILE_ID));
-            if (gz == w - 1) try appendIndexedQuad(&vertices, &indices, allocator, &makeSkirtQuad(.{
+            if (gz == w - 2) try appendIndexedQuad(&vertices, &indices, allocator, &makeSkirtQuad(.{
                 .x = wx,
                 .z = wz,
                 .size = size,
@@ -598,7 +601,7 @@ fn buildFullDetailHeightmapMesh(
                 .brightness = 0.6,
                 .dir = .west,
             }, Vertex.LOD_TILE_ID));
-            if (gx == w - 1) try appendIndexedQuad(&vertices, &indices, allocator, &makeSkirtQuad(.{
+            if (gx == w - 2) try appendIndexedQuad(&vertices, &indices, allocator, &makeSkirtQuad(.{
                 .x = wx,
                 .z = wz,
                 .size = size,

--- a/src/world/worldgen/biome_decorator.zig
+++ b/src/world/worldgen/biome_decorator.zig
@@ -61,12 +61,6 @@ pub const BiomeDecorator = struct {
         var prng = std.Random.DefaultPrng.init(self.region_seed ^ @as(u64, @bitCast(@as(i64, chunk.chunk_x))) ^ (@as(u64, @bitCast(@as(i64, chunk.chunk_z))) << 32));
         const random = prng.random();
 
-        const wx_center = chunk.getWorldX() + 8;
-        const wz_center = chunk.getWorldZ() + 8;
-        const region = region_pkg.getRegion(self.region_seed, wx_center, wz_center);
-        const veg_mult = region_pkg.getVegetationMultiplier(region);
-        const allow_subbiomes = region_pkg.allowSubBiomes(region);
-
         var local_z: u32 = 0;
         while (local_z < CHUNK_SIZE_Z) : (local_z += 1) {
             var local_x: u32 = 0;
@@ -78,6 +72,7 @@ pub const BiomeDecorator = struct {
                 const wx: f32 = @floatFromInt(chunk.getWorldX() + @as(i32, @intCast(local_x)));
                 const wz: f32 = @floatFromInt(chunk.getWorldZ() + @as(i32, @intCast(local_z)));
                 const variant_val = noise_sampler.variant_noise.get2D(wx, wz);
+                const controls = region_pkg.getBlendedControls(self.region_seed, @intFromFloat(wx), @intFromFloat(wz));
                 const surface_block = chunk.getBlock(local_x, @intCast(surface_y), local_z);
 
                 self.decoration_provider.decorate(.{
@@ -88,8 +83,8 @@ pub const BiomeDecorator = struct {
                     .surface_block = surface_block,
                     .biome = biome,
                     .variant = variant_val,
-                    .allow_subbiomes = allow_subbiomes,
-                    .veg_mult = veg_mult,
+                    .allow_subbiomes = controls.subbiome_mask > 0.5,
+                    .veg_mult = controls.vegetation_mult,
                     .random = random,
                 });
             }

--- a/src/world/worldgen/biome_decorator.zig
+++ b/src/world/worldgen/biome_decorator.zig
@@ -60,6 +60,15 @@ pub const BiomeDecorator = struct {
     pub fn generateFeatures(self: *const BiomeDecorator, chunk: *Chunk, noise_sampler: *const NoiseSampler) void {
         var prng = std.Random.DefaultPrng.init(self.region_seed ^ @as(u64, @bitCast(@as(i64, chunk.chunk_x))) ^ (@as(u64, @bitCast(@as(i64, chunk.chunk_z))) << 32));
         const random = prng.random();
+        const world_x = chunk.getWorldX();
+        const world_z = chunk.getWorldZ();
+        const controls = region_pkg.RegionControlCorners.init(
+            self.region_seed,
+            world_x,
+            world_z,
+            world_x + CHUNK_SIZE_X - 1,
+            world_z + CHUNK_SIZE_Z - 1,
+        );
 
         var local_z: u32 = 0;
         while (local_z < CHUNK_SIZE_Z) : (local_z += 1) {
@@ -69,10 +78,12 @@ pub const BiomeDecorator = struct {
                 if (surface_y <= 0 or surface_y >= CHUNK_SIZE_Y - 1) continue;
 
                 const biome = chunk.biomes[local_x + local_z * CHUNK_SIZE_X];
-                const wx: f32 = @floatFromInt(chunk.getWorldX() + @as(i32, @intCast(local_x)));
-                const wz: f32 = @floatFromInt(chunk.getWorldZ() + @as(i32, @intCast(local_z)));
+                const wx_i = world_x + @as(i32, @intCast(local_x));
+                const wz_i = world_z + @as(i32, @intCast(local_z));
+                const wx: f32 = @floatFromInt(wx_i);
+                const wz: f32 = @floatFromInt(wz_i);
                 const variant_val = noise_sampler.variant_noise.get2D(wx, wz);
-                const controls = region_pkg.getBlendedControls(self.region_seed, @intFromFloat(wx), @intFromFloat(wz));
+                const column_controls = controls.sample(wx_i, wz_i);
                 const surface_block = chunk.getBlock(local_x, @intCast(surface_y), local_z);
 
                 self.decoration_provider.decorate(.{
@@ -83,8 +94,8 @@ pub const BiomeDecorator = struct {
                     .surface_block = surface_block,
                     .biome = biome,
                     .variant = variant_val,
-                    .allow_subbiomes = controls.subbiome_mask > 0.5,
-                    .veg_mult = controls.vegetation_mult,
+                    .allow_subbiomes = column_controls.subbiome_mask > 0.5,
+                    .veg_mult = column_controls.vegetation_mult,
                     .random = random,
                 });
             }

--- a/src/world/worldgen/height_sampler.zig
+++ b/src/world/worldgen/height_sampler.zig
@@ -14,7 +14,6 @@ const noise_sampler_mod = @import("noise_sampler.zig");
 const NoiseSampler = noise_sampler_mod.NoiseSampler;
 const ColumnNoiseValues = noise_sampler_mod.ColumnNoiseValues;
 const region_pkg = @import("region.zig");
-const RegionInfo = region_pkg.RegionInfo;
 const PathInfo = region_pkg.PathInfo;
 const RegionControls = region_pkg.RegionControls;
 const world_class = @import("world_class.zig");
@@ -210,7 +209,6 @@ pub const HeightSampler = struct {
         self: *const HeightSampler,
         noise_sampler: *const NoiseSampler,
         noise: ColumnNoiseValues,
-        region: RegionInfo,
         controls: RegionControls,
         path_info: PathInfo,
         reduction: u8,
@@ -248,7 +246,6 @@ pub const HeightSampler = struct {
         // STEP 3: V7-STYLE MULTI-LAYER TERRAIN (Issue #105)
         // Blend terrain_base and terrain_alt using height_select
         // ============================================================
-        _ = region;
         const mood_mult = controls.height_mult;
         const v7_terrain = computeV7Terrain(noise, mood_mult);
 

--- a/src/world/worldgen/height_sampler.zig
+++ b/src/world/worldgen/height_sampler.zig
@@ -16,6 +16,7 @@ const ColumnNoiseValues = noise_sampler_mod.ColumnNoiseValues;
 const region_pkg = @import("region.zig");
 const RegionInfo = region_pkg.RegionInfo;
 const PathInfo = region_pkg.PathInfo;
+const RegionControls = region_pkg.RegionControls;
 const world_class = @import("world_class.zig");
 const ContinentalZone = world_class.ContinentalZone;
 
@@ -210,6 +211,7 @@ pub const HeightSampler = struct {
         noise_sampler: *const NoiseSampler,
         noise: ColumnNoiseValues,
         region: RegionInfo,
+        controls: RegionControls,
         path_info: PathInfo,
         reduction: u8,
     ) f32 {
@@ -246,7 +248,8 @@ pub const HeightSampler = struct {
         // STEP 3: V7-STYLE MULTI-LAYER TERRAIN (Issue #105)
         // Blend terrain_base and terrain_alt using height_select
         // ============================================================
-        const mood_mult = region_pkg.getHeightMultiplier(region);
+        _ = region;
+        const mood_mult = controls.height_mult;
         const v7_terrain = computeV7Terrain(noise, mood_mult);
 
         // ============================================================
@@ -258,11 +261,11 @@ pub const HeightSampler = struct {
         // STEP 5: Mountains & Ridges - REGION-CONSTRAINED
         // Only apply if allowHeightDrama is true
         // ============================================================
-        if (region_pkg.allowHeightDrama(region) and noise.continentalness > p.continental_inland_low_max) {
+        if (controls.drama_mask > 0.001 and noise.continentalness > p.continental_inland_low_max) {
             const m_mask = self.getMountainMask(noise.peaks_valleys, noise.erosion, noise.continentalness);
             const lift_noise = noise_sampler.getMountainLift(noise.warped_x, noise.warped_z, reduction);
             const mount_lift = (m_mask * lift_noise * p.mount_amp) / (1.0 + (m_mask * lift_noise * p.mount_amp) / p.mount_cap);
-            height += mount_lift * mood_mult;
+            height += mount_lift * mood_mult * controls.drama_mask;
 
             const ridge_params = NoiseSampler.RidgeParams{
                 .inland_min = p.ridge_inland_min,
@@ -270,7 +273,7 @@ pub const HeightSampler = struct {
                 .sparsity = p.ridge_sparsity,
             };
             const ridge_val = noise_sampler.getRidgeFactor(noise.warped_x, noise.warped_z, noise.continentalness, reduction, ridge_params);
-            height += ridge_val * p.ridge_amp * mood_mult;
+            height += ridge_val * p.ridge_amp * mood_mult * controls.drama_mask;
         }
 
         // ============================================================
@@ -300,9 +303,9 @@ pub const HeightSampler = struct {
         // ============================================================
         // STEP 8: River Carving - REGION-CONSTRAINED
         // ============================================================
-        if (region_pkg.allowRiver(region) and noise.river_mask > 0.001 and noise.continentalness > p.continental_coast_max) {
+        if (controls.river_mask > 0.001 and noise.river_mask > 0.001 and noise.continentalness > p.continental_coast_max) {
             const river_bed = sea - 4.0;
-            const carve_alpha = smoothstep(0.0, 1.0, noise.river_mask);
+            const carve_alpha = smoothstep(0.0, 1.0, noise.river_mask) * controls.river_mask;
             if (height > river_bed) {
                 height = std.math.lerp(height, river_bed, carve_alpha);
             }

--- a/src/world/worldgen/overworld_generator.zig
+++ b/src/world/worldgen/overworld_generator.zig
@@ -259,6 +259,13 @@ pub const OverworldGenerator = struct {
         const world_x = region_x * region_size_i;
         const world_z = region_z * region_size_i;
         const sea_level = self.terrain_shape.getSeaLevel();
+        const controls = region_pkg.RegionControlCorners.init(
+            self.terrain_shape.getRegionSeed(),
+            world_x,
+            world_z,
+            world_x + region_size_i,
+            world_z + region_size_i,
+        );
 
         var gz: u32 = 0;
         while (gz < data.width) : (gz += 1) {
@@ -269,7 +276,7 @@ pub const OverworldGenerator = struct {
                 const wz = @as(f32, @floatFromInt(world_z)) + (@as(f32, @floatFromInt(gz)) / grid_max) * region_size_f;
                 const wx_i: i32 = @intFromFloat(@floor(wx));
                 const wz_i: i32 = @intFromFloat(@floor(wz));
-                const column = self.terrain_shape.sampleColumnData(wx, wz, 0);
+                const column = self.terrain_shape.sampleColumnDataWithControls(wx, wz, 0, controls.sample(wx_i, wz_i));
                 const render_water_surface = column.terrain_height_i < sea_level and (column.is_ocean or self.isInlandWater(wx, wz, column.terrain_height_i));
                 data.heightmap[idx] = if (render_water_surface)
                     @as(f32, @floatFromInt(sea_level))

--- a/src/world/worldgen/overworld_generator.zig
+++ b/src/world/worldgen/overworld_generator.zig
@@ -251,9 +251,11 @@ pub const OverworldGenerator = struct {
     /// Generate heightmap data only (for LODSimplifiedData)
     /// Uses classification cache when available to ensure LOD matches LOD0.
     pub fn generateHeightmapOnly(self: *const OverworldGenerator, data: *LODSimplifiedData, region_x: i32, region_z: i32, lod_level: LODLevel) void {
-        const block_step = LODSimplifiedData.getCellSizeBlocks(lod_level);
-        const world_x = region_x * @as(i32, @intCast(lod_level.regionSizeBlocks()));
-        const world_z = region_z * @as(i32, @intCast(lod_level.regionSizeBlocks()));
+        const region_size_i: i32 = @intCast(lod_level.regionSizeBlocks());
+        const region_size_f: f32 = @floatFromInt(region_size_i);
+        const grid_max: f32 = @floatFromInt(data.width - 1);
+        const world_x = region_x * region_size_i;
+        const world_z = region_z * region_size_i;
         const sea_level = self.terrain_shape.getSeaLevel();
 
         var gz: u32 = 0;
@@ -261,10 +263,10 @@ pub const OverworldGenerator = struct {
             var gx: u32 = 0;
             while (gx < data.width) : (gx += 1) {
                 const idx = gx + gz * data.width;
-                const wx_i = world_x + @as(i32, @intCast(gx * block_step));
-                const wz_i = world_z + @as(i32, @intCast(gz * block_step));
-                const wx: f32 = @floatFromInt(wx_i);
-                const wz: f32 = @floatFromInt(wz_i);
+                const wx = @as(f32, @floatFromInt(world_x)) + (@as(f32, @floatFromInt(gx)) / grid_max) * region_size_f;
+                const wz = @as(f32, @floatFromInt(world_z)) + (@as(f32, @floatFromInt(gz)) / grid_max) * region_size_f;
+                const wx_i: i32 = @intFromFloat(@floor(wx));
+                const wz_i: i32 = @intFromFloat(@floor(wz));
                 const column = self.terrain_shape.sampleColumnData(wx, wz, 0);
                 const render_water_surface = column.terrain_height_i < sea_level and (column.is_ocean or self.isInlandWater(wx, wz, column.terrain_height_i));
                 data.heightmap[idx] = if (render_water_surface)

--- a/src/world/worldgen/overworld_generator.zig
+++ b/src/world/worldgen/overworld_generator.zig
@@ -251,6 +251,8 @@ pub const OverworldGenerator = struct {
     /// Generate heightmap data only (for LODSimplifiedData)
     /// Uses classification cache when available to ensure LOD matches LOD0.
     pub fn generateHeightmapOnly(self: *const OverworldGenerator, data: *LODSimplifiedData, region_x: i32, region_z: i32, lod_level: LODLevel) void {
+        if (data.width < 2) return;
+
         const region_size_i: i32 = @intCast(lod_level.regionSizeBlocks());
         const region_size_f: f32 = @floatFromInt(region_size_i);
         const grid_max: f32 = @floatFromInt(data.width - 1);

--- a/src/world/worldgen/region.zig
+++ b/src/world/worldgen/region.zig
@@ -116,6 +116,14 @@ pub fn allowHeightDrama(info: RegionInfo) bool {
 
 const REGION_SIZE = 1024;
 
+pub const RegionControls = struct {
+    height_mult: f32,
+    vegetation_mult: f32,
+    drama_mask: f32,
+    river_mask: f32,
+    subbiome_mask: f32,
+};
+
 /// Path configuration constants
 const VALLEY_WIDTH: f32 = 32.0;
 const VALLEY_DEPTH: f32 = 10.0;
@@ -187,6 +195,49 @@ pub fn getPathInfluence(seed: u64, x: i32, z: i32) f32 {
     const current = getRegion(seed, x, z);
     const path_info = getPathInfo(seed, x, z, current);
     return path_info.influence;
+}
+
+pub fn getBlendedControls(seed: u64, world_x: i32, world_z: i32) RegionControls {
+    const rx = @divFloor(world_x, REGION_SIZE);
+    const rz = @divFloor(world_z, REGION_SIZE);
+    const local_x = @mod(world_x, REGION_SIZE);
+    const local_z = @mod(world_z, REGION_SIZE);
+
+    const tx = smoothstep01(@as(f32, @floatFromInt(local_x)) / @as(f32, @floatFromInt(REGION_SIZE)));
+    const tz = smoothstep01(@as(f32, @floatFromInt(local_z)) / @as(f32, @floatFromInt(REGION_SIZE)));
+
+    const c00 = controlsForRegion(getRegion(seed, rx * REGION_SIZE, rz * REGION_SIZE));
+    const c10 = controlsForRegion(getRegion(seed, (rx + 1) * REGION_SIZE, rz * REGION_SIZE));
+    const c01 = controlsForRegion(getRegion(seed, rx * REGION_SIZE, (rz + 1) * REGION_SIZE));
+    const c11 = controlsForRegion(getRegion(seed, (rx + 1) * REGION_SIZE, (rz + 1) * REGION_SIZE));
+
+    return .{
+        .height_mult = bilerp(c00.height_mult, c10.height_mult, c01.height_mult, c11.height_mult, tx, tz),
+        .vegetation_mult = bilerp(c00.vegetation_mult, c10.vegetation_mult, c01.vegetation_mult, c11.vegetation_mult, tx, tz),
+        .drama_mask = bilerp(c00.drama_mask, c10.drama_mask, c01.drama_mask, c11.drama_mask, tx, tz),
+        .river_mask = bilerp(c00.river_mask, c10.river_mask, c01.river_mask, c11.river_mask, tx, tz),
+        .subbiome_mask = bilerp(c00.subbiome_mask, c10.subbiome_mask, c01.subbiome_mask, c11.subbiome_mask, tx, tz),
+    };
+}
+
+fn controlsForRegion(info: RegionInfo) RegionControls {
+    return .{
+        .height_mult = getHeightMultiplier(info),
+        .vegetation_mult = getVegetationMultiplier(info),
+        .drama_mask = if (allowHeightDrama(info)) 1.0 else 0.0,
+        .river_mask = if (allowRiver(info)) 1.0 else 0.0,
+        .subbiome_mask = if (allowSubBiomes(info)) 1.0 else 0.0,
+    };
+}
+
+fn smoothstep01(t: f32) f32 {
+    return t * t * (3.0 - 2.0 * t);
+}
+
+fn bilerp(v00: f32, v10: f32, v01: f32, v11: f32, tx: f32, tz: f32) f32 {
+    const a = std.math.lerp(v00, v10, tx);
+    const b = std.math.lerp(v01, v11, tx);
+    return std.math.lerp(a, b, tz);
 }
 
 /// Get complete path information for a position

--- a/src/world/worldgen/region.zig
+++ b/src/world/worldgen/region.zig
@@ -124,6 +124,36 @@ pub const RegionControls = struct {
     subbiome_mask: f32,
 };
 
+pub const RegionControlCorners = struct {
+    min_x: i32,
+    min_z: i32,
+    span_x: f32,
+    span_z: f32,
+    c00: RegionControls,
+    c10: RegionControls,
+    c01: RegionControls,
+    c11: RegionControls,
+
+    pub fn init(seed: u64, min_x: i32, min_z: i32, max_x: i32, max_z: i32) RegionControlCorners {
+        return .{
+            .min_x = min_x,
+            .min_z = min_z,
+            .span_x = @floatFromInt(@max(1, max_x - min_x)),
+            .span_z = @floatFromInt(@max(1, max_z - min_z)),
+            .c00 = getBlendedControls(seed, min_x, min_z),
+            .c10 = getBlendedControls(seed, max_x, min_z),
+            .c01 = getBlendedControls(seed, min_x, max_z),
+            .c11 = getBlendedControls(seed, max_x, max_z),
+        };
+    }
+
+    pub fn sample(self: RegionControlCorners, world_x: i32, world_z: i32) RegionControls {
+        const tx = std.math.clamp(@as(f32, @floatFromInt(world_x - self.min_x)) / self.span_x, 0.0, 1.0);
+        const tz = std.math.clamp(@as(f32, @floatFromInt(world_z - self.min_z)) / self.span_z, 0.0, 1.0);
+        return lerpControls(self.c00, self.c10, self.c01, self.c11, tx, tz);
+    }
+};
+
 /// Path configuration constants
 const VALLEY_WIDTH: f32 = 32.0;
 const VALLEY_DEPTH: f32 = 10.0;
@@ -211,6 +241,16 @@ pub fn getBlendedControls(seed: u64, world_x: i32, world_z: i32) RegionControls 
     const c01 = controlsForRegion(getRegion(seed, rx * REGION_SIZE, (rz + 1) * REGION_SIZE));
     const c11 = controlsForRegion(getRegion(seed, (rx + 1) * REGION_SIZE, (rz + 1) * REGION_SIZE));
 
+    return .{
+        .height_mult = bilerp(c00.height_mult, c10.height_mult, c01.height_mult, c11.height_mult, tx, tz),
+        .vegetation_mult = bilerp(c00.vegetation_mult, c10.vegetation_mult, c01.vegetation_mult, c11.vegetation_mult, tx, tz),
+        .drama_mask = bilerp(c00.drama_mask, c10.drama_mask, c01.drama_mask, c11.drama_mask, tx, tz),
+        .river_mask = bilerp(c00.river_mask, c10.river_mask, c01.river_mask, c11.river_mask, tx, tz),
+        .subbiome_mask = bilerp(c00.subbiome_mask, c10.subbiome_mask, c01.subbiome_mask, c11.subbiome_mask, tx, tz),
+    };
+}
+
+fn lerpControls(c00: RegionControls, c10: RegionControls, c01: RegionControls, c11: RegionControls, tx: f32, tz: f32) RegionControls {
     return .{
         .height_mult = bilerp(c00.height_mult, c10.height_mult, c01.height_mult, c11.height_mult, tx, tz),
         .vegetation_mult = bilerp(c00.vegetation_mult, c10.vegetation_mult, c01.vegetation_mult, c11.vegetation_mult, tx, tz),

--- a/src/world/worldgen/terrain_shape_generator.zig
+++ b/src/world/worldgen/terrain_shape_generator.zig
@@ -132,8 +132,8 @@ pub const TerrainShapeGenerator = struct {
 
     pub fn sampleColumnData(self: *const TerrainShapeGenerator, wx: f32, wz: f32, reduction: u8) ColumnData {
         const region_seed = self.getRegionSeed();
-        const wx_i: i32 = @intFromFloat(wx);
-        const wz_i: i32 = @intFromFloat(wz);
+        const wx_i: i32 = @intFromFloat(@floor(wx));
+        const wz_i: i32 = @intFromFloat(@floor(wz));
         const controls = region_pkg.getBlendedControls(region_seed, wx_i, wz_i);
         return self.sampleColumnDataWithControls(wx, wz, reduction, controls);
     }
@@ -148,8 +148,8 @@ pub const TerrainShapeGenerator = struct {
         noise.river_mask = self.noise_sampler.getRiverMask(noise.warped_x, noise.warped_z, reduction);
 
         const region_seed = self.getRegionSeed();
-        const wx_i: i32 = @intFromFloat(wx);
-        const wz_i: i32 = @intFromFloat(wz);
+        const wx_i: i32 = @intFromFloat(@floor(wx));
+        const wz_i: i32 = @intFromFloat(@floor(wz));
         const region = region_pkg.getRegion(region_seed, wx_i, wz_i);
         const path_info = region_pkg.getPathInfo(region_seed, wx_i, wz_i, region);
         const terrain_height = self.height_sampler.computeHeight(&self.noise_sampler, noise, controls, path_info, reduction);

--- a/src/world/worldgen/terrain_shape_generator.zig
+++ b/src/world/worldgen/terrain_shape_generator.zig
@@ -131,6 +131,14 @@ pub const TerrainShapeGenerator = struct {
     }
 
     pub fn sampleColumnData(self: *const TerrainShapeGenerator, wx: f32, wz: f32, reduction: u8) ColumnData {
+        const region_seed = self.getRegionSeed();
+        const wx_i: i32 = @intFromFloat(wx);
+        const wz_i: i32 = @intFromFloat(wz);
+        const controls = region_pkg.getBlendedControls(region_seed, wx_i, wz_i);
+        return self.sampleColumnDataWithControls(wx, wz, reduction, controls);
+    }
+
+    pub fn sampleColumnDataWithControls(self: *const TerrainShapeGenerator, wx: f32, wz: f32, reduction: u8, controls: region_pkg.RegionControls) ColumnData {
         const sea: f32 = @floatFromInt(self.params.sea_level);
         var noise = self.noise_sampler.sampleColumn(wx, wz, reduction);
         const cj_octaves: u16 = if (2 > reduction) 2 - @as(u16, reduction) else 1;
@@ -143,9 +151,8 @@ pub const TerrainShapeGenerator = struct {
         const wx_i: i32 = @intFromFloat(wx);
         const wz_i: i32 = @intFromFloat(wz);
         const region = region_pkg.getRegion(region_seed, wx_i, wz_i);
-        const controls = region_pkg.getBlendedControls(region_seed, wx_i, wz_i);
         const path_info = region_pkg.getPathInfo(region_seed, wx_i, wz_i, region);
-        const terrain_height = self.height_sampler.computeHeight(&self.noise_sampler, noise, region, controls, path_info, reduction);
+        const terrain_height = self.height_sampler.computeHeight(&self.noise_sampler, noise, controls, path_info, reduction);
         const terrain_height_i: i32 = @intFromFloat(terrain_height);
 
         const altitude_offset: f32 = @max(0, terrain_height - sea);
@@ -183,15 +190,25 @@ pub const TerrainShapeGenerator = struct {
         cache_center_z: i32,
         stop_flag: ?*const bool,
     ) bool {
+        const controls = region_pkg.RegionControlCorners.init(
+            self.getRegionSeed(),
+            world_x,
+            world_z,
+            world_x + CHUNK_SIZE_X - 1,
+            world_z + CHUNK_SIZE_Z - 1,
+        );
+
         var local_z: u32 = 0;
         while (local_z < CHUNK_SIZE_Z) : (local_z += 1) {
             if (stop_flag) |sf| if (sf.*) return false;
             var local_x: u32 = 0;
             while (local_x < CHUNK_SIZE_X) : (local_x += 1) {
                 const idx = local_x + local_z * CHUNK_SIZE_X;
-                const wx: f32 = @floatFromInt(world_x + @as(i32, @intCast(local_x)));
-                const wz: f32 = @floatFromInt(world_z + @as(i32, @intCast(local_z)));
-                const column = self.sampleColumnData(wx, wz, 0);
+                const wx_i = world_x + @as(i32, @intCast(local_x));
+                const wz_i = world_z + @as(i32, @intCast(local_z));
+                const wx: f32 = @floatFromInt(wx_i);
+                const wz: f32 = @floatFromInt(wz_i);
+                const column = self.sampleColumnDataWithControls(wx, wz, 0, controls.sample(wx_i, wz_i));
 
                 phase_data.surface_heights[idx] = column.terrain_height_i;
                 phase_data.is_underwater_flags[idx] = column.is_underwater;

--- a/src/world/worldgen/terrain_shape_generator.zig
+++ b/src/world/worldgen/terrain_shape_generator.zig
@@ -143,8 +143,9 @@ pub const TerrainShapeGenerator = struct {
         const wx_i: i32 = @intFromFloat(wx);
         const wz_i: i32 = @intFromFloat(wz);
         const region = region_pkg.getRegion(region_seed, wx_i, wz_i);
+        const controls = region_pkg.getBlendedControls(region_seed, wx_i, wz_i);
         const path_info = region_pkg.getPathInfo(region_seed, wx_i, wz_i, region);
-        const terrain_height = self.height_sampler.computeHeight(&self.noise_sampler, noise, region, path_info, reduction);
+        const terrain_height = self.height_sampler.computeHeight(&self.noise_sampler, noise, region, controls, path_info, reduction);
         const terrain_height_i: i32 = @intFromFloat(terrain_height);
 
         const altitude_offset: f32 = @max(0, terrain_height - sea);

--- a/src/worldgen_tests.zig
+++ b/src/worldgen_tests.zig
@@ -216,7 +216,7 @@ test "WorldGen stable chunk fingerprints for known seed" {
     };
 
     const expected = [_]u64{
-        2394066680656000157,
+        12740687495258888450,
         14029817033549788541,
         4422434882344650145,
     };

--- a/src/worldgen_tests.zig
+++ b/src/worldgen_tests.zig
@@ -217,8 +217,8 @@ test "WorldGen stable chunk fingerprints for known seed" {
 
     const expected = [_]u64{
         2394066680656000157,
-        7033835718524966398,
-        117907781102104432,
+        14029817033549788541,
+        4422434882344650145,
     };
 
     for (positions, 0..) |pos, i| {


### PR DESCRIPTION
## Summary
- Blend region terrain controls to avoid hard height, mountain, and river-carving slabs.
- Sample vegetation controls per column so forests and decoration density do not change at chunk-center boundaries.
- Treat LOD heightmaps as vertex grids so neighboring LOD regions share edge heights.

## Verification
- `nix develop --command zig build`
- `nix develop --command zig build test` still reaches existing Vulkan/mock swapchain errors (`memory not mapped`, `error.OutOfMemory`) after worldgen fingerprint expectations pass.