### PR TITLE
feat: add stale branch cleanup workflow

### DIFF
--- a/.github/workflows/stale-branch-cleanup.yml
+++ b/.github/workflows/stale-branch-cleanup.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   issues: write
+  pull-requests: read
 
 jobs:
   cleanup:

--- a/.github/workflows/stale-branch-cleanup.yml
+++ b/.github/workflows/stale-branch-cleanup.yml
@@ -1,0 +1,22 @@
+name: Stale Branch Cleanup
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Delete stale branches behind dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/stale_branch_cleanup.sh

--- a/scripts/stale_branch_cleanup.sh
+++ b/scripts/stale_branch_cleanup.sh
@@ -14,7 +14,7 @@ fi
 
 stale_epoch=$(date -d "-${STALE_DAYS} days" +%s 2>/dev/null || date -v-${STALE_DAYS}d +%s)
 
-gh api "repos/{owner}/{repo}/branches" --paginate --jq '.[].name' | while IFS= read -r name; do
+while IFS= read -r name; do
     if [[ "$name" == "$DEFAULT_BRANCH" || "$name" == "main" || "$name" == "master" ]]; then
         skipped+=("$name: protected")
         continue
@@ -34,7 +34,12 @@ gh api "repos/{owner}/{repo}/branches" --paginate --jq '.[].name' | while IFS= r
         continue
     fi
 
