### PR TITLE


7 edge case tests for vulkan-device

### DIFF
--- a/src/engine/graphics/vulkan_device_edge_tests.zig
+++ b/src/engine/graphics/vulkan_device_edge_tests.zig
@@ -1,0 +1,124 @@
+const std = @import("std");
+const testing = std.testing;
+const c = @import("../../c.zig").c;
+const vulkan_device = @import("vulkan_device.zig");
+const VulkanDevice = vulkan_device.VulkanDevice;
+const checkVk = vulkan_device.checkVk;
+
+// ============================================================================
+// initDebugMessenger Early Return Tests
+// ============================================================================
+
+test "VulkanDevice.initDebugMessenger early returns when debug_utils disabled" {
+    var device = VulkanDevice{
+        .allocator = testing.allocator,
+        .debug_utils_enabled = false,
+        .debug_messenger = null,
+        .instance = @ptrFromInt(0x1234),
+    };
+
+    // Should return early without calling any Vulkan debug functions
+    device.initDebugMessenger();
+
+    // debug_messenger should remain null since early return happened
+    try testing.expect(device.debug_messenger == null);
+}
+
+test "VulkanDevice.initDebugMessenger early returns when messenger already created" {
+    var device = VulkanDevice{
+        .allocator = testing.allocator,
+        .debug_utils_enabled = true,
+        .debug_messenger = @ptrFromInt(0x5678), // Already set
+        .instance = @ptrFromInt(0x1234),
+    };
+
+    // Should return early because debug_messenger != null
+    device.initDebugMessenger();
+
+    // debug_messenger should remain unchanged
+    try testing.expect(device.debug_messenger != null);
+}
+
+// ============================================================================
+// MSAA Sample Count Edge Cases
+// ============================================================================
+
+test "VulkanDevice MSAA defaults to 1 when no sample flags set" {
+    const device = VulkanDevice{
+        .allocator = testing.allocator,
+        .vk_device = null,
+        .queue = null,
+    };
+
+    // Default max_msaa_samples is 1
+    try testing.expectEqual(@as(u8, 1), device.max_msaa_samples);
+}
+
+test "VulkanDevice MSAA can be set to boundary values" {
+    var device = VulkanDevice{
+        .allocator = testing.allocator,
+        .vk_device = null,
+        .queue = null,
+    };
+
+    // Test min boundary (1)
+    device.max_msaa_samples = 1;
+    try testing.expectEqual(@as(u8, 1), device.max_msaa_samples);
+
+    // Test mid boundary (4)
+    device.max_msaa_samples = 4;
+    try testing.expectEqual(@as(u8, 4), device.max_msaa_samples);
+
+    // Test max boundary (8)
+    device.max_msaa_samples = 8;
+    try testing.expectEqual(@as(u8, 8), device.max_msaa_samples);
+}
+
+// ============================================================================
+// Recovery State Machine Tests
+// ============================================================================
+
+test "VulkanDevice recovery_fail_count increments independently" {
+    var device = VulkanDevice{
+        .allocator = testing.allocator,
+        .vk_device = null,
+        .queue = null,
+        .recovery_fail_count = 0,
+    };
+
+    device.recovery_fail_count = 3;
+    try testing.expectEqual(@as(u32, 3), device.recovery_fail_count);
+
+    device.recovery_fail_count += 1;
+    try testing.expectEqual(@as(u32, 4), device.recovery_fail_count);
+}
+
+test "VulkanDevice recovery_success_count increments independently" {
+    var device = VulkanDevice{
+        .allocator = testing.allocator,
+        .vk_device = null,
+        .queue = null,
+        .recovery_success_count = 0,
+    };
+
+    device.recovery_success_count = 2;
+    try testing.expectEqual(@as(u32, 2), device.recovery_success_count);
+
+    device.recovery_success_count += 1;
+    try testing.expectEqual(@as(u32, 3), device.recovery_success_count);
+}
+
+// ============================================================================
+// checkVk Extended Error Code Coverage
+// ============================================================================
+
+test "checkVk maps VK_ERROR_VALIDATION_FAILED_EXT to Unknown" {
+    // This error code is less common but should still map to Unknown
+    try testing.expectError(error.Unknown, checkVk(c.VK_ERROR_VALIDATION_FAILED_EXT));
+}
+
+test "checkVk maps VK_SUBOPTIMAL_KHR to Unknown" {
+    // SUBOPTIMAL is a success variant, but current implementation maps it to Unknown
+    // This documents current behavior
+    try testing.expectError(error.Unknown, checkVk(c.VK_SUBOPTIMAL_KHR));
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -26,6 +26,7 @@ test {
     _ = @import("engine/graphics/vulkan_device.zig");
     _ = @import("engine/graphics/vulkan_device_tests.zig");
     _ = @import("engine/graphics/vulkan_device_internal_tests.zig");
+    _ = @import("engine/graphics/vulkan_device_edge_tests.zig");
     _ = @import("engine/graphics/vulkan/rhi_state_control_tests.zig");
     _ = @import("engine/graphics/vulkan/ssao_system_tests.zig");
     _ = @import("engine/graphics/vulkan/pipeline_manager_tests.zig");


### PR DESCRIPTION


Tests committed. Added `vulkan_device_edge_tests.zig` with 7 tests covering:
- `initDebugMessenger` early return paths (debug disabled, messenger already created)
- MSAA boundary values (1, 4, 8)
- Recovery counter independence
- Extended `checkVk` error code mapping (VK_ERROR_VALIDATION_FAILED_EXT, VK_SUBOPTIMAL_KHR)

Triggered by scheduled workflow

<a href="https://opencode.ai/s/ulD0pHC0"><img width="200" alt="New%20session%20-%202026-04-27T21%3A00%3A02.184Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTI3VDIxOjAwOjAyLjE4NFo=.png?model=minimax-coding-plan/MiniMax-M2.7&version=1.14.28&id=ulD0pHC0" /></a>
[opencode session](https://opencode.ai/s/ulD0pHC0)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/25019241478)