### PR TITLE
feat: add extended block render shapes

### DIFF
--- a/modules/world-core/src/biome_and_block_tests.zig
+++ b/modules/world-core/src/biome_and_block_tests.zig
@@ -142,11 +142,14 @@ test "BlockType render_pass for cutout blocks" {
 test "BlockType render_shape for cross blocks" {
     try testing.expectEqual(block_registry.RenderShape.cross, getBlockDefinition(.flower_red).render_shape);
     try testing.expectEqual(block_registry.RenderShape.cross, getBlockDefinition(.flower_yellow).render_shape);
-    try testing.expectEqual(block_registry.RenderShape.cross, getBlockDefinition(.tall_grass).render_shape);
     try testing.expectEqual(block_registry.RenderShape.cross, getBlockDefinition(.dead_bush).render_shape);
     try testing.expectEqual(block_registry.RenderShape.cross, getBlockDefinition(.acacia_sapling).render_shape);
     try testing.expectEqual(block_registry.RenderShape.cross, getBlockDefinition(.bamboo).render_shape);
     try testing.expectEqual(block_registry.RenderShape.cross, getBlockDefinition(.torch).render_shape);
+}
+
+test "BlockType render_shape for tall cross blocks" {
+    try testing.expectEqual(block_registry.RenderShape.tall_cross, getBlockDefinition(.tall_grass).render_shape);
 }
 
 test "BlockType render_shape for cube blocks" {

--- a/modules/world-core/src/block_registry.zig
+++ b/modules/world-core/src/block_registry.zig
@@ -33,6 +33,10 @@ pub const RenderShape = enum {
     cube,
     /// 2 diagonal quads crossing at center (flowers, saplings, dead bush)
     cross,
+    /// Single horizontal quad (carpet, snow layers, floor vegetation)
+    flat_quad,
+    /// 2-block-high X-shaped billboard (tall plants)
+    tall_cross,
 };
 
 pub const BlockDefinition = struct {
@@ -324,7 +328,8 @@ pub const BLOCK_REGISTRY = blk: {
 
         // 8. Render Shape
         def.render_shape = switch (id) {
-            .flower_red, .flower_yellow, .tall_grass, .dead_bush, .acacia_sapling, .bamboo, .torch => .cross,
+            .tall_grass => .tall_cross,
+            .flower_red, .flower_yellow, .dead_bush, .acacia_sapling, .bamboo, .torch => .cross,
             else => .cube,
         };
 

--- a/modules/world-core/src/block_registry_tests.zig
+++ b/modules/world-core/src/block_registry_tests.zig
@@ -105,4 +105,6 @@ test "RenderPass enum has expected variants" {
 test "RenderShape enum has expected variants" {
     try testing.expectEqual(@as(u2, 0), @intFromEnum(block_registry.RenderShape.cube));
     try testing.expectEqual(@as(u2, 1), @intFromEnum(block_registry.RenderShape.cross));
+    try testing.expectEqual(@as(u2, 2), @intFromEnum(block_registry.RenderShape.flat_quad));
+    try testing.expectEqual(@as(u2, 3), @intFromEnum(block_registry.RenderShape.tall_cross));
 }

--- a/modules/world-meshing/src/chunk_mesh.zig
+++ b/modules/world-meshing/src/chunk_mesh.zig
@@ -25,6 +25,8 @@ const VertexAllocation = chunk_alloc_mod.VertexAllocation;
 // Meshing stage modules
 const greedy_mesher = @import("meshing/greedy_mesher.zig");
 const cross_mesher = @import("meshing/cross_mesher.zig");
+const flat_quad_mesher = @import("meshing/flat_quad_mesher.zig");
+const tall_cross_mesher = @import("meshing/tall_cross_mesher.zig");
 const boundary = @import("meshing/boundary.zig");
 
 // Re-export public types for external consumers
@@ -149,8 +151,10 @@ pub const ChunkMesh = struct {
             try greedy_mesher.meshSlice(self.allocator, chunk, neighbors, .south, sz, si, &solid_verts, &cutout_verts, &fluid_verts, atlas);
         }
 
-        // Mesh cross/billboard blocks (flowers, saplings, etc.)
+        // Mesh non-cube cutout shapes (flowers, saplings, flat floor quads, tall plants)
         try cross_mesher.meshCrossBlocks(self.allocator, chunk, neighbors, si, &cutout_verts, atlas);
+        try flat_quad_mesher.meshFlatQuadBlocks(self.allocator, chunk, neighbors, si, &cutout_verts, atlas);
+        try tall_cross_mesher.meshTallCrossBlocks(self.allocator, chunk, neighbors, si, &cutout_verts, atlas);
 
         // Store subchunk data temporarily (will be merged later)
         self.mutex.lock();

--- a/modules/world-meshing/src/meshing/flat_quad_mesher.zig
+++ b/modules/world-meshing/src/meshing/flat_quad_mesher.zig
@@ -1,0 +1,150 @@
+//! Flat quad meshing for floor-aligned cutout blocks.
+//!
+//! Emits one horizontal quad per block, slightly above the block base to avoid
+//! z-fighting with the supporting cube top face.
+
+const std = @import("std");
+
+const world_core = @import("world-core");
+const Chunk = world_core.Chunk;
+const PackedLight = world_core.PackedLight;
+const CHUNK_SIZE_X = world_core.CHUNK_SIZE_X;
+const CHUNK_SIZE_Z = world_core.CHUNK_SIZE_Z;
+const block_registry = world_core.block_registry;
+const TextureAtlas = @import("engine-assets").TextureAtlas;
+const rhi_mod = @import("engine-rhi");
+const Vertex = rhi_mod.Vertex;
+
+const boundary = @import("boundary.zig");
+const NeighborChunks = boundary.NeighborChunks;
+const SUBCHUNK_SIZE = boundary.SUBCHUNK_SIZE;
+const lighting_sampler = @import("lighting_sampler.zig");
+const biome_colors = @import("../biome_colors.zig");
+
+const FLAT_QUAD_Y_OFFSET: f32 = 0.03125;
+
+pub fn meshFlatQuadBlocks(
+    allocator: std.mem.Allocator,
+    chunk: *const Chunk,
+    neighbors: NeighborChunks,
+    si: u32,
+    cutout_list: *std.ArrayListUnmanaged(Vertex),
+    atlas: *const TextureAtlas,
+) !void {
+    const y0: i32 = @intCast(si * SUBCHUNK_SIZE);
+    const y1: i32 = y0 + SUBCHUNK_SIZE;
+
+    var y: i32 = y0;
+    while (y < y1) : (y += 1) {
+        var z: u32 = 0;
+        while (z < CHUNK_SIZE_Z) : (z += 1) {
+            var x: u32 = 0;
+            while (x < CHUNK_SIZE_X) : (x += 1) {
+                const block = chunk.getBlockSafe(@intCast(x), y, @intCast(z));
+                const def = block_registry.getBlockDefinition(block);
+                if (def.render_shape != .flat_quad) continue;
+
+                const xi: i32 = @intCast(x);
+                const zi: i32 = @intCast(z);
+                const light = sampleShapeLight(chunk, neighbors, xi, y, zi);
+                const entrance_bounce = sampleShapeEntranceBounce(chunk, neighbors, xi, y, zi);
+                const entrance_dir = boundary.getEntranceDirCross(chunk, neighbors, xi, y, zi);
+                const norm_light = lighting_sampler.normalizeLightValues(light, entrance_bounce, entrance_dir);
+                const col = getShapeColor(chunk, neighbors, xi, zi, def);
+
+                const tiles = atlas.getTilesForBlock(@intFromEnum(block));
+                const tile_id: u16 = @intCast(tiles.side);
+
+                const xf: f32 = @floatFromInt(x);
+                const yf: f32 = @as(f32, @floatFromInt(y)) + FLAT_QUAD_Y_OFFSET;
+                const zf: f32 = @floatFromInt(z);
+
+                try emitFlatQuad(allocator, cutout_list, xf, yf, zf, col, norm_light, tile_id);
+            }
+        }
+    }
+}
+
+fn sampleShapeLight(chunk: *const Chunk, neighbors: NeighborChunks, x: i32, y: i32, z: i32) PackedLight {
+    var result = PackedLight.init(0, 0);
+    var ox: i32 = -1;
+    while (ox <= 1) : (ox += 1) {
+        var oz: i32 = -1;
+        while (oz <= 1) : (oz += 1) {
+            const light = boundary.getLightCross(chunk, neighbors, x + ox, y, z + oz);
+            result.sky_light = @max(result.sky_light, light.getSkyLight());
+            result.block_light_r = @max(result.block_light_r, light.getBlockLightR());
+            result.block_light_g = @max(result.block_light_g, light.getBlockLightG());
+            result.block_light_b = @max(result.block_light_b, light.getBlockLightB());
+        }
+    }
+    return result;
+}
+
+fn sampleShapeEntranceBounce(chunk: *const Chunk, neighbors: NeighborChunks, x: i32, y: i32, z: i32) u4 {
+    var result: u4 = 0;
+    var ox: i32 = -1;
+    while (ox <= 1) : (ox += 1) {
+        var oz: i32 = -1;
+        while (oz <= 1) : (oz += 1) {
+            result = @max(result, boundary.getEntranceBounceCross(chunk, neighbors, x + ox, y, z + oz));
+        }
+    }
+    return result;
+}
+
+fn getShapeColor(chunk: *const Chunk, neighbors: NeighborChunks, x: i32, z: i32, def: *const block_registry.BlockDefinition) [3]f32 {
+    const tint: [3]f32 = if (def.is_tintable) blk: {
+        var r: f32 = 0;
+        var g: f32 = 0;
+        var b: f32 = 0;
+        var count: f32 = 0;
+        var ox: i32 = -1;
+        while (ox <= 1) : (ox += 1) {
+            var oz: i32 = -1;
+            while (oz <= 1) : (oz += 1) {
+                const biome_id = boundary.getBiomeAt(chunk, neighbors, x + ox, z + oz);
+                const colors = biome_colors.getBiomeColors(biome_id);
+                r += colors.grass[0];
+                g += colors.grass[1];
+                b += colors.grass[2];
+                count += 1.0;
+            }
+        }
+        break :blk .{ r / count, g / count, b / count };
+    } else .{ 1.0, 1.0, 1.0 };
+
+    return .{
+        def.default_color[0] * tint[0],
+        def.default_color[1] * tint[1],
+        def.default_color[2] * tint[2],
+    };
+}
+
+fn emitFlatQuad(
+    allocator: std.mem.Allocator,
+    verts: *std.ArrayListUnmanaged(Vertex),
+    x: f32,
+    y: f32,
+    z: f32,
+    col: [3]f32,
+    light: lighting_sampler.NormalizedLight,
+    tile_id: u16,
+) !void {
+    const positions = [4][3]f32{
+        .{ x, y, z },
+        .{ x + 1, y, z },
+        .{ x + 1, y, z + 1 },
+        .{ x, y, z + 1 },
+    };
+    const uv = [4][2]f32{ .{ 0, 1 }, .{ 1, 1 }, .{ 1, 0 }, .{ 0, 0 } };
+    const normal = [3]f32{ 0, 1, 0 };
+    const ao: f32 = 1.0;
+
+    const v = [6][3]f32{ positions[0], positions[1], positions[2], positions[0], positions[2], positions[3] };
+    const u = [6][2]f32{ uv[0], uv[1], uv[2], uv[0], uv[2], uv[3] };
+
+    for (0..6) |i| {
+        try verts.append(allocator, Vertex.initWithEntrance(v[i], col, normal, u[i], tile_id, light.skylight, light.blocklight, ao, light.entrance_bounce, light.entrance_dir));
+    }
+}

--- a/modules/world-meshing/src/meshing/greedy_mesher.zig
+++ b/modules/world-meshing/src/meshing/greedy_mesher.zig
@@ -85,16 +85,16 @@ pub fn meshSlice(
             const b1_emits = b1_def.is_solid or (b1_def.is_fluid and !b2_def.is_fluid);
             const b2_emits = b2_def.is_solid or (b2_def.is_fluid and !b1_def.is_fluid);
 
-            const b1_cross = b1_def.render_shape == .cross;
-            const b2_cross = b2_def.render_shape == .cross;
+            const b1_cube = b1_def.render_shape == .cube;
+            const b2_cube = b2_def.render_shape == .cube;
 
-            if (boundary.isEmittingSubchunk(axis, s - 1, u, v, y_min, y_max) and b1_emits and !b1_cross and !b2_def.occludes(b1_def, axis)) {
+            if (boundary.isEmittingSubchunk(axis, s - 1, u, v, y_min, y_max) and b1_emits and b1_cube and !b2_def.occludes(b1_def, axis)) {
                 const light = lighting_sampler.sampleLightAtBoundary(chunk, neighbors, axis, s, u, v, si, true);
                 const entrance_bounce = lighting_sampler.sampleEntranceBounceAtBoundary(chunk, neighbors, axis, s, u, v, si, true);
                 const entrance_dir = lighting_sampler.sampleEntranceDirAtBoundary(chunk, neighbors, axis, s, u, v, si, true);
                 const color = biome_color_sampler.getBlockColor(chunk, neighbors, axis, s - 1, u, v, b1);
                 mask[u + v * du] = .{ .block = b1, .side = true, .light = light, .entrance_bounce = entrance_bounce, .entrance_dir = entrance_dir, .color = color };
-            } else if (boundary.isEmittingSubchunk(axis, s, u, v, y_min, y_max) and b2_emits and !b2_cross and !b1_def.occludes(b2_def, axis)) {
+            } else if (boundary.isEmittingSubchunk(axis, s, u, v, y_min, y_max) and b2_emits and b2_cube and !b1_def.occludes(b2_def, axis)) {
                 const light = lighting_sampler.sampleLightAtBoundary(chunk, neighbors, axis, s, u, v, si, false);
                 const entrance_bounce = lighting_sampler.sampleEntranceBounceAtBoundary(chunk, neighbors, axis, s, u, v, si, false);
                 const entrance_dir = lighting_sampler.sampleEntranceDirAtBoundary(chunk, neighbors, axis, s, u, v, si, false);

--- a/modules/world-meshing/src/meshing/tall_cross_mesher.zig
+++ b/modules/world-meshing/src/meshing/tall_cross_mesher.zig
@@ -1,0 +1,158 @@
+//! Tall cross/billboard meshing for 2-block-high vegetation.
+//!
+//! Emits the same two diagonal billboard planes as cross meshing, but stretches
+//! them across two vertical blocks from the bottom block position.
+
+const std = @import("std");
+
+const world_core = @import("world-core");
+const Chunk = world_core.Chunk;
+const PackedLight = world_core.PackedLight;
+const CHUNK_SIZE_X = world_core.CHUNK_SIZE_X;
+const CHUNK_SIZE_Z = world_core.CHUNK_SIZE_Z;
+const block_registry = world_core.block_registry;
+const TextureAtlas = @import("engine-assets").TextureAtlas;
+const rhi_mod = @import("engine-rhi");
+const Vertex = rhi_mod.Vertex;
+
+const boundary = @import("boundary.zig");
+const NeighborChunks = boundary.NeighborChunks;
+const SUBCHUNK_SIZE = boundary.SUBCHUNK_SIZE;
+const lighting_sampler = @import("lighting_sampler.zig");
+const biome_colors = @import("../biome_colors.zig");
+
+pub fn meshTallCrossBlocks(
+    allocator: std.mem.Allocator,
+    chunk: *const Chunk,
+    neighbors: NeighborChunks,
+    si: u32,
+    cutout_list: *std.ArrayListUnmanaged(Vertex),
+    atlas: *const TextureAtlas,
+) !void {
+    const y0: i32 = @intCast(si * SUBCHUNK_SIZE);
+    const y1: i32 = y0 + SUBCHUNK_SIZE;
+
+    var y: i32 = y0;
+    while (y < y1) : (y += 1) {
+        var z: u32 = 0;
+        while (z < CHUNK_SIZE_Z) : (z += 1) {
+            var x: u32 = 0;
+            while (x < CHUNK_SIZE_X) : (x += 1) {
+                const block = chunk.getBlockSafe(@intCast(x), y, @intCast(z));
+                const def = block_registry.getBlockDefinition(block);
+                if (def.render_shape != .tall_cross) continue;
+
+                const xi: i32 = @intCast(x);
+                const zi: i32 = @intCast(z);
+                const light = sampleTallCrossLight(chunk, neighbors, xi, y, zi);
+                const entrance_bounce = sampleTallCrossEntranceBounce(chunk, neighbors, xi, y, zi);
+                const entrance_dir = boundary.getEntranceDirCross(chunk, neighbors, xi, y, zi);
+                const norm_light = lighting_sampler.normalizeLightValues(light, entrance_bounce, entrance_dir);
+                const col = getTallCrossColor(chunk, neighbors, xi, zi, def);
+
+                const tiles = atlas.getTilesForBlock(@intFromEnum(block));
+                const tile_id: u16 = @intCast(tiles.side);
+
+                const xf: f32 = @floatFromInt(x);
+                const yf: f32 = @floatFromInt(y);
+                const zf: f32 = @floatFromInt(z);
+
+                try emitTallCrossQuad(allocator, cutout_list, .{ xf, yf, zf }, .{ xf + 1, yf + 2, zf + 1 }, col, norm_light, tile_id);
+                try emitTallCrossQuad(allocator, cutout_list, .{ xf + 1, yf, zf }, .{ xf, yf + 2, zf + 1 }, col, norm_light, tile_id);
+            }
+        }
+    }
+}
+
+fn sampleTallCrossLight(chunk: *const Chunk, neighbors: NeighborChunks, x: i32, y: i32, z: i32) PackedLight {
+    var result = PackedLight.init(0, 0);
+    var oy: i32 = 0;
+    while (oy <= 1) : (oy += 1) {
+        var ox: i32 = -1;
+        while (ox <= 1) : (ox += 1) {
+            var oz: i32 = -1;
+            while (oz <= 1) : (oz += 1) {
+                const light = boundary.getLightCross(chunk, neighbors, x + ox, y + oy, z + oz);
+                result.sky_light = @max(result.sky_light, light.getSkyLight());
+                result.block_light_r = @max(result.block_light_r, light.getBlockLightR());
+                result.block_light_g = @max(result.block_light_g, light.getBlockLightG());
+                result.block_light_b = @max(result.block_light_b, light.getBlockLightB());
+            }
+        }
+    }
+    return result;
+}
+
+fn sampleTallCrossEntranceBounce(chunk: *const Chunk, neighbors: NeighborChunks, x: i32, y: i32, z: i32) u4 {
+    var result: u4 = 0;
+    var oy: i32 = 0;
+    while (oy <= 1) : (oy += 1) {
+        var ox: i32 = -1;
+        while (ox <= 1) : (ox += 1) {
+            var oz: i32 = -1;
+            while (oz <= 1) : (oz += 1) {
+                result = @max(result, boundary.getEntranceBounceCross(chunk, neighbors, x + ox, y + oy, z + oz));
+            }
+        }
+    }
+    return result;
+}
+
+fn getTallCrossColor(chunk: *const Chunk, neighbors: NeighborChunks, x: i32, z: i32, def: *const block_registry.BlockDefinition) [3]f32 {
+    const tint: [3]f32 = if (def.is_tintable) blk: {
+        var r: f32 = 0;
+        var g: f32 = 0;
+        var b: f32 = 0;
+        var count: f32 = 0;
+        var ox: i32 = -1;
+        while (ox <= 1) : (ox += 1) {
+            var oz: i32 = -1;
+            while (oz <= 1) : (oz += 1) {
+                const biome_id = boundary.getBiomeAt(chunk, neighbors, x + ox, z + oz);
+                const colors = biome_colors.getBiomeColors(biome_id);
+                r += colors.grass[0];
+                g += colors.grass[1];
+                b += colors.grass[2];
+                count += 1.0;
+            }
+        }
+        break :blk .{ r / count, g / count, b / count };
+    } else .{ 1.0, 1.0, 1.0 };
+
+    return .{
+        def.default_color[0] * tint[0],
+        def.default_color[1] * tint[1],
+        def.default_color[2] * tint[2],
+    };
+}
+
+fn emitTallCrossQuad(
+    allocator: std.mem.Allocator,
+    verts: *std.ArrayListUnmanaged(Vertex),
+    p0: [3]f32,
+    p1: [3]f32,
+    col: [3]f32,
+    light: lighting_sampler.NormalizedLight,
+    tile_id: u16,
+) !void {
+    const bl = [3]f32{ p0[0], p0[1], p0[2] };
+    const br = [3]f32{ p1[0], p0[1], p1[2] };
+    const tr = [3]f32{ p1[0], p1[1], p1[2] };
+    const tl = [3]f32{ p0[0], p1[1], p0[2] };
+
+    const dx = p1[0] - p0[0];
+    const dz = p1[2] - p0[2];
+    const len = @sqrt(dx * dx + dz * dz);
+    const normal = [3]f32{ -dz / len, 0, dx / len };
+    const ao: f32 = 1.0;
+
+    const positions = [4][3]f32{ bl, br, tr, tl };
+    const uv = [4][2]f32{ .{ 0, 1 }, .{ 1, 1 }, .{ 1, 0 }, .{ 0, 0 } };
+
+    const v = [6][3]f32{ positions[0], positions[1], positions[2], positions[0], positions[2], positions[3] };
+    const u = [6][2]f32{ uv[0], uv[1], uv[2], uv[0], uv[2], uv[3] };
+
+    for (0..6) |i| {
+        try verts.append(allocator, Vertex.initWithEntrance(v[i], col, normal, u[i], tile_id, light.skylight, light.blocklight, ao, light.entrance_bounce, light.entrance_dir));
+    }
+}

--- a/src/world_inline_tests.zig
+++ b/src/world_inline_tests.zig
@@ -345,6 +345,21 @@ test "adjacent transparent blocks share face" {
     try testing.expect(total_verts < 72);
 }
 
+test "tall cross block generates cutout billboard vertices only" {
+    var atlas: TextureAtlas = undefined;
+    @memset(std.mem.asBytes(&atlas.tile_mappings), 0);
+
+    var chunk = Chunk.init(0, 0);
+    chunk.setBlock(8, 64, 8, .tall_grass);
+
+    var mesh = ChunkMesh.init(testing.allocator);
+    defer mesh.deinitWithoutRHI();
+    try mesh.buildWithNeighbors(&chunk, .empty, &atlas);
+
+    try testing.expectEqual(null, mesh.pending_solid);
+    try testing.expectEqual(@as(usize, 12), mesh.pending_cutout.?.len);
+}
+
 // ============================================================================
 // Meshing Stage Module Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- Adds `flat_quad` and `tall_cross` render shapes to the block registry.
- Adds dedicated flat quad and tall cross cutout meshers and wires them into chunk meshing.
- Treats all non-cube render shapes as shape-meshed blocks, and updates tall grass to use the new tall cross shape.

## Verification
- `nix develop --command zig fmt src/ modules/world-core/src/block_registry.zig modules/world-meshing/src/chunk_mesh.zig modules/world-meshing/src/meshing/greedy_mesher.zig modules/world-meshing/src/meshing/flat_quad_mesher.zig modules/world-meshing/src/meshing/tall_cross_mesher.zig modules/world-core/src/block_registry_tests.zig modules/world-core/src/biome_and_block_tests.zig`
- `nix develop --command zig build test`
- `nix develop --command zig build`
- `nix develop --command zig build run -Dskip-present -Dauto-world=normal -Dstartup-diagnostic-seconds=5` timed out after shader compilation output at both 30s and 60s; no crash output was captured.

Closes #623