### PR TITLE
refactor: extract opencode-pr prompt into reusable load-prompt action

### DIFF
--- a/.github/actions/load-prompt/action.yml
+++ b/.github/actions/load-prompt/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: false
     default: PROMPT
     description: Name of the environment variable to write the rendered prompt to
+  variables:
+    required: false
+    default: ""
+    description: Space-separated list of variable names to substitute (restricts envsubst expansion)
 
 runs:
   using: composite
@@ -16,8 +20,22 @@ runs:
     - name: Load and substitute prompt
       shell: bash
       run: |
+        ENV_VAR="${{ inputs.env-var }}"
+        if [[ ! "$ENV_VAR" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+          echo "Invalid env-var name: $ENV_VAR" >&2
+          exit 1
+        fi
+
+        if ! command -v envsubst &> /dev/null; then
+          sudo apt-get update -qq && sudo apt-get install -y -qq gettext-base
+        fi
+
         {
-          echo "${{ inputs.env-var }}<<ENVEOF"
-          envsubst < "${{ inputs.prompt-file }}"
+          echo "${ENV_VAR}<<ENVEOF"
+          if [ -n "${{ inputs.variables }}" ]; then
+            envsubst '${{ inputs.variables }}' < "${{ inputs.prompt-file }}"
+          else
+            envsubst < "${{ inputs.prompt-file }}"
+          fi
           echo "ENVEOF"
         } >> "$GITHUB_ENV"

--- a/.github/actions/load-prompt/action.yml
+++ b/.github/actions/load-prompt/action.yml
@@ -1,0 +1,23 @@
+name: Load Prompt
+description: Load a markdown prompt template and substitute environment variables via envsubst
+
+inputs:
+  prompt-file:
+    required: true
+    description: Path to the .md prompt template file
+  env-var:
+    required: false
+    default: PROMPT
+    description: Name of the environment variable to write the rendered prompt to
+
+runs:
+  using: composite
+  steps:
+    - name: Load and substitute prompt
+      shell: bash
+      run: |
+        {
+          echo "${{ inputs.env-var }}<<ENVEOF"
+          envsubst < "${{ inputs.prompt-file }}"
+          echo "ENVEOF"
+        } >> "$GITHUB_ENV"

--- a/.github/prompts/pr-review.md
+++ b/.github/prompts/pr-review.md
@@ -1,0 +1,157 @@
+You are reviewing a pull request for the ZigCraft repository.
+
+**PR to review:** #$PR_NUMBER
+Use `gh pr diff $PR_NUMBER` and `gh pr view $PR_NUMBER` to examine the changes.
+
+Give full review coverage to PRs created by the automated test writer, especially PRs labeled `automated-test`, and verify whether any linked issues are fully addressed.
+
+ZigCraft is a high-performance Minecraft-style voxel engine built with Zig, SDL3, and Vulkan. It uses Nix for dependency management, a custom RHI (Render Hardware Interface) abstraction layer, and a multithreaded job system for world generation and meshing.
+
+**Tech Stack:**
+- Zig 0.16+ with strict memory management (explicit allocators, defer/errdefer)
+- SDL3 for windowing and input
+- Vulkan for rendering (only backend, via RHI abstraction)
+- Nix for reproducible builds (`nix develop --command zig build`)
+- GLSL shaders validated via glslangValidator
+
+**Build Commands:**
+- `nix develop --command zig build test` - Unit tests + shader validation
+- `nix develop --command zig build test -- --test-filter "test name"` - Single test
+- `nix develop --command zig fmt src/` - Format code
+
+**Prioritize review attention on:**
+- RHI/Vulkan correctness (buffer/texture handles, pipeline state, synchronization)
+- Memory safety (allocator usage, defer cleanup, ArrayListUnmanaged patterns)
+- Threading/concurrency (JobSystem usage, chunk pin/unpin, mutex protection)
+- GPU resource lifecycle (creation, destruction, double-buffering with MAX_FRAMES_IN_FLIGHT)
+- Packed struct correctness for GPU data (PackedLight, Vertex)
+- Coordinate system correctness (world vs chunk vs local, worldToChunk/worldToLocal)
+- Shader uniform naming (must match RHI exactly)
+
+$PREVIOUS_REVIEWS
+
+---
+
+**YOUR TASK:** Analyze the CURRENT code changes and previous reviews above, then output your review in the following STRICT STRUCTURE:
+
+**CRITICAL INSTRUCTIONS:**
+1. **CHECK PREVIOUS ISSUES FIRST:** Look at the "Previous Automated Reviews" section above. For each issue previously reported (Critical, High, Medium, Low), verify if it still exists in the current code.
+2. **ACKNOWLEDGE FIXES:** If a previously reported issue has been fixed, state "✅ **[FIXED]** Previous issue: [brief description]" in the appropriate section.
+3. **ONLY REPORT NEW/UNRESOLVED ISSUES:** Do NOT re-report issues that have already been fixed. Only report issues that are still present in the current code.
+4. **TRACK CHANGES:** If an issue was reported in a previous review but the code has changed, verify the new code and report the issue with updated file:line references if it still exists.
+
+---
+
+## 📋 Summary
+First, check if the PR description mentions any linked issues (e.g., "Closes #123", "Fixes #456", "Resolves #789"). 
+
+## 📌 Review Metadata
+- **Reviewed Commit SHA:** `$HEAD_SHA`
+- **Reviewed PR:** #$PR_NUMBER
+    
+If linked issues are found:
+- Mention the issue number(s) explicitly
+- Verify the PR actually implements what the issue(s) requested
+- State whether the implementation fully satisfies the issue requirements
+    
+Then provide 2-3 sentences summarizing the PR purpose, scope, and overall quality.
+
+## 🔴 Critical Issues (Must Fix - Blocks Merge)
+**IMPORTANT:** Check previous reviews first. If critical issues were reported before, verify if they're fixed. If fixed, say "✅ All previously reported critical issues have been resolved."
+
+Only report NEW critical issues that could cause crashes, security vulnerabilities, data loss, or major bugs.
+
+For each issue, use this exact format:
+```
+**[CRITICAL]** `File:Line` - Issue Title
+**Confidence:** High|Medium|Low (how sure you are this is a real problem)
+**Description:** Clear explanation of the issue
+**Impact:** What could go wrong if merged
+**Suggested Fix:** Specific code changes needed
+```
+
+## ⚠️ High Priority Issues (Should Fix)
+Same approach as Critical - check previous reviews first, acknowledge fixes, only report unresolved issues.
+
+Same format as Critical, but with **[HIGH]** prefix.
+
+## 💡 Medium Priority Issues (Nice to Fix)
+Same approach - verify previous reports, acknowledge fixes, report only still-present issues.
+
+Same format, with **[MEDIUM]** prefix.
+
+## ℹ️ Low Priority Suggestions (Optional)
+Same approach.
+
+Same format, with **[LOW]** prefix.
+
+## 📊 SOLID Principles Score
+| Principle | Score | Notes |
+|-----------|-------|-------|
+| Single Responsibility | 0-10 | Brief justification |
+| Open/Closed | 0-10 | Brief justification |
+| Liskov Substitution | 0-10 | Brief justification |
+| Interface Segregation | 0-10 | Brief justification |
+| Dependency Inversion | 0-10 | Brief justification |
+| **Average** | **X.X** | |
+
+## 🎯 Final Assessment
+
+### Overall Confidence Score: XX%
+Rate your confidence in this PR being ready to merge (0-100%).
+**How to interpret:**
+- 0-30%: Major concerns, do not merge without significant rework
+- 31-60%: Moderate concerns, several issues need addressing
+- 61-80%: Minor concerns, mostly ready with some fixes
+- 81-100%: High confidence, ready to merge or with trivial fixes
+
+### Confidence Breakdown:
+- **Code Quality:** XX% (how well-written is the code?)
+- **Completeness:** XX% (does it fulfill requirements?)
+- **Risk Level:** XX% (how risky is this change?)
+- **Test Coverage:** XX% (are changes adequately tested?)
+
+### Merge Readiness:
+- [ ] All critical issues resolved
+- [ ] SOLID average score >= 6.0
+- [ ] Overall confidence >= 60%
+- [ ] No security concerns
+- [ ] Tests present and passing (if applicable)
+
+### Verdict:
+**MERGE** | **MERGE WITH FIXES** | **DO NOT MERGE**
+
+One-sentence explanation of the verdict.
+
+## Machine Readable Verdict
+
+Append this exact JSON block at the end of your review. Do not wrap it in another code block and do not add trailing commentary after it.
+
+```json
+{
+  "reviewed_sha": "$HEAD_SHA",
+  "critical_issues": 0,
+  "high_priority_issues": 0,
+  "medium_priority_issues": 0,
+  "overall_confidence_score": 0,
+  "recommendation": "MERGE"
+}
+```
+
+Rules for the JSON block:
+- `reviewed_sha` must match the PR head SHA above.
+- Counts must be integers.
+- `overall_confidence_score` must be an integer from 0 to 100.
+- If any critical, high, or medium issues remain, the counts must reflect them.
+- Use `MERGE` only when there are no unresolved critical, high, or medium issues and the score is at least 80.
+
+---
+
+**Review Guidelines:**
+1. **MOST IMPORTANT:** Always check previous reviews and verify if issues are fixed before reporting them again
+2. Acknowledge fixes explicitly with ✅ **[FIXED]** markers
+3. Check the PR description for linked issues ("Fixes #123", "Closes #456", etc.) and verify the implementation
+4. Be extremely specific with file paths and line numbers
+5. Confidence scores should reflect how certain you are - use "Low" when unsure
+6. If you have nothing meaningful to add to a section, write "None identified" instead of omitting it
+7. Always provide actionable fixes, never just complaints

--- a/.github/workflows/opencode-pr.yml
+++ b/.github/workflows/opencode-pr.yml
@@ -37,12 +37,16 @@ jobs:
         id: resolve-pr
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "pr_number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
-            echo "pr_head_sha=${{ inputs.head_sha }}" >> "$GITHUB_OUTPUT"
+            PR_NUMBER="${{ inputs.pr_number }}"
+            HEAD_SHA="${{ inputs.head_sha }}"
           else
-            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-            echo "pr_head_sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
+          echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -101,6 +105,10 @@ jobs:
       - name: Prepare opencode cache
         run: mkdir -p /tmp/opencode-cache && echo "XDG_CACHE_HOME=/tmp/opencode-cache" >> "$GITHUB_ENV"
 
+      - uses: ./.github/actions/load-prompt
+        with:
+          prompt-file: .github/prompts/pr-review.md
+
       - name: Run opencode
         id: ai_review
         uses: anomalyco/opencode/github@latest
@@ -111,164 +119,7 @@ jobs:
         with:
           model: kimi-for-coding/k2p6
           use_github_token: true
-          prompt: |
-            You are reviewing a pull request for the ZigCraft repository.
-
-            **PR to review:** #${{ steps.resolve-pr.outputs.pr_number }}
-            Use `gh pr diff ${{ steps.resolve-pr.outputs.pr_number }}` and `gh pr view ${{ steps.resolve-pr.outputs.pr_number }}` to examine the changes.
-
-            Give full review coverage to PRs created by the automated test writer, especially PRs labeled `automated-test`, and verify whether any linked issues are fully addressed.
-
-            ZigCraft is a high-performance Minecraft-style voxel engine built with Zig, SDL3, and Vulkan. It uses Nix for dependency management, a custom RHI (Render Hardware Interface) abstraction layer, and a multithreaded job system for world generation and meshing.
-
-            **Tech Stack:**
-            - Zig 0.16+ with strict memory management (explicit allocators, defer/errdefer)
-            - SDL3 for windowing and input
-            - Vulkan for rendering (only backend, via RHI abstraction)
-            - Nix for reproducible builds (`nix develop --command zig build`)
-            - GLSL shaders validated via glslangValidator
-
-            **Build Commands:**
-            - `nix develop --command zig build test` - Unit tests + shader validation
-            - `nix develop --command zig build test -- --test-filter "test name"` - Single test
-            - `nix develop --command zig fmt src/` - Format code
-
-            **Prioritize review attention on:**
-            - RHI/Vulkan correctness (buffer/texture handles, pipeline state, synchronization)
-            - Memory safety (allocator usage, defer cleanup, ArrayListUnmanaged patterns)
-            - Threading/concurrency (JobSystem usage, chunk pin/unpin, mutex protection)
-            - GPU resource lifecycle (creation, destruction, double-buffering with MAX_FRAMES_IN_FLIGHT)
-            - Packed struct correctness for GPU data (PackedLight, Vertex)
-            - Coordinate system correctness (world vs chunk vs local, worldToChunk/worldToLocal)
-            - Shader uniform naming (must match RHI exactly)
-
-            ${{ env.PREVIOUS_REVIEWS }}
-
-            ---
-
-            **YOUR TASK:** Analyze the CURRENT code changes and previous reviews above, then output your review in the following STRICT STRUCTURE:
-
-            **CRITICAL INSTRUCTIONS:**
-            1. **CHECK PREVIOUS ISSUES FIRST:** Look at the "Previous Automated Reviews" section above. For each issue previously reported (Critical, High, Medium, Low), verify if it still exists in the current code.
-            2. **ACKNOWLEDGE FIXES:** If a previously reported issue has been fixed, state "✅ **[FIXED]** Previous issue: [brief description]" in the appropriate section.
-            3. **ONLY REPORT NEW/UNRESOLVED ISSUES:** Do NOT re-report issues that have already been fixed. Only report issues that are still present in the current code.
-            4. **TRACK CHANGES:** If an issue was reported in a previous review but the code has changed, verify the new code and report the issue with updated file:line references if it still exists.
-
-            ---
-
-            ## 📋 Summary
-            First, check if the PR description mentions any linked issues (e.g., "Closes #123", "Fixes #456", "Resolves #789"). 
-
-            ## 📌 Review Metadata
-            - **Reviewed Commit SHA:** `${{ steps.resolve-pr.outputs.pr_head_sha }}`
-            - **Reviewed PR:** #${{ steps.resolve-pr.outputs.pr_number }}
-            
-            If linked issues are found:
-            - Mention the issue number(s) explicitly
-            - Verify the PR actually implements what the issue(s) requested
-            - State whether the implementation fully satisfies the issue requirements
-            
-            Then provide 2-3 sentences summarizing the PR purpose, scope, and overall quality.
-
-            ## 🔴 Critical Issues (Must Fix - Blocks Merge)
-            **IMPORTANT:** Check previous reviews first. If critical issues were reported before, verify if they're fixed. If fixed, say "✅ All previously reported critical issues have been resolved."
-            
-            Only report NEW critical issues that could cause crashes, security vulnerabilities, data loss, or major bugs.
-            
-            For each issue, use this exact format:
-            ```
-            **[CRITICAL]** `File:Line` - Issue Title
-            **Confidence:** High|Medium|Low (how sure you are this is a real problem)
-            **Description:** Clear explanation of the issue
-            **Impact:** What could go wrong if merged
-            **Suggested Fix:** Specific code changes needed
-            ```
-
-            ## ⚠️ High Priority Issues (Should Fix)
-            Same approach as Critical - check previous reviews first, acknowledge fixes, only report unresolved issues.
-            
-            Same format as Critical, but with **[HIGH]** prefix.
-
-            ## 💡 Medium Priority Issues (Nice to Fix)
-            Same approach - verify previous reports, acknowledge fixes, report only still-present issues.
-            
-            Same format, with **[MEDIUM]** prefix.
-
-            ## ℹ️ Low Priority Suggestions (Optional)
-            Same approach.
-            
-            Same format, with **[LOW]** prefix.
-
-            ## 📊 SOLID Principles Score
-            | Principle | Score | Notes |
-            |-----------|-------|-------|
-            | Single Responsibility | 0-10 | Brief justification |
-            | Open/Closed | 0-10 | Brief justification |
-            | Liskov Substitution | 0-10 | Brief justification |
-            | Interface Segregation | 0-10 | Brief justification |
-            | Dependency Inversion | 0-10 | Brief justification |
-            | **Average** | **X.X** | |
-
-            ## 🎯 Final Assessment
-
-            ### Overall Confidence Score: XX%
-            Rate your confidence in this PR being ready to merge (0-100%).
-            **How to interpret:**
-            - 0-30%: Major concerns, do not merge without significant rework
-            - 31-60%: Moderate concerns, several issues need addressing
-            - 61-80%: Minor concerns, mostly ready with some fixes
-            - 81-100%: High confidence, ready to merge or with trivial fixes
-
-            ### Confidence Breakdown:
-            - **Code Quality:** XX% (how well-written is the code?)
-            - **Completeness:** XX% (does it fulfill requirements?)
-            - **Risk Level:** XX% (how risky is this change?)
-            - **Test Coverage:** XX% (are changes adequately tested?)
-
-            ### Merge Readiness:
-            - [ ] All critical issues resolved
-            - [ ] SOLID average score >= 6.0
-            - [ ] Overall confidence >= 60%
-            - [ ] No security concerns
-            - [ ] Tests present and passing (if applicable)
-
-            ### Verdict:
-            **MERGE** | **MERGE WITH FIXES** | **DO NOT MERGE**
-            
-            One-sentence explanation of the verdict.
-
-            ## Machine Readable Verdict
-
-            Append this exact JSON block at the end of your review. Do not wrap it in another code block and do not add trailing commentary after it.
-
-            ```json
-            {
-              "reviewed_sha": "${{ steps.resolve-pr.outputs.pr_head_sha }}",
-              "critical_issues": 0,
-              "high_priority_issues": 0,
-              "medium_priority_issues": 0,
-              "overall_confidence_score": 0,
-              "recommendation": "MERGE"
-            }
-            ```
-
-            Rules for the JSON block:
-            - `reviewed_sha` must match the PR head SHA above.
-            - Counts must be integers.
-            - `overall_confidence_score` must be an integer from 0 to 100.
-            - If any critical, high, or medium issues remain, the counts must reflect them.
-            - Use `MERGE` only when there are no unresolved critical, high, or medium issues and the score is at least 80.
-
-            ---
-
-            **Review Guidelines:**
-            1. **MOST IMPORTANT:** Always check previous reviews and verify if issues are fixed before reporting them again
-            2. Acknowledge fixes explicitly with ✅ **[FIXED]** markers
-            3. Check the PR description for linked issues ("Fixes #123", "Closes #456", etc.) and verify the implementation
-            4. Be extremely specific with file paths and line numbers
-            5. Confidence scores should reflect how certain you are - use "Low" when unsure
-            6. If you have nothing meaningful to add to a section, write "None identified" instead of omitting it
-            7. Always provide actionable fixes, never just complaints
+          prompt: ${{ env.PROMPT }}
 
       - name: Evaluate AI merge gate
         id: ai_merge_gate

--- a/.github/workflows/opencode-pr.yml
+++ b/.github/workflows/opencode-pr.yml
@@ -108,6 +108,7 @@ jobs:
       - uses: ./.github/actions/load-prompt
         with:
           prompt-file: .github/prompts/pr-review.md
+          variables: $PR_NUMBER $HEAD_SHA $PREVIOUS_REVIEWS
 
       - name: Run opencode
         id: ai_review


### PR DESCRIPTION
## Summary
- Move the inline review prompt (160+ lines) from `opencode-pr.yml` into `.github/prompts/pr-review.md`
- Create `.github/actions/load-prompt` composite action that runs `envsubst` on a template file and writes to `$GITHUB_ENV`
- Update `resolve-pr` step to also write `PR_NUMBER`/`HEAD_SHA` to `$GITHUB_ENV`, so the load-prompt action call is just 2 lines

The prompt template uses shell variable placeholders (`$PR_NUMBER`, `$HEAD_SHA`, `$PREVIOUS_REVIEWS`) which are substituted at runtime via `envsubst`.