### PR TITLE
fix: tune wetland terrain shaping

### DIFF
--- a/modules/world-worldgen/src/biome_registry.zig
+++ b/modules/world-worldgen/src/biome_registry.zig
@@ -541,7 +541,7 @@ pub const BIOME_REGISTRY: []const BiomeDefinition = &.{
         .priority = 5,
         .surface = .{ .top = .grass, .filler = .dirt, .depth_range = 2 },
         .vegetation = .{ .tree_types = &.{.swamp_oak} },
-        .terrain = .{ .clamp_to_sea_level = true, .height_offset = -2 },
+        .terrain = .{ .clamp_to_sea_level = true },
         .colors = .{
             .grass = .{ 0.24, 0.54, 0.20 },
             .foliage = .{ 0.18, 0.46, 0.16 },
@@ -722,7 +722,7 @@ pub const BIOME_REGISTRY: []const BiomeDefinition = &.{
         .priority = 6,
         .surface = .{ .top = .mud, .filler = .mud, .depth_range = 4 },
         .vegetation = .{ .tree_types = &.{.mangrove} },
-        .terrain = .{ .clamp_to_sea_level = true, .height_offset = -1 },
+        .terrain = .{ .clamp_to_sea_level = true },
         .colors = .{ .grass = .{ 0.26, 0.58, 0.18 }, .foliage = .{ 0.22, 0.52, 0.16 }, .water = .{ 0.16, 0.38, 0.30 } },
     },
     .{
@@ -942,7 +942,7 @@ pub const BIOME_REGISTRY: []const BiomeDefinition = &.{
         .priority = 0, // Lowest priority
         .surface = .{ .top = .grass, .filler = .dirt, .depth_range = 2 },
         .vegetation = .{ .tree_types = &.{.swamp_oak}, .decoration_rules = &.{.{ .block = .tall_grass, .place_on = &.{.grass}, .chance = 0.5 }} },
-        .terrain = .{ .height_offset = -1, .smoothing = 0.3 },
+        .terrain = .{ .height_amplitude = 0.25, .smoothing = 0.65 },
         .colors = .{
             .grass = .{ 0.20, 0.58, 0.20 },
             .foliage = .{ 0.16, 0.50, 0.16 },

--- a/modules/world-worldgen/src/terrain_modifier_tests.zig
+++ b/modules/world-worldgen/src/terrain_modifier_tests.zig
@@ -2,7 +2,9 @@
 
 const std = @import("std");
 const testing = std.testing;
-const TerrainModifier = @import("biome_registry.zig").TerrainModifier;
+const biome_registry = @import("biome_registry.zig");
+const TerrainModifier = biome_registry.TerrainModifier;
+const getBiomeDefinition = biome_registry.getBiomeDefinition;
 
 const SEA_LEVEL: f32 = 62.0;
 
@@ -53,4 +55,31 @@ test "TerrainModifier combines amplitude smoothing clamp and offset deterministi
 
     try testing.expectApproxEqAbs(@as(f32, 96.0), shaped.applyHeight(102.0, SEA_LEVEL), 0.0001);
     try testing.expectApproxEqAbs(@as(f32, 66.0), clamped.applyHeight(102.0, SEA_LEVEL), 0.0001);
+}
+
+test "wetland terrain modifiers flatten and lower sampled heights" {
+    const base_low: f32 = 80.0;
+    const base_high: f32 = 112.0;
+    const plains = getBiomeDefinition(.plains).terrain;
+    const swamp = getBiomeDefinition(.swamp).terrain;
+    const mangrove = getBiomeDefinition(.mangrove_swamp).terrain;
+    const marsh = getBiomeDefinition(.marsh).terrain;
+
+    try testing.expectApproxEqAbs(SEA_LEVEL, swamp.applyHeight(base_high, SEA_LEVEL), 0.0001);
+    try testing.expectApproxEqAbs(SEA_LEVEL, mangrove.applyHeight(base_high, SEA_LEVEL), 0.0001);
+
+    const plains_relief = plains.applyHeight(base_high, SEA_LEVEL) - plains.applyHeight(base_low, SEA_LEVEL);
+    const marsh_relief = marsh.applyHeight(base_high, SEA_LEVEL) - marsh.applyHeight(base_low, SEA_LEVEL);
+    try testing.expect(marsh.applyHeight(base_high, SEA_LEVEL) < plains.applyHeight(base_high, SEA_LEVEL));
+    try testing.expect(marsh_relief < plains_relief);
+}
+
+test "wetland terrain keeps swamp and mangrove surfaces vegetation-compatible" {
+    const swamp = getBiomeDefinition(.swamp);
+    const mangrove = getBiomeDefinition(.mangrove_swamp);
+
+    try testing.expectApproxEqAbs(SEA_LEVEL, swamp.terrain.applyHeight(96.0, SEA_LEVEL), 0.0001);
+    try testing.expectApproxEqAbs(SEA_LEVEL, mangrove.terrain.applyHeight(96.0, SEA_LEVEL), 0.0001);
+    try testing.expectEqual(.grass, swamp.surface.top);
+    try testing.expectEqual(.mud, mangrove.surface.top);
 }

--- a/modules/world-worldgen/src/terrain_shape_generator.zig
+++ b/modules/world-worldgen/src/terrain_shape_generator.zig
@@ -115,6 +115,48 @@ pub const TerrainShapeGenerator = struct {
         return self.height_sampler.getContinentalZone(c);
     }
 
+    fn updateSlopes(phase_data: *ChunkPhaseData) void {
+        var local_z: u32 = 0;
+        while (local_z < CHUNK_SIZE_Z) : (local_z += 1) {
+            var local_x: u32 = 0;
+            while (local_x < CHUNK_SIZE_X) : (local_x += 1) {
+                const idx = local_x + local_z * CHUNK_SIZE_X;
+                const terrain_h = phase_data.surface_heights[idx];
+                var max_slope: i32 = 0;
+                if (local_x > 0) max_slope = @max(max_slope, @as(i32, @intCast(@abs(terrain_h - phase_data.surface_heights[idx - 1]))));
+                if (local_x < CHUNK_SIZE_X - 1) max_slope = @max(max_slope, @as(i32, @intCast(@abs(terrain_h - phase_data.surface_heights[idx + 1]))));
+                if (local_z > 0) max_slope = @max(max_slope, @as(i32, @intCast(@abs(terrain_h - phase_data.surface_heights[idx - CHUNK_SIZE_X]))));
+                if (local_z < CHUNK_SIZE_Z - 1) max_slope = @max(max_slope, @as(i32, @intCast(@abs(terrain_h - phase_data.surface_heights[idx + CHUNK_SIZE_X]))));
+                phase_data.slopes[idx] = max_slope;
+            }
+        }
+    }
+
+    fn applyWetlandTerrainModifiers(self: *const TerrainShapeGenerator, phase_data: *ChunkPhaseData) void {
+        const sea: f32 = @floatFromInt(self.params.sea_level);
+
+        var local_z: u32 = 0;
+        while (local_z < CHUNK_SIZE_Z) : (local_z += 1) {
+            var local_x: u32 = 0;
+            while (local_x < CHUNK_SIZE_X) : (local_x += 1) {
+                const idx = local_x + local_z * CHUNK_SIZE_X;
+                const biome_id = phase_data.biome_ids[idx];
+                const biome_tag = @intFromEnum(biome_id);
+                const is_wetland = biome_tag == @intFromEnum(BiomeId.swamp) or
+                    biome_tag == @intFromEnum(BiomeId.mangrove_swamp) or
+                    biome_tag == @intFromEnum(BiomeId.marsh);
+                if (!is_wetland) continue;
+
+                const biome_def = biome_mod.getBiomeDefinition(biome_id);
+                const base_height: f32 = @floatFromInt(phase_data.surface_heights[idx]);
+                const terrain_height = biome_def.terrain.applyHeight(base_height, sea);
+
+                phase_data.surface_heights[idx] = @intFromFloat(terrain_height);
+                phase_data.is_underwater_flags[idx] = terrain_height < sea;
+            }
+        }
+    }
+
     pub fn getNoiseSampler(self: *const TerrainShapeGenerator) *const NoiseSampler {
         return &self.noise_sampler;
     }
@@ -224,21 +266,10 @@ pub const TerrainShapeGenerator = struct {
             }
         }
 
-        local_z = 0;
-        while (local_z < CHUNK_SIZE_Z) : (local_z += 1) {
-            if (stop_flag) |sf| if (sf.*) return false;
-            var local_x: u32 = 0;
-            while (local_x < CHUNK_SIZE_X) : (local_x += 1) {
-                const idx = local_x + local_z * CHUNK_SIZE_X;
-                const terrain_h = phase_data.surface_heights[idx];
-                var max_slope: i32 = 0;
-                if (local_x > 0) max_slope = @max(max_slope, @as(i32, @intCast(@abs(terrain_h - phase_data.surface_heights[idx - 1]))));
-                if (local_x < CHUNK_SIZE_X - 1) max_slope = @max(max_slope, @as(i32, @intCast(@abs(terrain_h - phase_data.surface_heights[idx + 1]))));
-                if (local_z > 0) max_slope = @max(max_slope, @as(i32, @intCast(@abs(terrain_h - phase_data.surface_heights[idx - CHUNK_SIZE_X]))));
-                if (local_z < CHUNK_SIZE_Z - 1) max_slope = @max(max_slope, @as(i32, @intCast(@abs(terrain_h - phase_data.surface_heights[idx + CHUNK_SIZE_X]))));
-                phase_data.slopes[idx] = max_slope;
-            }
-        }
+        updateSlopes(phase_data);
+
+        self.applyWetlandTerrainModifiers(phase_data);
+        updateSlopes(phase_data);
 
         local_z = 0;
         while (local_z < CHUNK_SIZE_Z) : (local_z += 1) {

--- a/modules/world-worldgen/src/terrain_shape_generator.zig
+++ b/modules/world-worldgen/src/terrain_shape_generator.zig
@@ -115,9 +115,10 @@ pub const TerrainShapeGenerator = struct {
         return self.height_sampler.getContinentalZone(c);
     }
 
-    fn updateSlopes(phase_data: *ChunkPhaseData) void {
+    fn updateSlopes(phase_data: *ChunkPhaseData, stop_flag: ?*const bool) bool {
         var local_z: u32 = 0;
         while (local_z < CHUNK_SIZE_Z) : (local_z += 1) {
+            if (stop_flag) |sf| if (sf.*) return false;
             var local_x: u32 = 0;
             while (local_x < CHUNK_SIZE_X) : (local_x += 1) {
                 const idx = local_x + local_z * CHUNK_SIZE_X;
@@ -130,6 +131,7 @@ pub const TerrainShapeGenerator = struct {
                 phase_data.slopes[idx] = max_slope;
             }
         }
+        return true;
     }
 
     fn applyWetlandTerrainModifiers(self: *const TerrainShapeGenerator, phase_data: *ChunkPhaseData) void {
@@ -141,10 +143,9 @@ pub const TerrainShapeGenerator = struct {
             while (local_x < CHUNK_SIZE_X) : (local_x += 1) {
                 const idx = local_x + local_z * CHUNK_SIZE_X;
                 const biome_id = phase_data.biome_ids[idx];
-                const biome_tag = @intFromEnum(biome_id);
-                const is_wetland = biome_tag == @intFromEnum(BiomeId.swamp) or
-                    biome_tag == @intFromEnum(BiomeId.mangrove_swamp) or
-                    biome_tag == @intFromEnum(BiomeId.marsh);
+                const is_wetland = biome_id == .swamp or
+                    biome_id == .mangrove_swamp or
+                    biome_id == .marsh;
                 if (!is_wetland) continue;
 
                 const biome_def = biome_mod.getBiomeDefinition(biome_id);
@@ -266,10 +267,7 @@ pub const TerrainShapeGenerator = struct {
             }
         }
 
-        updateSlopes(phase_data);
-
-        self.applyWetlandTerrainModifiers(phase_data);
-        updateSlopes(phase_data);
+        if (!updateSlopes(phase_data, stop_flag)) return false;
 
         local_z = 0;
         while (local_z < CHUNK_SIZE_Z) : (local_z += 1) {
@@ -346,6 +344,9 @@ pub const TerrainShapeGenerator = struct {
                 }
             }
         }
+
+        self.applyWetlandTerrainModifiers(phase_data);
+        if (!updateSlopes(phase_data, stop_flag)) return false;
 
         local_z = 0;
         while (local_z < CHUNK_SIZE_Z) : (local_z += 1) {


### PR DESCRIPTION
## Summary
- Apply wetland terrain modifiers during chunk preparation for swamp, mangrove swamp, and marsh biomes only.
- Tune wetland modifiers to flatten/lower terrain near sea level while preserving mud/grass surface compatibility.
- Recompute slopes after wetland shaping so coastal classification uses the adjusted terrain.

## Verification
- nix develop --command zig fmt modules/world-worldgen/src/terrain_shape_generator.zig modules/world-worldgen/src/biome_registry.zig modules/world-worldgen/src/terrain_modifier_tests.zig
- nix develop --command zig build test

Fixes #651