### PR TITLE
feat: modernize UI menus with bidirectional nav, scrolling, and world management

### DIFF
--- a/src/game/screens/graphics.zig
+++ b/src/game/screens/graphics.zig
@@ -118,7 +118,8 @@ pub const GraphicsScreen = struct {
             if (comptime std.mem.eql(u8, decl.name, "render_distance")) continue;
             total_rows += 1;
         }
-        const total_content_h: f32 = @as(f32, @floatFromInt(total_rows)) * row_height + 40.0 * ui_scale;
+        const warning_extra: f32 = if (render_settings_mod.getPresetConfig(settings.render_distance_preset).show_warning) 22.0 * ui_scale else 0.0;
+        const total_content_h: f32 = @as(f32, @floatFromInt(total_rows)) * row_height + 40.0 * ui_scale + warning_extra;
         const max_scroll = @max(0.0, total_content_h - content_h);
         self.scroll_offset = @max(0.0, @min(self.scroll_offset, max_scroll));
 

--- a/src/game/screens/graphics.zig
+++ b/src/game/screens/graphics.zig
@@ -11,8 +11,7 @@ const Settings = settings_pkg.Settings;
 const render_settings_mod = @import("../../engine/graphics/render_settings.zig");
 const RenderDistancePreset = render_settings_mod.RenderDistancePreset;
 
-const PANEL_WIDTH_MAX = 850.0;
-const PANEL_HEIGHT_BASE = 850.0;
+const PANEL_WIDTH_MAX = 1100.0;
 const BG_COLOR = Color.rgba(0.025, 0.045, 0.065, 0.95);
 const BORDER_COLOR = Color.rgba(0.42, 0.66, 0.82, 0.78);
 const TITLE_COLOR = Color.rgba(1.0, 0.93, 0.76, 1.0);
