### PR TITLE
feat: use multi-parameter biome selection

### DIFF
--- a/modules/world-worldgen/src/biome.zig
+++ b/modules/world-worldgen/src/biome.zig
@@ -81,6 +81,7 @@ pub const getTransitionBiome = biome_edge_detector.getTransitionBiome;
 pub const selectBiomeVoronoi = biome_selector.selectBiomeVoronoi;
 pub const selectBiomeVoronoiWithRiver = biome_selector.selectBiomeVoronoiWithRiver;
 pub const selectBiome = biome_selector.selectBiome;
+pub const selectBiomeMultiParam = biome_selector.selectBiomeMultiParam;
 pub const selectBiomeWithRiver = biome_selector.selectBiomeWithRiver;
 pub const computeClimateParams = biome_selector.computeClimateParams;
 pub const BiomeSelection = biome_selector.BiomeSelection;

--- a/modules/world-worldgen/src/biome_registry.zig
+++ b/modules/world-worldgen/src/biome_registry.zig
@@ -119,26 +119,36 @@ pub const BiomeDefinition = struct {
         return true;
     }
 
-    /// Score how well this biome matches the given climate parameters
-    /// Only temperature, humidity, and elevation affect the score (structural already filtered)
+    /// Score how well this biome matches the given climate parameters.
+    /// Climate-space selection uses all available soft parameters; height and
+    /// slope remain structural filters handled by the constraint-aware selector.
     pub fn scoreClimate(self: BiomeDefinition, params: ClimateParams) f32 {
-        // Check if within climate ranges
         if (!self.temperature.contains(params.temperature)) return 0;
         if (!self.humidity.contains(params.humidity)) return 0;
         if (!self.elevation.contains(params.elevation)) return 0;
+        if (!self.continentalness.contains(params.continentalness)) return 0;
+        if (!self.ruggedness.contains(params.ruggedness)) return 0;
+        if (params.ridge_mask < self.min_ridge_mask or params.ridge_mask > self.max_ridge_mask) return 0;
 
-        // Compute weighted distance from ideal center
-        const t_dist = self.temperature.distanceFromCenter(params.temperature);
-        const h_dist = self.humidity.distanceFromCenter(params.humidity);
-        const e_dist = self.elevation.distanceFromCenter(params.elevation);
+        var dist_sum: f32 = 0.0;
+        var dist_count: f32 = 0.0;
+        accumulateRangeDistance(self.temperature, params.temperature, &dist_sum, &dist_count);
+        accumulateRangeDistance(self.humidity, params.humidity, &dist_sum, &dist_count);
+        accumulateRangeDistance(self.elevation, params.elevation, &dist_sum, &dist_count);
+        accumulateRangeDistance(self.continentalness, params.continentalness, &dist_sum, &dist_count);
+        accumulateRangeDistance(self.ruggedness, params.ruggedness, &dist_sum, &dist_count);
+        accumulateRangeDistance(.{ .min = self.min_ridge_mask, .max = self.max_ridge_mask }, params.ridge_mask, &dist_sum, &dist_count);
 
-        // Average distance (lower is better)
-        const avg_dist = (t_dist + h_dist + e_dist) / 3.0;
+        const avg_dist = if (dist_count > 0.0) dist_sum / dist_count else 0.0;
 
-        // Convert to score (higher is better), add priority bonus
         return (1.0 - avg_dist) + @as(f32, @floatFromInt(self.priority)) * 0.01;
     }
 };
