### PR TITLE
feat: add attached render shape foundation

### DIFF
--- a/modules/world-core/src/biome_and_block_tests.zig
+++ b/modules/world-core/src/biome_and_block_tests.zig
@@ -152,6 +152,10 @@ test "BlockType render_shape for tall cross blocks" {
     try testing.expectEqual(block_registry.RenderShape.tall_cross, getBlockDefinition(.tall_grass).render_shape);
 }
 
+test "BlockType render_shape for wall attached blocks" {
+    try testing.expectEqual(block_registry.RenderShape.wall_attached, getBlockDefinition(.vine).render_shape);
+}
+
 test "BlockType render_shape for cube blocks" {
     try testing.expectEqual(block_registry.RenderShape.cube, getBlockDefinition(.stone).render_shape);
     try testing.expectEqual(block_registry.RenderShape.cube, getBlockDefinition(.grass).render_shape);

--- a/modules/world-core/src/block_registry.zig
+++ b/modules/world-core/src/block_registry.zig
@@ -37,6 +37,52 @@ pub const RenderShape = enum {
     flat_quad,
     /// 2-block-high X-shaped billboard (tall plants)
     tall_cross,
+    /// Face-attached non-cube geometry driven by RenderShapeData.attachment
+    wall_attached,
+    /// Placeholder for block-specific custom mesh variants (slabs, stairs, doors, fences)
+    custom_mesh,
+};
+
+pub const AttachmentFaces = packed struct {
+    top: bool = false,
+    bottom: bool = false,
+    north: bool = false,
+    south: bool = false,
+    east: bool = false,
+    west: bool = false,
+
+    pub fn walls() AttachmentFaces {
+        return .{ .north = true, .south = true, .east = true, .west = true };
+    }
+
+    pub fn contains(self: AttachmentFaces, face: Face) bool {
+        return switch (face) {
+            .top => self.top,
+            .bottom => self.bottom,
+            .north => self.north,
+            .south => self.south,
+            .east => self.east,
+            .west => self.west,
+        };
+    }
+};
+
+pub const AttachmentSpec = struct {
+    default_face: Face,
+    allowed_faces: AttachmentFaces,
+};
+
+pub const CustomMeshVariant = enum {
+    none,
+    slab,
+    stairs,
+    door,
+    fence,
+};
+
+pub const RenderShapeData = struct {
+    attachment: ?AttachmentSpec = null,
+    custom_mesh: CustomMeshVariant = .none,
 };
 
 pub const BlockDefinition = struct {
@@ -48,6 +94,7 @@ pub const BlockDefinition = struct {
     is_fluid: bool,
     render_pass: RenderPass,
     render_shape: RenderShape,
+    render_shape_data: RenderShapeData,
     light_emission: [3]u4,
     default_color: [3]f32,
     texture_top: []const u8,
@@ -117,6 +164,7 @@ pub const BLOCK_REGISTRY = blk: {
             .is_fluid = false,
             .render_pass = .solid,
             .render_shape = .cube,
+            .render_shape_data = .{},
             .light_emission = .{ 0, 0, 0 },
             .default_color = .{ 1, 0, 1 },
             .texture_top = "unknown",
@@ -145,6 +193,7 @@ pub const BLOCK_REGISTRY = blk: {
             .is_fluid = false,
             .render_pass = .solid,
             .render_shape = .cube,
+            .render_shape_data = .{},
             .light_emission = .{ 0, 0, 0 },
             .default_color = .{ 1, 1, 1 },
             .texture_top = field.name,
@@ -330,7 +379,18 @@ pub const BLOCK_REGISTRY = blk: {
         def.render_shape = switch (id) {
             .tall_grass => .tall_cross,
             .flower_red, .flower_yellow, .dead_bush, .acacia_sapling, .bamboo, .torch => .cross,
+            .vine => .wall_attached,
             else => .cube,
+        };
+
+        def.render_shape_data = switch (id) {
+            .vine => .{
+                .attachment = .{
+                    .default_face = .north,
+                    .allowed_faces = AttachmentFaces.walls(),
+                },
+            },
+            else => .{},
         };
 
         definitions[int_id] = def;

--- a/modules/world-core/src/block_registry_tests.zig
+++ b/modules/world-core/src/block_registry_tests.zig
@@ -103,8 +103,34 @@ test "RenderPass enum has expected variants" {
 }
 
 test "RenderShape enum has expected variants" {
-    try testing.expectEqual(@as(u2, 0), @intFromEnum(block_registry.RenderShape.cube));
-    try testing.expectEqual(@as(u2, 1), @intFromEnum(block_registry.RenderShape.cross));
-    try testing.expectEqual(@as(u2, 2), @intFromEnum(block_registry.RenderShape.flat_quad));
-    try testing.expectEqual(@as(u2, 3), @intFromEnum(block_registry.RenderShape.tall_cross));
+    try testing.expectEqual(@as(u3, 0), @intFromEnum(block_registry.RenderShape.cube));
+    try testing.expectEqual(@as(u3, 1), @intFromEnum(block_registry.RenderShape.cross));
+    try testing.expectEqual(@as(u3, 2), @intFromEnum(block_registry.RenderShape.flat_quad));
+    try testing.expectEqual(@as(u3, 3), @intFromEnum(block_registry.RenderShape.tall_cross));
+    try testing.expectEqual(@as(u3, 4), @intFromEnum(block_registry.RenderShape.wall_attached));
+    try testing.expectEqual(@as(u3, 5), @intFromEnum(block_registry.RenderShape.custom_mesh));
+}
+
+test "AttachmentFaces walls contains only cardinal faces" {
+    const walls = block_registry.AttachmentFaces.walls();
+    try testing.expect(walls.contains(.north));
+    try testing.expect(walls.contains(.south));
+    try testing.expect(walls.contains(.east));
+    try testing.expect(walls.contains(.west));
+    try testing.expect(!walls.contains(.top));
+    try testing.expect(!walls.contains(.bottom));
+}
+
+test "vine is wall-attached render shape fixture" {
+    const vine = block_registry.getBlockDefinition(.vine);
+    try testing.expectEqual(block_registry.RenderShape.wall_attached, vine.render_shape);
+    const attachment = vine.render_shape_data.attachment orelse return error.TestExpectedEqual;
+    try testing.expectEqual(Face.north, attachment.default_face);
+    try testing.expect(attachment.allowed_faces.contains(attachment.default_face));
+}
+
+test "RenderShapeData can represent custom mesh variants" {
+    const data = block_registry.RenderShapeData{ .custom_mesh = .stairs };
+    try testing.expectEqual(block_registry.CustomMeshVariant.stairs, data.custom_mesh);
+    try testing.expectEqual(null, data.attachment);
 }

--- a/modules/world-core/src/root.zig
+++ b/modules/world-core/src/root.zig
@@ -24,8 +24,12 @@ pub const ALL_FACES = block.ALL_FACES;
 
 pub const BlockDefinition = block_registry.BlockDefinition;
 pub const BLOCK_REGISTRY = block_registry.BLOCK_REGISTRY;
+pub const AttachmentFaces = block_registry.AttachmentFaces;
+pub const AttachmentSpec = block_registry.AttachmentSpec;
+pub const CustomMeshVariant = block_registry.CustomMeshVariant;
 pub const RenderPass = block_registry.RenderPass;
 pub const RenderShape = block_registry.RenderShape;
+pub const RenderShapeData = block_registry.RenderShapeData;
 pub const getBlockDefinition = block_registry.getBlockDefinition;
 
 pub const CHUNK_SIZE_X = chunk_constants.CHUNK_SIZE_X;

--- a/modules/world-meshing/src/chunk_mesh.zig
+++ b/modules/world-meshing/src/chunk_mesh.zig
@@ -27,6 +27,7 @@ const greedy_mesher = @import("meshing/greedy_mesher.zig");
 const cross_mesher = @import("meshing/cross_mesher.zig");
 const flat_quad_mesher = @import("meshing/flat_quad_mesher.zig");
 const tall_cross_mesher = @import("meshing/tall_cross_mesher.zig");
+const wall_attached_mesher = @import("meshing/wall_attached_mesher.zig");
 const boundary = @import("meshing/boundary.zig");
 
 // Re-export public types for external consumers
@@ -151,10 +152,11 @@ pub const ChunkMesh = struct {
             try greedy_mesher.meshSlice(self.allocator, chunk, neighbors, .south, sz, si, &solid_verts, &cutout_verts, &fluid_verts, atlas);
         }
 
-        // Mesh non-cube cutout shapes (flowers, saplings, flat floor quads, tall plants)
+        // Mesh non-cube cutout shapes (flowers, saplings, flat floor quads, tall plants, attached quads)
         try cross_mesher.meshCrossBlocks(self.allocator, chunk, neighbors, si, &cutout_verts, atlas);
         try flat_quad_mesher.meshFlatQuadBlocks(self.allocator, chunk, neighbors, si, &cutout_verts, atlas);
         try tall_cross_mesher.meshTallCrossBlocks(self.allocator, chunk, neighbors, si, &cutout_verts, atlas);
+        try wall_attached_mesher.meshWallAttachedBlocks(self.allocator, chunk, neighbors, si, &cutout_verts, atlas);
 
         // Store subchunk data temporarily (will be merged later)
         self.mutex.lock();

--- a/modules/world-meshing/src/chunk_mesh_tests.zig
+++ b/modules/world-meshing/src/chunk_mesh_tests.zig
@@ -1,7 +1,10 @@
 const std = @import("std");
 const testing = std.testing;
 const ChunkMesh = @import("chunk_mesh.zig").ChunkMesh;
+const NeighborChunks = @import("chunk_mesh.zig").NeighborChunks;
 const NUM_SUBCHUNKS = @import("chunk_mesh.zig").NUM_SUBCHUNKS;
+const world_core = @import("world-core");
+const TextureAtlas = @import("engine-assets").TextureAtlas;
 const RenderContext = @import("engine-rhi").RenderContext;
 
 test "ChunkMesh.init creates mesh with null allocations" {
@@ -58,4 +61,21 @@ test "ChunkMesh subchunk arrays are initially null" {
         try testing.expectEqual(null, mesh.subchunk_cutout[i]);
         try testing.expectEqual(null, mesh.subchunk_fluid[i]);
     }
+}
+
+test "ChunkMesh emits wall-attached fixture cutout quad" {
+    var chunk = world_core.Chunk.init(0, 0);
+    chunk.setBlock(1, 1, 1, .vine);
+
+    var atlas: TextureAtlas = undefined;
+    atlas.tile_mappings = [_]TextureAtlas.BlockTiles{TextureAtlas.BlockTiles.uniform(7)} ** 256;
+
+    var mesh = ChunkMesh.init(testing.allocator);
+    defer mesh.deinitWithoutRHI();
+
+    try mesh.buildWithNeighbors(&chunk, NeighborChunks.empty, &atlas);
+
+    try testing.expectEqual(@as(usize, 6), mesh.pending_cutout.?.len);
+    try testing.expectEqual(null, mesh.pending_solid);
+    try testing.expectEqual(null, mesh.pending_fluid);
 }

--- a/modules/world-meshing/src/meshing/wall_attached_mesher.zig
+++ b/modules/world-meshing/src/meshing/wall_attached_mesher.zig
@@ -1,0 +1,180 @@
+//! Face-attached cutout meshing for blocks such as vines.
+//!
+//! The selected attachment face comes from immutable block registry data so the
+//! worker-thread meshing path stays deterministic until per-block state exists.
+
+const std = @import("std");
+
+const world_core = @import("world-core");
+const Chunk = world_core.Chunk;
+const Face = world_core.Face;
+const PackedLight = world_core.PackedLight;
+const CHUNK_SIZE_X = world_core.CHUNK_SIZE_X;
+const CHUNK_SIZE_Z = world_core.CHUNK_SIZE_Z;
+const block_registry = world_core.block_registry;
+const TextureAtlas = @import("engine-assets").TextureAtlas;
+const rhi_mod = @import("engine-rhi");
+const Vertex = rhi_mod.Vertex;
+
+const boundary = @import("boundary.zig");
+const NeighborChunks = boundary.NeighborChunks;
+const SUBCHUNK_SIZE = boundary.SUBCHUNK_SIZE;
+const lighting_sampler = @import("lighting_sampler.zig");
+const biome_colors = @import("../biome_colors.zig");
+
+const WALL_QUAD_OFFSET: f32 = 0.03125;
+
+const AttachedQuad = struct {
+    positions: [4][3]f32,
+    normal: [3]f32,
+};
+
+pub fn meshWallAttachedBlocks(
+    allocator: std.mem.Allocator,
+    chunk: *const Chunk,
+    neighbors: NeighborChunks,
+    si: u32,
+    cutout_list: *std.ArrayListUnmanaged(Vertex),
+    atlas: *const TextureAtlas,
+) !void {
+    const y0: i32 = @intCast(si * SUBCHUNK_SIZE);
+    const y1: i32 = y0 + SUBCHUNK_SIZE;
+
+    var y: i32 = y0;
+    while (y < y1) : (y += 1) {
+        var z: u32 = 0;
+        while (z < CHUNK_SIZE_Z) : (z += 1) {
+            var x: u32 = 0;
+            while (x < CHUNK_SIZE_X) : (x += 1) {
+                const block = chunk.getBlockSafe(@intCast(x), y, @intCast(z));
+                const def = block_registry.getBlockDefinition(block);
+                if (def.render_shape != .wall_attached) continue;
+
+                const attachment = def.render_shape_data.attachment orelse continue;
+                if (!attachment.allowed_faces.contains(attachment.default_face)) continue;
+
+                const xi: i32 = @intCast(x);
+                const zi: i32 = @intCast(z);
+                const light = sampleAttachedLight(chunk, neighbors, xi, y, zi);
+                const entrance_bounce = sampleAttachedEntranceBounce(chunk, neighbors, xi, y, zi);
+                const entrance_dir = boundary.getEntranceDirCross(chunk, neighbors, xi, y, zi);
+                const norm_light = lighting_sampler.normalizeLightValues(light, entrance_bounce, entrance_dir);
+                const col = getAttachedColor(chunk, neighbors, xi, zi, def);
+
+                const tiles = atlas.getTilesForBlock(@intFromEnum(block));
+                const tile_id: u16 = @intCast(tiles.side);
+
+                const xf: f32 = @floatFromInt(x);
+                const yf: f32 = @floatFromInt(y);
+                const zf: f32 = @floatFromInt(z);
+
+                try emitAttachedQuad(allocator, cutout_list, xf, yf, zf, attachment.default_face, col, norm_light, tile_id);
+            }
+        }
+    }
+}
+
+fn sampleAttachedLight(chunk: *const Chunk, neighbors: NeighborChunks, x: i32, y: i32, z: i32) PackedLight {
+    var result = PackedLight.init(0, 0);
+    var ox: i32 = -1;
+    while (ox <= 1) : (ox += 1) {
+        var oz: i32 = -1;
+        while (oz <= 1) : (oz += 1) {
+            const light = boundary.getLightCross(chunk, neighbors, x + ox, y, z + oz);
+            result.sky_light = @max(result.sky_light, light.getSkyLight());
+            result.block_light_r = @max(result.block_light_r, light.getBlockLightR());
+            result.block_light_g = @max(result.block_light_g, light.getBlockLightG());
+            result.block_light_b = @max(result.block_light_b, light.getBlockLightB());
+        }
+    }
+    return result;
+}
+
+fn sampleAttachedEntranceBounce(chunk: *const Chunk, neighbors: NeighborChunks, x: i32, y: i32, z: i32) u4 {
+    var result: u4 = 0;
+    var ox: i32 = -1;
+    while (ox <= 1) : (ox += 1) {
+        var oz: i32 = -1;
+        while (oz <= 1) : (oz += 1) {
+            result = @max(result, boundary.getEntranceBounceCross(chunk, neighbors, x + ox, y, z + oz));
+        }
+    }
+    return result;
+}
+
+fn getAttachedColor(chunk: *const Chunk, neighbors: NeighborChunks, x: i32, z: i32, def: *const block_registry.BlockDefinition) [3]f32 {
+    const tint: [3]f32 = if (def.is_tintable) blk: {
+        var r: f32 = 0;
+        var g: f32 = 0;
+        var b: f32 = 0;
+        var count: f32 = 0;
+        var ox: i32 = -1;
+        while (ox <= 1) : (ox += 1) {
+            var oz: i32 = -1;
+            while (oz <= 1) : (oz += 1) {
+                const biome_id = boundary.getBiomeAt(chunk, neighbors, x + ox, z + oz);
+                const colors = biome_colors.getBiomeColors(biome_id);
+                r += colors.grass[0];
+                g += colors.grass[1];
+                b += colors.grass[2];
+                count += 1.0;
+            }
+        }
+        break :blk .{ r / count, g / count, b / count };
+    } else .{ 1.0, 1.0, 1.0 };
+
+    return .{
+        def.default_color[0] * tint[0],
+        def.default_color[1] * tint[1],
+        def.default_color[2] * tint[2],
+    };
+}
+
+fn emitAttachedQuad(
+    allocator: std.mem.Allocator,
+    verts: *std.ArrayListUnmanaged(Vertex),
+    x: f32,
+    y: f32,
+    z: f32,
+    face: Face,
+    col: [3]f32,
+    light: lighting_sampler.NormalizedLight,
+    tile_id: u16,
+) !void {
+    const o = WALL_QUAD_OFFSET;
+    const quad: AttachedQuad = switch (face) {
+        .north => .{
+            .positions = [4][3]f32{ .{ x + 1, y, z + o }, .{ x, y, z + o }, .{ x, y + 1, z + o }, .{ x + 1, y + 1, z + o } },
+            .normal = [3]f32{ 0, 0, -1 },
+        },
+        .south => .{
+            .positions = [4][3]f32{ .{ x, y, z + 1 - o }, .{ x + 1, y, z + 1 - o }, .{ x + 1, y + 1, z + 1 - o }, .{ x, y + 1, z + 1 - o } },
+            .normal = [3]f32{ 0, 0, 1 },
+        },
+        .east => .{
+            .positions = [4][3]f32{ .{ x + 1 - o, y, z }, .{ x + 1 - o, y, z + 1 }, .{ x + 1 - o, y + 1, z + 1 }, .{ x + 1 - o, y + 1, z } },
+            .normal = [3]f32{ 1, 0, 0 },
+        },
+        .west => .{
+            .positions = [4][3]f32{ .{ x + o, y, z + 1 }, .{ x + o, y, z }, .{ x + o, y + 1, z }, .{ x + o, y + 1, z + 1 } },
+            .normal = [3]f32{ -1, 0, 0 },
+        },
+        .top => .{
+            .positions = [4][3]f32{ .{ x, y + 1 - o, z }, .{ x + 1, y + 1 - o, z }, .{ x + 1, y + 1 - o, z + 1 }, .{ x, y + 1 - o, z + 1 } },
+            .normal = [3]f32{ 0, 1, 0 },
+        },
+        .bottom => .{
+            .positions = [4][3]f32{ .{ x, y + o, z + 1 }, .{ x + 1, y + o, z + 1 }, .{ x + 1, y + o, z }, .{ x, y + o, z } },
+            .normal = [3]f32{ 0, -1, 0 },
+        },
+    };
+
+    const uv = [4][2]f32{ .{ 0, 1 }, .{ 1, 1 }, .{ 1, 0 }, .{ 0, 0 } };
+    const ao: f32 = 1.0;
+    const v = [6][3]f32{ quad.positions[0], quad.positions[1], quad.positions[2], quad.positions[0], quad.positions[2], quad.positions[3] };
+    const u = [6][2]f32{ uv[0], uv[1], uv[2], uv[0], uv[2], uv[3] };
+
+    for (0..6) |i| {
+        try verts.append(allocator, Vertex.initWithEntrance(v[i], col, quad.normal, u[i], tile_id, light.skylight, light.blocklight, ao, light.entrance_bounce, light.entrance_dir));
+    }
+}

--- a/modules/world-meshing/src/root.zig
+++ b/modules/world-meshing/src/root.zig
@@ -17,6 +17,7 @@ pub const meshing = struct {
     pub const greedy_mesher = @import("meshing/greedy_mesher.zig");
     pub const lighting_sampler = @import("meshing/lighting_sampler.zig");
     pub const quadric_simplifier = @import("meshing/quadric_simplifier.zig");
+    pub const wall_attached_mesher = @import("meshing/wall_attached_mesher.zig");
 };
 
 pub const ChunkMesh = chunk_mesh.ChunkMesh;


### PR DESCRIPTION
## Summary
- Adds render-shape metadata for face attachments and future custom mesh variants.
- Uses `vine` as the first deterministic wall-attached fixture and routes it through a generic attached cutout mesher.
- Adds registry and chunk mesh tests covering attachment metadata and emitted wall-attached geometry.

## Verification
- `nix develop --command zig fmt modules/world-core/src/block_registry.zig modules/world-core/src/block_registry_tests.zig modules/world-core/src/biome_and_block_tests.zig modules/world-core/src/root.zig modules/world-meshing/src/chunk_mesh.zig modules/world-meshing/src/chunk_mesh_tests.zig modules/world-meshing/src/root.zig modules/world-meshing/src/meshing/wall_attached_mesher.zig`
- `nix develop --command zig build test`
- `nix develop --command zig build -Doptimize=ReleaseFast`

## Runtime Check
- `nix develop --command zig build run -Dskip-present -Dauto-world=normal -Dstartup-diagnostic-seconds=5` timed out after shader validation output at 30s.
- `nix develop --command zig build run -Dskip-present -Dsmoke-test` timed out after shader validation output at both 60s and 120s.

Closes #627.