@@ -21,6 +20,7 @@ const MUTED_COLOR = Color.rgba(0.48, 0.60, 0.70, 0.92);
 
 pub const GraphicsScreen = struct {
     context: EngineContext,
+    scroll_offset: f32,
 
     pub const vtable = IScreen.VTable{
         .deinit = deinit,
@@ -33,6 +33,7 @@ pub const GraphicsScreen = struct {
         const self = try allocator.create(GraphicsScreen);
         self.* = .{
             .context = context,
+            .scroll_offset = 0.0,
         };
         return self;
     }
@@ -45,7 +46,6 @@ pub const GraphicsScreen = struct {
     pub fn update(ptr: *anyopaque, dt: f32) !void {
         const self: *@This() = @ptrCast(@alignCast(ptr));
         _ = dt;
-
         if (self.context.input_mapper.isActionPressed(self.context.input, .ui_back)) {
             self.context.saveSettings();
             self.context.screen_manager.popScreen();
@@ -58,9 +58,7 @@ pub const GraphicsScreen = struct {
         const settings = ctx.settings;
         const rs = ctx.render_settings;
 
-        // Draw background screen if it exists
         try ctx.screen_manager.drawParentScreen(ptr, ui);
-
         ui.begin();
         defer ui.end();
 
@@ -75,113 +73,169 @@ pub const GraphicsScreen = struct {
 
         const auto_scale: f32 = @max(1.0, screen_h / 720.0);
         const ui_scale: f32 = auto_scale * settings.ui_scale;
-        const label_scale: f32 = 1.45 * ui_scale;
-        const btn_scale: f32 = 1.35 * ui_scale;
-        const title_scale: f32 = 3.0 * ui_scale;
-        const row_height: f32 = 48.0 * ui_scale;
-        const btn_height: f32 = 34.0 * ui_scale;
-        const toggle_width: f32 = 180.0 * ui_scale;
+        const label_scale: f32 = 1.35 * ui_scale;
+        const btn_scale: f32 = 1.25 * ui_scale;
+        const title_scale: f32 = 2.8 * ui_scale;
+        const row_height: f32 = 44.0 * ui_scale;
+        const btn_height: f32 = 32.0 * ui_scale;
+        const toggle_width: f32 = 160.0 * ui_scale;
+        const arrow_width: f32 = 36.0 * ui_scale;
 
-        const pw: f32 = @min(screen_w * 0.8, PANEL_WIDTH_MAX * ui_scale);
-        const ph: f32 = @min(screen_h - 80.0 * ui_scale, PANEL_HEIGHT_BASE * ui_scale);
+        const margin: f32 = 40.0 * ui_scale;
+        const pw: f32 = @min(screen_w - margin * 2.0, PANEL_WIDTH_MAX * ui_scale);
+        const ph: f32 = screen_h - margin * 2.0;
         const px: f32 = (screen_w - pw) * 0.5;
-        const py: f32 = (screen_h - ph) * 0.5;
+        const py: f32 = margin;
+
+        const header_h: f32 = 72.0 * ui_scale;
+        const footer_h: f32 = 64.0 * ui_scale;
+        const content_top: f32 = py + header_h;
+        const content_bottom: f32 = py + ph - footer_h;
 
         drawGraphicsBackdrop(ui, screen_w, screen_h, ui_scale);
         ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = ph }, BG_COLOR);
         ui.drawRect(.{ .x = px, .y = py, .width = 7.0 * ui_scale, .height = ph }, Color.rgba(0.95, 0.62, 0.24, 0.95));
-        ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = 72.0 * ui_scale }, Color.rgba(0.12, 0.22, 0.30, 0.64));
+        ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = header_h }, Color.rgba(0.12, 0.22, 0.30, 0.64));
         ui.drawRect(.{ .x = px + pw - 2.0 * ui_scale, .y = py, .width = 2.0 * ui_scale, .height = ph }, Color.rgba(0.48, 0.76, 0.93, 0.62));
         ui.drawRectOutline(.{ .x = px, .y = py, .width = pw, .height = ph }, BORDER_COLOR, 2.0 * ui_scale);
-        Font.drawText(ui, "GRAPHICS SETTINGS", px + 34.0 * ui_scale, py + 24.0 * ui_scale, title_scale, TITLE_COLOR);
-        Font.drawText(ui, "Renderer quality, post effects, and distance budgets.", px + 38.0 * ui_scale, py + 56.0 * ui_scale, 1.05 * ui_scale, MUTED_COLOR);
+        Font.drawText(ui, "GRAPHICS SETTINGS", px + 34.0 * ui_scale, py + 20.0 * ui_scale, title_scale, TITLE_COLOR);
+        Font.drawText(ui, "Renderer quality, post effects, and distance budgets.", px + 38.0 * ui_scale, py + 48.0 * ui_scale, 1.0 * ui_scale, MUTED_COLOR);
 
-        var sy: f32 = py + 96.0 * ui_scale;
+        // Content clipping area
+        const content_h: f32 = content_bottom - content_top;
+        ui.drawRect(.{ .x = px + 18.0 * ui_scale, .y = content_top, .width = pw - 36.0 * ui_scale, .height = content_h }, Color.rgba(0.010, 0.020, 0.030, 0.40));
+        ui.drawRectOutline(.{ .x = px + 18.0 * ui_scale, .y = content_top, .width = pw - 36.0 * ui_scale, .height = content_h }, Color.rgba(0.20, 0.36, 0.48, 0.50), 1.0 * ui_scale);
+
+        // Scroll
+        const scroll_dy = ctx.input.getScrollDelta().y;
+        self.scroll_offset -= scroll_dy * 28.0 * ui_scale;
+
+        // Calculate total content height
+        var total_rows: usize = 2; // preset + render distance
+        inline for (comptime std.meta.declarations(Settings.metadata)) |decl| {
+            if (comptime std.mem.eql(u8, decl.name, "msaa_samples")) continue;
+            if (comptime std.mem.eql(u8, decl.name, "render_distance_preset")) continue;
+            if (comptime std.mem.eql(u8, decl.name, "render_distance")) continue;
+            total_rows += 1;
+        }
+        const total_content_h: f32 = @as(f32, @floatFromInt(total_rows)) * row_height + 40.0 * ui_scale;
+        const max_scroll = @max(0.0, total_content_h - content_h);
+        self.scroll_offset = @max(0.0, @min(self.scroll_offset, max_scroll));
+
+        // Scrollbar
+        if (max_scroll > 0.0) {
+            const sb_x: f32 = px + pw - 24.0 * ui_scale;
+            const sb_w: f32 = 6.0 * ui_scale;
+            const sb_track_h: f32 = content_h - 20.0 * ui_scale;
+            const sb_track_y: f32 = content_top + 10.0 * ui_scale;
+            ui.drawRect(.{ .x = sb_x, .y = sb_track_y, .width = sb_w, .height = sb_track_h }, Color.rgba(0.15, 0.25, 0.35, 0.60));
+            const sb_thumb_h: f32 = @max(20.0 * ui_scale, sb_track_h * (content_h / total_content_h));
+            const sb_thumb_y: f32 = sb_track_y + (sb_track_h - sb_thumb_h) * (self.scroll_offset / max_scroll);
+            ui.drawRect(.{ .x = sb_x, .y = sb_thumb_y, .width = sb_w, .height = sb_thumb_h }, Color.rgba(0.60, 0.80, 0.95, 0.80));
+        }
+
+        var sy: f32 = content_top + 10.0 * ui_scale - self.scroll_offset;
         const lx: f32 = px + 40.0 * ui_scale;
-        const vx: f32 = px + pw - 220.0 * ui_scale;
+        const vx: f32 = px + pw - 240.0 * ui_scale;
+        const content_left: f32 = px + 26.0 * ui_scale;
+        const content_right: f32 = px + pw - 36.0 * ui_scale;
+
+        // Helper to check if row is visible
+        const isVisible = struct {
+            fn check(y: f32, h: f32, top: f32, bottom: f32) bool {
+                return y + h >= top and y <= bottom;
+            }
+        }.check;
 
         // Quality Preset
-        Font.drawText(ui, "OVERALL QUALITY", lx, sy, label_scale, LABEL_COLOR);
-
-        if (settings_pkg.json_presets.graphics_presets.items.len > 0) {
-            const preset_idx = settings_pkg.json_presets.getIndex(settings);
-            if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, getPresetLabel(preset_idx), btn_scale, mouse_x, mouse_y, mouse_clicked)) {
-                const next_idx = (preset_idx + 1) % (settings_pkg.json_presets.graphics_presets.items.len + 1);
-                if (next_idx < settings_pkg.json_presets.graphics_presets.items.len) {
-                    settings_pkg.json_presets.apply(settings, next_idx);
-                    rs.setAnisotropicFiltering(settings.anisotropic_filtering);
-                    rs.setTexturesEnabled(settings.textures_enabled);
-                    rs.setTAABlendFactor(settings.taa_blend_factor);
-                    rs.setTAAVelocityRejection(settings.taa_velocity_rejection);
-                    if (settings.taa_enabled) {
-                        settings.fxaa_enabled = false;
-                        rs.setFXAA(false);
-                    } else {
-                        rs.setFXAA(settings.fxaa_enabled);
+        if (isVisible(sy, row_height, content_top, content_bottom)) {
+            Font.drawText(ui, "OVERALL QUALITY", lx, sy, label_scale, LABEL_COLOR);
+            if (settings_pkg.json_presets.graphics_presets.items.len > 0) {
+                const preset_idx = settings_pkg.json_presets.getIndex(settings);
+                const preset_count = settings_pkg.json_presets.graphics_presets.items.len + 1;
+                if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 4.0, .width = arrow_width, .height = btn_height }, "<", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+                    const prev_idx = if (preset_idx == 0) preset_count - 1 else preset_idx - 1;
+                    if (prev_idx < settings_pkg.json_presets.graphics_presets.items.len) {
+                        settings_pkg.json_presets.apply(settings, prev_idx);
+                        applyPresetSideEffects(settings, rs);
                     }
-                } else {
-                    // Custom selected, nothing changes in values but UI label updates to CUSTOM (via getPresetIndex next frame)
+                }
+                Font.drawTextCentered(ui, getPresetLabel(preset_idx), vx + arrow_width + toggle_width * 0.5, sy + (btn_height - 7.0 * btn_scale) * 0.5, btn_scale, TITLE_COLOR);
+                if (Widgets.drawButton(ui, .{ .x = vx + arrow_width + toggle_width, .y = sy - 4.0, .width = arrow_width, .height = btn_height }, ">", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+                    const next_idx = (preset_idx + 1) % preset_count;
+                    if (next_idx < settings_pkg.json_presets.graphics_presets.items.len) {
+                        settings_pkg.json_presets.apply(settings, next_idx);
+                        applyPresetSideEffects(settings, rs);
+                    }
                 }
             }
-        } else {
-            _ = Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, "ERROR", btn_scale, mouse_x, mouse_y, false);
         }
-        sy += row_height + 10.0 * ui_scale;
+        sy += row_height;
 
         // Render Distance Preset
-        Font.drawText(ui, "RENDER DISTANCE", lx, sy, label_scale, LABEL_COLOR);
-        const current_rdp = @intFromEnum(settings.render_distance_preset);
-        const rdp_label = settings.render_distance_preset.label();
-        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, rdp_label, btn_scale, mouse_x, mouse_y, mouse_clicked)) {
-            const next = (current_rdp + 1) % @as(u32, RenderDistancePreset.count);
-            settings.render_distance_preset = @enumFromInt(next);
-            const preset_cfg = render_settings_mod.getPresetConfig(settings.render_distance_preset);
-            settings.render_distance = preset_cfg.lod_radii[0];
+        if (isVisible(sy, row_height, content_top, content_bottom)) {
+            Font.drawText(ui, "RENDER DISTANCE", lx, sy, label_scale, LABEL_COLOR);
+            const current_rdp = @intFromEnum(settings.render_distance_preset);
+            const rdp_label = settings.render_distance_preset.label();
+            const rdp_count = @as(u32, RenderDistancePreset.count);
+            if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 4.0, .width = arrow_width, .height = btn_height }, "<", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+                const prev = if (current_rdp == 0) rdp_count - 1 else current_rdp - 1;
+                settings.render_distance_preset = @enumFromInt(prev);
+                const preset_cfg = render_settings_mod.getPresetConfig(settings.render_distance_preset);
+                settings.render_distance = preset_cfg.lod_radii[0];
+            }
+            Font.drawTextCentered(ui, rdp_label, vx + arrow_width + toggle_width * 0.5, sy + (btn_height - 7.0 * btn_scale) * 0.5, btn_scale, TITLE_COLOR);
+            if (Widgets.drawButton(ui, .{ .x = vx + arrow_width + toggle_width, .y = sy - 4.0, .width = arrow_width, .height = btn_height }, ">", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+                const next = (current_rdp + 1) % rdp_count;
+                settings.render_distance_preset = @enumFromInt(next);
+                const preset_cfg = render_settings_mod.getPresetConfig(settings.render_distance_preset);
+                settings.render_distance = preset_cfg.lod_radii[0];
+            }
         }
         sy += row_height;
 
         // Extreme preset warning
         {
             const preset_cfg = render_settings_mod.getPresetConfig(settings.render_distance_preset);
-            if (preset_cfg.show_warning) {
-                ui.drawRect(.{ .x = lx, .y = sy - 5.0, .width = pw - 80.0 * ui_scale, .height = 20.0 * ui_scale }, Color.rgba(0.6, 0.1, 0.1, 0.8));
-                Font.drawText(ui, "WARNING: Extreme render distance may cause instability on GPUs with <8GB VRAM", lx + 5.0, sy, 1.2 * ui_scale, Color.rgba(1.0, 0.7, 0.3, 1.0));
-                sy += 25.0 * ui_scale;
+            if (preset_cfg.show_warning and isVisible(sy, 22.0 * ui_scale, content_top, content_bottom)) {
+                ui.drawRect(.{ .x = content_left, .y = sy - 4.0, .width = content_right - content_left, .height = 18.0 * ui_scale }, Color.rgba(0.6, 0.1, 0.1, 0.8));
+                Font.drawText(ui, "WARNING: Extreme render distance may cause instability on GPUs with <8GB VRAM", lx, sy, 1.1 * ui_scale, Color.rgba(1.0, 0.7, 0.3, 1.0));
             }
+            if (preset_cfg.show_warning) sy += 22.0 * ui_scale;
         }
 
         var buf: [64]u8 = undefined;
 
-        // Auto-generated UI from metadata
         inline for (comptime std.meta.declarations(Settings.metadata)) |decl| {
             if (comptime std.mem.eql(u8, decl.name, "msaa_samples")) continue;
             if (comptime std.mem.eql(u8, decl.name, "render_distance_preset")) continue;
+            if (comptime std.mem.eql(u8, decl.name, "render_distance")) continue;
 
             const meta = @field(Settings.metadata, decl.name);
             const val_ptr = &@field(settings, decl.name);
             const val_type = @TypeOf(val_ptr.*);
             const old_val = val_ptr.*;
 
-            Font.drawText(ui, meta.label, lx, sy, label_scale, LABEL_COLOR);
+            if (isVisible(sy, row_height, content_top, content_bottom)) {
+                Font.drawText(ui, meta.label, lx, sy, label_scale, LABEL_COLOR);
 
-            switch (meta.kind) {
-                .toggle => {
-                    const label = if (val_ptr.*) "ENABLED" else "DISABLED";
-                    if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, label, btn_scale, mouse_x, mouse_y, mouse_clicked)) {
-                        val_ptr.* = !val_ptr.*;
-                    }
-                },
-                .choice => |choice| {
-                    var current_label: []const u8 = "UNKNOWN";
-                    if (choice.values) |values| {
-                        for (values, 0..) |v, i| {
-                            if (v == val_ptr.*) {
-                                if (i < choice.labels.len) current_label = choice.labels[i];
-                                break;
+                switch (meta.kind) {
+                    .toggle => {
+                        const label = if (val_ptr.*) "ENABLED" else "DISABLED";
+                        if (Widgets.drawButton(ui, .{ .x = vx + arrow_width, .y = sy - 4.0, .width = toggle_width, .height = btn_height }, label, btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+                            val_ptr.* = !val_ptr.*;
+                        }
+                    },
+                    .choice => |choice| {
+                        var current_label: []const u8 = "UNKNOWN";
+                        if (choice.values) |values| {
+                            for (values, 0..) |v, i| {
+                                if (v == val_ptr.*) {
+                                    if (i < choice.labels.len) current_label = choice.labels[i];
+                                    break;
+                                }
                             }
                         }
-                    }
-                    if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, current_label, btn_scale, mouse_x, mouse_y, mouse_clicked)) {
                         if (choice.values) |values| {
                             var current_idx: usize = 0;
                             for (values, 0..) |v, i| {
@@ -190,62 +244,66 @@ pub const GraphicsScreen = struct {
                                     break;
                                 }
                             }
-                            // Cycle: Left click forward, Right click backward (if we had right click)
-                            // For now, standard cycle
-                            const next_idx = (current_idx + 1) % values.len;
-                            val_ptr.* = @as(val_type, @intCast(values[next_idx]));
+                            if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 4.0, .width = arrow_width, .height = btn_height }, "<", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+                                const prev_idx = if (current_idx == 0) values.len - 1 else current_idx - 1;
+                                val_ptr.* = @as(val_type, @intCast(values[prev_idx]));
+                            }
+                            Font.drawTextCentered(ui, current_label, vx + arrow_width + toggle_width * 0.5, sy + (btn_height - 7.0 * btn_scale) * 0.5, btn_scale, TITLE_COLOR);
+                            if (Widgets.drawButton(ui, .{ .x = vx + arrow_width + toggle_width, .y = sy - 4.0, .width = arrow_width, .height = btn_height }, ">", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+                                const next_idx = (current_idx + 1) % values.len;
+                                val_ptr.* = @as(val_type, @intCast(values[next_idx]));
+                            }
                         }
-                    }
-                },
-                .slider => |slider| {
-                    const val_str = std.fmt.bufPrint(&buf, "{d:.1}", .{val_ptr.*}) catch "ERR";
-
-                    if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, val_str, btn_scale, mouse_x, mouse_y, mouse_clicked)) {
-                        // Left-click: increment with wrap to max-step for step alignment
-                        if (val_ptr.* + slider.step > slider.max + 0.001) {
-                            val_ptr.* = slider.max - slider.step;
-                        } else {
-                            val_ptr.* += slider.step;
-                        }
-                    } else {
-                        const button_rect = .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height };
-                        const is_hovered = (mouse_x >= button_rect.x and mouse_x <= button_rect.x + button_rect.width and mouse_y >= button_rect.y and mouse_y <= button_rect.y + button_rect.height);
-                        if (is_hovered and mouse_clicked_right) {
-                            // Right-click: decrement with wrap to max-step for step alignment
-                            if (val_ptr.* - slider.step < slider.min - 0.001) {
+                    },
+                    .slider => |slider| {
+                        const val_str = std.fmt.bufPrint(&buf, "{d:.1}", .{val_ptr.*}) catch "ERR";
+                        if (Widgets.drawButton(ui, .{ .x = vx + arrow_width, .y = sy - 4.0, .width = toggle_width, .height = btn_height }, val_str, btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+                            if (val_ptr.* + slider.step > slider.max + 0.001) {
                                 val_ptr.* = slider.max - slider.step;
                             } else {
-                                val_ptr.* -= slider.step;
+                                val_ptr.* += slider.step;
+                            }
+                        } else {
+                            const button_rect = .{ .x = vx + arrow_width, .y = sy - 4.0, .width = toggle_width, .height = btn_height };
+                            const is_hovered = (mouse_x >= button_rect.x and mouse_x <= button_rect.x + button_rect.width and mouse_y >= button_rect.y and mouse_y <= button_rect.y + button_rect.height);
+                            if (is_hovered and mouse_clicked_right) {
+                                if (val_ptr.* - slider.step < slider.min - 0.001) {
+                                    val_ptr.* = slider.max - slider.step;
+                                } else {
+                                    val_ptr.* -= slider.step;
+                                }
                             }
                         }
-                    }
-                },
-                .int_range => |range| {
-                    const val_str = std.fmt.bufPrint(&buf, "{d}", .{val_ptr.*}) catch "ERR";
-
-                    if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, val_str, btn_scale, mouse_x, mouse_y, mouse_clicked)) {
-                        // Left-click: increment with wrap to max-step for step alignment
-                        if (val_ptr.* + range.step > range.max) {
-                            val_ptr.* = range.max - range.step;
-                        } else {
-                            val_ptr.* += range.step;
-                        }
-                    } else {
-                        const button_rect = .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height };
-                        const is_hovered = (mouse_x >= button_rect.x and mouse_x <= button_rect.x + button_rect.width and mouse_y >= button_rect.y and mouse_y <= button_rect.y + button_rect.height);
-                        if (is_hovered and mouse_clicked_right) {
-                            // Right-click: decrement with wrap to max-step for step alignment
-                            if (val_ptr.* - range.step < range.min) {
+                    },
+                    .int_range => |range| {
+                        const val_str = std.fmt.bufPrint(&buf, "{d}", .{val_ptr.*}) catch "ERR";
+                        if (Widgets.drawButton(ui, .{ .x = vx + arrow_width, .y = sy - 4.0, .width = toggle_width, .height = btn_height }, val_str, btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+                            if (val_ptr.* + range.step > range.max) {
                                 val_ptr.* = range.max - range.step;
                             } else {
-                                val_ptr.* -= range.step;
+                                val_ptr.* += range.step;
+                            }
+                        } else {
+                            const button_rect = .{ .x = vx + arrow_width, .y = sy - 4.0, .width = toggle_width, .height = btn_height };
+                            const is_hovered = (mouse_x >= button_rect.x and mouse_x <= button_rect.x + button_rect.width and mouse_y >= button_rect.y and mouse_y <= button_rect.y + button_rect.height);
+                            if (is_hovered and mouse_clicked_right) {
+                                if (val_ptr.* - range.step < range.min) {
+                                    val_ptr.* = range.max - range.step;
+                                } else {
+                                    val_ptr.* -= range.step;
+                                }
                             }
                         }
-                    }
-                },
+                    },
+                }
+
+                if (std.mem.eql(u8, decl.name, "lpv_quality_preset")) {
+                    const legend = getLPVQualityLegend(settings.lpv_quality_preset);
+                    Font.drawText(ui, legend, vx - 80.0 * ui_scale, sy + row_height - 14.0 * ui_scale, 1.1 * ui_scale, Color.rgba(0.72, 0.86, 0.98, 1.0));
+                }
             }
 
-            // Handle side effects
+            // Side effects always run (even if not visible)
             if (val_ptr.* != old_val) {
                 if (std.mem.eql(u8, decl.name, "anisotropic_filtering")) {
                     rs.setAnisotropicFiltering(settings.anisotropic_filtering);
@@ -283,35 +341,16 @@ pub const GraphicsScreen = struct {
                     rs.setFilmGrainEnabled(settings.film_grain_enabled);
                 } else if (std.mem.eql(u8, decl.name, "film_grain_intensity")) {
                     rs.setFilmGrainIntensity(settings.film_grain_intensity);
-                } else if (std.mem.eql(u8, decl.name, "render_distance_preset")) {
-                    const preset_cfg = render_settings_mod.getPresetConfig(settings.render_distance_preset);
-                    settings.render_distance = preset_cfg.lod_radii[0];
-                    settings.lod_enabled = true;
                 }
-            }
-
-            if (std.mem.eql(u8, decl.name, "lpv_quality_preset")) {
-                const legend = getLPVQualityLegend(settings.lpv_quality_preset);
-                Font.drawText(ui, legend, vx - 90.0 * ui_scale, sy + row_height - 10.0 * ui_scale, 1.2 * ui_scale, Color.rgba(0.72, 0.86, 0.98, 1.0));
-            }
-
-            if (std.mem.eql(u8, decl.name, "render_distance_preset")) {
-                const preset_cfg = render_settings_mod.getPresetConfig(settings.render_distance_preset);
-                var info_buf: [64]u8 = undefined;
-                const info = std.fmt.bufPrint(&info_buf, "LOD: {} {} {} {}", .{
-                    preset_cfg.lod_radii[0],
-                    preset_cfg.lod_radii[1],
-                    preset_cfg.lod_radii[2],
-                    preset_cfg.lod_radii[3],
-                }) catch "LOD: ?";
-                Font.drawText(ui, info, vx - 170.0 * ui_scale, sy + row_height - 10.0 * ui_scale, 1.2 * ui_scale, Color.rgba(0.5, 0.8, 1.0, 1.0));
             }
 
             sy += row_height;
         }
 
-        // Back button
-        if (Widgets.drawButton(ui, .{ .x = px + (pw - 150.0 * ui_scale) * 0.5, .y = py + ph - 60.0 * ui_scale, .width = 150.0 * ui_scale, .height = 45.0 * ui_scale }, "BACK", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        // Footer / Back button
+        const footer_y: f32 = py + ph - footer_h + 10.0 * ui_scale;
+        ui.drawRect(.{ .x = px, .y = py + ph - footer_h, .width = pw, .height = 2.0 * ui_scale }, Color.rgba(0.20, 0.36, 0.48, 0.50));
+        if (Widgets.drawButton(ui, .{ .x = px + (pw - 150.0 * ui_scale) * 0.5, .y = footer_y, .width = 150.0 * ui_scale, .height = 42.0 * ui_scale }, "BACK", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             ctx.saveSettings();
             ctx.screen_manager.popScreen();
         }
@@ -326,6 +365,19 @@ pub const GraphicsScreen = struct {
         return Screen.makeScreen(@This(), self);
     }
 };
+
+fn applyPresetSideEffects(settings: *Settings, rs: anytype) void {
+    rs.setAnisotropicFiltering(settings.anisotropic_filtering);
+    rs.setTexturesEnabled(settings.textures_enabled);
+    rs.setTAABlendFactor(settings.taa_blend_factor);
+    rs.setTAAVelocityRejection(settings.taa_velocity_rejection);
+    if (settings.taa_enabled) {
+        settings.fxaa_enabled = false;
+        rs.setFXAA(false);
+    } else {
+        rs.setFXAA(settings.fxaa_enabled);
+    }
+}
 
 fn drawGraphicsBackdrop(ui: *UISystem, screen_w: f32, screen_h: f32, ui_scale: f32) void {
     ui.drawRect(.{ .x = 0, .y = 0, .width = screen_w, .height = screen_h }, Color.rgba(0.010, 0.018, 0.030, 0.82));

--- a/src/game/screens/settings.zig
+++ b/src/game/screens/settings.zig
@@ -106,7 +106,7 @@ pub const SettingsScreen = struct {
         // Calculate content start Y to center everything vertically
         const section_gap: f32 = 20.0 * ui_scale;
         const label_h: f32 = 20.0 * ui_scale;
-        const total_content: f32 = 2.0 * label_h + 7.0 * row_height + 2.0 * section_gap + 48.0 * ui_scale;
+        const total_content: f32 = 2.0 * label_h + 9.0 * row_height + 2.0 * section_gap + 42.0 * ui_scale;
         var sy: f32 = content_top + @max(10.0 * ui_scale, (content_bottom - content_top - total_content) * 0.4);
 
         // DISPLAY section

--- a/src/game/screens/settings.zig
+++ b/src/game/screens/settings.zig
@@ -11,8 +11,7 @@ const Settings = settings_pkg.Settings;
 const GraphicsScreen = @import("graphics.zig").GraphicsScreen;
 const apply_logic = settings_pkg.apply_logic;
 
-const PANEL_WIDTH_MAX = 760.0;
-const PANEL_HEIGHT_BASE = 820.0;
+const PANEL_WIDTH_MAX = 900.0;
 const BG_COLOR = Color.rgba(0.025, 0.045, 0.065, 0.95);
 const BORDER_COLOR = Color.rgba(0.42, 0.66, 0.82, 0.78);
 const TITLE_COLOR = Color.rgba(1.0, 0.93, 0.76, 1.0);
@@ -58,9 +57,7 @@ pub const SettingsScreen = struct {
         const settings = ctx.settings;
         const rs = ctx.render_settings;
 
-        // Draw background screen if it exists
         try ctx.screen_manager.drawParentScreen(ptr, ui);
-
         ui.begin();
         defer ui.end();
 
@@ -74,38 +71,60 @@ pub const SettingsScreen = struct {
 
         const auto_scale: f32 = @max(1.0, screen_h / 720.0);
         const ui_scale: f32 = auto_scale * settings.ui_scale;
-        const label_scale: f32 = 1.75 * ui_scale;
-        const btn_scale: f32 = 1.55 * ui_scale;
-        const title_scale: f32 = 3.0 * ui_scale;
-        const row_height: f32 = 52.0 * ui_scale;
-        const btn_height: f32 = 38.0 * ui_scale;
-        const btn_width: f32 = 40.0 * ui_scale;
-        const toggle_width: f32 = 160.0 * ui_scale;
+        const label_scale: f32 = 1.55 * ui_scale;
+        const btn_scale: f32 = 1.35 * ui_scale;
+        const title_scale: f32 = 2.8 * ui_scale;
+        const row_height: f32 = 48.0 * ui_scale;
+        const btn_height: f32 = 34.0 * ui_scale;
+        const btn_width: f32 = 38.0 * ui_scale;
+        const toggle_width: f32 = 150.0 * ui_scale;
 
-        const pw: f32 = @min(screen_w * 0.75, PANEL_WIDTH_MAX * ui_scale);
-        const ph: f32 = @min(screen_h - 80.0 * ui_scale, PANEL_HEIGHT_BASE * ui_scale);
+        const margin: f32 = 50.0 * ui_scale;
+        const pw: f32 = @min(screen_w - margin * 2.0, PANEL_WIDTH_MAX * ui_scale);
+        const ph: f32 = screen_h - margin * 2.0;
         const px: f32 = (screen_w - pw) * 0.5;
-        const py: f32 = (screen_h - ph) * 0.5;
+        const py: f32 = margin;
+
+        const header_h: f32 = 72.0 * ui_scale;
+        const footer_h: f32 = 64.0 * ui_scale;
+        const content_top: f32 = py + header_h;
+        const content_bottom: f32 = py + ph - footer_h;
 
         drawSettingsBackdrop(ui, screen_w, screen_h, ui_scale);
         ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = ph }, BG_COLOR);
         ui.drawRect(.{ .x = px, .y = py, .width = 7.0 * ui_scale, .height = ph }, Color.rgba(0.95, 0.62, 0.24, 0.95));
-        ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = 72.0 * ui_scale }, Color.rgba(0.12, 0.22, 0.30, 0.64));
+        ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = header_h }, Color.rgba(0.12, 0.22, 0.30, 0.64));
         ui.drawRect(.{ .x = px + pw - 2.0 * ui_scale, .y = py, .width = 2.0 * ui_scale, .height = ph }, Color.rgba(0.48, 0.76, 0.93, 0.62));
         ui.drawRectOutline(.{ .x = px, .y = py, .width = pw, .height = ph }, BORDER_COLOR, 2.0 * ui_scale);
-        Font.drawText(ui, "SETTINGS", px + 34.0 * ui_scale, py + 24.0 * ui_scale, title_scale, TITLE_COLOR);
-        Font.drawText(ui, "Tune the renderer and input feel.", px + 38.0 * ui_scale, py + 56.0 * ui_scale, 1.05 * ui_scale, MUTED_COLOR);
-        var sy: f32 = py + 96.0 * ui_scale;
-        const lx: f32 = px + 50.0 * ui_scale;
+        Font.drawText(ui, "SETTINGS", px + 34.0 * ui_scale, py + 20.0 * ui_scale, title_scale, TITLE_COLOR);
+        Font.drawText(ui, "Tune the renderer and input feel.", px + 38.0 * ui_scale, py + 48.0 * ui_scale, 1.0 * ui_scale, MUTED_COLOR);
+
+        // Layout constants
+        const ix: f32 = px + 40.0 * ui_scale;
         const vx: f32 = px + pw - 250.0 * ui_scale;
 
-        drawSectionLabel(ui, lx, sy - 28.0 * ui_scale, "DISPLAY", ui_scale);
+        // Calculate content start Y to center everything vertically
+        const section_gap: f32 = 20.0 * ui_scale;
+        const label_h: f32 = 20.0 * ui_scale;
+        const total_content: f32 = 2.0 * label_h + 7.0 * row_height + 2.0 * section_gap + 48.0 * ui_scale;
+        var sy: f32 = content_top + @max(10.0 * ui_scale, (content_bottom - content_top - total_content) * 0.4);
+
+        // DISPLAY section
+        drawSectionLabel(ui, ix, sy, "DISPLAY", ui_scale);
+        sy += label_h + 6.0 * ui_scale;
 
         // Resolution
-        Font.drawText(ui, "RESOLUTION", lx, sy, label_scale, LABEL_COLOR);
+        Font.drawText(ui, "RESOLUTION", ix, sy, label_scale, LABEL_COLOR);
         const res_idx = settings.getResolutionIndex();
         const res_label = settings_pkg.RESOLUTIONS[res_idx].label;
-        if (Widgets.drawButton(ui, .{ .x = vx - 20.0, .y = sy - 5.0, .width = 180.0 * ui_scale, .height = btn_height }, res_label, btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        const res_val_w: f32 = 150.0 * ui_scale;
+        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 4.0, .width = btn_width, .height = btn_height }, "<", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+            const new_idx = if (res_idx == 0) settings_pkg.RESOLUTIONS.len - 1 else res_idx - 1;
+            settings.setResolutionByIndex(new_idx);
+            ctx.window_manager.setSize(settings.window_width, settings.window_height);
+        }
+        Font.drawTextCentered(ui, res_label, vx + btn_width + res_val_w * 0.5, sy + (btn_height - 7.0 * btn_scale) * 0.5, btn_scale, TITLE_COLOR);
+        if (Widgets.drawButton(ui, .{ .x = vx + btn_width + res_val_w, .y = sy - 4.0, .width = btn_width, .height = btn_height }, ">", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             const new_idx = (res_idx + 1) % settings_pkg.RESOLUTIONS.len;
             settings.setResolutionByIndex(new_idx);
             ctx.window_manager.setSize(settings.window_width, settings.window_height);
@@ -113,90 +132,98 @@ pub const SettingsScreen = struct {
         sy += row_height;
 
         // Render Distance
-        Font.drawText(ui, "RENDER DISTANCE", lx, sy, label_scale, LABEL_COLOR);
+        Font.drawText(ui, "RENDER DISTANCE", ix, sy, label_scale, LABEL_COLOR);
         Font.drawNumber(ui, @intCast(settings.render_distance), vx + 70.0 * ui_scale, sy, TITLE_COLOR);
-        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = btn_width, .height = btn_height }, "-", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 4.0, .width = btn_width, .height = btn_height }, "-", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             if (settings.render_distance > 1) settings.render_distance -= 1;
         }
-        if (Widgets.drawButton(ui, .{ .x = vx + 120.0 * ui_scale, .y = sy - 5.0, .width = btn_width, .height = btn_height }, "+", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        if (Widgets.drawButton(ui, .{ .x = vx + 120.0 * ui_scale, .y = sy - 4.0, .width = btn_width, .height = btn_height }, "+", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             settings.render_distance += 1;
         }
         sy += row_height;
 
         // Sensitivity
-        Font.drawText(ui, "SENSITIVITY", lx, sy, label_scale, LABEL_COLOR);
+        Font.drawText(ui, "SENSITIVITY", ix, sy, label_scale, LABEL_COLOR);
         Font.drawNumber(ui, @intFromFloat(settings.mouse_sensitivity), vx + 70.0 * ui_scale, sy, TITLE_COLOR);
-        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = btn_width, .height = btn_height }, "-", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 4.0, .width = btn_width, .height = btn_height }, "-", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             if (settings.mouse_sensitivity > 10.0) settings.mouse_sensitivity -= 5.0;
         }
-        if (Widgets.drawButton(ui, .{ .x = vx + 120.0 * ui_scale, .y = sy - 5.0, .width = btn_width, .height = btn_height }, "+", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        if (Widgets.drawButton(ui, .{ .x = vx + 120.0 * ui_scale, .y = sy - 4.0, .width = btn_width, .height = btn_height }, "+", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             if (settings.mouse_sensitivity < 200.0) settings.mouse_sensitivity += 5.0;
         }
         sy += row_height;
 
         // FOV
-        Font.drawText(ui, "FOV", lx, sy, label_scale, LABEL_COLOR);
+        Font.drawText(ui, "FOV", ix, sy, label_scale, LABEL_COLOR);
         Font.drawNumber(ui, @intFromFloat(settings.fov), vx + 70.0 * ui_scale, sy, TITLE_COLOR);
-        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = btn_width, .height = btn_height }, "-", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 4.0, .width = btn_width, .height = btn_height }, "-", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             if (settings.fov > 30.0) settings.fov -= 5.0;
         }
-        if (Widgets.drawButton(ui, .{ .x = vx + 120.0 * ui_scale, .y = sy - 5.0, .width = btn_width, .height = btn_height }, "+", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        if (Widgets.drawButton(ui, .{ .x = vx + 120.0 * ui_scale, .y = sy - 4.0, .width = btn_width, .height = btn_height }, "+", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             if (settings.fov < 120.0) settings.fov += 5.0;
         }
         sy += row_height;
 
         // VSync
-        Font.drawText(ui, "VSYNC", lx, sy, label_scale, LABEL_COLOR);
-        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, if (settings.vsync) "ENABLED" else "DISABLED", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        Font.drawText(ui, "VSYNC", ix, sy, label_scale, LABEL_COLOR);
+        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 4.0, .width = toggle_width, .height = btn_height }, if (settings.vsync) "ENABLED" else "DISABLED", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             settings.vsync = !settings.vsync;
             apply_logic.applyToRenderSettings(settings, rs);
         }
-        sy += row_height + 12.0 * ui_scale;
+        sy += row_height + section_gap;
 
         // Advanced Graphics Button
-        if (Widgets.drawButton(ui, .{ .x = px + (pw - 250.0 * ui_scale) * 0.5, .y = sy, .width = 250.0 * ui_scale, .height = btn_height + 10.0 * ui_scale }, "ADVANCED GRAPHICS...", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        if (Widgets.drawButton(ui, .{ .x = px + (pw - 250.0 * ui_scale) * 0.5, .y = sy, .width = 250.0 * ui_scale, .height = btn_height + 8.0 * ui_scale }, "ADVANCED GRAPHICS...", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             const graphics_screen = try GraphicsScreen.init(ctx.allocator, ctx);
             errdefer graphics_screen.deinit(graphics_screen);
             ctx.screen_manager.pushScreen(graphics_screen.screen());
         }
-        sy += row_height + 12.0 * ui_scale;
+        sy += row_height + section_gap;
 
-        drawSectionLabel(ui, lx, sy - 14.0 * ui_scale, "SYSTEMS", ui_scale);
-        sy += 18.0 * ui_scale;
+        // SYSTEMS section
+        drawSectionLabel(ui, ix, sy, "SYSTEMS", ui_scale);
+        sy += label_h + 6.0 * ui_scale;
 
         // UI Scale
-        Font.drawText(ui, "UI SCALE", lx, sy, label_scale, LABEL_COLOR);
+        Font.drawText(ui, "UI SCALE", ix, sy, label_scale, LABEL_COLOR);
         const ui_scale_label = settings_pkg.ui_helpers.getUIScaleLabel(settings.ui_scale);
-        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, ui_scale_label, btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        const ui_val_w: f32 = 90.0 * ui_scale;
+        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 4.0, .width = btn_width, .height = btn_height }, "<", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+            settings.ui_scale = settings_pkg.ui_helpers.prevUIScale(settings.ui_scale);
+        }
+        Font.drawTextCentered(ui, ui_scale_label, vx + btn_width + ui_val_w * 0.5, sy + (btn_height - 7.0 * btn_scale) * 0.5, btn_scale, TITLE_COLOR);
+        if (Widgets.drawButton(ui, .{ .x = vx + btn_width + ui_val_w, .y = sy - 4.0, .width = btn_width, .height = btn_height }, ">", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             settings.ui_scale = settings_pkg.ui_helpers.cycleUIScale(settings.ui_scale);
         }
         sy += row_height;
 
         // LOD System
-        Font.drawText(ui, "LOD SYSTEM", lx, sy, label_scale, LABEL_COLOR);
-        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, if (settings.lod_enabled) "ENABLED" else "DISABLED", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        Font.drawText(ui, "LOD SYSTEM", ix, sy, label_scale, LABEL_COLOR);
+        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 4.0, .width = toggle_width, .height = btn_height }, if (settings.lod_enabled) "ENABLED" else "DISABLED", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             settings.lod_enabled = !settings.lod_enabled;
         }
         sy += row_height;
 
         // Textures
-        Font.drawText(ui, "TEXTURES", lx, sy, label_scale, LABEL_COLOR);
-        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, if (settings.textures_enabled) "ENABLED" else "DISABLED", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        Font.drawText(ui, "TEXTURES", ix, sy, label_scale, LABEL_COLOR);
+        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 4.0, .width = toggle_width, .height = btn_height }, if (settings.textures_enabled) "ENABLED" else "DISABLED", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             settings.textures_enabled = !settings.textures_enabled;
             apply_logic.applyToRenderSettings(settings, rs);
         }
         sy += row_height;
 
         // Wireframe (debug)
