### PR TITLE
feat: add multi-parameter biome point scoring

### DIFF
--- a/modules/world-worldgen/src/biome.zig
+++ b/modules/world-worldgen/src/biome.zig
@@ -79,6 +79,7 @@ pub const getTransitionBiome = biome_edge_detector.getTransitionBiome;
 // ============================================================================
 
 pub const selectBiomeVoronoi = biome_selector.selectBiomeVoronoi;
+pub const selectBiomeVoronoiMultiParam = biome_selector.selectBiomeVoronoiMultiParam;
 pub const selectBiomeVoronoiWithRiver = biome_selector.selectBiomeVoronoiWithRiver;
 pub const selectBiome = biome_selector.selectBiome;
 pub const selectBiomeMultiParam = biome_selector.selectBiomeMultiParam;

--- a/modules/world-worldgen/src/biome_registry.zig
+++ b/modules/world-worldgen/src/biome_registry.zig
@@ -163,12 +163,19 @@ pub const ClimateParams = struct {
 /// Biome identifiers - shared with core chunk storage.
 pub const BiomeId = @import("world-core").BiomeId;
 
-/// Voronoi point defining a biome's position in climate space
-/// Biomes are selected by finding the closest point to the sampled heat/humidity
+/// Voronoi point defining a biome's position in multi-parameter climate space.
+/// Biomes are selected by finding the closest point to sampled climate and
+/// terrain-shape values after structural filters are applied.
 pub const BiomePoint = struct {
     id: BiomeId,
     heat: f32, // 0-100 scale (cold to hot)
     humidity: f32, // 0-100 scale (dry to wet)
+    /// Optional normalized center values. When omitted, the selector derives
+    /// continentalness and elevation from the structural constraint ranges.
+    elevation: ?f32 = null,
+    continentalness: ?f32 = null,
+    ruggedness: f32 = 0.35,
+    ridge_mask: f32 = 0.0,
     weight: f32 = 1.0, // Cell size multiplier (larger = bigger biome regions)
     y_min: i32 = 0, // Minimum Y level
     y_max: i32 = 256, // Maximum Y level
@@ -178,6 +185,18 @@ pub const BiomePoint = struct {
     min_continental: f32 = 0.0,
     /// Maximum continentalness. Set < 0.35 for ocean-only biomes
     max_continental: f32 = 1.0,
+
+    pub fn elevationCenter(self: BiomePoint) f32 {
+        if (self.elevation) |value| return value;
+        if (self.y_min > 0) return std.math.clamp(@as(f32, @floatFromInt(self.y_min)) / 256.0, 0.0, 1.0);
+        if (self.y_max < 256) return std.math.clamp(@as(f32, @floatFromInt(self.y_max)) / 256.0, 0.0, 1.0);
+        return 0.5;
+    }
+
+    pub fn continentalnessCenter(self: BiomePoint) f32 {
+        if (self.continentalness) |value| return value;
+        return (self.min_continental + self.max_continental) * 0.5;
+    }
 };
 
 /// Structural constraints for biome selection
@@ -214,7 +233,7 @@ pub const BIOME_POINTS = [_]BiomePoint{
     .{ .id = .taiga, .heat = 20, .humidity = 60, .weight = 1.0, .min_continental = 0.42 },
     .{ .id = .snowy_taiga, .heat = 8, .humidity = 72, .weight = 0.5, .min_continental = 0.48 },
     .{ .id = .old_growth_taiga, .heat = 30, .humidity = 86, .weight = 0.45, .min_continental = 0.55 },
-    .{ .id = .snowy_mountains, .heat = 10, .humidity = 40, .weight = 0.8, .min_continental = 0.68, .y_min = 112 },
+    .{ .id = .snowy_mountains, .heat = 10, .humidity = 40, .continentalness = 0.72, .weight = 0.8, .min_continental = 0.68, .y_min = 112 },
     .{ .id = .grove, .heat = 18, .humidity = 65, .weight = 0.75, .min_continental = 0.66, .y_min = 88, .y_max = 132, .max_slope = 12 },
     .{ .id = .snowy_slopes, .heat = 8, .humidity = 45, .weight = 0.7, .min_continental = 0.72, .y_min = 112, .y_max = 165 },
     .{ .id = .frozen_peaks, .heat = 4, .humidity = 35, .weight = 0.55, .min_continental = 0.78, .y_min = 138 },

--- a/modules/world-worldgen/src/biome_selector.zig
+++ b/modules/world-worldgen/src/biome_selector.zig
@@ -15,11 +15,27 @@ const BLEND_EPSILON = registry.BLEND_EPSILON;
 // Voronoi Biome Selection (Issue #106)
 // ============================================================================
 
-/// Select biome using Voronoi diagram in heat/humidity space
-/// Returns the biome whose point is closest to the given heat/humidity values
+/// Select biome using Voronoi diagram in heat/humidity space.
+/// Compatibility wrapper for callers that do not have erosion/ridge data.
 pub fn selectBiomeVoronoi(heat: f32, humidity: f32, height: i32, continentalness: f32, slope: i32) BiomeId {
+    return selectBiomeVoronoiMultiParam(heat, humidity, height, continentalness, 0.35, 0.0, slope);
+}
+
+/// Select biome using multi-parameter Voronoi distance.
+/// Heat/humidity preserve their historical 0-100 scale; normalized dimensions
+/// are scaled to the same range so each axis can materially affect selection.
+pub fn selectBiomeVoronoiMultiParam(
+    heat: f32,
+    humidity: f32,
+    height: i32,
+    continentalness: f32,
+    ruggedness: f32,
+    ridge_mask: f32,
+    slope: i32,
+) BiomeId {
     var min_dist: f32 = std.math.inf(f32);
     var closest: BiomeId = .plains;
+    const elevation = normalizedHeight(height);
 
     for (BIOME_POINTS) |point| {
         // Check height constraint
@@ -31,10 +47,21 @@ pub fn selectBiomeVoronoi(heat: f32, humidity: f32, height: i32, continentalness
         // Check continentalness constraint
         if (continentalness < point.min_continental or continentalness > point.max_continental) continue;
 
-        // Calculate weighted Euclidean distance in heat/humidity space
+        // Calculate weighted Euclidean distance in multi-parameter climate space.
         const d_heat = heat - point.heat;
         const d_humidity = humidity - point.humidity;
-        var dist = @sqrt(d_heat * d_heat + d_humidity * d_humidity);
+        const d_elevation = (elevation - point.elevationCenter()) * 100.0;
+        const d_continentalness = (continentalness - point.continentalnessCenter()) * 100.0;
+        const d_ruggedness = (ruggedness - point.ruggedness) * 100.0;
+        const d_ridge_mask = (ridge_mask - point.ridge_mask) * 100.0;
+        var dist = @sqrt(
+            d_heat * d_heat +
+                d_humidity * d_humidity +
+                d_elevation * d_elevation +
+                d_continentalness * d_continentalness +
+                d_ruggedness * d_ruggedness +
+                d_ridge_mask * d_ridge_mask,
+        );
 
         // Weight adjusts effective cell size (larger weight = closer distance = more likely)
         dist /= point.weight;
@@ -46,6 +73,10 @@ pub fn selectBiomeVoronoi(heat: f32, humidity: f32, height: i32, continentalness
     }
 
     return closest;
+}
+
+fn normalizedHeight(height: i32) f32 {
+    return std.math.clamp(@as(f32, @floatFromInt(height)) / 256.0, 0.0, 1.0);
 }
 
 /// Select biome using Voronoi with river override
@@ -63,7 +94,7 @@ pub fn selectBiomeVoronoiWithRiver(
         if (heat <= 20.0) return .frozen_river;
         return .river;
     }
-    return selectBiomeVoronoi(heat, humidity, height, continentalness, slope);
+    return selectBiomeVoronoiMultiParam(heat, humidity, height, continentalness, 0.35, 0.0, slope);
 }
 
 // ============================================================================

--- a/modules/world-worldgen/src/biome_selector_tests.zig
+++ b/modules/world-worldgen/src/biome_selector_tests.zig
@@ -15,6 +15,7 @@ const BiomeId = registry.BiomeId;
 const ClimateParams = registry.ClimateParams;
 const StructuralParams = registry.StructuralParams;
 const selectBiomeVoronoi = selector.selectBiomeVoronoi;
+const selectBiomeVoronoiMultiParam = selector.selectBiomeVoronoiMultiParam;
 const selectBiomeVoronoiWithRiver = selector.selectBiomeVoronoiWithRiver;
 const selectBiome = selector.selectBiome;
 const selectBiomeMultiParam = selector.selectBiomeMultiParam;
@@ -26,6 +27,7 @@ const selectBiomeWithConstraintsAndRiver = selector.selectBiomeWithConstraintsAn
 const selectBiomeSimple = selector.selectBiomeSimple;
 const computeClimateParams = selector.computeClimateParams;
 const BiomeSelection = selector.BiomeSelection;
+const BIOME_POINTS = registry.BIOME_POINTS;
 
 // ============================================================================
 // computeClimateParams Tests
@@ -443,6 +445,35 @@ test "selectBiomeMultiParam uses ruggedness and ridge mask" {
 
 test "selectBiomeVoronoi falls back to plains when structural filters exclude all points" {
     try testing.expectEqual(BiomeId.plains, selectBiomeVoronoi(50, 50, 300, 1.1, 255));
+}
+
+test "selectBiomeVoronoiMultiParam keeps migrated biome points selectable" {
+    for (BIOME_POINTS) |point| {
+        const height = @divFloor(point.y_min + point.y_max, 2);
+        const biome = selectBiomeVoronoiMultiParam(
+            point.heat,
+            point.humidity,
+            height,
+            point.continentalnessCenter(),
+            point.ruggedness,
+            point.ridge_mask,
+            @min(point.max_slope, 1),
+        );
+
+        errdefer std.debug.print(
+            "migrated biome point {s} selected {s}\n",
+            .{ @tagName(point.id), @tagName(biome) },
+        );
+        try testing.expectEqual(point.id, biome);
+    }
+}
+
+test "selectBiomeVoronoiMultiParam separates equal heat humidity by continentalness" {
+    const deep = selectBiomeVoronoiMultiParam(50, 50, 50, 0.10, 0.35, 0.0, 1);
+    const shallow = selectBiomeVoronoiMultiParam(50, 50, 50, 0.28, 0.35, 0.0, 1);
+
+    try testing.expectEqual(BiomeId.deep_ocean, deep);
+    try testing.expectEqual(BiomeId.ocean, shallow);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Extend legacy biome point data with elevation, continentalness, ruggedness, and ridge-mask centers.
- Add multi-parameter Voronoi scoring while keeping existing selector wrappers compatible.
- Cover migrated biome points with selector regression tests.

## Verification
- `nix develop --command zig fmt modules/world-worldgen/src/biome_registry.zig modules/world-worldgen/src/biome_selector.zig modules/world-worldgen/src/biome_selector_tests.zig modules/world-worldgen/src/biome.zig`
- `nix develop --command zig build test`

Fixes #655