### PR TITLE
ci: cache zig build artifacts

### DIFF
--- a/.github/actions/setup-zig-cache/action.yml
+++ b/.github/actions/setup-zig-cache/action.yml
@@ -1,0 +1,49 @@
+name: Setup Zig Cache
+description: Restore Zig compiler caches and export ZIG_GLOBAL_CACHE_DIR
+
+inputs:
+  cache-key-prefix:
+    description: Prefix for the Zig cache key
+    required: false
+    default: zig
+  global-cache-dir:
+    description: Zig global cache directory
+    required: false
+    default: .zig-cache-global
+  local-cache-dir:
+    description: Zig local cache directory
+    required: false
+    default: .zig-cache
+
+runs:
+  using: composite
+  steps:
+    - name: Export Zig cache environment
+      shell: bash
+      run: |
+        set -euo pipefail
+        global_cache="${{ github.workspace }}/${{ inputs.global-cache-dir }}"
+        local_cache="${{ github.workspace }}/${{ inputs.local-cache-dir }}"
+        mkdir -p "$global_cache" "$local_cache"
+        echo "ZIG_GLOBAL_CACHE_DIR=$global_cache" >> "$GITHUB_ENV"
+
+    - name: Restore Zig cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ github.workspace }}/${{ inputs.global-cache-dir }}
+          ${{ github.workspace }}/${{ inputs.local-cache-dir }}
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ hashFiles('build.zig', 'build.zig.zon', 'flake.nix', 'flake.lock') }}-${{ hashFiles('src/**', 'modules/**', 'libs/**', 'assets/shaders/**') }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ hashFiles('build.zig', 'build.zig.zon', 'flake.nix', 'flake.lock') }}-
+          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-
+
+    - name: Summarize Zig cache
+      shell: bash
+      run: |
+        {
+          echo "### Zig Cache"
+          echo "- Global cache: ${{ github.workspace }}/${{ inputs.global-cache-dir }}"
+          echo "- Local cache: ${{ github.workspace }}/${{ inputs.local-cache-dir }}"
+          echo "- Key prefix: ${{ inputs.cache-key-prefix }}-${{ runner.os }}"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,6 +32,11 @@ jobs:
     - name: Setup Nix
       uses: ./.github/actions/setup-nix
 
+    - name: Setup Zig cache
+      uses: ./.github/actions/setup-zig-cache
+      with:
+        cache-key-prefix: zig-ci-graphics
+
     - name: Start headless Wayland compositor
       uses: ./.github/actions/start-weston
 
@@ -47,7 +52,6 @@ jobs:
         log-file: benchmark.log
         command: nix develop .#ci-graphics --command bash scripts/run_benchmark.sh --duration "$BENCHMARK_DURATION" --presets low,medium,high --output-dir benchmark-results
       env:
-        ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
         XDG_RUNTIME_DIR: /tmp/runtime-runner
         WAYLAND_DISPLAY: headless
         ZIGCRAFT_SAFE_MODE: '1'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
             - 'flake.nix'
             - 'flake.lock'
             - '.github/actions/setup-nix/**'
+            - '.github/actions/setup-zig-cache/**'
 
   build:
     permissions:
@@ -111,6 +112,12 @@ jobs:
       if: needs.changes.outputs.code_changes == 'true'
       uses: ./.github/actions/setup-nix
 
+    - name: Setup Zig cache
+      if: needs.changes.outputs.code_changes == 'true'
+      uses: ./.github/actions/setup-zig-cache
+      with:
+        cache-key-prefix: zig-ci-unit
+
     - name: Run unit tests
       if: needs.changes.outputs.code_changes == 'true'
       uses: ./.github/actions/run-with-log
@@ -119,8 +126,6 @@ jobs:
         timeout: 25m
         log-file: unit-test.log
         command: nix develop .#ci-unit --command zig build test
-      env:
-        ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
 
     - name: Upload unit test log
       if: failure()
@@ -152,6 +157,12 @@ jobs:
       if: needs.changes.outputs.code_changes == 'true'
       uses: ./.github/actions/setup-nix
 
+    - name: Setup Zig cache
+      if: needs.changes.outputs.code_changes == 'true'
+      uses: ./.github/actions/setup-zig-cache
+      with:
+        cache-key-prefix: zig-ci-graphics
+
     - name: Start headless Wayland compositor
       if: needs.changes.outputs.code_changes == 'true'
       uses: ./.github/actions/start-weston
@@ -164,8 +175,6 @@ jobs:
         timeout: 15m
         log-file: integration-test.log
         command: nix develop .#ci-graphics --command zig build test-integration
-      env:
-        ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
 
     - name: Setup Lavapipe Vulkan
       if: needs.changes.outputs.code_changes == 'true'
@@ -180,7 +189,6 @@ jobs:
         log-file: world-smoke-test.log
         command: nix develop .#ci-graphics --command zig build run -Dsmoke-test=true -Dskip-present=true
       env:
-        ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
         XDG_RUNTIME_DIR: /tmp/runtime-runner
         WAYLAND_DISPLAY: headless
         ZIGCRAFT_SMOKE_FRAMES: "3"


### PR DESCRIPTION
## Summary
- Add a reusable `setup-zig-cache` composite action for Zig global and local build caches
- Restore Zig caches in Blacksmith unit, integration, and benchmark jobs
- Export `ZIG_GLOBAL_CACHE_DIR` centrally instead of repeating it per command

## Validation
- Ruby YAML parse for workflows and composite actions
- `nix run nixpkgs#actionlint -- -color`