-        Font.drawText(ui, "WIREFRAME", lx, sy, label_scale, MUTED_COLOR);
-        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 5.0, .width = toggle_width, .height = btn_height }, if (settings.wireframe_enabled) "ENABLED" else "DISABLED", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        Font.drawText(ui, "WIREFRAME", ix, sy, label_scale, MUTED_COLOR);
+        if (Widgets.drawButton(ui, .{ .x = vx, .y = sy - 4.0, .width = toggle_width, .height = btn_height }, if (settings.wireframe_enabled) "ENABLED" else "DISABLED", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             settings.wireframe_enabled = !settings.wireframe_enabled;
             apply_logic.applyToRenderSettings(settings, rs);
         }
-        Font.drawText(ui, "(DEBUG)", vx + toggle_width + 10.0, sy, 1.1 * ui_scale, MUTED_COLOR);
+        Font.drawText(ui, "(DEBUG)", vx + toggle_width + 10.0, sy, 1.0 * ui_scale, MUTED_COLOR);
 
-        // Back button
-        if (Widgets.drawButton(ui, .{ .x = px + (pw - 150.0 * ui_scale) * 0.5, .y = py + ph - 70.0 * ui_scale, .width = 150.0 * ui_scale, .height = 50.0 * ui_scale }, "BACK", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        // Footer / Back button
+        const footer_y: f32 = py + ph - footer_h + 10.0 * ui_scale;
+        ui.drawRect(.{ .x = px, .y = py + ph - footer_h, .width = pw, .height = 2.0 * ui_scale }, Color.rgba(0.20, 0.36, 0.48, 0.50));
+        if (Widgets.drawButton(ui, .{ .x = px + (pw - 150.0 * ui_scale) * 0.5, .y = footer_y, .width = 150.0 * ui_scale, .height = 42.0 * ui_scale }, "BACK", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             ctx.saveSettings();
             ctx.screen_manager.popScreen();
         }
@@ -222,5 +249,5 @@ fn drawSettingsBackdrop(ui: *UISystem, screen_w: f32, screen_h: f32, ui_scale: f
 
 fn drawSectionLabel(ui: *UISystem, x: f32, y: f32, label: []const u8, ui_scale: f32) void {
     ui.drawRect(.{ .x = x, .y = y + 8.0 * ui_scale, .width = 26.0 * ui_scale, .height = 2.0 * ui_scale }, Color.rgba(0.95, 0.62, 0.24, 0.86));
-    Font.drawText(ui, label, x + 36.0 * ui_scale, y, 1.05 * ui_scale, MUTED_COLOR);
+    Font.drawText(ui, label, x + 36.0 * ui_scale, y, 1.0 * ui_scale, MUTED_COLOR);
 }

--- a/src/game/screens/singleplayer.zig
+++ b/src/game/screens/singleplayer.zig
@@ -10,8 +10,7 @@ const IScreen = Screen.IScreen;
 const EngineContext = Screen.EngineContext;
 const seed_gen = @import("../seed.zig");
 const log = @import("engine-core").log;
-const Key = @import("../../engine/core/interfaces.zig").Key;
-const IRawInputProvider = @import("../../engine/input/interfaces.zig").IRawInputProvider;
+const text_input = @import("../text_input.zig");
 const Input = @import("engine-input").Input;
 const WorldScreen = @import("world.zig").WorldScreen;
 const WorldListScreen = @import("world_list.zig").WorldListScreen;
@@ -74,10 +73,10 @@ pub const SingleplayerScreen = struct {
         }
 
         if (self.seed_focused) {
-            try handleTextTyping(&self.seed_input, self.context.allocator, self.context.input, 32);
+            try text_input.handleTextTyping(&self.seed_input, self.context.allocator, self.context.input, 32);
         }
         if (self.name_focused) {
-            try handleTextTyping(&self.name_input, self.context.allocator, self.context.input, 32);
+            try text_input.handleTextTyping(&self.name_input, self.context.allocator, self.context.input, 32);
         }
     }
 
@@ -209,7 +208,8 @@ pub const SingleplayerScreen = struct {
         }
         if (Widgets.drawButton(ui, .{ .x = ix + hw + 15.0 * ui_scale, .y = bottom_btn_y, .width = hw, .height = btn_row_h }, "CREATE", btn_scale, mouse_x, mouse_y, mouse_clicked) or ctx.input_mapper.isActionPressed(ctx.input, .ui_confirm)) {
             const seed = try seed_gen.resolveSeed(&self.seed_input, ctx.allocator);
-            const world_name = if (self.name_input.items.len > 0) self.name_input.items else "New World";
+            const trimmed_name = std.mem.trim(u8, self.name_input.items, " \t\r\n");
+            const world_name = if (trimmed_name.len > 0) trimmed_name else "New World";
             log.log.info("World seed: {} | Type: {s} | Name: {s}", .{ seed, registry.getGeneratorInfo(self.selected_generator_index).name, world_name });
             saveNewWorld(ctx.allocator, seed, self.selected_generator_index, world_name) catch |err| {
                 log.log.warn("Failed to save level.dat for new world: {}", .{err});
@@ -265,20 +265,4 @@ fn saveNewWorld(allocator: std.mem.Allocator, seed: u64, generator_index: usize,
         log.log.warn("Cannot save world: failed to write level.dat: {}", .{err});
         return err;
     };
-}
-
-fn handleTextTyping(text_input: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, input: IRawInputProvider, max_len: usize) !void {
-    if (input.isKeyPressed(.backspace)) {
-        if (text_input.items.len > 0) _ = text_input.pop();
-    }
-    const shift = input.isKeyDown(.left_shift) or input.isKeyDown(.right_shift);
-    const letters = [_]Key{ .a, .b, .c, .d, .e, .f, .g, .h, .i, .j, .k, .l, .m, .n, .o, .p, .q, .r, .s, .t, .u, .v, .w, .x, .y, .z };
-    inline for (letters) |key| if (input.isKeyPressed(key) and text_input.items.len < max_len) {
-        var ch: u8 = @intCast(@intFromEnum(key));
-        if (shift) ch = std.ascii.toUpper(ch);
-        try text_input.append(allocator, ch);
-    };
-    const digits = [_]Key{ .@"0", .@"1", .@"2", .@"3", .@"4", .@"5", .@"6", .@"7", .@"8", .@"9" };
-    inline for (digits) |key| if (input.isKeyPressed(key) and text_input.items.len < max_len) try text_input.append(allocator, @intCast(@intFromEnum(key)));
-    if (input.isKeyPressed(.space) and text_input.items.len < max_len) try text_input.append(allocator, ' ');
 }

--- a/src/game/screens/singleplayer.zig
+++ b/src/game/screens/singleplayer.zig
@@ -24,8 +24,7 @@ fn getenv(name: [:0]const u8) ?[]const u8 {
     return std.mem.span(value);
 }
 
-const PANEL_WIDTH_MAX = 650.0;
-const PANEL_HEIGHT_BASE = 400.0;
+const PANEL_WIDTH_MAX = 780.0;
 const BG_COLOR = Color.rgba(0.025, 0.045, 0.065, 0.94);
 const BORDER_COLOR = Color.rgba(0.42, 0.66, 0.82, 0.80);
 const TITLE_COLOR = Color.rgba(1.0, 0.93, 0.76, 1.0);
@@ -35,6 +34,8 @@ pub const SingleplayerScreen = struct {
     context: EngineContext,
     seed_input: std.ArrayListUnmanaged(u8),
     seed_focused: bool,
+    name_input: std.ArrayListUnmanaged(u8),
+    name_focused: bool,
     selected_generator_index: usize,
 
     pub const vtable = IScreen.VTable{
@@ -48,7 +49,9 @@ pub const SingleplayerScreen = struct {
         self.* = .{
             .context = context,
             .seed_input = std.ArrayListUnmanaged(u8).empty,
-            .seed_focused = true,
+            .seed_focused = false,
+            .name_input = std.ArrayListUnmanaged(u8).empty,
+            .name_focused = true,
             .selected_generator_index = 0,
         };
         return self;
@@ -57,6 +60,7 @@ pub const SingleplayerScreen = struct {
     pub fn deinit(ptr: *anyopaque) void {
         const self: *@This() = @ptrCast(@alignCast(ptr));
         self.seed_input.deinit(self.context.allocator);
+        self.name_input.deinit(self.context.allocator);
         self.context.allocator.destroy(self);
     }
 
@@ -70,7 +74,10 @@ pub const SingleplayerScreen = struct {
         }
 
         if (self.seed_focused) {
-            try handleSeedTyping(&self.seed_input, self.context.allocator, self.context.input, 32);
+            try handleTextTyping(&self.seed_input, self.context.allocator, self.context.input, 32);
+        }
+        if (self.name_focused) {
+            try handleTextTyping(&self.name_input, self.context.allocator, self.context.input, 32);
         }
     }
 
@@ -89,74 +96,122 @@ pub const SingleplayerScreen = struct {
         const screen_w: f32 = @floatFromInt(ctx.input.getWindowWidth());
         const screen_h: f32 = @floatFromInt(ctx.input.getWindowHeight());
 
-        // Scale UI based on screen height
         const ui_scale: f32 = @max(1.0, screen_h / 720.0);
-        const title_scale: f32 = 3.1 * ui_scale;
-        const label_scale: f32 = 1.75 * ui_scale;
-        const btn_scale: f32 = 1.75 * ui_scale;
-        const input_scale: f32 = 1.55 * ui_scale;
+        const title_scale: f32 = 3.0 * ui_scale;
+        const label_scale: f32 = 1.65 * ui_scale;
+        const btn_scale: f32 = 1.55 * ui_scale;
+        const input_scale: f32 = 1.45 * ui_scale;
 
-        const pw: f32 = @min(screen_w * 0.7, PANEL_WIDTH_MAX * ui_scale);
-        const ph: f32 = (PANEL_HEIGHT_BASE + 44.0) * ui_scale;
+        const margin: f32 = 60.0 * ui_scale;
+        const pw: f32 = @min(screen_w - margin * 2.0, PANEL_WIDTH_MAX * ui_scale);
+        const ph: f32 = screen_h - margin * 2.0;
         const px: f32 = (screen_w - pw) * 0.5;
-        const py: f32 = screen_h * 0.18;
+        const py: f32 = margin;
+
+        const header_h: f32 = 80.0 * ui_scale;
+        const footer_h: f32 = 70.0 * ui_scale;
+        const content_top: f32 = py + header_h;
+        const content_bottom: f32 = py + ph - footer_h;
+        const content_h: f32 = content_bottom - content_top;
 
         drawCreateWorldBackdrop(ui, screen_w, screen_h, ui_scale);
         ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = ph }, BG_COLOR);
         ui.drawRect(.{ .x = px, .y = py, .width = 7.0 * ui_scale, .height = ph }, Color.rgba(0.95, 0.62, 0.24, 0.95));
-        ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = 72.0 * ui_scale }, Color.rgba(0.12, 0.22, 0.30, 0.62));
+        ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = header_h }, Color.rgba(0.12, 0.22, 0.30, 0.62));
         ui.drawRectOutline(.{ .x = px, .y = py, .width = pw, .height = ph }, BORDER_COLOR, 2.0 * ui_scale);
-        Font.drawText(ui, "CREATE WORLD", px + 34.0 * ui_scale, py + 24.0 * ui_scale, title_scale, TITLE_COLOR);
-        Font.drawText(ui, "Choose a seed and terrain profile.", px + 38.0 * ui_scale, py + 57.0 * ui_scale, 1.05 * ui_scale, Color.rgba(0.58, 0.73, 0.84, 0.92));
-        const ly: f32 = py + 104.0 * ui_scale;
-        Font.drawText(ui, "SEED", px + 30.0 * ui_scale, ly, label_scale, LABEL_COLOR);
-        const ih: f32 = 52.0 * ui_scale;
-        const iy: f32 = ly + 28.0 * ui_scale;
-        const rw: f32 = 150.0 * ui_scale;
-        const iw: f32 = pw - 30.0 * ui_scale - rw - 15.0 * ui_scale - 30.0 * ui_scale;
-        const ix: f32 = px + 30.0 * ui_scale;
-        const rx: f32 = ix + iw + 15.0 * ui_scale;
-        const seed_rect = Rect{ .x = ix, .y = iy, .width = iw, .height = ih };
-        const random_rect = Rect{ .x = rx, .y = iy, .width = rw, .height = ih };
-        if (mouse_clicked) self.seed_focused = seed_rect.contains(mouse_x, mouse_y);
+        Font.drawText(ui, "CREATE WORLD", px + 34.0 * ui_scale, py + 22.0 * ui_scale, title_scale, TITLE_COLOR);
+        Font.drawText(ui, "Name your world, choose a seed and terrain profile.", px + 38.0 * ui_scale, py + 54.0 * ui_scale, 1.0 * ui_scale, Color.rgba(0.58, 0.73, 0.84, 0.92));
 
         const cursor_visible = @as(u32, @truncate(@as(u64, @intFromFloat(ctx.time.elapsed * 2.0)))) % 2 == 0;
+        const ih: f32 = 48.0 * ui_scale;
+        const ix: f32 = px + 30.0 * ui_scale;
+        const iw: f32 = pw - 60.0 * ui_scale;
+
+        // Calculate centered vertical positions for 3 sections + buttons within content area
+        const section_gap: f32 = 28.0 * ui_scale;
+        const label_h: f32 = 22.0 * ui_scale;
+        const desc_h: f32 = 18.0 * ui_scale;
+        const btn_row_h: f32 = 42.0 * ui_scale;
+        const total_content_needed: f32 = 3.0 * label_h + 3.0 * ih + 2.0 * section_gap + desc_h + section_gap + btn_row_h + 10.0 * ui_scale;
+        const start_y: f32 = content_top + @max(10.0 * ui_scale, (content_h - total_content_needed) * 0.3);
+
+        // World Name
+        var cy: f32 = start_y;
+        Font.drawText(ui, "WORLD NAME", ix, cy, label_scale, LABEL_COLOR);
+        cy += label_h + 4.0 * ui_scale;
+        const name_rect = Rect{ .x = ix, .y = cy, .width = iw, .height = ih };
+        if (mouse_clicked) self.name_focused = name_rect.contains(mouse_x, mouse_y);
+        Widgets.drawTextInput(ui, name_rect, self.name_input.items, "ENTER WORLD NAME", input_scale, self.name_focused, cursor_visible);
+
+        // Seed
+        cy += ih + section_gap;
+        Font.drawText(ui, "SEED", ix, cy, label_scale, LABEL_COLOR);
+        cy += label_h + 4.0 * ui_scale;
+        const rw: f32 = 140.0 * ui_scale;
+        const sw: f32 = iw - rw - 15.0 * ui_scale;
+        const seed_rect = Rect{ .x = ix, .y = cy, .width = sw, .height = ih };
+        const random_rect = Rect{ .x = ix + sw + 15.0 * ui_scale, .y = cy, .width = rw, .height = ih };
+        if (mouse_clicked) {
+            const in_seed = seed_rect.contains(mouse_x, mouse_y);
+            const in_name = name_rect.contains(mouse_x, mouse_y);
+            self.seed_focused = in_seed;
+            self.name_focused = in_name;
+        }
         Widgets.drawTextInput(ui, seed_rect, self.seed_input.items, "LEAVE BLANK FOR RANDOM", input_scale, self.seed_focused, cursor_visible);
 
         if (Widgets.drawButton(ui, random_rect, "RANDOM", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             const gen = seed_gen.randomSeedValue();
             try seed_gen.setSeedInput(&self.seed_input, ctx.allocator, gen);
             self.seed_focused = true;
+            self.name_focused = false;
         }
 
-        const gy: f32 = iy + ih + 24.0 * ui_scale;
-        Font.drawText(ui, "WORLD TYPE", px + 30.0 * ui_scale, gy, label_scale, LABEL_COLOR);
-        const g_rect = Rect{ .x = px + 30.0 * ui_scale, .y = gy + 28.0 * ui_scale, .width = pw - 60.0 * ui_scale, .height = ih };
+        // World Type
+        cy += ih + section_gap;
+        Font.drawText(ui, "WORLD TYPE", ix, cy, label_scale, LABEL_COLOR);
+        cy += label_h + 4.0 * ui_scale;
+        const arrow_w: f32 = 44.0 * ui_scale;
+        const g_label_w: f32 = iw - 2.0 * arrow_w - 2.0 * 10.0 * ui_scale;
         const g_info = registry.getGeneratorInfo(self.selected_generator_index);
-        var g_label_buf: [128]u8 = undefined;
-        const g_label = try std.fmt.bufPrint(&g_label_buf, "{s} ({}/{})", .{ g_info.name, self.selected_generator_index + 1, registry.getGeneratorCount() });
-        if (Widgets.drawButton(ui, g_rect, g_label, btn_scale, mouse_x, mouse_y, mouse_clicked)) {
-            self.selected_generator_index = (self.selected_generator_index + 1) % registry.getGeneratorCount();
-        }
-        Font.drawText(ui, g_info.description, px + 30.0 * ui_scale, g_rect.y + g_rect.height + 12.0 * ui_scale, label_scale * 0.62, Color.rgba(0.55, 0.68, 0.78, 0.95));
+        const gen_count = registry.getGeneratorCount();
 
-        const byy: f32 = py + ph - 135.0 * ui_scale;
-        const hw: f32 = (pw - 30.0 * ui_scale - 15.0 * ui_scale - 30.0 * ui_scale) / 2.0;
-        const btn_h: f32 = 45.0 * ui_scale;
-        if (Widgets.drawButton(ui, .{ .x = px + 30.0 * ui_scale, .y = byy, .width = pw - 60.0 * ui_scale, .height = btn_h }, "LOAD WORLD", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        if (Widgets.drawButton(ui, .{ .x = ix, .y = cy, .width = arrow_w, .height = ih }, "<", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+            if (self.selected_generator_index == 0) {
+                self.selected_generator_index = gen_count - 1;
+            } else {
+                self.selected_generator_index -= 1;
+            }
+        }
+        var g_label_buf: [128]u8 = undefined;
+        const g_label = try std.fmt.bufPrint(&g_label_buf, "{s} ({}/{})", .{ g_info.name, self.selected_generator_index + 1, gen_count });
+        Font.drawTextCentered(ui, g_label, ix + arrow_w + 10.0 * ui_scale + g_label_w * 0.5, cy + (ih - 7.0 * btn_scale) * 0.5, btn_scale, TITLE_COLOR);
+        if (Widgets.drawButton(ui, .{ .x = ix + arrow_w + g_label_w + 20.0 * ui_scale, .y = cy, .width = arrow_w, .height = ih }, ">", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+            self.selected_generator_index = (self.selected_generator_index + 1) % gen_count;
+        }
+        cy += ih + 8.0 * ui_scale;
+        Font.drawText(ui, g_info.description, ix, cy, label_scale * 0.62, Color.rgba(0.55, 0.68, 0.78, 0.95));
+
+        // Footer buttons - positioned at fixed bottom of panel
+        const footer_y: f32 = py + ph - footer_h + 10.0 * ui_scale;
+        ui.drawRect(.{ .x = px, .y = py + ph - footer_h, .width = pw, .height = 2.0 * ui_scale }, Color.rgba(0.20, 0.36, 0.48, 0.50));
+
+        const load_btn_y: f32 = footer_y;
+        if (Widgets.drawButton(ui, .{ .x = ix, .y = load_btn_y, .width = iw, .height = btn_row_h }, "LOAD WORLD", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             const wl_screen = try WorldListScreen.init(ctx.allocator, ctx);
             errdefer wl_screen.deinit(wl_screen);
             ctx.screen_manager.pushScreen(wl_screen.screen());
         }
 
-        const byy2: f32 = byy + btn_h + 15.0 * ui_scale;
-        if (Widgets.drawButton(ui, .{ .x = px + 30.0 * ui_scale, .y = byy2, .width = hw, .height = btn_h }, "BACK", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
+        const bottom_btn_y: f32 = load_btn_y + btn_row_h + 10.0 * ui_scale;
+        const hw: f32 = (iw - 15.0 * ui_scale) / 2.0;
+        if (Widgets.drawButton(ui, .{ .x = ix, .y = bottom_btn_y, .width = hw, .height = btn_row_h }, "BACK", btn_scale, mouse_x, mouse_y, mouse_clicked)) {
             ctx.screen_manager.popScreen();
         }
-        if (Widgets.drawButton(ui, .{ .x = px + 30.0 * ui_scale + hw + 15.0 * ui_scale, .y = byy2, .width = hw, .height = btn_h }, "CREATE", btn_scale, mouse_x, mouse_y, mouse_clicked) or ctx.input_mapper.isActionPressed(ctx.input, .ui_confirm)) {
+        if (Widgets.drawButton(ui, .{ .x = ix + hw + 15.0 * ui_scale, .y = bottom_btn_y, .width = hw, .height = btn_row_h }, "CREATE", btn_scale, mouse_x, mouse_y, mouse_clicked) or ctx.input_mapper.isActionPressed(ctx.input, .ui_confirm)) {
             const seed = try seed_gen.resolveSeed(&self.seed_input, ctx.allocator);
-            log.log.info("World seed: {} | Type: {s}", .{ seed, registry.getGeneratorInfo(self.selected_generator_index).name });
-            saveNewWorld(ctx.allocator, seed, self.selected_generator_index) catch |err| {
+            const world_name = if (self.name_input.items.len > 0) self.name_input.items else "New World";
+            log.log.info("World seed: {} | Type: {s} | Name: {s}", .{ seed, registry.getGeneratorInfo(self.selected_generator_index).name, world_name });
+            saveNewWorld(ctx.allocator, seed, self.selected_generator_index, world_name) catch |err| {
                 log.log.warn("Failed to save level.dat for new world: {}", .{err});
             };
             const world_screen = try WorldScreen.init(ctx.allocator, ctx, seed, self.selected_generator_index);
@@ -178,7 +233,7 @@ fn drawCreateWorldBackdrop(ui: *UISystem, screen_w: f32, screen_h: f32, ui_scale
     ui.drawRect(.{ .x = screen_w - 180.0 * ui_scale, .y = screen_h * 0.62 - 116.0 * ui_scale, .width = 118.0 * ui_scale, .height = 116.0 * ui_scale }, Color.rgba(0.50, 0.29, 0.12, 0.38));
 }
 
-fn saveNewWorld(allocator: std.mem.Allocator, seed: u64, generator_index: usize) !void {
+fn saveNewWorld(allocator: std.mem.Allocator, seed: u64, generator_index: usize, world_name: []const u8) !void {
     const home = getenv("HOME") orelse {
         log.log.warn("Cannot save world: HOME not set", .{});
         return error.NoHome;
@@ -206,24 +261,24 @@ fn saveNewWorld(allocator: std.mem.Allocator, seed: u64, generator_index: usize)
         return err;
     };
     defer save_dir.close();
-    world_list.writeLevelDat(allocator, save_dir, dir_name, seed, generator_index, timestamp) catch |err| {
+    world_list.writeLevelDat(allocator, save_dir, world_name, seed, generator_index, timestamp) catch |err| {
         log.log.warn("Cannot save world: failed to write level.dat: {}", .{err});
         return err;
     };
 }
 
-fn handleSeedTyping(seed_input: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, input: IRawInputProvider, max_len: usize) !void {
+fn handleTextTyping(text_input: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, input: IRawInputProvider, max_len: usize) !void {
     if (input.isKeyPressed(.backspace)) {
-        if (seed_input.items.len > 0) _ = seed_input.pop();
+        if (text_input.items.len > 0) _ = text_input.pop();
     }
     const shift = input.isKeyDown(.left_shift) or input.isKeyDown(.right_shift);
     const letters = [_]Key{ .a, .b, .c, .d, .e, .f, .g, .h, .i, .j, .k, .l, .m, .n, .o, .p, .q, .r, .s, .t, .u, .v, .w, .x, .y, .z };
-    inline for (letters) |key| if (input.isKeyPressed(key) and seed_input.items.len < max_len) {
+    inline for (letters) |key| if (input.isKeyPressed(key) and text_input.items.len < max_len) {
         var ch: u8 = @intCast(@intFromEnum(key));
         if (shift) ch = std.ascii.toUpper(ch);
-        try seed_input.append(allocator, ch);
+        try text_input.append(allocator, ch);
     };
     const digits = [_]Key{ .@"0", .@"1", .@"2", .@"3", .@"4", .@"5", .@"6", .@"7", .@"8", .@"9" };
-    inline for (digits) |key| if (input.isKeyPressed(key) and seed_input.items.len < max_len) try seed_input.append(allocator, @intCast(@intFromEnum(key)));
-    if (input.isKeyPressed(.space) and seed_input.items.len < max_len) try seed_input.append(allocator, ' ');
+    inline for (digits) |key| if (input.isKeyPressed(key) and text_input.items.len < max_len) try text_input.append(allocator, @intCast(@intFromEnum(key)));
+    if (input.isKeyPressed(.space) and text_input.items.len < max_len) try text_input.append(allocator, ' ');
 }

--- a/src/game/screens/world_list.zig
+++ b/src/game/screens/world_list.zig
@@ -10,14 +10,16 @@ const EngineContext = Screen.EngineContext;
 const WorldScreen = @import("world.zig").WorldScreen;
 const log = @import("engine-core").log;
 const fs = @import("fs");
+const Key = @import("../../engine/core/interfaces.zig").Key;
+const IRawInputProvider = @import("../../engine/input/interfaces.zig").IRawInputProvider;
 
 fn getenv(name: [:0]const u8) ?[]const u8 {
     const value = std.c.getenv(name) orelse return null;
     return std.mem.span(value);
 }
 
-const PANEL_WIDTH_MAX = 700.0;
-const PANEL_HEIGHT_BASE = 500.0;
+const PANEL_WIDTH_MAX = 900.0;
+const PANEL_HEIGHT_BASE = 640.0;
 const BG_COLOR = Color.rgba(0.025, 0.045, 0.065, 0.95);
 const BORDER_COLOR = Color.rgba(0.42, 0.66, 0.82, 0.78);
 const TITLE_COLOR = Color.rgba(1.0, 0.93, 0.76, 1.0);
@@ -29,6 +31,8 @@ const ROW_BG = Color.rgba(0.035, 0.065, 0.090, 0.88);
 const DELETE_COLOR = Color.rgba(0.85, 0.25, 0.25, 1.0);
 const CONFIRM_BG = Color.rgba(0.18, 0.10, 0.10, 0.97);
 const CONFIRM_BORDER = Color.rgba(0.7, 0.2, 0.2, 1.0);
+const RENAME_BG = Color.rgba(0.10, 0.14, 0.20, 0.97);
+const RENAME_BORDER = Color.rgba(0.42, 0.66, 0.82, 1.0);
 
 pub const SAVE_DIR = ".local/share/zigcraft/saves";
 
@@ -99,12 +103,12 @@ pub fn readLevelDat(allocator: std.mem.Allocator, save_dir: fs.Dir) ?LevelDat {
     };
 }
 
-pub fn scanWorlds(allocator: std.mem.Allocator) ![]const WorldEntry {
+pub fn scanWorlds(allocator: std.mem.Allocator) ![]WorldEntry {
     const home = getenv("HOME") orelse return allocator.alloc(WorldEntry, 0);
     return scanWorldsInHome(allocator, home);
 }
 
-pub fn scanWorldsInHome(allocator: std.mem.Allocator, home: []const u8) ![]const WorldEntry {
+pub fn scanWorldsInHome(allocator: std.mem.Allocator, home: []const u8) ![]WorldEntry {
     var home_dir = fs.openDirAbsolute(home, .{}) catch return allocator.alloc(WorldEntry, 0);
     defer home_dir.close();
     home_dir.makePath(SAVE_DIR) catch {};
@@ -178,10 +182,14 @@ pub fn deleteWorld(allocator: std.mem.Allocator, dir_path: []const u8) void {
 
 pub const WorldListScreen = struct {
     context: EngineContext,
-    worlds: []const WorldEntry,
+    worlds: []WorldEntry,
     selected: ?usize,
     scroll_offset: f32,
     confirm_delete: bool,
+    confirm_clear_all: bool,
+    confirm_rename: bool,
+    rename_buffer: std.ArrayListUnmanaged(u8),
+    rename_focused: bool,
 
     pub const vtable = IScreen.VTable{
         .deinit = deinit,
@@ -200,6 +208,10 @@ pub const WorldListScreen = struct {
             .selected = null,
             .scroll_offset = 0.0,
             .confirm_delete = false,
+            .confirm_clear_all = false,
+            .confirm_rename = false,
+            .rename_buffer = std.ArrayListUnmanaged(u8).empty,
+            .rename_focused = false,
         };
         return self;
     }
@@ -211,6 +223,7 @@ pub const WorldListScreen = struct {
             if (e.dir_path.len > 0) self.context.allocator.free(e.dir_path);
         }
         self.context.allocator.free(self.worlds);
+        self.rename_buffer.deinit(self.context.allocator);
         self.context.allocator.destroy(self);
     }
 
@@ -218,11 +231,19 @@ pub const WorldListScreen = struct {
         const self: *@This() = @ptrCast(@alignCast(ptr));
         _ = dt;
         if (self.context.input_mapper.isActionPressed(self.context.input, .ui_back)) {
-            if (self.confirm_delete) {
+            if (self.confirm_rename) {
+                self.confirm_rename = false;
+                self.rename_buffer.clearRetainingCapacity();
+            } else if (self.confirm_delete) {
                 self.confirm_delete = false;
+            } else if (self.confirm_clear_all) {
+                self.confirm_clear_all = false;
             } else {
                 self.context.screen_manager.popScreen();
             }
+        }
+        if (self.confirm_rename and self.rename_focused) {
+            try handleTextTyping(&self.rename_buffer, self.context.allocator, self.context.input, 32);
         }
     }
 
@@ -240,12 +261,13 @@ pub const WorldListScreen = struct {
         const ui_scale: f32 = @max(1.0, screen_h / 720.0);
         const title_scale: f32 = 3.0 * ui_scale;
         const label_scale: f32 = 1.55 * ui_scale;
-        const btn_scale: f32 = 1.55 * ui_scale;
+        const btn_scale: f32 = 1.45 * ui_scale;
         const row_scale: f32 = 1.45 * ui_scale;
-        const pw: f32 = @min(screen_w * 0.75, PANEL_WIDTH_MAX * ui_scale);
-        const ph: f32 = @min(screen_h - 96.0 * ui_scale, PANEL_HEIGHT_BASE * ui_scale);
+        const pw: f32 = @min(screen_w * 0.85, PANEL_WIDTH_MAX * ui_scale);
+        const ph: f32 = @min(screen_h - 80.0 * ui_scale, PANEL_HEIGHT_BASE * ui_scale);
         const px: f32 = (screen_w - pw) * 0.5;
         const py: f32 = (screen_h - ph) * 0.5;
+        const modal_open = self.confirm_delete or self.confirm_clear_all or self.confirm_rename;
         drawListBackdrop(ui, screen_w, screen_h, ui_scale);
         ui.drawRect(.{ .x = px, .y = py, .width = pw, .height = ph }, BG_COLOR);
         ui.drawRect(.{ .x = px, .y = py, .width = 7.0 * ui_scale, .height = ph }, Color.rgba(0.95, 0.62, 0.24, 0.95));
@@ -254,10 +276,14 @@ pub const WorldListScreen = struct {
         ui.drawRectOutline(.{ .x = px, .y = py, .width = pw, .height = ph }, BORDER_COLOR, 2.0 * ui_scale);
         Font.drawText(ui, "LOAD WORLD", px + 34.0 * ui_scale, py + 24.0 * ui_scale, title_scale, TITLE_COLOR);
         Font.drawText(ui, "Select a saved world snapshot.", px + 38.0 * ui_scale, py + 56.0 * ui_scale, 1.05 * ui_scale, MUTED_COLOR);
+        var count_buf: [64]u8 = undefined;
+        const count_text = std.fmt.bufPrint(&count_buf, "{} WORLDS", .{self.worlds.len}) catch "?";
+        const count_w = Font.measureTextWidth(count_text, 1.05 * ui_scale);
+        Font.drawText(ui, count_text, px + pw - 34.0 * ui_scale - count_w, py + 56.0 * ui_scale, 1.05 * ui_scale, MUTED_COLOR);
         const scroll_dy = ctx.input.getScrollDelta().y;
         self.scroll_offset -= scroll_dy * 30.0 * ui_scale;
         const list_top: f32 = py + 92.0 * ui_scale;
-        const list_bottom: f32 = py + ph - 90.0 * ui_scale;
+        const list_bottom: f32 = py + ph - 100.0 * ui_scale;
         const row_h: f32 = 55.0 * ui_scale;
         const max_scroll = @max(0.0, @as(f32, @floatFromInt(self.worlds.len)) * row_h - (list_bottom - list_top));
         self.scroll_offset = @max(0.0, @min(self.scroll_offset, max_scroll));
@@ -284,7 +310,7 @@ pub const WorldListScreen = struct {
             }
             ui.drawRect(.{ .x = row_rect.x, .y = row_rect.y, .width = 4.0 * ui_scale, .height = row_rect.height }, if (is_selected) Color.rgba(0.95, 0.62, 0.24, 0.95) else Color.rgba(0.30, 0.50, 0.64, 0.64));
             ui.drawRectOutline(row_rect, if (is_selected) Color.rgba(0.70, 0.92, 1.0, 1.0) else Color.rgba(0.20, 0.36, 0.48, 0.74), 1.0);
-            if (mc and row_hovered and !self.confirm_delete) {
+            if (mc and row_hovered and !modal_open) {
                 self.selected = i;
             }
             const text_x: f32 = row_rect.x + 12.0 * ui_scale;
@@ -297,35 +323,68 @@ pub const WorldListScreen = struct {
             const seed_w = Font.measureTextWidth(seed_text, row_scale * 0.65);
             Font.drawText(ui, last_text, text_x + seed_w + 15.0 * ui_scale, name_y + 18.0 * ui_scale, row_scale * 0.65, MUTED_COLOR);
         }
-        const btn_h: f32 = 46.0 * ui_scale;
-        const byy: f32 = py + ph - 70.0 * ui_scale;
-        const btn_w: f32 = (pw - 40.0 * ui_scale) / 3.0;
+        // Bottom buttons: BACK, LOAD, RENAME, DELETE, CLEAR ALL
+        const btn_h: f32 = 44.0 * ui_scale;
+        const byy: f32 = py + ph - 68.0 * ui_scale;
+        const btn_gap: f32 = 10.0 * ui_scale;
+        const btn_w: f32 = (pw - 20.0 * ui_scale - 4.0 * btn_gap) / 5.0;
         const bx_base: f32 = px + 10.0 * ui_scale;
+        // BACK
         if (Widgets.drawButton(ui, .{ .x = bx_base, .y = byy, .width = btn_w, .height = btn_h }, "BACK", btn_scale, mx, my, mc)) {
             ctx.screen_manager.popScreen();
         }
-        const load_enabled = self.selected != null and !self.confirm_delete;
+        // LOAD
+        const load_enabled = self.selected != null and !modal_open;
         if (!load_enabled) {
-            ui.drawRect(.{ .x = bx_base + btn_w + 10.0 * ui_scale, .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.1, 0.12, 0.16, 0.7));
-            ui.drawRectOutline(.{ .x = bx_base + btn_w + 10.0 * ui_scale, .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.2, 0.22, 0.26, 1.0), 2.0);
-            Font.drawTextCentered(ui, "LOAD", bx_base + btn_w + 10.0 * ui_scale + btn_w * 0.5, byy + (btn_h - 7.0 * btn_scale) * 0.5, btn_scale, Color.rgba(0.4, 0.42, 0.46, 1.0));
+            ui.drawRect(.{ .x = bx_base + btn_w + btn_gap, .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.1, 0.12, 0.16, 0.7));
+            ui.drawRectOutline(.{ .x = bx_base + btn_w + btn_gap, .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.2, 0.22, 0.26, 1.0), 2.0);
+            Font.drawTextCentered(ui, "LOAD", bx_base + btn_w + btn_gap + btn_w * 0.5, byy + (btn_h - 7.0 * btn_scale) * 0.5, btn_scale, Color.rgba(0.4, 0.42, 0.46, 1.0));
         } else {
-            if (Widgets.drawButton(ui, .{ .x = bx_base + btn_w + 10.0 * ui_scale, .y = byy, .width = btn_w, .height = btn_h }, "LOAD", btn_scale, mx, my, mc)) {
+            if (Widgets.drawButton(ui, .{ .x = bx_base + btn_w + btn_gap, .y = byy, .width = btn_w, .height = btn_h }, "LOAD", btn_scale, mx, my, mc)) {
                 if (self.selected) |idx| {
                     try self.loadWorld(idx);
                 }
             }
         }
-        const del_enabled = self.selected != null and !self.confirm_delete;
-        if (!del_enabled) {
-            ui.drawRect(.{ .x = bx_base + 2.0 * (btn_w + 10.0 * ui_scale), .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.1, 0.1, 0.12, 0.7));
-            ui.drawRectOutline(.{ .x = bx_base + 2.0 * (btn_w + 10.0 * ui_scale), .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.2, 0.2, 0.22, 1.0), 2.0);
-            Font.drawTextCentered(ui, "DELETE", bx_base + 2.0 * (btn_w + 10.0 * ui_scale) + btn_w * 0.5, byy + (btn_h - 7.0 * btn_scale) * 0.5, btn_scale, Color.rgba(0.4, 0.35, 0.35, 1.0));
+        // RENAME
+        const rename_enabled = self.selected != null and !modal_open;
+        if (!rename_enabled) {
+            ui.drawRect(.{ .x = bx_base + 2.0 * (btn_w + btn_gap), .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.1, 0.12, 0.16, 0.7));
+            ui.drawRectOutline(.{ .x = bx_base + 2.0 * (btn_w + btn_gap), .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.2, 0.22, 0.26, 1.0), 2.0);
+            Font.drawTextCentered(ui, "RENAME", bx_base + 2.0 * (btn_w + btn_gap) + btn_w * 0.5, byy + (btn_h - 7.0 * btn_scale) * 0.5, btn_scale, Color.rgba(0.4, 0.42, 0.46, 1.0));
         } else {
-            if (Widgets.drawButton(ui, .{ .x = bx_base + 2.0 * (btn_w + 10.0 * ui_scale), .y = byy, .width = btn_w, .height = btn_h }, "DELETE", btn_scale, mx, my, mc)) {
+            if (Widgets.drawButton(ui, .{ .x = bx_base + 2.0 * (btn_w + btn_gap), .y = byy, .width = btn_w, .height = btn_h }, "RENAME", btn_scale, mx, my, mc)) {
+                if (self.selected) |idx| {
+                    self.rename_buffer.clearRetainingCapacity();
+                    try self.rename_buffer.appendSlice(self.context.allocator, self.worlds[idx].name);
+                    self.confirm_rename = true;
+                    self.rename_focused = true;
+                }
+            }
+        }
+        // DELETE
+        const del_enabled = self.selected != null and !modal_open;
+        if (!del_enabled) {
+            ui.drawRect(.{ .x = bx_base + 3.0 * (btn_w + btn_gap), .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.1, 0.1, 0.12, 0.7));
+            ui.drawRectOutline(.{ .x = bx_base + 3.0 * (btn_w + btn_gap), .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.2, 0.2, 0.22, 1.0), 2.0);
+            Font.drawTextCentered(ui, "DELETE", bx_base + 3.0 * (btn_w + btn_gap) + btn_w * 0.5, byy + (btn_h - 7.0 * btn_scale) * 0.5, btn_scale, Color.rgba(0.4, 0.35, 0.35, 1.0));
+        } else {
+            if (Widgets.drawButton(ui, .{ .x = bx_base + 3.0 * (btn_w + btn_gap), .y = byy, .width = btn_w, .height = btn_h }, "DELETE", btn_scale, mx, my, mc)) {
                 self.confirm_delete = true;
             }
         }
+        // CLEAR ALL
+        const clear_enabled = self.worlds.len > 0 and !modal_open;
+        if (!clear_enabled) {
+            ui.drawRect(.{ .x = bx_base + 4.0 * (btn_w + btn_gap), .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.1, 0.1, 0.12, 0.7));
+            ui.drawRectOutline(.{ .x = bx_base + 4.0 * (btn_w + btn_gap), .y = byy, .width = btn_w, .height = btn_h }, Color.rgba(0.2, 0.2, 0.22, 1.0), 2.0);
+            Font.drawTextCentered(ui, "CLEAR ALL", bx_base + 4.0 * (btn_w + btn_gap) + btn_w * 0.5, byy + (btn_h - 7.0 * btn_scale) * 0.5, btn_scale, Color.rgba(0.4, 0.35, 0.35, 1.0));
+        } else {
+            if (Widgets.drawButton(ui, .{ .x = bx_base + 4.0 * (btn_w + btn_gap), .y = byy, .width = btn_w, .height = btn_h }, "CLEAR ALL", btn_scale, mx, my, mc)) {
+                self.confirm_clear_all = true;
+            }
+        }
+        // Delete confirmation dialog
         if (self.confirm_delete) {
             if (self.selected) |idx| {
                 const cw: f32 = 420.0 * ui_scale;
@@ -348,6 +407,64 @@ pub const WorldListScreen = struct {
                 }
                 if (Widgets.drawButton(ui, .{ .x = cx + cbw + 20.0 * ui_scale, .y = cby, .width = cbw, .height = 40.0 * ui_scale }, "CONFIRM", btn_scale, mx, my, mc)) {
                     self.confirmDelete(idx) catch {};
+                }
+            }
+        }
+        // Clear all confirmation dialog
+        if (self.confirm_clear_all) {
+            const cw: f32 = 460.0 * ui_scale;
+            const ch: f32 = 170.0 * ui_scale;
+            const cx: f32 = (screen_w - cw) * 0.5;
+            const cy: f32 = (screen_h - ch) * 0.5;
+            ui.drawRect(.{ .x = 0, .y = 0, .width = screen_w, .height = screen_h }, Color.rgba(0, 0, 0, 0.6));
+            ui.drawRect(.{ .x = cx, .y = cy, .width = cw, .height = ch }, CONFIRM_BG);
+            ui.drawRectOutline(.{ .x = cx, .y = cy, .width = cw, .height = ch }, CONFIRM_BORDER, 2.0);
+            const msg_scale: f32 = 1.8 * ui_scale;
+            Font.drawTextCentered(ui, "CLEAR ALL WORLDS?", cx + cw * 0.5, cy + 20.0 * ui_scale, msg_scale, DELETE_COLOR);
+            var count_buf2: [64]u8 = undefined;
+            const count_msg = std.fmt.bufPrint(&count_buf2, "THIS WILL DELETE {} WORLDS", .{self.worlds.len}) catch "?";
+            Font.drawTextCentered(ui, count_msg, cx + cw * 0.5, cy + 50.0 * ui_scale, msg_scale * 0.75, LABEL_COLOR);
+            Font.drawTextCentered(ui, "THIS CANNOT BE UNDONE", cx + cw * 0.5, cy + 72.0 * ui_scale, msg_scale * 0.65, Color.rgba(0.7, 0.5, 0.5, 1.0));
+            const cbw: f32 = (cw - 30.0 * ui_scale) / 2.0;
+            const cby: f32 = cy + ch - 55.0 * ui_scale;
+            if (Widgets.drawButton(ui, .{ .x = cx + 10.0 * ui_scale, .y = cby, .width = cbw, .height = 40.0 * ui_scale }, "CANCEL", btn_scale, mx, my, mc)) {
+                self.confirm_clear_all = false;
+            }
+            if (Widgets.drawButton(ui, .{ .x = cx + cbw + 20.0 * ui_scale, .y = cby, .width = cbw, .height = 40.0 * ui_scale }, "CONFIRM", btn_scale, mx, my, mc)) {
+                self.clearAllWorlds() catch {};
+            }
+        }
+        // Rename dialog
+        if (self.confirm_rename) {
+            if (self.selected) |idx| {
+                const cw: f32 = 460.0 * ui_scale;
+                const ch: f32 = 180.0 * ui_scale;
+                const cx: f32 = (screen_w - cw) * 0.5;
+                const cy: f32 = (screen_h - ch) * 0.5;
+                ui.drawRect(.{ .x = 0, .y = 0, .width = screen_w, .height = screen_h }, Color.rgba(0, 0, 0, 0.6));
+                ui.drawRect(.{ .x = cx, .y = cy, .width = cw, .height = ch }, RENAME_BG);
+                ui.drawRectOutline(.{ .x = cx, .y = cy, .width = cw, .height = ch }, RENAME_BORDER, 2.0);
+                const msg_scale: f32 = 1.8 * ui_scale;
+                Font.drawTextCentered(ui, "RENAME WORLD", cx + cw * 0.5, cy + 20.0 * ui_scale, msg_scale, TITLE_COLOR);
+                var name_buf2: [128]u8 = undefined;
+                const current_msg = std.fmt.bufPrint(&name_buf2, "CURRENT: '{s}'", .{self.worlds[idx].name}) catch "'?'";
+                Font.drawTextCentered(ui, current_msg, cx + cw * 0.5, cy + 48.0 * ui_scale, msg_scale * 0.7, MUTED_COLOR);
+                const input_h: f32 = 40.0 * ui_scale;
+                const input_y: f32 = cy + 72.0 * ui_scale;
+                const input_rect = Rect{ .x = cx + 20.0 * ui_scale, .y = input_y, .width = cw - 40.0 * ui_scale, .height = input_h };
+                const cursor_visible = @as(u32, @truncate(@as(u64, @intFromFloat(ctx.time.elapsed * 2.0)))) % 2 == 0;
+                if (mc) {
+                    self.rename_focused = input_rect.contains(mx, my);
+                }
+                Widgets.drawTextInput(ui, input_rect, self.rename_buffer.items, "ENTER NEW NAME", 1.4 * ui_scale, self.rename_focused, cursor_visible);
+                const cbw: f32 = (cw - 30.0 * ui_scale) / 2.0;
+                const cby: f32 = cy + ch - 55.0 * ui_scale;
+                if (Widgets.drawButton(ui, .{ .x = cx + 10.0 * ui_scale, .y = cby, .width = cbw, .height = 40.0 * ui_scale }, "CANCEL", btn_scale, mx, my, mc)) {
+                    self.confirm_rename = false;
+                    self.rename_buffer.clearRetainingCapacity();
+                }
+                if (Widgets.drawButton(ui, .{ .x = cx + cbw + 20.0 * ui_scale, .y = cby, .width = cbw, .height = 40.0 * ui_scale }, "OK", btn_scale, mx, my, mc)) {
+                    self.renameWorld(idx) catch {};
                 }
             }
         }
@@ -389,7 +506,53 @@ pub const WorldListScreen = struct {
         self.confirm_delete = false;
         self.scroll_offset = 0.0;
     }
+
+    fn renameWorld(self: *@This(), idx: usize) !void {
+        const allocator = self.context.allocator;
+        if (self.rename_buffer.items.len == 0) return;
+        const world = self.worlds[idx];
+        var save_dir = fs.openDirAbsolute(world.dir_path, .{}) catch return;
+        defer save_dir.close();
+        writeLevelDat(allocator, save_dir, self.rename_buffer.items, world.seed, world.generator_index, world.last_played) catch |err| {
+            log.log.warn("Failed to write level.dat for rename: {}", .{err});
+            return;
+        };
+        const new_name = try allocator.dupe(u8, self.rename_buffer.items);
+        allocator.free(self.worlds[idx].name);
+        self.worlds[idx].name = new_name;
+        self.confirm_rename = false;
+        self.rename_buffer.clearRetainingCapacity();
+    }
+
+    fn clearAllWorlds(self: *@This()) !void {
+        const allocator = self.context.allocator;
+        for (self.worlds) |e| {
+            deleteWorld(allocator, e.dir_path);
+            allocator.free(e.name);
+        }
+        allocator.free(self.worlds);
+        self.worlds = try allocator.alloc(WorldEntry, 0);
+        self.selected = null;
+        self.confirm_clear_all = false;
+        self.scroll_offset = 0.0;
+    }
 };
+
+fn handleTextTyping(text_input: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, input: IRawInputProvider, max_len: usize) !void {
+    if (input.isKeyPressed(.backspace)) {
+        if (text_input.items.len > 0) _ = text_input.pop();
+    }
+    const shift = input.isKeyDown(.left_shift) or input.isKeyDown(.right_shift);
+    const letters = [_]Key{ .a, .b, .c, .d, .e, .f, .g, .h, .i, .j, .k, .l, .m, .n, .o, .p, .q, .r, .s, .t, .u, .v, .w, .x, .y, .z };
+    inline for (letters) |key| if (input.isKeyPressed(key) and text_input.items.len < max_len) {
+        var ch: u8 = @intCast(@intFromEnum(key));
+        if (shift) ch = std.ascii.toUpper(ch);
+        try text_input.append(allocator, ch);
+    };
+    const digits = [_]Key{ .@"0", .@"1", .@"2", .@"3", .@"4", .@"5", .@"6", .@"7", .@"8", .@"9" };
+    inline for (digits) |key| if (input.isKeyPressed(key) and text_input.items.len < max_len) try text_input.append(allocator, @intCast(@intFromEnum(key)));
+    if (input.isKeyPressed(.space) and text_input.items.len < max_len) try text_input.append(allocator, ' ');
+}
 
 fn drawListBackdrop(ui: *UISystem, screen_w: f32, screen_h: f32, ui_scale: f32) void {
     ui.drawRect(.{ .x = 0, .y = 0, .width = screen_w, .height = screen_h }, Color.rgba(0.010, 0.018, 0.030, 0.90));

--- a/src/game/screens/world_list.zig
+++ b/src/game/screens/world_list.zig
@@ -10,8 +10,7 @@ const EngineContext = Screen.EngineContext;
 const WorldScreen = @import("world.zig").WorldScreen;
 const log = @import("engine-core").log;
 const fs = @import("fs");
-const Key = @import("../../engine/core/interfaces.zig").Key;
-const IRawInputProvider = @import("../../engine/input/interfaces.zig").IRawInputProvider;
+const text_input = @import("../text_input.zig");
 
 fn getenv(name: [:0]const u8) ?[]const u8 {
     const value = std.c.getenv(name) orelse return null;
@@ -243,7 +242,7 @@ pub const WorldListScreen = struct {
             }
         }
         if (self.confirm_rename and self.rename_focused) {
-            try handleTextTyping(&self.rename_buffer, self.context.allocator, self.context.input, 32);
+            try text_input.handleTextTyping(&self.rename_buffer, self.context.allocator, self.context.input, 32);
         }
     }
 
@@ -510,6 +509,8 @@ pub const WorldListScreen = struct {
     fn renameWorld(self: *@This(), idx: usize) !void {
         const allocator = self.context.allocator;
         if (self.rename_buffer.items.len == 0) return;
+        const new_name = try allocator.dupe(u8, self.rename_buffer.items);
+        errdefer allocator.free(new_name);
         const world = self.worlds[idx];
         var save_dir = fs.openDirAbsolute(world.dir_path, .{}) catch return;
         defer save_dir.close();
@@ -517,7 +518,6 @@ pub const WorldListScreen = struct {
             log.log.warn("Failed to write level.dat for rename: {}", .{err});
             return;
         };
-        const new_name = try allocator.dupe(u8, self.rename_buffer.items);
         allocator.free(self.worlds[idx].name);
         self.worlds[idx].name = new_name;
         self.confirm_rename = false;
@@ -526,33 +526,19 @@ pub const WorldListScreen = struct {
 
     fn clearAllWorlds(self: *@This()) !void {
         const allocator = self.context.allocator;
+        const new_worlds = try allocator.alloc(WorldEntry, 0);
+        errdefer allocator.free(new_worlds);
         for (self.worlds) |e| {
             deleteWorld(allocator, e.dir_path);
             allocator.free(e.name);
         }
         allocator.free(self.worlds);
-        self.worlds = try allocator.alloc(WorldEntry, 0);
+        self.worlds = new_worlds;
         self.selected = null;
         self.confirm_clear_all = false;
         self.scroll_offset = 0.0;
     }
 };
-
-fn handleTextTyping(text_input: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, input: IRawInputProvider, max_len: usize) !void {
-    if (input.isKeyPressed(.backspace)) {
-        if (text_input.items.len > 0) _ = text_input.pop();
-    }
-    const shift = input.isKeyDown(.left_shift) or input.isKeyDown(.right_shift);
-    const letters = [_]Key{ .a, .b, .c, .d, .e, .f, .g, .h, .i, .j, .k, .l, .m, .n, .o, .p, .q, .r, .s, .t, .u, .v, .w, .x, .y, .z };
-    inline for (letters) |key| if (input.isKeyPressed(key) and text_input.items.len < max_len) {
-        var ch: u8 = @intCast(@intFromEnum(key));
-        if (shift) ch = std.ascii.toUpper(ch);
-        try text_input.append(allocator, ch);
-    };
-    const digits = [_]Key{ .@"0", .@"1", .@"2", .@"3", .@"4", .@"5", .@"6", .@"7", .@"8", .@"9" };
-    inline for (digits) |key| if (input.isKeyPressed(key) and text_input.items.len < max_len) try text_input.append(allocator, @intCast(@intFromEnum(key)));
-    if (input.isKeyPressed(.space) and text_input.items.len < max_len) try text_input.append(allocator, ' ');
-}
 
 fn drawListBackdrop(ui: *UISystem, screen_w: f32, screen_h: f32, ui_scale: f32) void {
     ui.drawRect(.{ .x = 0, .y = 0, .width = screen_w, .height = screen_h }, Color.rgba(0.010, 0.018, 0.030, 0.90));

--- a/src/game/screens/world_list.zig
+++ b/src/game/screens/world_list.zig
@@ -508,13 +508,14 @@ pub const WorldListScreen = struct {
 
     fn renameWorld(self: *@This(), idx: usize) !void {
         const allocator = self.context.allocator;
-        if (self.rename_buffer.items.len == 0) return;
-        const new_name = try allocator.dupe(u8, self.rename_buffer.items);
+        const trimmed = std.mem.trim(u8, self.rename_buffer.items, " \t\r\n");
+        if (trimmed.len == 0) return;
+        const new_name = try allocator.dupe(u8, trimmed);
         errdefer allocator.free(new_name);
         const world = self.worlds[idx];
         var save_dir = fs.openDirAbsolute(world.dir_path, .{}) catch return;
         defer save_dir.close();
-        writeLevelDat(allocator, save_dir, self.rename_buffer.items, world.seed, world.generator_index, world.last_played) catch |err| {
+        writeLevelDat(allocator, save_dir, trimmed, world.seed, world.generator_index, world.last_played) catch |err| {
             log.log.warn("Failed to write level.dat for rename: {}", .{err});
             return;
         };

--- a/src/game/settings/ui_helpers.zig
+++ b/src/game/settings/ui_helpers.zig
@@ -85,6 +85,15 @@ pub fn cycleUIScale(current: f32) f32 {
     return 0.5;
 }
 
+pub fn prevUIScale(current: f32) f32 {
+    if (current >= 1.6) return 1.5;
+    if (current >= 1.3) return 1.25;
+    if (current >= 1.1) return 1.0;
+    if (current >= 0.8) return 0.75;
+    if (current >= 0.55) return 0.5;
+    return 2.0;
+}
+
 pub fn getPresetLabel(idx: usize) []const u8 {
     if (idx >= json_presets.graphics_presets.items.len) return "CUSTOM";
     return json_presets.graphics_presets.items[idx].name;

--- a/src/game/text_input.zig
+++ b/src/game/text_input.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+const Key = @import("../engine/core/interfaces.zig").Key;
+const IRawInputProvider = @import("../engine/input/interfaces.zig").IRawInputProvider;
+
+pub fn handleTextTyping(text_input: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, input: IRawInputProvider, max_len: usize) !void {
+    if (input.isKeyPressed(.backspace)) {
+        if (text_input.items.len > 0) _ = text_input.pop();
+    }
+    const shift = input.isKeyDown(.left_shift) or input.isKeyDown(.right_shift);
+    const letters = [_]Key{ .a, .b, .c, .d, .e, .f, .g, .h, .i, .j, .k, .l, .m, .n, .o, .p, .q, .r, .s, .t, .u, .v, .w, .x, .y, .z };
+    inline for (letters) |key| if (input.isKeyPressed(key) and text_input.items.len < max_len) {
+        var ch: u8 = @intCast(@intFromEnum(key));
+        if (shift) ch = std.ascii.toUpper(ch);
+        try text_input.append(allocator, ch);
+    };
+    const digits = [_]Key{ .@"0", .@"1", .@"2", .@"3", .@"4", .@"5", .@"6", .@"7", .@"8", .@"9" };
+    inline for (digits) |key| if (input.isKeyPressed(key) and text_input.items.len < max_len) try text_input.append(allocator, @intCast(@intFromEnum(key)));
+    if (input.isKeyPressed(.space) and text_input.items.len < max_len) try text_input.append(allocator, ' ');
+}


### PR DESCRIPTION
## Summary
- Added back/forward navigation arrows (</>) to settings, graphics, and singleplayer screens
- Added scrolling to graphics settings panel with scrollbar and clipping
- Added world naming input when creating new worlds
- Added RENAME and CLEAR ALL buttons to world list screen
- Fixed overlapping elements by using fixed footer layouts
- Expanded panels to use more screen space
- Added `prevUIScale()` helper for backward UI scale cycling

## Changes
- `settings.zig`: Back/forward resolution arrows, centered content layout
- `graphics.zig`: Scrollable content area, fixed back button, removed duplicate render distance row
- `singleplayer.zig`: World name input, back/forward generator arrows, fixed footer layout
- `world_list.zig`: Rename dialog, clear-all confirmation, world count display
- `ui_helpers.zig`: `prevUIScale()` function