+
+fn accumulateRangeDistance(range: Range, value: f32, dist_sum: *f32, dist_count: *f32) void {
+    dist_sum.* += range.distanceFromCenter(value);
+    dist_count.* += 1.0;
+}
 
 /// Climate parameters computed per (x,z) column
 pub const ClimateParams = struct {
@@ -147,6 +157,7 @@ pub const ClimateParams = struct {
     elevation: f32, // Normalized: 0=sea level, 1=max height
     continentalness: f32, // 0=deep ocean, 1=deep inland
     ruggedness: f32, // 0=smooth, 1=mountainous (erosion inverted)
+    ridge_mask: f32 = 0.0, // 0=valley/flat, 1=strong ridge/peak influence
 };
 
 /// Biome identifiers - shared with core chunk storage.

--- a/modules/world-worldgen/src/biome_registry_tests.zig
+++ b/modules/world-worldgen/src/biome_registry_tests.zig
@@ -238,6 +238,46 @@ test "BiomeDefinition scoreClimate returns zero outside climate range" {
     try testing.expectEqual(@as(f32, 0), score);
 }
 
+test "BiomeDefinition scoreClimate returns zero outside continentalness range" {
+    const def = getBiomeDefinition(.desert);
+    const params = ClimateParams{
+        .temperature = 0.9,
+        .humidity = 0.1,
+        .elevation = 0.5,
+        .continentalness = 0.2,
+        .ruggedness = 0.2,
+    };
+    const score = def.scoreClimate(params);
+    try testing.expectEqual(@as(f32, 0), score);
+}
+
+test "BiomeDefinition scoreClimate returns zero outside ruggedness range" {
+    const def = getBiomeDefinition(.meadow);
+    const params = ClimateParams{
+        .temperature = 0.45,
+        .humidity = 0.55,
+        .elevation = 0.5,
+        .continentalness = 0.7,
+        .ruggedness = 0.9,
+    };
+    const score = def.scoreClimate(params);
+    try testing.expectEqual(@as(f32, 0), score);
+}
+
+test "BiomeDefinition scoreClimate returns zero outside ridge mask range" {
+    const def = getBiomeDefinition(.jagged_peaks);
+    const params = ClimateParams{
+        .temperature = 0.32,
+        .humidity = 0.45,
+        .elevation = 0.85,
+        .continentalness = 0.85,
+        .ruggedness = 0.85,
+        .ridge_mask = 0.1,
+    };
+    const score = def.scoreClimate(params);
+    try testing.expectEqual(@as(f32, 0), score);
+}
+
 test "BiomeDefinition scoreClimate returns positive for matching" {
     const def = getBiomeDefinition(.plains);
     const params = ClimateParams{

--- a/modules/world-worldgen/src/biome_selector.zig
+++ b/modules/world-worldgen/src/biome_selector.zig
@@ -67,7 +67,7 @@ pub fn selectBiomeVoronoiWithRiver(
 }
 
 // ============================================================================
-// Score-based Biome Selection
+// Multi-parameter Biome Selection
 // ============================================================================
 
 /// Select the best matching biome for given climate parameters
@@ -76,6 +76,30 @@ pub fn selectBiome(params: ClimateParams) BiomeId {
     var best_biome: BiomeId = .plains; // Default fallback
 
     for (BIOME_REGISTRY) |biome| {
+        const s = biome.scoreClimate(params);
+        if (s > best_score) {
+            best_score = s;
+            best_biome = biome.id;
+        }
+    }
+
+    return best_biome;
+}
+
+/// Select the best matching biome using climate and structural parameters.
+/// This is the full six-parameter path: temperature, humidity, elevation,
+/// continentalness, ruggedness, and ridge mask all influence eligibility or score.
+pub fn selectBiomeMultiParam(climate: ClimateParams, structural: StructuralParams) BiomeId {
+    var params = climate;
+    params.continentalness = structural.continentalness;
+    params.ridge_mask = structural.ridge_mask;
+
+    var best_score: f32 = 0;
+    var best_biome: BiomeId = .plains;
+
+    for (BIOME_REGISTRY) |biome| {
+        if (!biome.meetsStructuralConstraints(structural.height, structural.slope, structural.continentalness, structural.ridge_mask)) continue;
+
         const s = biome.scoreClimate(params);
         if (s > best_score) {
             best_score = s;
@@ -212,29 +236,22 @@ pub fn selectBiomeWithRiverBlended(params: ClimateParams, river_mask: f32) Biome
 }
 
 // ============================================================================
-// Constraint-based Selection (Voronoi + structural filtering)
+// Constraint-based Selection (multi-parameter + structural filtering)
 // ============================================================================
 
-/// Select biome using Voronoi diagram in heat/humidity space (Issue #106)
-/// Climate temperature/humidity are converted to heat/humidity scale (0-100)
-/// Structural constraints (height, continentalness) filter eligible biomes
+/// Select biome using the full climate and terrain parameter set.
+/// Structural constraints filter eligibility before the soft climate score runs.
 pub fn selectBiomeWithConstraints(climate: ClimateParams, structural: StructuralParams) BiomeId {
-    // Convert climate params to Voronoi heat/humidity scale (0-100)
-    // Temperature 0-1 -> Heat 0-100
-    // Humidity 0-1 -> Humidity 0-100
-    const heat = climate.temperature * 100.0;
-    const humidity = climate.humidity * 100.0;
-
-    return selectBiomeVoronoi(heat, humidity, structural.height, structural.continentalness, structural.slope);
+    return selectBiomeMultiParam(climate, structural);
 }
 
 /// Select biome with structural constraints and river override
 pub fn selectBiomeWithConstraintsAndRiver(climate: ClimateParams, structural: StructuralParams, river_mask: f32) BiomeId {
-    // Convert climate params to Voronoi heat/humidity scale (0-100)
-    const heat = climate.temperature * 100.0;
-    const humidity = climate.humidity * 100.0;
-
-    return selectBiomeVoronoiWithRiver(heat, humidity, structural.height, structural.continentalness, structural.slope, river_mask);
+    if (river_mask > 0.5 and structural.height < 120) {
+        if (climate.temperature <= 0.20) return .frozen_river;
+        return .river;
+    }
+    return selectBiomeWithConstraints(climate, structural);
 }
 
 // ============================================================================

--- a/modules/world-worldgen/src/biome_selector_tests.zig
+++ b/modules/world-worldgen/src/biome_selector_tests.zig
@@ -17,6 +17,7 @@ const StructuralParams = registry.StructuralParams;
 const selectBiomeVoronoi = selector.selectBiomeVoronoi;
 const selectBiomeVoronoiWithRiver = selector.selectBiomeVoronoiWithRiver;
 const selectBiome = selector.selectBiome;
+const selectBiomeMultiParam = selector.selectBiomeMultiParam;
 const selectBiomeWithRiver = selector.selectBiomeWithRiver;
 const selectBiomeBlended = selector.selectBiomeBlended;
 const selectBiomeWithRiverBlended = selector.selectBiomeWithRiverBlended;
@@ -411,8 +412,33 @@ test "selectBiomeWithConstraints documents ridge mask baseline behavior" {
         .ridge_mask = 1.0,
     };
 
-    try testing.expectEqual(BiomeId.mountains, selectBiomeWithConstraints(climate, low_ridge));
-    try testing.expectEqual(BiomeId.mountains, selectBiomeWithConstraints(climate, high_ridge));
+    try testing.expect(selectBiomeWithConstraints(climate, low_ridge) != .jagged_peaks);
+    try testing.expect(selectBiomeWithConstraints(climate, high_ridge) != .plains);
+}
+
+test "selectBiomeMultiParam uses ruggedness and ridge mask" {
+    const climate = ClimateParams{
+        .temperature = 0.32,
+        .humidity = 0.45,
+        .elevation = 0.85,
+        .continentalness = 0.85,
+        .ruggedness = 0.85,
+    };
+    const low_ridge = StructuralParams{
+        .height = 150,
+        .slope = 18,
+        .continentalness = 0.85,
+        .ridge_mask = 0.1,
+    };
+    const high_ridge = StructuralParams{
+        .height = 150,
+        .slope = 18,
+        .continentalness = 0.85,
+        .ridge_mask = 0.7,
+    };
+
+    try testing.expect(selectBiomeMultiParam(climate, low_ridge) != .jagged_peaks);
+    try testing.expectEqual(BiomeId.jagged_peaks, selectBiomeMultiParam(climate, high_ridge));
 }
 
 test "selectBiomeVoronoi falls back to plains when structural filters exclude all points" {

--- a/src/worldgen_tests.zig
+++ b/src/worldgen_tests.zig
@@ -219,8 +219,8 @@ test "WorldGen stable chunk fingerprints for known seed" {
 
     const expected = [_]u64{
         1589085686761579315,
-        10106071382427144696,
-        12283863255206387139,
+        3398558120687224261,
+        12563833883354114501,
     };
 
     for (positions, 0..) |pos, i| {
@@ -660,21 +660,21 @@ test "selectBiomeVoronoiWithRiver returns river when mask active" {
     try testing.expect(no_river != .river);
 }
 
-test "selectBiomeWithConstraints uses Voronoi selection" {
+test "selectBiomeWithConstraints uses multi-parameter selection" {
     const biome_mod = world_worldgen.biome;
 
     const climate = biome_mod.ClimateParams{
         .temperature = 0.9,
         .humidity = 0.1,
         .elevation = 0.4,
-        .continentalness = 0.5,
+        .continentalness = 0.6,
         .ruggedness = 0.2,
     };
 
     const structural = biome_mod.StructuralParams{
         .height = 70,
         .slope = 2,
-        .continentalness = 0.5,
+        .continentalness = 0.6,
         .ridge_mask = 0.1,
     };
 
@@ -922,7 +922,7 @@ test "BiomeSource selectBiome hot dry returns desert" {
     try testing.expectEqual(result, BiomeId.desert);
 }
 
-test "BiomeSource selectBiome cold wet returns taiga" {
+test "BiomeSource selectBiome cold wet returns snowy taiga" {
     const biome_mod = world_worldgen.biome;
     const source = BiomeSource.init();
 
@@ -942,7 +942,7 @@ test "BiomeSource selectBiome cold wet returns taiga" {
     };
 
     const result = source.selectBiome(climate, structural, 0.0);
-    try testing.expectEqual(result, BiomeId.taiga);
+    try testing.expectEqual(BiomeId.snowy_taiga, result);
 }
 
 test "BiomeSource selectBiome river override" {


### PR DESCRIPTION
## Summary
- Extend biome climate scoring to include continentalness, ruggedness, and ridge mask alongside temperature, humidity, and elevation.
- Route constraint-aware biome selection through the full multi-parameter scorer while preserving legacy Voronoi helpers.
- Add regression coverage for the new parameter constraints and update deterministic worldgen expectations.

## Verification
- `nix develop --command zig build test -- --test-filter biome`
- `nix develop --command zig build test`

Fixes #654