### PR TITLE
ci: extract workflow scripts

### DIFF
--- a/.github/actions/start-weston/action.yml
+++ b/.github/actions/start-weston/action.yml
@@ -46,6 +46,9 @@ runs:
         chmod 700 "${{ inputs.runtime-dir }}"
         export XDG_RUNTIME_DIR="${{ inputs.runtime-dir }}"
 
+        echo "Realizing ${{ inputs.nix-shell }} before starting Weston"
+        nix develop "${{ inputs.nix-shell }}" --command true
+
         nix develop "${{ inputs.nix-shell }}" --command weston \
           --socket="${{ inputs.socket }}" \
           --backend=headless-backend.so \

--- a/.github/workflows/model-update-checker.yml
+++ b/.github/workflows/model-update-checker.yml
@@ -35,276 +35,55 @@ jobs:
 
       - name: Fetch and analyze models.dev API
         id: fetch-models
-        run: |
-          MODEL_ID="${{ inputs.model_id || 'minimax-coding-plan/MiniMax-M2.7' }}"
-          FAMILY_ONLY="${{ inputs.family_only || 'true' }}"
-          
-          {
-            echo "model_id=${MODEL_ID}"
-            echo "family_only=${FAMILY_ONLY}"
-          } >> "$GITHUB_OUTPUT"
-
-          API_RESPONSE=$(curl -s https://models.dev/api.json)
-          
-          if [ -z "$API_RESPONSE" ]; then
-            echo "error=Failed to fetch models.dev API" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          PROVIDER=$(echo "$MODEL_ID" | cut -d/ -f1)
-          MODEL=$(echo "$MODEL_ID" | cut -d/ -f2)
-          
-          {
-            echo "provider=${PROVIDER}"
-            echo "model=${MODEL}"
-          } >> "$GITHUB_OUTPUT"
-
-          MODEL_EXISTS=$(echo "$API_RESPONSE" | jq -r ".\"${PROVIDER}\".models.\"${MODEL}\" != null")
-          if [ "$MODEL_EXISTS" != "true" ]; then
-            echo "error=Model ${MODEL_ID} not found in models.dev" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          CURRENT_LAST_UPDATED=$(echo "$API_RESPONSE" | jq -r ".\"${PROVIDER}\".models.\"${MODEL}\".last_updated")
-          CURRENT_RELEASE_DATE=$(echo "$API_RESPONSE" | jq -r ".\"${PROVIDER}\".models.\"${MODEL}\".release_date")
-          MODEL_NAME=$(echo "$API_RESPONSE" | jq -r ".\"${PROVIDER}\".models.\"${MODEL}\".name")
-          
-          {
-            echo "current_last_updated=${CURRENT_LAST_UPDATED}"
-            echo "current_release_date=${CURRENT_RELEASE_DATE}"
-            echo "model_name=${MODEL_NAME}"
-          } >> "$GITHUB_OUTPUT"
-
-          PROVIDER_MODELS=$(echo "$API_RESPONSE" | jq -r ".\"${PROVIDER}\".models | keys[]")
-          echo "all_models=${PROVIDER_MODELS}" >> "$GITHUB_OUTPUT"
+        env:
+          MODEL_ID: ${{ inputs.model_id || 'minimax-coding-plan/MiniMax-M2.7' }}
+          FAMILY_ONLY: ${{ inputs.family_only || 'true' }}
+        run: bash scripts/model_update_checker.sh fetch-models
 
       - name: Extract model family and find newer variants
         id: analyze-family
-        run: |
-          API_RESPONSE=$(curl -s https://models.dev/api.json)
-          PROVIDER="${{ steps.fetch-models.outputs.provider }}"
-          CURRENT_MODEL="${{ steps.fetch-models.outputs.model }}"
-          FAMILY_ONLY="${{ steps.fetch-models.outputs.family_only }}"
-          
-          BASE_PREFIX="${CURRENT_MODEL%%-[0-9.]*}-"
-          
-          {
-            echo "base_prefix=${BASE_PREFIX}"
-          } >> "$GITHUB_OUTPUT"
-          
-          FAMILY_MODELS=$(echo "$API_RESPONSE" | jq -r ".\"${PROVIDER}\".models | to_entries[] | select(.key | startswith(\"${BASE_PREFIX}\")) | .key" 2>/dev/null)
-          echo "family_models=${FAMILY_MODELS}" >> "$GITHUB_OUTPUT"
-
-          LATEST_MODEL=""
-          LATEST_RELEASE=""
-          for model in $FAMILY_MODELS; do
-            RELEASE=$(echo "$API_RESPONSE" | jq -r ".\"${PROVIDER}\".models.\"${model}\".release_date")
-            if [ -z "$LATEST_RELEASE" ] || [ "$(printf '%s\n' "$RELEASE" "$LATEST_RELEASE" | sort -r | head -1)" = "$RELEASE" ]; then
-              LATEST_RELEASE="$RELEASE"
-              LATEST_MODEL="$model"
-            fi
-          done
-          
-          {
-            echo "latest_family_model=${LATEST_MODEL}"
-            echo "latest_release_date=${LATEST_RELEASE}"
-          } >> "$GITHUB_OUTPUT"
-
-          if [ "$CURRENT_MODEL" != "$LATEST_MODEL" ]; then
-            {
-              echo "update_type=family"
-              echo "new_model=${LATEST_MODEL}"
-              echo "update_reason=Newer model variant ${LATEST_MODEL} available (released ${LATEST_RELEASE})"
-            } >> "$GITHUB_OUTPUT"
-          elif [ "$FAMILY_ONLY" = "false" ]; then
-            CURRENT_TRACKED="${{ steps.fetch-models.outputs.current_last_updated }}"
-            if [ -n "$CURRENT_TRACKED" ] && [ "$CURRENT_TRACKED" != "${{ steps.fetch-models.outputs.current_last_updated }}" ]; then
-              echo "update_type=spec" >> "$GITHUB_OUTPUT"
-            fi
-          fi
+        env:
+          PROVIDER: ${{ steps.fetch-models.outputs.provider }}
+          CURRENT_MODEL: ${{ steps.fetch-models.outputs.model }}
+          FAMILY_ONLY: ${{ steps.fetch-models.outputs.family_only }}
+          CURRENT_LAST_UPDATED: ${{ steps.fetch-models.outputs.current_last_updated }}
+        run: bash scripts/model_update_checker.sh analyze-family
 
       - name: Read tracked state
         id: read-state
-        run: |
-          STATE_FILE=".github/model-tracker.json"
-          
-          if [ -f "$STATE_FILE" ]; then
-            TRACKED_MODEL=$(jq -r '.tracked."${{ steps.fetch-models.outputs.model_id }}" // empty' "$STATE_FILE")
-            TRACKED_SPEC=$(jq -r '.specs."${{ steps.fetch-models.outputs.model_id }}" // empty' "$STATE_FILE")
-            {
-              echo "tracked_model=${TRACKED_MODEL}"
-              echo "tracked_spec=${TRACKED_SPEC}"
-            } >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo "tracked_model="
-              echo "tracked_spec="
-            } >> "$GITHUB_OUTPUT"
-          fi
+        env:
+          MODEL_ID: ${{ steps.fetch-models.outputs.model_id }}
+        run: bash scripts/model_update_checker.sh read-state
 
       - name: Determine if update is needed
         id: check-update
-        run: |
-          CURRENT_MODEL="${{ steps.fetch-models.outputs.model }}"
-          LATEST_FAMILY_MODEL="${{ steps.analyze-family.outputs.latest_family_model }}"
-          CURRENT_SPEC="${{ steps.fetch-models.outputs.current_last_updated }}"
-          TRACKED_MODEL="${{ steps.read-state.outputs.tracked_model }}"
-          TRACKED_SPEC="${{ steps.read-state.outputs.tracked_spec }}"
-          
-          UPDATE_NEEDED=false
-          UPDATE_REASON=""
-
-          # Check if family model has changed
-          if [ -n "$LATEST_FAMILY_MODEL" ] && [ "$CURRENT_MODEL" != "$LATEST_FAMILY_MODEL" ]; then
-            if [ "$TRACKED_MODEL" != "$LATEST_FAMILY_MODEL" ]; then
-              UPDATE_NEEDED=true
-              UPDATE_REASON="Newer model in family: ${LATEST_FAMILY_MODEL}"
-              {
-                echo "update_type=family"
-                echo "new_model_id=${{ steps.fetch-models.outputs.provider }}/${LATEST_FAMILY_MODEL}"
-              } >> "$GITHUB_OUTPUT"
-            fi
-          fi
-          
-          # Check if spec has been updated (last_updated changed)
-          if [ "$UPDATE_NEEDED" = "false" ] && [ -n "$TRACKED_SPEC" ] && [ "$TRACKED_SPEC" != "$CURRENT_SPEC" ]; then
-            UPDATE_NEEDED=true
-            UPDATE_REASON="Model spec updated: ${TRACKED_SPEC} -> ${CURRENT_SPEC}"
-            {
-              echo "update_type=spec"
-              echo "new_model_id=${{ steps.fetch-models.outputs.model_id }}"
-            } >> "$GITHUB_OUTPUT"
-          fi
-          
-          # First time tracking
-          if [ -z "$TRACKED_MODEL" ] && [ -z "$TRACKED_SPEC" ]; then
-            {
-              echo "update_type=initial"
-              echo "new_model_id=${{ steps.fetch-models.outputs.model_id }}"
-            } >> "$GITHUB_OUTPUT"
-            UPDATE_NEEDED=true
-            UPDATE_REASON="Initial tracking of model"
-          fi
-
-          {
-            echo "update_needed=${UPDATE_NEEDED}"
-            echo "update_reason=${UPDATE_REASON}"
-          } >> "$GITHUB_OUTPUT"
-          
-          echo "=== Update Check Results ==="
-          echo "Current model: ${CURRENT_MODEL}"
-          echo "Latest in family: ${LATEST_FAMILY_MODEL}"
-          echo "Tracked model: ${TRACKED_MODEL:-none}"
-          echo "Tracked spec: ${TRACKED_SPEC:-none}"
-          echo "Update needed: ${UPDATE_NEEDED}"
-          echo "Reason: ${UPDATE_REASON}"
+        env:
+          PROVIDER: ${{ steps.fetch-models.outputs.provider }}
+          MODEL_ID: ${{ steps.fetch-models.outputs.model_id }}
+          CURRENT_MODEL: ${{ steps.fetch-models.outputs.model }}
+          LATEST_FAMILY_MODEL: ${{ steps.analyze-family.outputs.latest_family_model }}
+          CURRENT_SPEC: ${{ steps.fetch-models.outputs.current_last_updated }}
+          TRACKED_MODEL: ${{ steps.read-state.outputs.tracked_model }}
+          TRACKED_SPEC: ${{ steps.read-state.outputs.tracked_spec }}
+        run: bash scripts/model_update_checker.sh check-update
 
       - name: Update tracker state
-        run: |
-          STATE_FILE=".github/model-tracker.json"
-          MODEL_ID="${{ steps.fetch-models.outputs.model_id }}"
-          CURRENT_SPEC="${{ steps.fetch-models.outputs.current_last_updated }}"
-          CURRENT_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          NEW_MODEL_ID="${{ steps.check-update.outputs.new_model_id }}"
-
-          mkdir -p .github
-
-          if [ -f "$STATE_FILE" ]; then
-            tmp=$(mktemp)
-            jq --arg model "$MODEL_ID" \
-               --arg newmodel "$NEW_MODEL_ID" \
-               --arg spec "$CURRENT_SPEC" \
-               --arg date "$CURRENT_DATE" \
-               '.tracked[$model] = $newmodel | .specs[$model] = $spec | .last_checked = $date' \
-               "$STATE_FILE" > "$tmp"
-            mv "$tmp" "$STATE_FILE"
-          else
-            printf '{"tracked": {"%s": "%s"}, "specs": {"%s": "%s"}, "last_checked": "%s"}' \
-              "$MODEL_ID" "$NEW_MODEL_ID" \
-              "$MODEL_ID" "$CURRENT_SPEC" \
-              "$CURRENT_DATE" > "$STATE_FILE"
-          fi
-
-          cat "$STATE_FILE"
+        env:
+          MODEL_ID: ${{ steps.fetch-models.outputs.model_id }}
+          CURRENT_SPEC: ${{ steps.fetch-models.outputs.current_last_updated }}
+          NEW_MODEL_ID: ${{ steps.check-update.outputs.new_model_id }}
+        run: bash scripts/model_update_checker.sh update-tracker
 
       - name: Find workflows using minimax models
         id: find-workflows
-        run: |
-          WORKFLOWS=$(grep -l "minimax-coding-plan/MiniMax" .github/workflows/*.yml 2>/dev/null | tr '\n' ',' | sed 's/,$//')
-          echo "workflows=${WORKFLOWS}" >> "$GITHUB_OUTPUT"
-          echo "Found: ${WORKFLOWS}"
+        run: bash scripts/model_update_checker.sh find-workflows
 
       - name: Create update PR
         if: steps.check-update.outputs.update_needed == 'true'
-        run: |
-          CURRENT_MODEL="${{ steps.fetch-models.outputs.model }}"
-          NEW_MODEL_ID="${{ steps.check-update.outputs.new_model_id }}"
-          NEW_MODEL=$(echo "$NEW_MODEL_ID" | cut -d/ -f2)
-          UPDATE_REASON="${{ steps.check-update.outputs.update_reason }}"
-          UPDATE_TYPE="${{ steps.check-update.outputs.update_type }}"
-          WORKFLOWS="${{ steps.find-workflows.outputs.workflows }}"
-          
-          BRANCH_NAME="model-update/${NEW_MODEL_ID//\//-}"
-
-          echo "Creating branch: $BRANCH_NAME"
-          git checkout -b "$BRANCH_NAME"
-
-          echo "=== Update Summary ==="
-          echo "Current: ${CURRENT_MODEL}"
-          echo "New: ${NEW_MODEL}"
-          echo "Type: ${UPDATE_TYPE}"
-          echo "Workflows: ${WORKFLOWS}"
-
-          # Update workflows - replace old model with new model
-          for workflow in .github/workflows/*.yml; do
-            if grep -q "minimax-coding-plan/MiniMax" "$workflow"; then
-              # Replace any MiniMax model reference with the new one
-              sed -i "s|minimax-coding-plan/MiniMax-[A-Za-z0-9.]*|${NEW_MODEL_ID}|g" "$workflow"
-              echo "Updated: $workflow"
-            fi
-          done
-
-          git diff --stat
-
-          git add .github/model-tracker.json
-          if [ -n "$WORKFLOWS" ]; then
-            for w in $(echo "$WORKFLOWS" | tr ',' ' '); do
-              git add "$w"
-            done
-          fi
-          
-          git commit -m "chore: update model from ${CURRENT_MODEL} to ${NEW_MODEL}"
-
-          git push -u origin "$BRANCH_NAME"
-
-          if [ -n "$WORKFLOWS" ]; then
-            WORKFLOWS_LIST=$(echo "$WORKFLOWS" | tr ',' '\n' | while read -r f; do echo "- \`$f\`"; done | tr '\n' ' ')
-          else
-            WORKFLOWS_LIST="(no workflow files found)"
-          fi
-
-          PR_BODY_FILE=$(mktemp)
-          printf '%s\n' \
-            "## Model Update" \
-            "" \
-            "This PR updates the AI model used in our OpenCode workflows." \
-            "" \
-            "**Change:** ${UPDATE_REASON}" \
-            "" \
-            "**Files updated:**" \
-            "${WORKFLOWS_LIST}" \
-            "" \
-            "**Verification:**" \
-            "- [ ] Confirm model exists in models.dev" \
-            "- [ ] Review updated workflow files" \
-            "- [ ] Run tests if available" \
-            "" \
-            "---" \
-            "Auto-generated by Model Update Checker workflow" > "$PR_BODY_FILE"
-
-          gh pr create \
-            --base dev \
-            --title "model: Update to ${NEW_MODEL}" \
-            --body-file "$PR_BODY_FILE"
-
-          echo "PR created successfully"
+        env:
+          CURRENT_MODEL: ${{ steps.fetch-models.outputs.model }}
+          NEW_MODEL_ID: ${{ steps.check-update.outputs.new_model_id }}
+          UPDATE_REASON: ${{ steps.check-update.outputs.update_reason }}
+          UPDATE_TYPE: ${{ steps.check-update.outputs.update_type }}
+          WORKFLOWS: ${{ steps.find-workflows.outputs.workflows }}
+        run: bash scripts/model_update_checker.sh create-pr

--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -36,41 +36,7 @@ jobs:
         id: select-module
         env:
           INPUT_MODULE: ${{ inputs.module }}
-        run: |
-          MODULES=(
-            "engine/graphics"
-            "engine/core"
-            "engine/math"
-            "engine/input"
-            "engine/ui"
-            "engine/atmosphere"
-            "engine/audio"
-            "engine/ecs"
-            "engine/physics"
-            "world"
-            "world/meshing"
-            "world/worldgen"
-            "game"
-          )
-
-          COUNT=${#MODULES[@]}
-
-          if [ -n "$INPUT_MODULE" ]; then
-            if ! echo "$INPUT_MODULE" | grep -qE '^[a-zA-Z0-9_ /-]+$'; then
-              echo "ERROR: Invalid module input: '$INPUT_MODULE'" >&2
-              exit 1
-            fi
-            SELECTED="$INPUT_MODULE"
-            echo "Manual dispatch: scanning ${SELECTED}"
-          else
-            DAY=$((10#$(date +%j)))
-            INDEX=$((DAY % COUNT))
-            SELECTED="${MODULES[${INDEX}]}"
-            echo "Scheduled run: day=${DAY} index=${INDEX} → ${SELECTED}"
-          fi
-
-          echo "module=${SELECTED}" >> "$GITHUB_OUTPUT"
-          echo "module_path=src/${SELECTED}" >> "$GITHUB_OUTPUT"
+        run: bash scripts/select_audit_module.sh
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -78,41 +44,26 @@ jobs:
           token: ${{ secrets.OPENCODE_PAT }}
 
       - name: Configure git identity
-        run: |
-          git config user.name "opencode[bot]"
-          git config user.email "opencode[bot]@users.noreply.github.com"
+        run: bash scripts/configure_git_identity.sh "opencode[bot]" "opencode[bot]@users.noreply.github.com"
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
       - name: Ensure automated-audit label exists
-        run: |
-          if ! gh label list --json name --jq '.[].name' | grep -q '^automated-audit$'; then
-            gh label create "automated-audit" \
-              --description "Issues found by automated opencode audit scans" \
-              --color "1D76DB" || true
-          fi
+        run: bash scripts/ensure_label.sh "automated-audit" "Issues found by automated opencode audit scans" "1D76DB"
         env:
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
 
       - name: Validate module directory exists
-        run: |
-          MODULE_PATH="${{ steps.select-module.outputs.module_path }}"
-          if [ ! -d "$MODULE_PATH" ]; then
-            echo "::warning::Module directory '$MODULE_PATH' does not exist — audit may be limited to partial or no source files"
-            echo "Listing parent directory:"
-            PARENT=$(dirname "$MODULE_PATH")
-            ls -la "$PARENT" 2>/dev/null || echo "Parent directory '$PARENT' also missing"
-          else
-            echo "Module directory confirmed: $MODULE_PATH"
-            echo "Files in module:"
-            find "$MODULE_PATH" -name '*.zig' | head -20
-          fi
+        env:
+          MODULE_PATH: ${{ steps.select-module.outputs.module_path }}
+        run: bash scripts/validate_audit_module.sh
 
       - name: Ensure opencode cache dir exists
         run: |
           sudo chmod u+w ~/.cache 2>/dev/null || true
-          mkdir -p /tmp/opencode-cache ~/.local/share/opencode
+          bash scripts/prepare_opencode_cache.sh
+          mkdir -p ~/.local/share/opencode
 
       - name: Load audit prompt
         uses: ./.github/actions/load-prompt
@@ -136,67 +87,6 @@ jobs:
 
       - name: Compliance guard — enforce issue-only output
         if: always()
-        run: |
-          echo "=== Checking for audit compliance violations ==="
-
-          BOT_LOGIN="github-actions[bot]"
-
-          VIOLATIONS=0
-
-          CUTOFF=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
-          NEW_PRS=$(gh pr list --author "$BOT_LOGIN" --state open --limit 20 \
-            --json number,title,headRefName,createdAt,body \
-            --jq '.[] | select(.createdAt >= "'"$CUTOFF"'") | select(.title | startswith("[Audit]"))')
-
-          if [ -n "$NEW_PRS" ]; then
-            echo "::error::Compliance violation detected: agent created pull request(s) instead of issue(s)"
-            echo "$NEW_PRS" | jq -c '.number' | while read -r PR_NUM; do
-              PR_NUM=$(echo "$PR_NUM" | tr -d '"')
-              echo "  ❌ Closing rogue PR #$PR_NUM"
-
-              PR_BODY=$(gh pr view "$PR_NUM" --json body --jq '.body')
-              PR_TITLE=$(gh pr view "$PR_NUM" --json title --jq '.title')
-              BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName')
-
-              ISSUE_TITLE="[Audit] ${PR_TITLE}"
-              ISSUE_BODY=$(cat <<ISSUE_EOF
-          ## ⚠️ Auto-converted from rogue PR #$PR_NUM
-
-          The audit agent incorrectly created a pull request instead of a GitHub issue.
-          The finding has been automatically converted below.
-
-          ---
-
-          $PR_BODY
-          ISSUE_EOF
-          )
-
-              echo "  📝 Creating issue from PR content..."
-              gh issue create \
-                --label "automated-audit" \
-                --title "$ISSUE_TITLE" \
-                --body "$ISSUE_BODY" || echo "  ⚠️ Failed to create issue from PR"
-
-              gh pr close "$PR_NUM" --comment "Auto-closed by compliance guard: audit workflow must create issues, not PRs." --delete-branch
-
-              VIOLATIONS=$((VIOLATIONS + 1))
-            done
-          fi
-
-          BOT_BRANCHES=$(gh api "repos/${{ github.repository }}/branches" \
-            --jq ".[] | select(.name | startswith(\"opencode/\")) | .name" 2>/dev/null || echo "")
-
-          if [ -n "$BOT_BRANCHES" ]; then
-            echo "::warning::Found opencode/ branches that may be audit violations:"
-            echo "$BOT_BRANCHES" | while read -r BRANCH; do
-              echo "  ⚠️ Branch: $BRANCH"
-            done
-          fi
-
-          if [ "$VIOLATIONS" -gt 0 ]; then
-            echo "::error::Compliance guard corrected $VIOLATIONS violation(s). PR(s) closed and converted to issue(s)."
-          else
-            echo "✅ No compliance violations detected."
-          fi
+        run: bash scripts/audit_compliance_guard.sh
         env:
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}

--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -32,16 +32,16 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.OPENCODE_PAT }}
+
       - name: Select module to scan
         id: select-module
         env:
           INPUT_MODULE: ${{ inputs.module }}
         run: bash scripts/select_audit_module.sh
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.OPENCODE_PAT }}
 
       - name: Configure git identity
         run: bash scripts/configure_git_identity.sh "opencode[bot]" "opencode[bot]@users.noreply.github.com"

--- a/.github/workflows/opencode-pr.yml
+++ b/.github/workflows/opencode-pr.yml
@@ -33,6 +33,13 @@ jobs:
       statuses: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.head_sha || github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          token: ${{ github.token }}
+
       - name: Resolve PR context
         id: resolve-pr
         env:
@@ -41,13 +48,6 @@ jobs:
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: bash scripts/resolve_pr_context.sh
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.resolve-pr.outputs.pr_head_sha }}
-          fetch-depth: 0
-          token: ${{ github.token }}
 
       - name: Configure git
         run: bash scripts/configure_git_identity.sh "github-actions[bot]" "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/opencode-pr.yml
+++ b/.github/workflows/opencode-pr.yml
@@ -35,18 +35,12 @@ jobs:
     steps:
       - name: Resolve PR context
         id: resolve-pr
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PR_NUMBER="${{ inputs.pr_number }}"
-            HEAD_SHA="${{ inputs.head_sha }}"
-          else
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          fi
-          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "pr_head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
-          echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          INPUT_HEAD_SHA: ${{ inputs.head_sha }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash scripts/resolve_pr_context.sh
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,46 +50,11 @@ jobs:
           token: ${{ github.token }}
 
       - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+        run: bash scripts/configure_git_identity.sh "github-actions[bot]" "github-actions[bot]@users.noreply.github.com"
 
       - name: Fetch previous opencode reviews
         id: previous-reviews
-        run: |
-          PR_NUMBER="${{ steps.resolve-pr.outputs.pr_number }}"
-          
-          echo "Fetching previous automated reviews..."
-          
-          gh api /repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews \
-            --jq '.[] | select(.user.login == "opencode-agent[bot]") | {body: .body, submitted_at: .submitted_at}' > /tmp/opencode_reviews.json 2>/dev/null || echo "[]" > /tmp/opencode_reviews.json
-          
-          gh api /repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments \
-            --jq '.[] | select(.user.login == "opencode-agent[bot]") | {body: .body, path: .path, line: .line, created_at: .created_at}' > /tmp/opencode_comments.json 2>/dev/null || echo "[]" > /tmp/opencode_comments.json
-          
-          REVIEW_CONTENT="## Previous Automated Reviews from opencode-agent:\n\n"
-          
-          if [ -s /tmp/opencode_reviews.json ] && [ "$(cat /tmp/opencode_reviews.json)" != "[]" ]; then
-            while IFS= read -r review; do
-              if [ -n "$review" ] && [ "$review" != "null" ]; then
-                body=$(echo "$review" | jq -r '.body // empty')
-                date=$(echo "$review" | jq -r '.submitted_at // empty')
-                if [ -n "$body" ] && [ "$body" != "null" ]; then
-                  REVIEW_CONTENT="${REVIEW_CONTENT}### Review from ${date}\n${body}\n\n---\n\n"
-                fi
-              fi
-            done < /tmp/opencode_reviews.json
-          else
-            REVIEW_CONTENT="${REVIEW_CONTENT}No previous automated reviews found.\n"
-          fi
-          
-          {
-            echo "PREVIOUS_REVIEWS<<EOF"
-            printf '%s\n' "$REVIEW_CONTENT"
-            echo "EOF"
-          } >> "$GITHUB_ENV"
-          
-          echo "Previous reviews fetched and formatted for context"
+        run: bash scripts/fetch_previous_opencode_reviews.sh
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -103,7 +62,7 @@ jobs:
         uses: ./.github/actions/setup-nix
 
       - name: Prepare opencode cache
-        run: mkdir -p /tmp/opencode-cache && echo "XDG_CACHE_HOME=/tmp/opencode-cache" >> "$GITHUB_ENV"
+        run: bash scripts/prepare_opencode_cache.sh
 
       - uses: ./.github/actions/load-prompt
         with:
@@ -124,52 +83,13 @@ jobs:
 
       - name: Evaluate AI merge gate
         id: ai_merge_gate
-        run: |
-          PR_NUMBER="${{ steps.resolve-pr.outputs.pr_number }}"
-          HEAD_SHA="${{ steps.resolve-pr.outputs.pr_head_sha }}"
-
-          PARSE_JSON=$(bash scripts/evaluate_ai_merge_gate.sh "${{ github.repository }}" "$PR_NUMBER" "$HEAD_SHA")
-
-          STATE=$(printf '%s' "$PARSE_JSON" | jq -r '.state')
-          DESCRIPTION=$(printf '%s' "$PARSE_JSON" | jq -r '.description')
-
-          gh api repos/${{ github.repository }}/statuses/${HEAD_SHA} \
-            -f state="$STATE" \
-            -f context='ai-merge-gate' \
-            -f description="$DESCRIPTION" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUMBER}"
-
-          if [ "$STATE" = "success" ]; then
-            CLOSING_REFS=$(gh pr view "$PR_NUMBER" \
-              --json closingIssuesReferences \
-              --jq '[.closingIssuesReferences[].number] | map("Closes #" + tostring) | join("\n")')
-
-            if [ -n "$CLOSING_REFS" ]; then
-              gh pr merge "$PR_NUMBER" --auto --squash --body "$CLOSING_REFS" || true
-            else
-              gh pr merge "$PR_NUMBER" --auto --squash || true
-            fi
-          fi
+        run: bash scripts/publish_ai_merge_gate.sh
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Mark AI review complete
         if: always()
-        run: |
-          PR_NUMBER="${{ steps.resolve-pr.outputs.pr_number }}"
-          HEAD_SHA="${{ steps.resolve-pr.outputs.pr_head_sha }}"
-          SHORT_SHA="${HEAD_SHA:0:7}"
-          OUTCOME="${{ steps.ai_review.outcome }}"
-          STATE="success"
-
-          if [ "$OUTCOME" != "success" ]; then
-            STATE="failure"
-          fi
-
-          gh api repos/${{ github.repository }}/statuses/${HEAD_SHA} \
-            -f state="$STATE" \
-            -f context='ai-review' \
-            -f description="AI review ${STATE} for ${SHORT_SHA}" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUMBER}"
         env:
+          AI_REVIEW_OUTCOME: ${{ steps.ai_review.outcome }}
           GH_TOKEN: ${{ github.token }}
+        run: bash scripts/mark_ai_review_complete.sh

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -32,22 +32,22 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Select module to test
-        id: select-module
-        env:
-          INPUT_MODULE: ${{ inputs.module }}
-          BASE_BRANCH: ${{ github.event.repository.default_branch }}
-        run: bash scripts/select_test_writer_module.sh
-
       # OPENCODE_PAT must be a classic PAT with `repo` scope (full control of private repositories)
       # or a fine-grained PAT with Contents: Read & Write on this repository.
       # Without write permission, git push will fail with 403.
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.select-module.outputs.base_branch }}
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           token: ${{ secrets.OPENCODE_PAT }}
+
+      - name: Select module to test
+        id: select-module
+        env:
+          INPUT_MODULE: ${{ inputs.module }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        run: bash scripts/select_test_writer_module.sh
 
       - name: Configure git identity
         run: bash scripts/configure_git_identity.sh "opencode[bot]" "opencode[bot]@users.noreply.github.com"

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -36,116 +36,8 @@ jobs:
         id: select-module
         env:
           INPUT_MODULE: ${{ inputs.module }}
-        run: |
-          GRAPHICS_MODULES=(
-            "graphics/vulkan-device"
-            "graphics/vulkan-resources"
-            "graphics/vulkan-pipelines"
-            "graphics/vulkan-swapchain"
-            "graphics/vulkan-frame"
-            "graphics/rhi-types"
-            "graphics/shadows"
-            "graphics/post-process"
-          )
-
-          OTHER_MODULES=(
-            "engine/core"
-            "engine/math"
-            "engine/input"
-            "world"
-            "world/meshing"
-            "world/worldgen"
-            "engine/ecs"
-            "game"
-          )
-
-          if [ -n "$INPUT_MODULE" ]; then
-            if ! echo "$INPUT_MODULE" | grep -qE '^[a-zA-Z0-9_/-]+$'; then
-              echo "ERROR: Invalid module input: '$INPUT_MODULE'" >&2
-              exit 1
-            fi
-            SELECTED="$INPUT_MODULE"
-            echo "Manual dispatch: writing tests for ${SELECTED}"
-          else
-            GRAPHICS_COUNT=${#GRAPHICS_MODULES[@]}
-            OTHER_COUNT=${#OTHER_MODULES[@]}
-
-            SLOT=$(($(date +%s) / 28800))
-            PARITY=$((SLOT % 2))
-
-            if [ "$PARITY" -eq 0 ]; then
-              INDEX=$((SLOT % GRAPHICS_COUNT))
-              SELECTED="${GRAPHICS_MODULES[${INDEX}]}"
-              echo "Graphics slot: parity=${PARITY} index=${INDEX} -> ${SELECTED}"
-            else
-              INDEX=$((SLOT % OTHER_COUNT))
-              SELECTED="${OTHER_MODULES[${INDEX}]}"
-              echo "Other slot: parity=${PARITY} index=${INDEX} -> ${SELECTED}"
-            fi
-          fi
-
-          BRANCH_NAME="test/$(echo "${SELECTED}" | tr '/' '-')"
-
-          case "$SELECTED" in
-            graphics/vulkan-device)
-              SCAN_PATHS="modules/engine-graphics/src/vulkan_device.zig modules/engine-graphics/src/vulkan/device.zig modules/engine-graphics/src/vulkan/rhi_state_control.zig"
-              ;;
-            graphics/vulkan-resources)
-              SCAN_PATHS="modules/engine-graphics/src/vulkan/resource_manager.zig modules/engine-graphics/src/vulkan/resource_texture_ops.zig modules/engine-graphics/src/vulkan/rhi_resource_lifecycle.zig modules/engine-graphics/src/vulkan/rhi_resource_setup.zig"
-              ;;
-            graphics/vulkan-pipelines)
-              SCAN_PATHS="modules/engine-graphics/src/vulkan/pipeline_manager.zig modules/engine-graphics/src/vulkan/pipeline_specialized.zig modules/engine-graphics/src/vulkan/shader_registry.zig modules/engine-graphics/src/vulkan/descriptor_manager.zig modules/engine-graphics/src/vulkan/descriptor_bindings.zig"
-              ;;
-            graphics/vulkan-swapchain)
-              SCAN_PATHS="modules/engine-graphics/src/vulkan/swapchain.zig modules/engine-graphics/src/vulkan/swapchain_presenter.zig modules/engine-graphics/src/vulkan_swapchain.zig"
-              ;;
-            graphics/vulkan-frame)
-              SCAN_PATHS="modules/engine-graphics/src/vulkan/frame_manager.zig modules/engine-graphics/src/vulkan/rhi_frame_orchestration.zig modules/engine-graphics/src/vulkan/render_pass_manager.zig modules/engine-graphics/src/vulkan/rhi_pass_orchestration.zig"
-              ;;
-            graphics/rhi-types)
-              SCAN_PATHS="modules/engine-rhi/src/rhi.zig modules/engine-rhi/src/rhi_types.zig modules/engine-graphics/src/rhi_vulkan.zig modules/engine-graphics/src/rhi_tests.zig"
-              ;;
-            graphics/shadows)
-              SCAN_PATHS="modules/engine-graphics/src/shadow_system.zig modules/engine-graphics/src/csm.zig modules/engine-graphics/src/vulkan/shadow_system.zig modules/engine-graphics/src/vulkan/rhi_shadow_bridge.zig modules/engine-graphics/src/shadow_scene.zig"
-              ;;
-            graphics/post-process)
-              SCAN_PATHS="modules/engine-graphics/src/vulkan/bloom_system.zig modules/engine-graphics/src/vulkan/fxaa_system.zig modules/engine-graphics/src/vulkan/taa_system.zig modules/engine-graphics/src/vulkan/ssao_system.zig modules/engine-graphics/src/vulkan/post_process_system.zig"
-              ;;
-            engine/core)
-              SCAN_PATHS="modules/engine-core/src/job_system.zig modules/engine-core/src/ring_buffer.zig modules/engine-core/src/time.zig modules/engine-core/src/log.zig modules/engine-core/src/window.zig"
-              ;;
-            engine/math)
-              SCAN_PATHS="modules/engine-math/src/vec3.zig modules/engine-math/src/mat4.zig modules/engine-math/src/frustum.zig modules/engine-math/src/utils.zig"
-              ;;
-            engine/input)
-              SCAN_PATHS="modules/engine-input/src/input.zig modules/engine-input/src/interfaces.zig"
-              ;;
-            world)
-              SCAN_PATHS="modules/world-core/src/chunk.zig modules/world-core/src/block.zig modules/world-core/src/block_registry.zig modules/world-meshing/src/chunk_storage.zig modules/world-meshing/src/chunk_allocator.zig modules/world-meshing/src/chunk_mesh.zig"
-              ;;
-            world/meshing)
-              SCAN_PATHS="modules/world-meshing/src/meshing/greedy_mesher.zig modules/world-meshing/src/meshing/ao_calculator.zig modules/world-meshing/src/meshing/lighting_sampler.zig modules/world-meshing/src/meshing/biome_color_sampler.zig modules/world-meshing/src/meshing/boundary.zig"
-              ;;
-            world/worldgen)
-              SCAN_PATHS="modules/world-worldgen/src/overworld_generator.zig modules/world-worldgen/src/biome.zig modules/world-worldgen/src/caves.zig modules/world-worldgen/src/terrain_shape_generator.zig modules/world-worldgen/src/coastal_generator.zig modules/world-worldgen/src/noise_sampler.zig modules/world-worldgen/src/height_sampler.zig modules/world-worldgen/src/surface_builder.zig"
-              ;;
-            engine/ecs)
-              SCAN_PATHS="modules/engine-ecs/src/storage.zig modules/engine-ecs/src/manager.zig modules/engine-ecs/src/entity.zig modules/engine-ecs/src/components.zig"
-              ;;
-            game)
-              SCAN_PATHS="src/game/player.zig src/game/screen.zig src/game/inventory.zig src/game/settings/ src/game/input_mapper.zig src/game/session.zig"
-              ;;
-            *)
-              SCAN_PATHS="src/${SELECTED}"
-              ;;
-          esac
-
-          {
-            echo "module=${SELECTED}"
-            echo "branch=${BRANCH_NAME}"
-            echo "base_branch=${{ github.event.repository.default_branch }}"
-            echo "scan_paths=${SCAN_PATHS}"
-          } >> "$GITHUB_OUTPUT"
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        run: bash scripts/select_test_writer_module.sh
 
       # OPENCODE_PAT must be a classic PAT with `repo` scope (full control of private repositories)
       # or a fine-grained PAT with Contents: Read & Write on this repository.
@@ -158,17 +50,10 @@ jobs:
           token: ${{ secrets.OPENCODE_PAT }}
 
       - name: Configure git identity
-        run: |
-          git config user.name "opencode[bot]"
-          git config user.email "opencode[bot]@users.noreply.github.com"
+        run: bash scripts/configure_git_identity.sh "opencode[bot]" "opencode[bot]@users.noreply.github.com"
 
       - name: Ensure test label exists
-        run: |
-          if ! gh label list --json name --jq '.[].name' | grep -q '^automated-test$'; then
-            gh label create "automated-test" \
-              --description "Test PRs created by automated opencode test writer" \
-              --color "0E8A16"
-          fi
+        run: bash scripts/ensure_label.sh "automated-test" "Test PRs created by automated opencode test writer" "0E8A16"
         env:
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
 
@@ -176,44 +61,21 @@ jobs:
         id: check-existing
         env:
           INPUT_MODULE: ${{ inputs.module }}
+          BASE_BRANCH: ${{ steps.select-module.outputs.base_branch }}
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
-        run: |
-          EXISTING=$(gh pr list \
-            --base ${{ steps.select-module.outputs.base_branch }} \
-            --state open \
-            --limit 50 \
-            --json number,headRefName,labels \
-            --jq '.[] | select((.headRefName | startswith("opencode/schedule-")) or ((.labels | map(.name)) | index("automated-test"))) | "#\(.number) (\(.headRefName))"' || true)
-          if [ -n "$EXISTING" ] && [ -z "$INPUT_MODULE" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Existing automated test PRs already open:"
-            printf '%s\n' "$EXISTING"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+        run: bash scripts/check_existing_test_prs.sh
 
       - name: Validate scan paths exist
         if: steps.check-existing.outputs.skip != 'true'
-        run: |
-          MISSING=0
-          for path in ${{ steps.select-module.outputs.scan_paths }}; do
-            if [ ! -e "$path" ]; then
-              echo "WARNING: scan path does not exist: $path"
-              MISSING=$((MISSING + 1))
-            fi
-          done
-          if [ "$MISSING" -gt 0 ]; then
-            echo "::warning::$MISSING scan path(s) missing — the scan_paths case statement in this workflow may need updating"
-          fi
+        env:
+          SCAN_PATHS: ${{ steps.select-module.outputs.scan_paths }}
+        run: bash scripts/validate_scan_paths.sh
 
       - name: Verify PAT push permissions
         if: steps.check-existing.outputs.skip != 'true'
-        run: |
-          if ! git push --dry-run origin HEAD:${{ steps.select-module.outputs.base_branch }} 2>/dev/null; then
-            echo "::error::OPENCODE_PAT cannot push to repository. Ensure the PAT has 'repo' scope (classic) or Contents: Read & Write (fine-grained)."
-            exit 1
-          fi
-          echo "PAT has push permissions."
+        env:
+          BASE_BRANCH: ${{ steps.select-module.outputs.base_branch }}
+        run: bash scripts/verify_pat_push_permissions.sh
 
       - name: Setup Nix
         if: steps.check-existing.outputs.skip != 'true'
@@ -245,27 +107,6 @@ jobs:
 
       - name: Find and label created PR
         if: steps.check-existing.outputs.skip != 'true'
-        run: |
-          MAX_RETRIES=8
-          HEAD_SHA=$(git rev-parse HEAD)
-          PR_NUM=""
-          for i in $(seq 1 "$MAX_RETRIES"); do
-            sleep $((i * 3))
-            echo "Attempt $i/$MAX_RETRIES: searching for PR for commit ${HEAD_SHA}..."
-            PR_NUM=$(gh api \
-              "repos/${{ github.repository }}/commits/${HEAD_SHA}/pulls" \
-              --jq '[.[] | select(.state == "open")] | .[0].number // empty' 2>/dev/null || true)
-            if [ -n "$PR_NUM" ]; then
-              break
-            fi
-          done
-          if [ -n "$PR_NUM" ]; then
-            echo "Found newly created PR #$PR_NUM for commit ${HEAD_SHA}"
-            if ! gh pr edit "$PR_NUM" --add-label "automated-test" 2>/dev/null; then
-              echo "::warning::Failed to add automated-test label to PR #$PR_NUM"
-            fi
-          else
-            echo "::warning::No open PR found for commit ${HEAD_SHA} after $MAX_RETRIES attempts"
-          fi
+        run: bash scripts/label_created_test_pr.sh
         env:
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - 'scripts/*.sh'
   pull_request:
     branches: [ dev ]
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - 'scripts/*.sh'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -43,3 +45,6 @@ jobs:
       - name: Parse composite action YAML
         run: |
           ruby -e 'require "yaml"; Dir[".github/actions/**/action.{yml,yaml}"].sort.each { |f| YAML.load_file(f); puts "OK #{f}" }'
+
+      - name: Check shell script syntax
+        run: bash -n scripts/*.sh

--- a/scripts/audit_compliance_guard.sh
+++ b/scripts/audit_compliance_guard.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "=== Checking for audit compliance violations ==="
+
+bot_login="github-actions[bot]"
+violations=0
+cutoff="$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)"
+new_prs=$(gh pr list --author "$bot_login" --state open --limit 20 \
+    --json number,title,headRefName,createdAt,body \
+    --jq '.[] | select(.createdAt >= "'"$cutoff"'") | select(.title | startswith("[Audit]"))')
+
+if [[ -n "$new_prs" ]]; then
+    echo "::error::Compliance violation detected: agent created pull request(s) instead of issue(s)"
+    while IFS= read -r pr_num; do
+        pr_num="${pr_num//\"/}"
+        [[ -n "$pr_num" ]] || continue
+        printf '  Closing rogue PR #%s\n' "$pr_num"
+
+        pr_body="$(gh pr view "$pr_num" --json body --jq '.body')"
+        pr_title="$(gh pr view "$pr_num" --json title --jq '.title')"
+
+        issue_title="[Audit] ${pr_title}"
+        issue_body=$(cat <<ISSUE_EOF
+## Auto-converted from rogue PR #$pr_num
+
+The audit agent incorrectly created a pull request instead of a GitHub issue.
+The finding has been automatically converted below.
+
+---
+
+$pr_body
+ISSUE_EOF
+)
+
+        echo "  Creating issue from PR content..."
+        gh issue create \
+            --label automated-audit \
+            --title "$issue_title" \
+            --body "$issue_body" || echo "  Failed to create issue from PR"
+
+        gh pr close "$pr_num" --comment "Auto-closed by compliance guard: audit workflow must create issues, not PRs." --delete-branch
+        violations=$((violations + 1))
+    done < <(printf '%s\n' "$new_prs" | jq -c '.number')
+fi
+
+bot_branches=$(gh api "repos/${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}/branches" \
+    --jq '.[] | select(.name | startswith("opencode/")) | .name' 2>/dev/null || echo "")
+
+if [[ -n "$bot_branches" ]]; then
+    echo "::warning::Found opencode/ branches that may be audit violations:"
+    while IFS= read -r branch; do
+        [[ -n "$branch" ]] || continue
+        printf '  Branch: %s\n' "$branch"
+    done <<< "$bot_branches"
+fi
+
+if [[ "$violations" -gt 0 ]]; then
+    printf '::error::Compliance guard corrected %d violation(s). PR(s) closed and converted to issue(s).\n' "$violations"
+else
+    echo "No compliance violations detected."
+fi

--- a/scripts/check_existing_test_prs.sh
+++ b/scripts/check_existing_test_prs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source scripts/github_actions_common.sh
+
+base_branch="${BASE_BRANCH:?BASE_BRANCH is required}"
+input_module="${INPUT_MODULE:-}"
+
+existing=$(gh pr list \
+    --base "$base_branch" \
+    --state open \
+    --limit 50 \
+    --json number,headRefName,labels \
+    --jq '.[] | select((.headRefName | startswith("opencode/schedule-")) or ((.labels | map(.name)) | index("automated-test"))) | "#\(.number) (\(.headRefName))"' || true)
+
+if [[ -n "$existing" && -z "$input_module" ]]; then
+    write_output skip true
+    printf 'Existing automated test PRs already open:\n%s\n' "$existing"
+else
+    write_output skip false
+fi

--- a/scripts/configure_git_identity.sh
+++ b/scripts/configure_git_identity.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+name="${1:?git user name required}"
+email="${2:?git user email required}"
+
+git config user.name "$name"
+git config user.email "$email"

--- a/scripts/configure_pat_git_identity.sh
+++ b/scripts/configure_pat_git_identity.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+pat_user_id="$(gh api user --jq '.id')"
+pat_user_login="$(gh api user --jq '.login')"
+
+git config user.name "$pat_user_login"
+git config user.email "${pat_user_id}+${pat_user_login}@users.noreply.github.com"

--- a/scripts/ensure_label.sh
+++ b/scripts/ensure_label.sh
@@ -7,5 +7,7 @@ description="${2:?description required}"
 color="${3:?color required}"
 
 if ! gh label list --json name --jq '.[].name' | grep -qxF "$label"; then
-    gh label create "$label" --description "$description" --color "$color" || true
+    if ! gh label create "$label" --description "$description" --color "$color"; then
+        printf '::warning::Failed to create label %s\n' "$label" >&2
+    fi
 fi

--- a/scripts/ensure_label.sh
+++ b/scripts/ensure_label.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+label="${1:?label required}"
+description="${2:?description required}"
+color="${3:?color required}"
+
+if ! gh label list --json name --jq '.[].name' | grep -qxF "$label"; then
+    gh label create "$label" --description "$description" --color "$color" || true
+fi

--- a/scripts/fetch_previous_opencode_reviews.sh
+++ b/scripts/fetch_previous_opencode_reviews.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source scripts/github_actions_common.sh
+
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+pr_number="${PR_NUMBER:?PR_NUMBER is required}"
+
+echo "Fetching previous automated reviews..."
+
+gh api "/repos/${repo}/pulls/${pr_number}/reviews" \
+    --jq '.[] | select(.user.login == "opencode-agent[bot]") | {body: .body, submitted_at: .submitted_at}' > /tmp/opencode_reviews.json 2>/dev/null || echo "[]" > /tmp/opencode_reviews.json
+
+gh api "/repos/${repo}/pulls/${pr_number}/comments" \
+    --jq '.[] | select(.user.login == "opencode-agent[bot]") | {body: .body, path: .path, line: .line, created_at: .created_at}' > /tmp/opencode_comments.json 2>/dev/null || echo "[]" > /tmp/opencode_comments.json
+
+review_content=$'## Previous Automated Reviews from opencode-agent:\n\n'
+
+if [[ -s /tmp/opencode_reviews.json && "$(cat /tmp/opencode_reviews.json)" != "[]" ]]; then
+    while IFS= read -r review; do
+        if [[ -n "$review" && "$review" != "null" ]]; then
+            body="$(printf '%s' "$review" | jq -r '.body // empty')"
+            date="$(printf '%s' "$review" | jq -r '.submitted_at // empty')"
+            if [[ -n "$body" && "$body" != "null" ]]; then
+                review_content+="### Review from ${date}"$'\n'
+                review_content+="${body}"$'\n\n---\n\n'
+            fi
+        fi
+    done < /tmp/opencode_reviews.json
+else
+    review_content+=$'No previous automated reviews found.\n'
+fi
+
+write_multiline_env PREVIOUS_REVIEWS "$review_content"
+echo "Previous reviews fetched and formatted for context"

--- a/scripts/github_actions_common.sh
+++ b/scripts/github_actions_common.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+require_env() {
+    local name="$1"
+    if [[ -z "${!name:-}" ]]; then
+        printf 'error: required environment variable %s is not set\n' "$name" >&2
+        exit 2
+    fi
+}
+
+write_output() {
+    local name="$1"
+    local value="$2"
+    require_env GITHUB_OUTPUT
+    if [[ "$value" == *$'\n'* ]]; then
+        {
+            printf '%s<<OUTEOF\n' "$name"
+            printf '%s\n' "$value"
+            printf 'OUTEOF\n'
+        } >> "$GITHUB_OUTPUT"
+    else
+        printf '%s=%s\n' "$name" "$value" >> "$GITHUB_OUTPUT"
+    fi
+}
+
+write_env() {
+    local name="$1"
+    local value="$2"
+    require_env GITHUB_ENV
+    printf '%s=%s\n' "$name" "$value" >> "$GITHUB_ENV"
+}
+
+write_multiline_env() {
+    local name="$1"
+    local value="$2"
+    require_env GITHUB_ENV
+    {
+        printf '%s<<ENVEOF\n' "$name"
+        printf '%s\n' "$value"
+        printf 'ENVEOF\n'
+    } >> "$GITHUB_ENV"
+}

--- a/scripts/label_created_test_pr.sh
+++ b/scripts/label_created_test_pr.sh
@@ -19,9 +19,11 @@ done
 
 if [[ -n "$pr_num" ]]; then
     printf 'Found newly created PR #%s for commit %s\n' "$pr_num" "$head_sha"
-    if ! gh pr edit "$pr_num" --add-label automated-test 2>/dev/null; then
-        printf '::warning::Failed to add automated-test label to PR #%s\n' "$pr_num"
+    label_error="$(mktemp)"
+    if ! gh pr edit "$pr_num" --add-label automated-test 2>"$label_error"; then
+        printf '::warning::Failed to add automated-test label to PR #%s: %s\n' "$pr_num" "$(tr '\n' ' ' < "$label_error")"
     fi
+    rm -f "$label_error"
 else
     printf '::warning::No open PR found for commit %s after %s attempts\n' "$head_sha" "$max_retries"
 fi

--- a/scripts/label_created_test_pr.sh
+++ b/scripts/label_created_test_pr.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+max_retries="${MAX_RETRIES:-8}"
+head_sha="$(git rev-parse HEAD)"
+pr_num=""
+
+for i in $(seq 1 "$max_retries"); do
+    sleep $((i * 3))
+    printf 'Attempt %s/%s: searching for PR for commit %s...\n' "$i" "$max_retries" "$head_sha"
+    pr_num=$(gh api \
+        "repos/${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}/commits/${head_sha}/pulls" \
+        --jq '[.[] | select(.state == "open")] | .[0].number // empty' 2>/dev/null || true)
+    if [[ -n "$pr_num" ]]; then
+        break
+    fi
+done
+
+if [[ -n "$pr_num" ]]; then
+    printf 'Found newly created PR #%s for commit %s\n' "$pr_num" "$head_sha"
+    if ! gh pr edit "$pr_num" --add-label automated-test 2>/dev/null; then
+        printf '::warning::Failed to add automated-test label to PR #%s\n' "$pr_num"
+    fi
+else
+    printf '::warning::No open PR found for commit %s after %s attempts\n' "$head_sha" "$max_retries"
+fi

--- a/scripts/mark_ai_review_complete.sh
+++ b/scripts/mark_ai_review_complete.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+pr_number="${PR_NUMBER:?PR_NUMBER is required}"
+head_sha="${HEAD_SHA:?HEAD_SHA is required}"
+outcome="${AI_REVIEW_OUTCOME:?AI_REVIEW_OUTCOME is required}"
+server_url="${GITHUB_SERVER_URL:-https://github.com}"
+short_sha="${head_sha:0:7}"
+state="success"
+
+if [[ "$outcome" != "success" ]]; then
+    state="failure"
+fi
+
+gh api "repos/${repo}/statuses/${head_sha}" \
+    -f state="$state" \
+    -f context=ai-review \
+    -f description="AI review ${state} for ${short_sha}" \
+    -f target_url="${server_url}/${repo}/pull/${pr_number}"

--- a/scripts/model_update_checker.sh
+++ b/scripts/model_update_checker.sh
@@ -45,7 +45,7 @@ cmd_fetch_models() {
 }
 
 cmd_analyze_family() {
-    local response provider current_model family_only base_prefix family_models latest_model latest_release model release current_tracked
+    local response provider current_model family_only base_prefix family_models latest_model latest_release model release
     response="$(api_response)"
     provider="${PROVIDER:?PROVIDER is required}"
     current_model="${CURRENT_MODEL:?CURRENT_MODEL is required}"
@@ -58,13 +58,14 @@ cmd_analyze_family() {
 
     latest_model=""
     latest_release=""
-    for model in $family_models; do
+    while IFS= read -r model; do
+        [[ -n "$model" ]] || continue
         release="$(jq -r ".\"${provider}\".models.\"${model}\".release_date" <<< "$response")"
         if [[ -z "$latest_release" || "$(printf '%s\n' "$release" "$latest_release" | sort -r | head -1)" == "$release" ]]; then
             latest_release="$release"
             latest_model="$model"
         fi
-    done
+    done <<< "$family_models"
 
     write_output latest_family_model "$latest_model"
     write_output latest_release_date "$latest_release"
@@ -73,11 +74,6 @@ cmd_analyze_family() {
         write_output update_type family
         write_output new_model "$latest_model"
         write_output update_reason "Newer model variant ${latest_model} available (released ${latest_release})"
-    elif [[ "$family_only" == "false" ]]; then
-        current_tracked="${CURRENT_LAST_UPDATED:-}"
-        if [[ -n "$current_tracked" && "$current_tracked" != "${CURRENT_LAST_UPDATED:-}" ]]; then
-            write_output update_type spec
-        fi
     fi
 }
 
@@ -177,7 +173,7 @@ cmd_create_pr() {
     local update_reason="${UPDATE_REASON:-}"
     local update_type="${UPDATE_TYPE:-}"
     local workflows="${WORKFLOWS:-}"
-    local new_model branch_name workflows_list pr_body_file
+    local new_model branch_name workflows_list pr_body_file escaped_model_id
 
     new_model="$(cut -d/ -f2 <<< "$new_model_id")"
     branch_name="model-update/${new_model_id//\//-}"
@@ -190,9 +186,11 @@ cmd_create_pr() {
     echo "Type: ${update_type}"
     echo "Workflows: ${workflows}"
 
+    escaped_model_id="$(printf '%s' "$new_model_id" | sed 's/[\\&|]/\\&/g')"
+
     for workflow in .github/workflows/*.yml; do
         if grep -q 'minimax-coding-plan/MiniMax' "$workflow"; then
-            sed -i "s|minimax-coding-plan/MiniMax-[A-Za-z0-9.]*|${new_model_id}|g" "$workflow"
+            sed -i "s|minimax-coding-plan/MiniMax-[A-Za-z0-9.]*|${escaped_model_id}|g" "$workflow"
             echo "Updated: $workflow"
         fi
     done

--- a/scripts/model_update_checker.sh
+++ b/scripts/model_update_checker.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source scripts/github_actions_common.sh
+
+api_response() {
+    curl -fsSL https://models.dev/api.json
+}
+
+cmd_fetch_models() {
+    local model_id="${MODEL_ID:-minimax-coding-plan/MiniMax-M2.7}"
+    local family_only="${FAMILY_ONLY:-true}"
+    local response provider model exists current_last_updated current_release_date model_name provider_models
+
+    write_output model_id "$model_id"
+    write_output family_only "$family_only"
+
+    response="$(api_response || true)"
+    if [[ -z "$response" ]]; then
+        write_output error "Failed to fetch models.dev API"
+        exit 0
+    fi
+
+    provider="$(cut -d/ -f1 <<< "$model_id")"
+    model="$(cut -d/ -f2 <<< "$model_id")"
+    write_output provider "$provider"
+    write_output model "$model"
+
+    exists="$(jq -r ".\"${provider}\".models.\"${model}\" != null" <<< "$response")"
+    if [[ "$exists" != "true" ]]; then
+        write_output error "Model ${model_id} not found in models.dev"
+        exit 0
+    fi
+
+    current_last_updated="$(jq -r ".\"${provider}\".models.\"${model}\".last_updated" <<< "$response")"
+    current_release_date="$(jq -r ".\"${provider}\".models.\"${model}\".release_date" <<< "$response")"
+    model_name="$(jq -r ".\"${provider}\".models.\"${model}\".name" <<< "$response")"
+    provider_models="$(jq -r ".\"${provider}\".models | keys[]" <<< "$response")"
+
+    write_output current_last_updated "$current_last_updated"
+    write_output current_release_date "$current_release_date"
+    write_output model_name "$model_name"
+    write_output all_models "$provider_models"
+}
+
+cmd_analyze_family() {
+    local response provider current_model family_only base_prefix family_models latest_model latest_release model release current_tracked
+    response="$(api_response)"
+    provider="${PROVIDER:?PROVIDER is required}"
+    current_model="${CURRENT_MODEL:?CURRENT_MODEL is required}"
+    family_only="${FAMILY_ONLY:-true}"
+    base_prefix="${current_model%%-[0-9.]*}-"
+
+    write_output base_prefix "$base_prefix"
+    family_models="$(jq -r ".\"${provider}\".models | to_entries[] | select(.key | startswith(\"${base_prefix}\")) | .key" <<< "$response" 2>/dev/null || true)"
+    write_output family_models "$family_models"
+
+    latest_model=""
+    latest_release=""
+    for model in $family_models; do
+        release="$(jq -r ".\"${provider}\".models.\"${model}\".release_date" <<< "$response")"
+        if [[ -z "$latest_release" || "$(printf '%s\n' "$release" "$latest_release" | sort -r | head -1)" == "$release" ]]; then
+            latest_release="$release"
+            latest_model="$model"
+        fi
+    done
+
+    write_output latest_family_model "$latest_model"
+    write_output latest_release_date "$latest_release"
+
+    if [[ "$current_model" != "$latest_model" ]]; then
+        write_output update_type family
+        write_output new_model "$latest_model"
+        write_output update_reason "Newer model variant ${latest_model} available (released ${latest_release})"
+    elif [[ "$family_only" == "false" ]]; then
+        current_tracked="${CURRENT_LAST_UPDATED:-}"
+        if [[ -n "$current_tracked" && "$current_tracked" != "${CURRENT_LAST_UPDATED:-}" ]]; then
+            write_output update_type spec
+        fi
+    fi
+}
+
+cmd_read_state() {
+    local state_file=".github/model-tracker.json"
+    local model_id="${MODEL_ID:?MODEL_ID is required}"
+
+    if [[ -f "$state_file" ]]; then
+        write_output tracked_model "$(jq -r '.tracked."'"$model_id"'" // empty' "$state_file")"
+        write_output tracked_spec "$(jq -r '.specs."'"$model_id"'" // empty' "$state_file")"
+    else
+        write_output tracked_model ""
+        write_output tracked_spec ""
+    fi
+}
+
+cmd_check_update() {
+    local current_model="${CURRENT_MODEL:?CURRENT_MODEL is required}"
+    local latest_family_model="${LATEST_FAMILY_MODEL:-}"
+    local current_spec="${CURRENT_SPEC:-}"
+    local tracked_model="${TRACKED_MODEL:-}"
+    local tracked_spec="${TRACKED_SPEC:-}"
+    local provider="${PROVIDER:?PROVIDER is required}"
+    local model_id="${MODEL_ID:?MODEL_ID is required}"
+    local update_needed=false update_reason=""
+
+    if [[ -n "$latest_family_model" && "$current_model" != "$latest_family_model" && "$tracked_model" != "$latest_family_model" ]]; then
+        update_needed=true
+        update_reason="Newer model in family: ${latest_family_model}"
+        write_output update_type family
+        write_output new_model_id "${provider}/${latest_family_model}"
+    fi
+
+    if [[ "$update_needed" == "false" && -n "$tracked_spec" && "$tracked_spec" != "$current_spec" ]]; then
+        update_needed=true
+        update_reason="Model spec updated: ${tracked_spec} -> ${current_spec}"
+        write_output update_type spec
+        write_output new_model_id "$model_id"
+    fi
+
+    if [[ -z "$tracked_model" && -z "$tracked_spec" ]]; then
+        update_needed=true
+        update_reason="Initial tracking of model"
+        write_output update_type initial
+        write_output new_model_id "$model_id"
+    fi
+
+    write_output update_needed "$update_needed"
+    write_output update_reason "$update_reason"
+
+    echo "=== Update Check Results ==="
+    echo "Current model: ${current_model}"
+    echo "Latest in family: ${latest_family_model}"
+    echo "Tracked model: ${tracked_model:-none}"
+    echo "Tracked spec: ${tracked_spec:-none}"
+    echo "Update needed: ${update_needed}"
+    echo "Reason: ${update_reason}"
+}
+
+cmd_update_tracker() {
+    local state_file=".github/model-tracker.json"
+    local model_id="${MODEL_ID:?MODEL_ID is required}"
+    local current_spec="${CURRENT_SPEC:-}"
+    local new_model_id="${NEW_MODEL_ID:-}"
+    local current_date tmp
+
+    current_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    mkdir -p .github
+
+    if [[ -f "$state_file" ]]; then
+        tmp="$(mktemp)"
+        jq --arg model "$model_id" \
+           --arg newmodel "$new_model_id" \
+           --arg spec "$current_spec" \
+           --arg date "$current_date" \
+           '.tracked[$model] = $newmodel | .specs[$model] = $spec | .last_checked = $date' \
+           "$state_file" > "$tmp"
+        mv "$tmp" "$state_file"
+    else
+        printf '{"tracked": {"%s": "%s"}, "specs": {"%s": "%s"}, "last_checked": "%s"}' \
+            "$model_id" "$new_model_id" "$model_id" "$current_spec" "$current_date" > "$state_file"
+    fi
+
+    cat "$state_file"
+}
+
+cmd_find_workflows() {
+    local workflows
+    workflows="$(grep -l 'minimax-coding-plan/MiniMax' .github/workflows/*.yml 2>/dev/null | tr '\n' ',' | sed 's/,$//' || true)"
+    write_output workflows "$workflows"
+    echo "Found: ${workflows}"
+}
+
+cmd_create_pr() {
+    local current_model="${CURRENT_MODEL:?CURRENT_MODEL is required}"
+    local new_model_id="${NEW_MODEL_ID:?NEW_MODEL_ID is required}"
+    local update_reason="${UPDATE_REASON:-}"
+    local update_type="${UPDATE_TYPE:-}"
+    local workflows="${WORKFLOWS:-}"
+    local new_model branch_name workflows_list pr_body_file
+
+    new_model="$(cut -d/ -f2 <<< "$new_model_id")"
+    branch_name="model-update/${new_model_id//\//-}"
+
+    echo "Creating branch: $branch_name"
+    git checkout -b "$branch_name"
+    echo "=== Update Summary ==="
+    echo "Current: ${current_model}"
+    echo "New: ${new_model}"
+    echo "Type: ${update_type}"
+    echo "Workflows: ${workflows}"
+
+    for workflow in .github/workflows/*.yml; do
+        if grep -q 'minimax-coding-plan/MiniMax' "$workflow"; then
+            sed -i "s|minimax-coding-plan/MiniMax-[A-Za-z0-9.]*|${new_model_id}|g" "$workflow"
+            echo "Updated: $workflow"
+        fi
+    done
+
+    git diff --stat
+    git add .github/model-tracker.json
+    if [[ -n "$workflows" ]]; then
+        for workflow in $(tr ',' ' ' <<< "$workflows"); do
+            git add "$workflow"
+        done
+    fi
+
+    git commit -m "chore: update model from ${current_model} to ${new_model}"
+    git push -u origin "$branch_name"
+
+    if [[ -n "$workflows" ]]; then
+        workflows_list="$(tr ',' '\n' <<< "$workflows" | while read -r f; do echo "- \`$f\`"; done | tr '\n' ' ')"
+    else
+        workflows_list="(no workflow files found)"
+    fi
+
+    pr_body_file="$(mktemp)"
+    printf '%s\n' \
+        "## Model Update" \
+        "" \
+        "This PR updates the AI model used in our OpenCode workflows." \
+        "" \
+        "**Change:** ${update_reason}" \
+        "" \
+        "**Files updated:**" \
+        "${workflows_list}" \
+        "" \
+        "**Verification:**" \
+        "- [ ] Confirm model exists in models.dev" \
+        "- [ ] Review updated workflow files" \
+        "- [ ] Run tests if available" \
+        "" \
+        "---" \
+        "Auto-generated by Model Update Checker workflow" > "$pr_body_file"
+
+    gh pr create --base dev --title "model: Update to ${new_model}" --body-file "$pr_body_file"
+    echo "PR created successfully"
+}
+
+case "${1:?subcommand required}" in
+    fetch-models) cmd_fetch_models ;;
+    analyze-family) cmd_analyze_family ;;
+    read-state) cmd_read_state ;;
+    check-update) cmd_check_update ;;
+    update-tracker) cmd_update_tracker ;;
+    find-workflows) cmd_find_workflows ;;
+    create-pr) cmd_create_pr ;;
+    *)
+        printf 'error: unknown subcommand: %s\n' "$1" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/prepare_opencode_cache.sh
+++ b/scripts/prepare_opencode_cache.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cache_dir="${1:-/tmp/opencode-cache}"
+mkdir -p "$cache_dir"
+printf 'XDG_CACHE_HOME=%s\n' "$cache_dir" >> "${GITHUB_ENV:?GITHUB_ENV is required}"

--- a/scripts/publish_ai_merge_gate.sh
+++ b/scripts/publish_ai_merge_gate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+pr_number="${PR_NUMBER:?PR_NUMBER is required}"
+head_sha="${HEAD_SHA:?HEAD_SHA is required}"
+server_url="${GITHUB_SERVER_URL:-https://github.com}"
+
+parse_json="$(bash scripts/evaluate_ai_merge_gate.sh "$repo" "$pr_number" "$head_sha")"
+state="$(printf '%s' "$parse_json" | jq -r '.state')"
+description="$(printf '%s' "$parse_json" | jq -r '.description')"
+
+gh api "repos/${repo}/statuses/${head_sha}" \
+    -f state="$state" \
+    -f context=ai-merge-gate \
+    -f description="$description" \
+    -f target_url="${server_url}/${repo}/pull/${pr_number}"
+
+if [[ "$state" == "success" ]]; then
+    closing_refs="$(gh pr view "$pr_number" \
+        --json closingIssuesReferences \
+        --jq '[.closingIssuesReferences[].number] | map("Closes #" + tostring) | join("\n")')"
+
+    if [[ -n "$closing_refs" ]]; then
+        gh pr merge "$pr_number" --auto --squash --body "$closing_refs" || true
+    else
+        gh pr merge "$pr_number" --auto --squash || true
+    fi
+fi

--- a/scripts/resolve_pr_context.sh
+++ b/scripts/resolve_pr_context.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source scripts/github_actions_common.sh
+
+if [[ "${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME is required}" == "workflow_dispatch" ]]; then
+    pr_number="${INPUT_PR_NUMBER:?INPUT_PR_NUMBER is required for workflow_dispatch}"
+    head_sha="${INPUT_HEAD_SHA:?INPUT_HEAD_SHA is required for workflow_dispatch}"
+else
+    pr_number="${EVENT_PR_NUMBER:?EVENT_PR_NUMBER is required}"
+    head_sha="${EVENT_HEAD_SHA:?EVENT_HEAD_SHA is required}"
+fi
+
+write_output pr_number "$pr_number"
+write_output pr_head_sha "$head_sha"
+write_env PR_NUMBER "$pr_number"
+write_env HEAD_SHA "$head_sha"

--- a/scripts/select_audit_module.sh
+++ b/scripts/select_audit_module.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source scripts/github_actions_common.sh
+
+input_module="${INPUT_MODULE:-}"
+modules=(
+    "engine/graphics"
+    "engine/core"
+    "engine/math"
+    "engine/input"
+    "engine/ui"
+    "engine/atmosphere"
+    "engine/audio"
+    "engine/ecs"
+    "engine/physics"
+    "world"
+    "world/meshing"
+    "world/worldgen"
+    "game"
+)
+
+if [[ -n "$input_module" ]]; then
+    if ! [[ "$input_module" =~ ^[a-zA-Z0-9_\ /-]+$ ]]; then
+        printf "ERROR: Invalid module input: '%s'\n" "$input_module" >&2
+        exit 1
+    fi
+    selected="$input_module"
+    printf 'Manual dispatch: scanning %s\n' "$selected"
+else
+    day=$((10#$(date +%j)))
+    index=$((day % ${#modules[@]}))
+    selected="${modules[$index]}"
+    printf 'Scheduled run: day=%s index=%s -> %s\n' "$day" "$index" "$selected"
+fi
+
+write_output module "$selected"
+write_output module_path "src/${selected}"

--- a/scripts/select_test_writer_module.sh
+++ b/scripts/select_test_writer_module.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source scripts/github_actions_common.sh
+
+input_module="${INPUT_MODULE:-}"
+base_branch="${BASE_BRANCH:-dev}"
+
+graphics_modules=(
+    "graphics/vulkan-device"
+    "graphics/vulkan-resources"
+    "graphics/vulkan-pipelines"
+    "graphics/vulkan-swapchain"
+    "graphics/vulkan-frame"
+    "graphics/rhi-types"
+    "graphics/shadows"
+    "graphics/post-process"
+)
+
+other_modules=(
+    "engine/core"
+    "engine/math"
+    "engine/input"
+    "world"
+    "world/meshing"
+    "world/worldgen"
+    "engine/ecs"
+    "game"
+)
+
+if [[ -n "$input_module" ]]; then
+    if ! [[ "$input_module" =~ ^[a-zA-Z0-9_/-]+$ ]]; then
+        printf "ERROR: Invalid module input: '%s'\n" "$input_module" >&2
+        exit 1
+    fi
+    selected="$input_module"
+    printf 'Manual dispatch: writing tests for %s\n' "$selected"
+else
+    graphics_count=${#graphics_modules[@]}
+    other_count=${#other_modules[@]}
+    slot=$(($(date +%s) / 28800))
+    parity=$((slot % 2))
+
+    if [[ "$parity" -eq 0 ]]; then
+        index=$((slot % graphics_count))
+        selected="${graphics_modules[$index]}"
+        printf 'Graphics slot: parity=%s index=%s -> %s\n' "$parity" "$index" "$selected"
+    else
+        index=$((slot % other_count))
+        selected="${other_modules[$index]}"
+        printf 'Other slot: parity=%s index=%s -> %s\n' "$parity" "$index" "$selected"
+    fi
+fi
+
+branch_name="test/$(printf '%s' "$selected" | tr '/' '-')"
+
+case "$selected" in
+    graphics/vulkan-device)
+        scan_paths="modules/engine-graphics/src/vulkan_device.zig modules/engine-graphics/src/vulkan/device.zig modules/engine-graphics/src/vulkan/rhi_state_control.zig"
+        ;;
+    graphics/vulkan-resources)
+        scan_paths="modules/engine-graphics/src/vulkan/resource_manager.zig modules/engine-graphics/src/vulkan/resource_texture_ops.zig modules/engine-graphics/src/vulkan/rhi_resource_lifecycle.zig modules/engine-graphics/src/vulkan/rhi_resource_setup.zig"
+        ;;
+    graphics/vulkan-pipelines)
+        scan_paths="modules/engine-graphics/src/vulkan/pipeline_manager.zig modules/engine-graphics/src/vulkan/pipeline_specialized.zig modules/engine-graphics/src/vulkan/shader_registry.zig modules/engine-graphics/src/vulkan/descriptor_manager.zig modules/engine-graphics/src/vulkan/descriptor_bindings.zig"
+        ;;
+    graphics/vulkan-swapchain)
+        scan_paths="modules/engine-graphics/src/vulkan/swapchain.zig modules/engine-graphics/src/vulkan/swapchain_presenter.zig modules/engine-graphics/src/vulkan_swapchain.zig"
+        ;;
+    graphics/vulkan-frame)
+        scan_paths="modules/engine-graphics/src/vulkan/frame_manager.zig modules/engine-graphics/src/vulkan/rhi_frame_orchestration.zig modules/engine-graphics/src/vulkan/render_pass_manager.zig modules/engine-graphics/src/vulkan/rhi_pass_orchestration.zig"
+        ;;
+    graphics/rhi-types)
+        scan_paths="modules/engine-rhi/src/rhi.zig modules/engine-rhi/src/rhi_types.zig modules/engine-graphics/src/rhi_vulkan.zig modules/engine-graphics/src/rhi_tests.zig"
+        ;;
+    graphics/shadows)
+        scan_paths="modules/engine-graphics/src/shadow_system.zig modules/engine-graphics/src/csm.zig modules/engine-graphics/src/vulkan/shadow_system.zig modules/engine-graphics/src/vulkan/rhi_shadow_bridge.zig modules/engine-graphics/src/shadow_scene.zig"
+        ;;
+    graphics/post-process)
+        scan_paths="modules/engine-graphics/src/vulkan/bloom_system.zig modules/engine-graphics/src/vulkan/fxaa_system.zig modules/engine-graphics/src/vulkan/taa_system.zig modules/engine-graphics/src/vulkan/ssao_system.zig modules/engine-graphics/src/vulkan/post_process_system.zig"
+        ;;
+    engine/core)
+        scan_paths="modules/engine-core/src/job_system.zig modules/engine-core/src/ring_buffer.zig modules/engine-core/src/time.zig modules/engine-core/src/log.zig modules/engine-core/src/window.zig"
+        ;;
+    engine/math)
+        scan_paths="modules/engine-math/src/vec3.zig modules/engine-math/src/mat4.zig modules/engine-math/src/frustum.zig modules/engine-math/src/utils.zig"
+        ;;
+    engine/input)
+        scan_paths="modules/engine-input/src/input.zig modules/engine-input/src/interfaces.zig"
+        ;;
+    world)
+        scan_paths="modules/world-core/src/chunk.zig modules/world-core/src/block.zig modules/world-core/src/block_registry.zig modules/world-meshing/src/chunk_storage.zig modules/world-meshing/src/chunk_allocator.zig modules/world-meshing/src/chunk_mesh.zig"
+        ;;
+    world/meshing)
+        scan_paths="modules/world-meshing/src/meshing/greedy_mesher.zig modules/world-meshing/src/meshing/ao_calculator.zig modules/world-meshing/src/meshing/lighting_sampler.zig modules/world-meshing/src/meshing/biome_color_sampler.zig modules/world-meshing/src/meshing/boundary.zig"
+        ;;
+    world/worldgen)
+        scan_paths="modules/world-worldgen/src/overworld_generator.zig modules/world-worldgen/src/biome.zig modules/world-worldgen/src/caves.zig modules/world-worldgen/src/terrain_shape_generator.zig modules/world-worldgen/src/coastal_generator.zig modules/world-worldgen/src/noise_sampler.zig modules/world-worldgen/src/height_sampler.zig modules/world-worldgen/src/surface_builder.zig"
+        ;;
+    engine/ecs)
+        scan_paths="modules/engine-ecs/src/storage.zig modules/engine-ecs/src/manager.zig modules/engine-ecs/src/entity.zig modules/engine-ecs/src/components.zig"
+        ;;
+    game)
+        scan_paths="src/game/player.zig src/game/screen.zig src/game/inventory.zig src/game/settings/ src/game/input_mapper.zig src/game/session.zig"
+        ;;
+    *)
+        scan_paths="src/${selected}"
+        ;;
+esac
+
+write_output module "$selected"
+write_output branch "$branch_name"
+write_output base_branch "$base_branch"
+write_output scan_paths "$scan_paths"

--- a/scripts/validate_audit_module.sh
+++ b/scripts/validate_audit_module.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+module_path="${MODULE_PATH:?MODULE_PATH is required}"
+
+if [[ ! -d "$module_path" ]]; then
+    printf "::warning::Module directory '%s' does not exist; audit may be limited to partial or no source files\n" "$module_path"
+    printf 'Listing parent directory:\n'
+    parent="$(dirname "$module_path")"
+    ls -la "$parent" 2>/dev/null || printf "Parent directory '%s' also missing\n" "$parent"
+else
+    printf 'Module directory confirmed: %s\n' "$module_path"
+    printf 'Files in module:\n'
+    find "$module_path" -name '*.zig' | head -20
+fi

--- a/scripts/validate_scan_paths.sh
+++ b/scripts/validate_scan_paths.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 scan_paths="${SCAN_PATHS:?SCAN_PATHS is required}"
 missing=0
 
+# SCAN_PATHS is intentionally space-delimited by select_test_writer_module.sh;
+# repository scan targets must not contain spaces.
 for path in $scan_paths; do
     if [[ ! -e "$path" ]]; then
         printf 'WARNING: scan path does not exist: %s\n' "$path"

--- a/scripts/validate_scan_paths.sh
+++ b/scripts/validate_scan_paths.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+scan_paths="${SCAN_PATHS:?SCAN_PATHS is required}"
+missing=0
+
+for path in $scan_paths; do
+    if [[ ! -e "$path" ]]; then
+        printf 'WARNING: scan path does not exist: %s\n' "$path"
+        missing=$((missing + 1))
+    fi
+done
+
+if [[ "$missing" -gt 0 ]]; then
+    printf '::warning::%d scan path(s) missing; update workflow scan-path mapping if needed\n' "$missing"
+fi

--- a/scripts/verify_pat_push_permissions.sh
+++ b/scripts/verify_pat_push_permissions.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+base_branch="${BASE_BRANCH:?BASE_BRANCH is required}"
+
+if ! git push --dry-run origin "HEAD:${base_branch}" 2>/dev/null; then
+    printf "::error::OPENCODE_PAT cannot push to repository. Ensure the PAT has 'repo' scope (classic) or Contents: Read & Write (fine-grained).\n" >&2
+    exit 1
+fi
+
+printf 'PAT has push permissions.\n'


### PR DESCRIPTION
## Summary
- Move long OpenCode workflow shell blocks into reusable scripts under `scripts/`
- Add script syntax validation to the workflow validation job
- Realize the Nix graphics shell before starting Weston to avoid readiness timeouts

## Validation
- `bash -n scripts/*.sh`
- Ruby YAML parse for workflows and composite actions
- `nix run nixpkgs#actionlint -- -color`
- `nix run nixpkgs#shellcheck -- <new extracted scripts>`

Note: full `shellcheck scripts/*.sh` still reports pre-existing warnings in unrelated scripts.