### PR TITLE
feat: tune hot dry biome terrain

### DIFF
--- a/modules/world-worldgen/src/biome_registry.zig
+++ b/modules/world-worldgen/src/biome_registry.zig
@@ -785,6 +785,7 @@ pub const BIOME_REGISTRY: []const BiomeDefinition = &.{
             .{ .block = .tall_grass, .place_on = &.{.grass}, .chance = 0.5 },
             .{ .block = .dead_bush, .place_on = &.{.grass}, .chance = 0.01 },
         } },
+        .terrain = .{ .height_amplitude = 0.8, .smoothing = 0.15 },
         .colors = .{ .grass = .{ 0.55, 0.55, 0.30 }, .foliage = .{ 0.50, 0.50, 0.28 } },
     },
     .{
@@ -802,7 +803,7 @@ pub const BIOME_REGISTRY: []const BiomeDefinition = &.{
             .{ .block = .tall_grass, .place_on = &.{.grass}, .chance = 0.4 },
             .{ .block = .dead_bush, .place_on = &.{.grass}, .chance = 0.02 },
         } },
-        .terrain = .{ .height_amplitude = 0.6, .smoothing = 0.3, .height_offset = 8.0 },
+        .terrain = .{ .height_amplitude = 0.6, .smoothing = 0.35, .height_offset = 10.0 },
         .colors = .{ .grass = .{ 0.58, 0.56, 0.30 }, .foliage = .{ 0.52, 0.50, 0.28 } },
     },
     .{
@@ -820,7 +821,7 @@ pub const BIOME_REGISTRY: []const BiomeDefinition = &.{
             .{ .block = .dead_bush, .place_on = &.{.grass}, .chance = 0.04 },
             .{ .block = .cobblestone, .place_on = &.{.grass}, .chance = 0.02 },
         } },
-        .terrain = .{ .height_amplitude = 1.3, .smoothing = 0.0 },
+        .terrain = .{ .height_amplitude = 1.35, .smoothing = 0.05 },
         .colors = .{ .grass = .{ 0.48, 0.50, 0.28 }, .foliage = .{ 0.44, 0.46, 0.26 } },
     },
     .{
@@ -834,6 +835,7 @@ pub const BIOME_REGISTRY: []const BiomeDefinition = &.{
         .priority = 6,
         .surface = .{ .top = .red_sand, .filler = .terracotta, .depth_range = 5 },
         .vegetation = .{ .tree_types = &.{}, .decoration_rules = &.{.{ .block = .cactus, .place_on = &.{.red_sand}, .chance = 0.02 }} },
+        .terrain = .{ .height_amplitude = 1.35, .smoothing = 0.08, .height_offset = 3.0 },
         .colors = .{ .grass = .{ 0.5, 0.4, 0.3 } },
     },
     .{
@@ -852,7 +854,7 @@ pub const BIOME_REGISTRY: []const BiomeDefinition = &.{
             .{ .block = .dead_bush, .place_on = &.{.red_sand}, .chance = 0.03 },
             .{ .block = .tall_grass, .place_on = &.{.grass}, .chance = 0.15 },
         } },
-        .terrain = .{ .height_amplitude = 1.0, .smoothing = 0.1 },
+        .terrain = .{ .height_amplitude = 1.15, .smoothing = 0.12, .height_offset = 4.0 },
         .colors = .{ .grass = .{ 0.52, 0.42, 0.32 }, .foliage = .{ 0.46, 0.38, 0.28 } },
     },
     .{
@@ -869,7 +871,7 @@ pub const BIOME_REGISTRY: []const BiomeDefinition = &.{
             .{ .block = .cactus, .place_on = &.{.red_sand}, .chance = 0.025 },
             .{ .block = .dead_bush, .place_on = &.{.red_sand}, .chance = 0.02 },
         } },
-        .terrain = .{ .height_amplitude = 1.8, .smoothing = 0.0 },
+        .terrain = .{ .height_amplitude = 1.85, .smoothing = 0.0, .height_offset = 6.0 },
         .colors = .{ .grass = .{ 0.48, 0.38, 0.28 } },
     },
     .{

--- a/modules/world-worldgen/src/biome_registry_tests.zig
+++ b/modules/world-worldgen/src/biome_registry_tests.zig
@@ -154,6 +154,31 @@ fn mountainsAmplitude() f32 {
     return getBiomeDefinition(.mountains).terrain.height_amplitude;
 }
 
+test "hot dry biome terrain modifiers define distinct relief profiles" {
+    const desert = getBiomeDefinition(.desert);
+    const savanna = getBiomeDefinition(.savanna);
+    const savanna_plateau = getBiomeDefinition(.savanna_plateau);
+    const windswept_savanna = getBiomeDefinition(.windswept_savanna);
+    const badlands = getBiomeDefinition(.badlands);
+    const wooded_badlands = getBiomeDefinition(.wooded_badlands);
+    const eroded_badlands = getBiomeDefinition(.eroded_badlands);
+
+    try testing.expect(desert.terrain.height_amplitude < savanna.terrain.height_amplitude);
+    try testing.expect(desert.terrain.smoothing > savanna.terrain.smoothing);
+
+    try testing.expectApproxEqAbs(@as(f32, 0.6), savanna_plateau.terrain.height_amplitude, 0.0001);
+    try testing.expect(savanna_plateau.terrain.smoothing > savanna.terrain.smoothing);
+    try testing.expect(savanna_plateau.terrain.height_offset > 0.0);
+
+    try testing.expect(windswept_savanna.terrain.height_amplitude > savanna.terrain.height_amplitude);
+    try testing.expect(windswept_savanna.terrain.smoothing < savanna.terrain.smoothing);
+
+    try testing.expect(badlands.terrain.height_amplitude > 1.0);
+    try testing.expect(wooded_badlands.terrain.height_amplitude > 1.0);
+    try testing.expect(eroded_badlands.terrain.height_amplitude > badlands.terrain.height_amplitude);
+    try testing.expect(eroded_badlands.terrain.height_offset > wooded_badlands.terrain.height_offset);
+}
+
 // ============================================================================
 // BiomeDefinition Climate Scoring Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- Tune hot/dry biome terrain modifiers for desert, savanna, savanna plateau, windswept savanna, and badlands variants.
- Add registry coverage for the intended hot/dry relief and smoothing relationships.

## Verification
- nix develop --command zig fmt modules/world-worldgen/src/biome_registry.zig modules/world-worldgen/src/biome_registry_tests.zig
- nix develop --command zig build test

Fixes #653