-    last_epoch=$(date -d "$last_date" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_date" +%s 2>/dev/null || echo "0")
+    last_epoch=$(date -d "$last_date" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_date" +%s 2>/dev/null || true)
+    if [[ -z "$last_epoch" ]]; then
+        skipped+=("$name: unable to parse last commit date")
+        continue
+    fi
+
     if [[ "$last_epoch" -gt "$stale_epoch" ]]; then
         skipped+=("$name: last commit ${last_date%%T*} is within ${STALE_DAYS} days")
         continue
@@ -46,8 +51,13 @@ gh api "repos/{owner}/{repo}/branches" --paginate --jq '.[].name' | while IFS= r
         continue
     fi
 
-    ahead=$(echo "$status" | jq -r '.ahead')
-    comp_status=$(echo "$status" | jq -r '.status')
+    ahead=$(echo "$status" | jq -r '.ahead // 0')
+    comp_status=$(echo "$status" | jq -r '.status // "unknown"')
+
+    if [[ "$ahead" == "null" || -z "$ahead" ]]; then
+        skipped+=("$name: invalid compare data")
+        continue
+    fi
 
     if [[ "$ahead" -gt 0 ]]; then
         skipped+=("$name: ${ahead} commit(s) ahead of ${DEFAULT_BRANCH}")
@@ -64,7 +74,7 @@ gh api "repos/{owner}/{repo}/branches" --paginate --jq '.[].name' | while IFS= r
         continue
     fi
     deleted+=("$name (last commit: ${last_date%%T*})")
-done
+done < <(gh api "repos/{owner}/{repo}/branches" --paginate --jq '.[].name')
 
 echo "Deleted branches:"
 printf '  - %s\n' "${deleted[@]+"${deleted[@]}"}"

--- a/scripts/stale_branch_cleanup.sh
+++ b/scripts/stale_branch_cleanup.sh
@@ -12,7 +12,11 @@ if ! command -v gh &>/dev/null; then
     exit 1
 fi
 
-stale_epoch=$(date -d "-${STALE_DAYS} days" +%s 2>/dev/null || date -v-${STALE_DAYS}d +%s)
+stale_epoch=$(date -d "-${STALE_DAYS} days" +%s 2>/dev/null || date -v-${STALE_DAYS}d +%s 2>/dev/null || true)
+if [[ -z "${stale_epoch:-}" ]]; then
+    echo "error: unable to calculate stale cutoff date" >&2
+    exit 1
+fi
 
 while IFS= read -r name; do
     if [[ "$name" == "$DEFAULT_BRANCH" || "$name" == "main" || "$name" == "master" ]]; then
@@ -61,6 +65,12 @@ while IFS= read -r name; do
 
     if [[ "$ahead" -gt 0 ]]; then
         skipped+=("$name: ${ahead} commit(s) ahead of ${DEFAULT_BRANCH}")
+        continue
+    fi
+
+    behind=$(echo "$status" | jq -r '.behind // 0')
+    if [[ "$ahead" -eq 0 && "$behind" -eq 0 ]]; then
+        skipped+=("$name: identical to ${DEFAULT_BRANCH}")
         continue
     fi
 

--- a/scripts/stale_branch_cleanup.sh
+++ b/scripts/stale_branch_cleanup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 DEFAULT_BRANCH="dev"
 STALE_DAYS=7
@@ -12,13 +12,17 @@ if ! command -v gh &>/dev/null; then
     exit 1
 fi
 
-stale_ts=$(date -d "-${STALE_DAYS} days" --iso-8601=seconds 2>/dev/null || date -v-${STALE_DAYS}d --iso-8601=seconds)
+stale_epoch=$(date -d "-${STALE_DAYS} days" +%s 2>/dev/null || date -v-${STALE_DAYS}d +%s)
 
-branches=$(gh api "repos/{owner}/{repo}/branches" --paginate --jq '.[].name')
-
-for name in ${branches}; do
+gh api "repos/{owner}/{repo}/branches" --paginate --jq '.[].name' | while IFS= read -r name; do
     if [[ "$name" == "$DEFAULT_BRANCH" || "$name" == "main" || "$name" == "master" ]]; then
         skipped+=("$name: protected")
+        continue
+    fi
+
+    pr_count=$(gh pr list --head "$name" --state open --json number --jq 'length' 2>/dev/null || echo "0")
+    if [[ "$pr_count" -gt 0 ]]; then
+        skipped+=("$name: has open PR")
         continue
     fi
 
@@ -30,13 +34,17 @@ for name in ${branches}; do
         continue
     fi
 
-    if [[ "$last_date" > "$stale_ts" ]]; then
-        skipped+=("$name: last commit $last_date is within ${STALE_DAYS} days")
+    last_epoch=$(date -d "$last_date" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_date" +%s 2>/dev/null || echo "0")
+    if [[ "$last_epoch" -gt "$stale_epoch" ]]; then
+        skipped+=("$name: last commit ${last_date%%T*} is within ${STALE_DAYS} days")
         continue
     fi
 
-    status=$(gh api "repos/{owner}/{repo}/compare/${DEFAULT_BRANCH}...${name}" \
-        --jq '{ahead: .ahead_by, behind: .behind_by, status: .status}')
+    if ! status=$(gh api "repos/{owner}/{repo}/compare/${DEFAULT_BRANCH}...${name}" \
+        --jq '{ahead: .ahead_by, behind: .behind_by, status: .status}' 2>/dev/null); then
+        skipped+=("$name: API error during compare")
+        continue
+    fi
 
     ahead=$(echo "$status" | jq -r '.ahead')
     comp_status=$(echo "$status" | jq -r '.status')
@@ -51,17 +59,22 @@ for name in ${branches}; do
         continue
     fi
 
-    gh api "repos/{owner}/{repo}/git/refs/heads/${name}" -X DELETE --silent
+    if ! gh api "repos/{owner}/{repo}/git/refs/heads/${name}" -X DELETE --silent 2>/dev/null; then
+        skipped+=("$name: failed to delete")
+        continue
+    fi
     deleted+=("$name (last commit: ${last_date%%T*})")
 done
 
 echo "Deleted branches:"
-printf '  - %s\n' "${deleted[@]}" 2>/dev/null || true
+printf '  - %s\n' "${deleted[@]+"${deleted[@]}"}"
 echo ""
 echo "Skipped branches:"
-printf '  - %s\n' "${skipped[@]}" 2>/dev/null || true
+printf '  - %s\n' "${skipped[@]+"${skipped[@]}"}"
 
 if [[ ${#deleted[@]} -gt 0 ]]; then
+    gh label create automation --color "#0366d6" --description "Automated processes" 2>/dev/null || true
+
     body=$(printf '### Stale Branch Cleanup Report\n\n')
     body+=$(printf '**%d** branch(es) deleted (no commits ahead of `%s`, last activity > %d days ago):\n\n' "${#deleted[@]}" "$DEFAULT_BRANCH" "$STALE_DAYS")
     for d in "${deleted[@]}"; do

--- a/scripts/stale_branch_cleanup.sh
+++ b/scripts/stale_branch_cleanup.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_BRANCH="dev"
+STALE_DAYS=7
+
+deleted=()
+skipped=()
+
+if ! command -v gh &>/dev/null; then
+    echo "error: gh CLI is required" >&2
+    exit 1
+fi
+
+stale_ts=$(date -d "-${STALE_DAYS} days" --iso-8601=seconds 2>/dev/null || date -v-${STALE_DAYS}d --iso-8601=seconds)
+
+branches=$(gh api "repos/{owner}/{repo}/branches" --paginate --jq '.[].name')
+
+for name in ${branches}; do
+    if [[ "$name" == "$DEFAULT_BRANCH" || "$name" == "main" || "$name" == "master" ]]; then
+        skipped+=("$name: protected")
+        continue
+    fi
+
+    last_date=$(gh api "repos/{owner}/{repo}/commits?sha=${name}&per_page=1" \
+        --jq '.[0].commit.committer.date' 2>/dev/null || true)
+
+    if [[ -z "$last_date" ]]; then
+        skipped+=("$name: no commits found")
+        continue
+    fi
+
+    if [[ "$last_date" > "$stale_ts" ]]; then
+        skipped+=("$name: last commit $last_date is within ${STALE_DAYS} days")
+        continue
+    fi
+
+    status=$(gh api "repos/{owner}/{repo}/compare/${DEFAULT_BRANCH}...${name}" \
+        --jq '{ahead: .ahead_by, behind: .behind_by, status: .status}')
+
+    ahead=$(echo "$status" | jq -r '.ahead')
+    comp_status=$(echo "$status" | jq -r '.status')
+
+    if [[ "$ahead" -gt 0 ]]; then
+        skipped+=("$name: ${ahead} commit(s) ahead of ${DEFAULT_BRANCH}")
+        continue
+    fi
+
+    if [[ "$comp_status" == "diverged" ]]; then
+        skipped+=("$name: diverged from ${DEFAULT_BRANCH}")
+        continue
+    fi
+
+    gh api "repos/{owner}/{repo}/git/refs/heads/${name}" -X DELETE --silent
+    deleted+=("$name (last commit: ${last_date%%T*})")
+done
+
+echo "Deleted branches:"
+printf '  - %s\n' "${deleted[@]}" 2>/dev/null || true
+echo ""
+echo "Skipped branches:"
+printf '  - %s\n' "${skipped[@]}" 2>/dev/null || true
+
+if [[ ${#deleted[@]} -gt 0 ]]; then
+    body=$(printf '### Stale Branch Cleanup Report\n\n')
+    body+=$(printf '**%d** branch(es) deleted (no commits ahead of `%s`, last activity > %d days ago):\n\n' "${#deleted[@]}" "$DEFAULT_BRANCH" "$STALE_DAYS")
+    for d in "${deleted[@]}"; do
+        body+=$(printf -- '- `%s`\n' "$d")
+    done
+    body+=$(printf '\nSkipped **%d** branch(es):\n\n' "${#skipped[@]}")
+    for s in "${skipped[@]}"; do
+        body+=$(printf -- '- `%s`\n' "$s")
+    done
+
+    today=$(date +%Y-%m-%d)
+    gh issue create \
+        --title "Stale branch cleanup - ${today}" \
+        --body "$body" \
+        --label "automation"
+else
+    echo "No stale branches to delete."
+fi


### PR DESCRIPTION
## Summary
- Adds a scheduled workflow (daily at 03:00 UTC) that deletes stale branches untouched for 7+ days and only behind `dev` (no ahead commits, not diverged)
- Logic lives in `scripts/stale_branch_cleanup.sh` using `gh api` — consistent with existing bash scripts in the repo
- Creates a cleanup report issue when branches are deleted