### PR TITLE
ci: Stabilize compute-heavy workflows

### DIFF
--- a/.github/actions/run-with-log/action.yml
+++ b/.github/actions/run-with-log/action.yml
@@ -1,0 +1,40 @@
+name: Run With Log
+description: Run a command with a timeout, tee output to a log, and summarize duration
+
+inputs:
+  name:
+    required: true
+    description: Human-readable command name for logs and summaries
+  command:
+    required: true
+    description: Bash command body to run
+  timeout:
+    required: false
+    default: 15m
+    description: Timeout duration passed to timeout(1)
+  log-file:
+    required: true
+    description: File to write command output to
+
+runs:
+  using: composite
+  steps:
+    - name: Run command with log
+      shell: bash
+      run: |
+        set -euo pipefail
+        START=$(date +%s)
+        COMMAND_FILE="$RUNNER_TEMP/run-with-log-${GITHUB_ACTION}.sh"
+        cat > "$COMMAND_FILE" <<'RUN_WITH_LOG_COMMAND'
+        ${{ inputs.command }}
+        RUN_WITH_LOG_COMMAND
+        chmod +x "$COMMAND_FILE"
+
+        echo "${{ inputs.name }} start: $(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee "${{ inputs.log-file }}"
+        timeout --preserve-status "${{ inputs.timeout }}" bash "$COMMAND_FILE" 2>&1 | tee -a "${{ inputs.log-file }}"
+        END=$(date +%s)
+        {
+          echo "### ${{ inputs.name }}"
+          echo "- Duration: $((END - START))s"
+          echo "- Runner: ${{ runner.name }} (${{ runner.os }})"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/setup-lavapipe/action.yml
+++ b/.github/actions/setup-lavapipe/action.yml
@@ -1,0 +1,21 @@
+name: Setup Lavapipe Vulkan
+description: Export Vulkan environment variables for Mesa Lavapipe and validation layers
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve Vulkan paths
+      shell: bash
+      run: |
+        set -euo pipefail
+        LVP_PATH=$(nix build --no-link --print-out-paths nixpkgs#mesa.drivers)/share/vulkan/icd.d/lvp_icd.x86_64.json
+        LAYER_PATH=$(nix build --no-link --print-out-paths nixpkgs#vulkan-validation-layers)/share/vulkan/explicit_layer.d
+        {
+          echo "VK_ICD_FILENAMES=$LVP_PATH"
+          echo "VK_LAYER_PATH=$LAYER_PATH"
+        } >> "$GITHUB_ENV"
+        {
+          echo "### Lavapipe Vulkan"
+          echo "- ICD: $LVP_PATH"
+          echo "- Layer path: $LAYER_PATH"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -14,6 +14,13 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Mark Nix setup start
+      shell: bash
+      run: |
+        START=$(date +%s)
+        echo "SETUP_NIX_START=$START" >> "$GITHUB_ENV"
+        echo "Nix setup start: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
     - name: Install Nix (primary)
       id: nix_install_primary
       continue-on-error: true
@@ -37,3 +44,14 @@ runs:
         primary-key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
         restore-prefixes-first-match: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-
         paths: ${{ inputs.cache-paths }}
+
+    - name: Mark Nix setup complete
+      shell: bash
+      run: |
+        END=$(date +%s)
+        START=${SETUP_NIX_START:-$END}
+        {
+          echo "### Nix Setup"
+          echo "- Duration: $((END - START))s"
+          echo "- Cache key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/start-weston/action.yml
+++ b/.github/actions/start-weston/action.yml
@@ -1,0 +1,76 @@
+name: Start Weston
+description: Start a headless Weston compositor and wait for the Wayland socket
+
+inputs:
+  nix-shell:
+    required: false
+    default: .#ci-graphics
+    description: Nix shell containing weston
+  runtime-dir:
+    required: false
+    default: /tmp/runtime-runner
+    description: XDG runtime directory for the compositor
+  socket:
+    required: false
+    default: headless
+    description: Wayland socket name
+  log-file:
+    required: false
+    default: weston.log
+    description: File to write Weston output to
+  pid-file:
+    required: false
+    default: /tmp/weston.pid
+    description: File to write Weston process ID to
+  wait-seconds:
+    required: false
+    default: "30"
+    description: Seconds to wait for the socket
+
+outputs:
+  pid-file:
+    description: PID file path
+    value: ${{ inputs.pid-file }}
+  log-file:
+    description: Log file path
+    value: ${{ inputs.log-file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Start compositor
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "${{ inputs.runtime-dir }}"
+        chmod 700 "${{ inputs.runtime-dir }}"
+        export XDG_RUNTIME_DIR="${{ inputs.runtime-dir }}"
+
+        nix develop "${{ inputs.nix-shell }}" --command weston \
+          --socket="${{ inputs.socket }}" \
+          --backend=headless-backend.so \
+          --width=1280 \
+          --height=720 > "${{ inputs.log-file }}" 2>&1 &
+        echo "$!" > "${{ inputs.pid-file }}"
+
+        {
+          echo "WAYLAND_DISPLAY=${{ inputs.socket }}"
+          echo "XDG_RUNTIME_DIR=${{ inputs.runtime-dir }}"
+        } >> "$GITHUB_ENV"
+
+        for i in $(seq 1 "${{ inputs.wait-seconds }}"); do
+          if [ -S "${{ inputs.runtime-dir }}/${{ inputs.socket }}" ]; then
+            echo "Weston ready after ${i}s"
+            exit 0
+          fi
+          if ! kill -0 "$(cat "${{ inputs.pid-file }}")" 2>/dev/null; then
+            echo "Weston exited before creating the Wayland socket" >&2
+            cat "${{ inputs.log-file }}" >&2 || true
+            exit 1
+          fi
+          sleep 1
+        done
+
+        echo "Timed out waiting for Weston Wayland socket" >&2
+        cat "${{ inputs.log-file }}" >&2 || true
+        exit 1

--- a/.github/actions/stop-weston/action.yml
+++ b/.github/actions/stop-weston/action.yml
@@ -1,0 +1,18 @@
+name: Stop Weston
+description: Stop a headless Weston compositor if it is running
+
+inputs:
+  pid-file:
+    required: false
+    default: /tmp/weston.pid
+    description: File containing Weston process ID
+
+runs:
+  using: composite
+  steps:
+    - name: Stop compositor
+      shell: bash
+      run: |
+        if [ -f "${{ inputs.pid-file }}" ]; then
+          kill "$(cat "${{ inputs.pid-file }}")" 2>/dev/null || true
+        fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,15 +34,31 @@ jobs:
 
     - name: Start headless Wayland compositor
       run: |
+        set -euo pipefail
         mkdir -p /tmp/runtime-runner
         chmod 700 /tmp/runtime-runner
         export XDG_RUNTIME_DIR=/tmp/runtime-runner
-        nix develop --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 &
+        nix develop .#ci-graphics --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 > weston.log 2>&1 &
+        echo "$!" > /tmp/weston.pid
         {
           echo "WAYLAND_DISPLAY=headless"
           echo "XDG_RUNTIME_DIR=/tmp/runtime-runner"
         } >> "$GITHUB_ENV"
-        sleep 5
+        for i in $(seq 1 30); do
+          if [ -S /tmp/runtime-runner/headless ]; then
+            echo "Weston ready after ${i}s"
+            exit 0
+          fi
+          if ! kill -0 "$(cat /tmp/weston.pid)" 2>/dev/null; then
+            echo "Weston exited before creating the Wayland socket" >&2
+            cat weston.log >&2 || true
+            exit 1
+          fi
+          sleep 1
+        done
+        echo "Timed out waiting for Weston Wayland socket" >&2
+        cat weston.log >&2 || true
+        exit 1
 
     - name: Run benchmark suite
       id: run_benchmark
@@ -53,11 +69,26 @@ jobs:
         ZIGCRAFT_SAFE_MODE: '1'
         BENCHMARK_DURATION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || '30' }}
       run: |
+        set -o pipefail
         LVP_PATH=$(nix build --no-link --print-out-paths nixpkgs#mesa.drivers)/share/vulkan/icd.d/lvp_icd.x86_64.json
         LAYER_PATH=$(nix build --no-link --print-out-paths nixpkgs#vulkan-validation-layers)/share/vulkan/explicit_layer.d
         export VK_ICD_FILENAMES=$LVP_PATH
         export VK_LAYER_PATH=$LAYER_PATH
-        nix develop --command bash scripts/run_benchmark.sh --duration "$BENCHMARK_DURATION" --presets low,medium,high --output-dir benchmark-results
+        START=$(date +%s)
+        timeout --preserve-status 75m nix develop .#ci-graphics --command bash scripts/run_benchmark.sh --duration "$BENCHMARK_DURATION" --presets low,medium,high --output-dir benchmark-results 2>&1 | tee benchmark.log
+        END=$(date +%s)
+        {
+          echo "### Benchmark"
+          echo "- Duration: $((END - START))s"
+          echo "- Runner: ${{ runner.name }} (${{ runner.os }})"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Stop headless Wayland compositor
+      if: always()
+      run: |
+        if [ -f /tmp/weston.pid ]; then
+          kill "$(cat /tmp/weston.pid)" 2>/dev/null || true
+        fi
 
     - name: Compare against baseline
       id: compare
@@ -71,7 +102,10 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: benchmark-results
-        path: benchmark-results
+        path: |
+          benchmark-results
+          benchmark.log
+          weston.log
         retention-days: 30
 
     - name: Publish commit status

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,62 +33,29 @@ jobs:
       uses: ./.github/actions/setup-nix
 
     - name: Start headless Wayland compositor
-      run: |
-        set -euo pipefail
-        mkdir -p /tmp/runtime-runner
-        chmod 700 /tmp/runtime-runner
-        export XDG_RUNTIME_DIR=/tmp/runtime-runner
-        nix develop .#ci-graphics --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 > weston.log 2>&1 &
-        echo "$!" > /tmp/weston.pid
-        {
-          echo "WAYLAND_DISPLAY=headless"
-          echo "XDG_RUNTIME_DIR=/tmp/runtime-runner"
-        } >> "$GITHUB_ENV"
-        for i in $(seq 1 30); do
-          if [ -S /tmp/runtime-runner/headless ]; then
-            echo "Weston ready after ${i}s"
-            exit 0
-          fi
-          if ! kill -0 "$(cat /tmp/weston.pid)" 2>/dev/null; then
-            echo "Weston exited before creating the Wayland socket" >&2
-            cat weston.log >&2 || true
-            exit 1
-          fi
-          sleep 1
-        done
-        echo "Timed out waiting for Weston Wayland socket" >&2
-        cat weston.log >&2 || true
-        exit 1
+      uses: ./.github/actions/start-weston
+
+    - name: Setup Lavapipe Vulkan
+      uses: ./.github/actions/setup-lavapipe
 
     - name: Run benchmark suite
       id: run_benchmark
+      uses: ./.github/actions/run-with-log
+      with:
+        name: Benchmark
+        timeout: 75m
+        log-file: benchmark.log
+        command: nix develop .#ci-graphics --command bash scripts/run_benchmark.sh --duration "$BENCHMARK_DURATION" --presets low,medium,high --output-dir benchmark-results
       env:
         ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
         XDG_RUNTIME_DIR: /tmp/runtime-runner
         WAYLAND_DISPLAY: headless
         ZIGCRAFT_SAFE_MODE: '1'
         BENCHMARK_DURATION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || '30' }}
-      run: |
-        set -o pipefail
-        LVP_PATH=$(nix build --no-link --print-out-paths nixpkgs#mesa.drivers)/share/vulkan/icd.d/lvp_icd.x86_64.json
-        LAYER_PATH=$(nix build --no-link --print-out-paths nixpkgs#vulkan-validation-layers)/share/vulkan/explicit_layer.d
-        export VK_ICD_FILENAMES=$LVP_PATH
-        export VK_LAYER_PATH=$LAYER_PATH
-        START=$(date +%s)
-        timeout --preserve-status 75m nix develop .#ci-graphics --command bash scripts/run_benchmark.sh --duration "$BENCHMARK_DURATION" --presets low,medium,high --output-dir benchmark-results 2>&1 | tee benchmark.log
-        END=$(date +%s)
-        {
-          echo "### Benchmark"
-          echo "- Duration: $((END - START))s"
-          echo "- Runner: ${{ runner.name }} (${{ runner.os }})"
-        } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Stop headless Wayland compositor
       if: always()
-      run: |
-        if [ -f /tmp/weston.pid ]; then
-          kill "$(cat /tmp/weston.pid)" 2>/dev/null || true
-        fi
+      uses: ./.github/actions/stop-weston
 
     - name: Compare against baseline
       id: compare

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,17 +113,12 @@ jobs:
 
     - name: Run unit tests
       if: needs.changes.outputs.code_changes == 'true'
-      run: |
-        set -o pipefail
-        START=$(date +%s)
-        echo "Unit test start: $(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee unit-test.log
-        timeout --preserve-status 25m nix develop .#ci-unit --command zig build test 2>&1 | tee -a unit-test.log
-        END=$(date +%s)
-        {
-          echo "### Unit Test"
-          echo "- Duration: $((END - START))s"
-          echo "- Runner: ${{ runner.name }} (${{ runner.os }})"
-        } >> "$GITHUB_STEP_SUMMARY"
+      uses: ./.github/actions/run-with-log
+      with:
+        name: Unit Test
+        timeout: 25m
+        log-file: unit-test.log
+        command: nix develop .#ci-unit --command zig build test
       env:
         ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
 
@@ -159,69 +154,41 @@ jobs:
 
     - name: Start headless Wayland compositor
       if: needs.changes.outputs.code_changes == 'true'
-      run: |
-        set -euo pipefail
-        mkdir -p /tmp/runtime-runner
-        chmod 700 /tmp/runtime-runner
-        export XDG_RUNTIME_DIR=/tmp/runtime-runner
-        nix develop .#ci-graphics --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 > weston.log 2>&1 &
-        echo "$!" > /tmp/weston.pid
-        {
-          echo "WAYLAND_DISPLAY=headless"
-          echo "XDG_RUNTIME_DIR=/tmp/runtime-runner"
-        } >> "$GITHUB_ENV"
-        for i in $(seq 1 30); do
-          if [ -S /tmp/runtime-runner/headless ]; then
-            echo "Weston ready after ${i}s"
-            exit 0
-          fi
-          if ! kill -0 "$(cat /tmp/weston.pid)" 2>/dev/null; then
-            echo "Weston exited before creating the Wayland socket" >&2
-            cat weston.log >&2 || true
-            exit 1
-          fi
-          sleep 1
-        done
-        echo "Timed out waiting for Weston Wayland socket" >&2
-        cat weston.log >&2 || true
-        exit 1
+      uses: ./.github/actions/start-weston
 
     - name: Run integration smoke test
       if: needs.changes.outputs.code_changes == 'true'
+      uses: ./.github/actions/run-with-log
+      with:
+        name: Integration Test
+        timeout: 15m
+        log-file: integration-test.log
+        command: nix develop .#ci-graphics --command zig build test-integration
       env:
         ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
-      run: |
-        set -o pipefail
-        START=$(date +%s)
-        timeout --preserve-status 15m nix develop .#ci-graphics --command zig build test-integration 2>&1 | tee integration-test.log
-        END=$(date +%s)
-        echo "- Integration test duration: $((END - START))s" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Setup Lavapipe Vulkan
+      if: needs.changes.outputs.code_changes == 'true'
+      uses: ./.github/actions/setup-lavapipe
 
     - name: Run world load smoke test (headless)
       if: needs.changes.outputs.code_changes == 'true'
+      uses: ./.github/actions/run-with-log
+      with:
+        name: World Smoke Test
+        timeout: 15m
+        log-file: world-smoke-test.log
+        command: nix develop .#ci-graphics --command zig build run -Dsmoke-test=true -Dskip-present=true
       env:
         ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
         XDG_RUNTIME_DIR: /tmp/runtime-runner
         WAYLAND_DISPLAY: headless
         ZIGCRAFT_SMOKE_FRAMES: "3"
         ZIGCRAFT_SAFE_MODE: "1"
-      run: |
-        set -o pipefail
-        LVP_PATH=$(nix build --no-link --print-out-paths nixpkgs#mesa.drivers)/share/vulkan/icd.d/lvp_icd.x86_64.json
-        LAYER_PATH=$(nix build --no-link --print-out-paths nixpkgs#vulkan-validation-layers)/share/vulkan/explicit_layer.d
-        export VK_ICD_FILENAMES=$LVP_PATH
-        export VK_LAYER_PATH=$LAYER_PATH
-        START=$(date +%s)
-        timeout --preserve-status 15m nix develop .#ci-graphics --command zig build run -Dsmoke-test=true -Dskip-present=true 2>&1 | tee world-smoke-test.log
-        END=$(date +%s)
-        echo "- World smoke test duration: $((END - START))s" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Stop headless Wayland compositor
       if: always() && needs.changes.outputs.code_changes == 'true'
-      run: |
-        if [ -f /tmp/weston.pid ]; then
-          kill "$(cat /tmp/weston.pid)" 2>/dev/null || true
-        fi
+      uses: ./.github/actions/stop-weston
 
     - name: Upload integration logs
       if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,10 @@ jobs:
         filters: |
           code_changes:
             - 'src/**'
+            - 'modules/**'
             - 'libs/**'
             - 'assets/shaders/**'
+            - 'scripts/**'
             - 'build.zig'
             - 'build.zig.zon'
             - 'flake.nix'
@@ -93,7 +95,7 @@ jobs:
       contents: read
       id-token: write
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: [changes, build]
     steps:
     - uses: actions/checkout@v4
@@ -111,9 +113,28 @@ jobs:
 
     - name: Run unit tests
       if: needs.changes.outputs.code_changes == 'true'
-      run: nix develop --command zig build test
+      run: |
+        set -o pipefail
+        START=$(date +%s)
+        echo "Unit test start: $(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee unit-test.log
+        timeout --preserve-status 25m nix develop .#ci-unit --command zig build test 2>&1 | tee -a unit-test.log
+        END=$(date +%s)
+        {
+          echo "### Unit Test"
+          echo "- Duration: $((END - START))s"
+          echo "- Runner: ${{ runner.name }} (${{ runner.os }})"
+        } >> "$GITHUB_STEP_SUMMARY"
       env:
         ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
+
+    - name: Upload unit test log
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: unit-test-log
+        path: unit-test.log
+        if-no-files-found: ignore
+        retention-days: 7
 
   integration-test:
     permissions:
@@ -139,22 +160,42 @@ jobs:
     - name: Start headless Wayland compositor
       if: needs.changes.outputs.code_changes == 'true'
       run: |
+        set -euo pipefail
         mkdir -p /tmp/runtime-runner
         chmod 700 /tmp/runtime-runner
         export XDG_RUNTIME_DIR=/tmp/runtime-runner
-        nix develop --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 &
+        nix develop .#ci-graphics --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 > weston.log 2>&1 &
+        echo "$!" > /tmp/weston.pid
         {
           echo "WAYLAND_DISPLAY=headless"
           echo "XDG_RUNTIME_DIR=/tmp/runtime-runner"
         } >> "$GITHUB_ENV"
-        sleep 5
+        for i in $(seq 1 30); do
+          if [ -S /tmp/runtime-runner/headless ]; then
+            echo "Weston ready after ${i}s"
+            exit 0
+          fi
+          if ! kill -0 "$(cat /tmp/weston.pid)" 2>/dev/null; then
+            echo "Weston exited before creating the Wayland socket" >&2
+            cat weston.log >&2 || true
+            exit 1
+          fi
+          sleep 1
+        done
+        echo "Timed out waiting for Weston Wayland socket" >&2
+        cat weston.log >&2 || true
+        exit 1
 
     - name: Run integration smoke test
       if: needs.changes.outputs.code_changes == 'true'
       env:
         ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
       run: |
-        nix develop --command zig build test-integration
+        set -o pipefail
+        START=$(date +%s)
+        timeout --preserve-status 15m nix develop .#ci-graphics --command zig build test-integration 2>&1 | tee integration-test.log
+        END=$(date +%s)
+        echo "- Integration test duration: $((END - START))s" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Run world load smoke test (headless)
       if: needs.changes.outputs.code_changes == 'true'
@@ -165,8 +206,31 @@ jobs:
         ZIGCRAFT_SMOKE_FRAMES: "3"
         ZIGCRAFT_SAFE_MODE: "1"
       run: |
+        set -o pipefail
         LVP_PATH=$(nix build --no-link --print-out-paths nixpkgs#mesa.drivers)/share/vulkan/icd.d/lvp_icd.x86_64.json
         LAYER_PATH=$(nix build --no-link --print-out-paths nixpkgs#vulkan-validation-layers)/share/vulkan/explicit_layer.d
         export VK_ICD_FILENAMES=$LVP_PATH
         export VK_LAYER_PATH=$LAYER_PATH
-        nix develop --command zig build run -Dsmoke-test=true -Dskip-present=true
+        START=$(date +%s)
+        timeout --preserve-status 15m nix develop .#ci-graphics --command zig build run -Dsmoke-test=true -Dskip-present=true 2>&1 | tee world-smoke-test.log
+        END=$(date +%s)
+        echo "- World smoke test duration: $((END - START))s" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Stop headless Wayland compositor
+      if: always() && needs.changes.outputs.code_changes == 'true'
+      run: |
+        if [ -f /tmp/weston.pid ]; then
+          kill "$(cat /tmp/weston.pid)" 2>/dev/null || true
+        fi
+
+    - name: Upload integration logs
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: integration-test-logs
+        path: |
+          integration-test.log
+          world-smoke-test.log
+          weston.log
+        if-no-files-found: ignore
+        retention-days: 7

--- a/.github/workflows/model-update-checker.yml
+++ b/.github/workflows/model-update-checker.yml
@@ -15,6 +15,10 @@ on:
         type: boolean
         default: 'true'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.model_id || 'default' }}
+  cancel-in-progress: false
+
 jobs:
   check-updates:
     runs-on: ubuntu-latest

--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -17,6 +17,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.module || 'scheduled' }}
+  cancel-in-progress: false
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.module || 'scheduled' }}
+  cancel-in-progress: false
+
 jobs:
   write-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/repo-automation.yml
+++ b/.github/workflows/repo-automation.yml
@@ -11,6 +11,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   label-pr:
     if: github.event_name == 'pull_request_target'

--- a/.github/workflows/stale-branch-cleanup.yml
+++ b/.github/workflows/stale-branch-cleanup.yml
@@ -10,9 +10,14 @@ permissions:
   issues: write
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -3,6 +3,10 @@ name: visual-test
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   visual-test:
     runs-on: ubuntu-latest
@@ -20,17 +24,33 @@ jobs:
 
       - name: Start headless Wayland compositor
         run: |
+          set -euo pipefail
           mkdir -p /tmp/runtime-runner
           chmod 700 /tmp/runtime-runner
           mkdir -p /tmp/opencode-cache
           export XDG_RUNTIME_DIR=/tmp/runtime-runner
-          nix develop --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 &
+          nix develop .#ci-graphics --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 > weston.log 2>&1 &
+          echo "$!" > /tmp/weston.pid
           {
             echo "WAYLAND_DISPLAY=headless"
             echo "XDG_RUNTIME_DIR=/tmp/runtime-runner"
             echo "XDG_CACHE_HOME=/tmp/opencode-cache"
           } >> "$GITHUB_ENV"
-          sleep 5
+          for i in $(seq 1 30); do
+            if [ -S /tmp/runtime-runner/headless ]; then
+              echo "Weston ready after ${i}s"
+              exit 0
+            fi
+            if ! kill -0 "$(cat /tmp/weston.pid)" 2>/dev/null; then
+              echo "Weston exited before creating the Wayland socket" >&2
+              cat weston.log >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Timed out waiting for Weston Wayland socket" >&2
+          cat weston.log >&2 || true
+          exit 1
 
       - name: Load visual verification prompt
         uses: ./.github/actions/load-prompt
@@ -67,11 +87,19 @@ jobs:
           ZIGCRAFT_SMOKE_FRAMES: "5"
           ZIGCRAFT_SAFE_RENDER: "1"
         run: |
+          set -o pipefail
           LVP_PATH=$(nix build --no-link --print-out-paths nixpkgs#mesa.drivers)/share/vulkan/icd.d/lvp_icd.x86_64.json
           LAYER_PATH=$(nix build --no-link --print-out-paths nixpkgs#vulkan-validation-layers)/share/vulkan/explicit_layer.d
           export VK_ICD_FILENAMES=$LVP_PATH
           export VK_LAYER_PATH=$LAYER_PATH
-          nix develop --command zig build run -Dscreenshot-path=screenshot.ppm -Dskip-present=true 2>&1 | tee build-output.log
+          START=$(date +%s)
+          timeout --preserve-status 20m nix develop .#ci-graphics --command zig build run -Dscreenshot-path=screenshot.ppm -Dskip-present=true 2>&1 | tee build-output.log
+          END=$(date +%s)
+          {
+            echo "### Visual Test"
+            echo "- Screenshot capture duration: $((END - START))s"
+            echo "- Runner: ${{ runner.name }} (${{ runner.os }})"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Convert PPM to PNG
         id: convert
@@ -104,8 +132,17 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: build-output-log
-          path: build-output.log
+          path: |
+            build-output.log
+            weston.log
           retention-days: 7
+
+      - name: Stop headless Wayland compositor
+        if: always()
+        run: |
+          if [ -f /tmp/weston.pid ]; then
+            kill "$(cat /tmp/weston.pid)" 2>/dev/null || true
+          fi
 
       - name: Run opencode visual verification
         if: steps.convert.outputs.screenshot_exists == 'true'

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -23,34 +23,12 @@ jobs:
         uses: ./.github/actions/setup-nix
 
       - name: Start headless Wayland compositor
+        uses: ./.github/actions/start-weston
+
+      - name: Prepare opencode cache
         run: |
-          set -euo pipefail
-          mkdir -p /tmp/runtime-runner
-          chmod 700 /tmp/runtime-runner
           mkdir -p /tmp/opencode-cache
-          export XDG_RUNTIME_DIR=/tmp/runtime-runner
-          nix develop .#ci-graphics --command weston --socket=headless --backend=headless-backend.so --width=1280 --height=720 > weston.log 2>&1 &
-          echo "$!" > /tmp/weston.pid
-          {
-            echo "WAYLAND_DISPLAY=headless"
-            echo "XDG_RUNTIME_DIR=/tmp/runtime-runner"
-            echo "XDG_CACHE_HOME=/tmp/opencode-cache"
-          } >> "$GITHUB_ENV"
-          for i in $(seq 1 30); do
-            if [ -S /tmp/runtime-runner/headless ]; then
-              echo "Weston ready after ${i}s"
-              exit 0
-            fi
-            if ! kill -0 "$(cat /tmp/weston.pid)" 2>/dev/null; then
-              echo "Weston exited before creating the Wayland socket" >&2
-              cat weston.log >&2 || true
-              exit 1
-            fi
-            sleep 1
-          done
-          echo "Timed out waiting for Weston Wayland socket" >&2
-          cat weston.log >&2 || true
-          exit 1
+          echo "XDG_CACHE_HOME=/tmp/opencode-cache" >> "$GITHUB_ENV"
 
       - name: Load visual verification prompt
         uses: ./.github/actions/load-prompt
@@ -77,29 +55,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
 
+      - name: Setup Lavapipe Vulkan
+        uses: ./.github/actions/setup-lavapipe
+
       - name: Run menu screenshot capture
         id: screenshot
         continue-on-error: true
+        uses: ./.github/actions/run-with-log
+        with:
+          name: Visual Test
+          timeout: 20m
+          log-file: build-output.log
+          command: nix develop .#ci-graphics --command zig build run -Dscreenshot-path=screenshot.ppm -Dskip-present=true
         env:
           ZIG_GLOBAL_CACHE_DIR: /tmp/zig-cache-global
           XDG_RUNTIME_DIR: /tmp/runtime-runner
           WAYLAND_DISPLAY: headless
           ZIGCRAFT_SMOKE_FRAMES: "5"
           ZIGCRAFT_SAFE_RENDER: "1"
-        run: |
-          set -o pipefail
-          LVP_PATH=$(nix build --no-link --print-out-paths nixpkgs#mesa.drivers)/share/vulkan/icd.d/lvp_icd.x86_64.json
-          LAYER_PATH=$(nix build --no-link --print-out-paths nixpkgs#vulkan-validation-layers)/share/vulkan/explicit_layer.d
-          export VK_ICD_FILENAMES=$LVP_PATH
-          export VK_LAYER_PATH=$LAYER_PATH
-          START=$(date +%s)
-          timeout --preserve-status 20m nix develop .#ci-graphics --command zig build run -Dscreenshot-path=screenshot.ppm -Dskip-present=true 2>&1 | tee build-output.log
-          END=$(date +%s)
-          {
-            echo "### Visual Test"
-            echo "- Screenshot capture duration: $((END - START))s"
-            echo "- Runner: ${{ runner.name }} (${{ runner.os }})"
-          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Convert PPM to PNG
         id: convert
@@ -139,10 +112,7 @@ jobs:
 
       - name: Stop headless Wayland compositor
         if: always()
-        run: |
-          if [ -f /tmp/weston.pid ]; then
-            kill "$(cat /tmp/weston.pid)" 2>/dev/null || true
-          fi
+        uses: ./.github/actions/stop-weston
 
       - name: Run opencode visual verification
         if: steps.convert.outputs.screenshot_exists == 'true'

--- a/flake.nix
+++ b/flake.nix
@@ -323,28 +323,73 @@
 
         packages.cimgui = cimgui;
 
-        devShells.default = pkgs.mkShell {
-          nativeBuildInputs = [
-            zig
-            pkgs.zls
-            pkgs.pkg-config
-            pkgs.glslang
-            pkgs.weston
-          ];
+        devShells = {
+          default = pkgs.mkShell {
+            nativeBuildInputs = [
+              zig
+              pkgs.zls
+              pkgs.pkg-config
+              pkgs.glslang
+              pkgs.weston
+            ];
 
-          buildInputs = [
-            pkgs.sdl3
-            pkgs.vulkan-loader
-            pkgs.vulkan-headers
-            pkgs.vulkan-validation-layers
-            pkgs.mesa.drivers
-            cimgui
-          ];
+            buildInputs = [
+              pkgs.sdl3
+              pkgs.vulkan-loader
+              pkgs.vulkan-headers
+              pkgs.vulkan-validation-layers
+              pkgs.mesa.drivers
+              cimgui
+            ];
 
-          shellHook = ''
-            echo "Zig ${zig_version} + SDL3 Dev Environment"
-            echo "Compiler: $(zig version)"
-          '';
+            shellHook = ''
+              echo "Zig ${zig_version} + SDL3 Dev Environment"
+              echo "Compiler: $(zig version)"
+            '';
+          };
+
+          ci-unit = pkgs.mkShell {
+            nativeBuildInputs = [
+              zig
+              pkgs.pkg-config
+              pkgs.glslang
+            ];
+
+            buildInputs = [
+              pkgs.sdl3
+              pkgs.vulkan-loader
+              pkgs.vulkan-headers
+              cimgui
+            ];
+
+            shellHook = ''
+              echo "Zig ${zig_version} CI unit environment"
+              echo "Compiler: $(zig version)"
+            '';
+          };
+
+          ci-graphics = pkgs.mkShell {
+            nativeBuildInputs = [
+              zig
+              pkgs.pkg-config
+              pkgs.glslang
+              pkgs.weston
+            ];
+
+            buildInputs = [
+              pkgs.sdl3
+              pkgs.vulkan-loader
+              pkgs.vulkan-headers
+              pkgs.vulkan-validation-layers
+              pkgs.mesa.drivers
+              cimgui
+            ];
+
+            shellHook = ''
+              echo "Zig ${zig_version} CI graphics environment"
+              echo "Compiler: $(zig version)"
+            '';
+          };
         };
       });
 }


### PR DESCRIPTION
## Summary
- Add lean CI Nix shells for unit and graphics workflows to reduce unnecessary dependency realization.
- Add reusable workflow helper actions for timed command logging, Weston lifecycle, and Lavapipe setup.
- Tighten workflow stability with broader build path filtering, longer unit timeout, command-level timeouts, log artifacts, and scheduled workflow concurrency.

## Verification
- Ruby YAML parse for workflows and composite actions
- `nix run nixpkgs#actionlint -- -color`
- `nix flake show --allow-import-from-derivation --no-write-lock-file`
- `nix develop .#ci-unit --command zig build test`