### PR TITLE
fix: retune biome transition boundaries

### DIFF
--- a/modules/world-worldgen/src/biome_edge_detector.zig
+++ b/modules/world-worldgen/src/biome_edge_detector.zig
@@ -14,7 +14,7 @@ pub const EDGE_STEP: u32 = 4;
 pub const EDGE_CHECK_RADII = [_]u32{ 4, 8, 12 };
 
 /// Target width of transition bands (blocks)
-pub const EDGE_WIDTH: u32 = 8;
+pub const EDGE_WIDTH: u32 = 12;
 
 /// Represents proximity to a biome boundary
 pub const EdgeBand = enum(u2) {
@@ -54,16 +54,42 @@ pub const TRANSITION_RULES = [_]TransitionRule{
 
     // Badlands <-> Temperate/Non-arid
     .{ .biome_a = .badlands, .biome_b = .forest, .transition = .dry_plains },
+    .{ .biome_a = .badlands, .biome_b = .birch_forest, .transition = .dry_plains },
+    .{ .biome_a = .badlands, .biome_b = .dark_forest, .transition = .dry_plains },
+    .{ .biome_a = .badlands, .biome_b = .flower_forest, .transition = .dry_plains },
     .{ .biome_a = .badlands, .biome_b = .plains, .transition = .dry_plains },
     .{ .biome_a = .badlands, .biome_b = .jungle, .transition = .savanna },
     .{ .biome_a = .badlands, .biome_b = .sparse_jungle, .transition = .savanna },
 
     // Wooded/Eroded badlands transitions
     .{ .biome_a = .wooded_badlands, .biome_b = .forest, .transition = .dry_plains },
+    .{ .biome_a = .wooded_badlands, .biome_b = .birch_forest, .transition = .dry_plains },
+    .{ .biome_a = .wooded_badlands, .biome_b = .dark_forest, .transition = .dry_plains },
+    .{ .biome_a = .wooded_badlands, .biome_b = .flower_forest, .transition = .dry_plains },
+    .{ .biome_a = .wooded_badlands, .biome_b = .plains, .transition = .dry_plains },
+    .{ .biome_a = .wooded_badlands, .biome_b = .jungle, .transition = .savanna },
+    .{ .biome_a = .wooded_badlands, .biome_b = .sparse_jungle, .transition = .savanna },
     .{ .biome_a = .eroded_badlands, .biome_b = .plains, .transition = .dry_plains },
+    .{ .biome_a = .eroded_badlands, .biome_b = .forest, .transition = .dry_plains },
+    .{ .biome_a = .eroded_badlands, .biome_b = .birch_forest, .transition = .dry_plains },
+    .{ .biome_a = .eroded_badlands, .biome_b = .dark_forest, .transition = .dry_plains },
+    .{ .biome_a = .eroded_badlands, .biome_b = .flower_forest, .transition = .dry_plains },
+    .{ .biome_a = .eroded_badlands, .biome_b = .jungle, .transition = .savanna },
+    .{ .biome_a = .eroded_badlands, .biome_b = .sparse_jungle, .transition = .savanna },
 
     // Savanna variant transitions
+    .{ .biome_a = .savanna, .biome_b = .forest, .transition = .dry_plains },
+    .{ .biome_a = .savanna, .biome_b = .birch_forest, .transition = .dry_plains },
+    .{ .biome_a = .savanna, .biome_b = .dark_forest, .transition = .dry_plains },
+    .{ .biome_a = .savanna, .biome_b = .flower_forest, .transition = .dry_plains },
     .{ .biome_a = .windswept_savanna, .biome_b = .forest, .transition = .dry_plains },
+    .{ .biome_a = .windswept_savanna, .biome_b = .birch_forest, .transition = .dry_plains },
+    .{ .biome_a = .windswept_savanna, .biome_b = .dark_forest, .transition = .dry_plains },
+    .{ .biome_a = .windswept_savanna, .biome_b = .flower_forest, .transition = .dry_plains },
+    .{ .biome_a = .savanna_plateau, .biome_b = .forest, .transition = .dry_plains },
+    .{ .biome_a = .savanna_plateau, .biome_b = .birch_forest, .transition = .dry_plains },
+    .{ .biome_a = .savanna_plateau, .biome_b = .dark_forest, .transition = .dry_plains },
+    .{ .biome_a = .savanna_plateau, .biome_b = .flower_forest, .transition = .dry_plains },
     .{ .biome_a = .savanna_plateau, .biome_b = .mountains, .transition = .foothills },
 
     // Jungle variant <-> Temperate
@@ -79,6 +105,7 @@ pub const TRANSITION_RULES = [_]TransitionRule{
     .{ .biome_a = .snow_tundra, .biome_b = .dark_forest, .transition = .snowy_taiga },
     .{ .biome_a = .snow_tundra, .biome_b = .flower_forest, .transition = .taiga },
     .{ .biome_a = .snow_tundra, .biome_b = .old_growth_taiga, .transition = .snowy_taiga },
+    .{ .biome_a = .old_growth_taiga, .biome_b = .dark_forest, .transition = .taiga },
 
     // Cold/coastal <-> temperate/coastal
     .{ .biome_a = .frozen_ocean, .biome_b = .ocean, .transition = .cold_ocean },
@@ -101,10 +128,18 @@ pub const TRANSITION_RULES = [_]TransitionRule{
     .{ .biome_a = .mountains, .biome_b = .dark_forest, .transition = .foothills },
     .{ .biome_a = .mountains, .biome_b = .flower_forest, .transition = .foothills },
     .{ .biome_a = .mountains, .biome_b = .old_growth_taiga, .transition = .foothills },
+    .{ .biome_a = .mountains, .biome_b = .meadow, .transition = .foothills },
+    .{ .biome_a = .mountains, .biome_b = .swamp, .transition = .foothills },
     .{ .biome_a = .snowy_mountains, .biome_b = .taiga, .transition = .foothills },
     .{ .biome_a = .snowy_mountains, .biome_b = .snowy_taiga, .transition = .foothills },
     .{ .biome_a = .snowy_mountains, .biome_b = .old_growth_taiga, .transition = .foothills },
     .{ .biome_a = .snowy_mountains, .biome_b = .snow_tundra, .transition = .foothills },
+    .{ .biome_a = .jagged_peaks, .biome_b = .plains, .transition = .foothills },
+    .{ .biome_a = .jagged_peaks, .biome_b = .forest, .transition = .foothills },
+    .{ .biome_a = .frozen_peaks, .biome_b = .snow_tundra, .transition = .foothills },
+    .{ .biome_a = .frozen_peaks, .biome_b = .snowy_taiga, .transition = .foothills },
+    .{ .biome_a = .stony_peaks, .biome_b = .plains, .transition = .foothills },
+    .{ .biome_a = .stony_peaks, .biome_b = .forest, .transition = .foothills },
 };
 
 /// Check if two biomes need a transition zone between them

--- a/src/worldgen_tests.zig
+++ b/src/worldgen_tests.zig
@@ -429,7 +429,7 @@ test "Biome structural constraints - desert elevation limit" {
 // Biome Edge Detection Tests (Issue #102)
 // ============================================================================
 
-test "needsTransition returns true for desert-forest pair" {
+test "needsTransition returns true for important harsh boundary pairs" {
     const biome_mod = world_worldgen.biome;
 
     try testing.expect(biome_mod.needsTransition(.desert, .forest) == true);
@@ -441,6 +441,14 @@ test "needsTransition returns true for desert-forest pair" {
     try testing.expect(biome_mod.needsTransition(.snow_tundra, .forest) == true);
 
     try testing.expect(biome_mod.needsTransition(.mountains, .plains) == true);
+    try testing.expect(biome_mod.needsTransition(.jagged_peaks, .forest) == true);
+
+    try testing.expect(biome_mod.needsTransition(.swamp, .dark_forest) == true);
+
+    try testing.expect(biome_mod.needsTransition(.badlands, .dark_forest) == true);
+    try testing.expect(biome_mod.needsTransition(.wooded_badlands, .plains) == true);
+    try testing.expect(biome_mod.needsTransition(.eroded_badlands, .forest) == true);
+    try testing.expect(biome_mod.needsTransition(.old_growth_taiga, .dark_forest) == true);
 }
 
 test "needsTransition returns false for compatible biomes" {
@@ -466,8 +474,14 @@ test "getTransitionBiome returns correct biome for pairs" {
     try testing.expectEqual(biome_mod.getTransitionBiome(.snow_tundra, .forest), .taiga);
 
     try testing.expectEqual(biome_mod.getTransitionBiome(.mountains, .plains), .foothills);
+    try testing.expectEqual(biome_mod.getTransitionBiome(.jagged_peaks, .forest), .foothills);
 
     try testing.expectEqual(biome_mod.getTransitionBiome(.swamp, .forest), .marsh);
+
+    try testing.expectEqual(biome_mod.getTransitionBiome(.badlands, .dark_forest), .dry_plains);
+    try testing.expectEqual(biome_mod.getTransitionBiome(.wooded_badlands, .plains), .dry_plains);
+    try testing.expectEqual(biome_mod.getTransitionBiome(.eroded_badlands, .forest), .dry_plains);
+    try testing.expectEqual(biome_mod.getTransitionBiome(.old_growth_taiga, .dark_forest), .taiga);
 }
 
 test "getTransitionBiome returns null for compatible pairs" {
@@ -494,12 +508,23 @@ test "Edge detection constants are properly defined" {
 
     try testing.expectEqual(biome_mod.EDGE_STEP, 4);
 
-    try testing.expectEqual(biome_mod.EDGE_WIDTH, 8);
+    try testing.expectEqual(biome_mod.EDGE_WIDTH, 12);
 
     try testing.expectEqual(biome_mod.EDGE_CHECK_RADII.len, 3);
     try testing.expectEqual(biome_mod.EDGE_CHECK_RADII[0], 4);
     try testing.expectEqual(biome_mod.EDGE_CHECK_RADII[1], 8);
     try testing.expectEqual(biome_mod.EDGE_CHECK_RADII[2], 12);
+}
+
+test "transition micro biomes are edge injected only" {
+    const biome_mod = world_worldgen.biome;
+    const transition_biomes = [_]world_worldgen.BiomeId{ .foothills, .marsh, .dry_plains, .coastal_plains };
+
+    for (transition_biomes) |biome_id| {
+        const definition = biome_mod.getBiomeDefinition(biome_id);
+        try testing.expect(definition.continentalness.min < 0.0);
+        try testing.expect(definition.continentalness.max < 0.0);
+    }
 }
 
 test "BiomeEdgeInfo struct fields" {


### PR DESCRIPTION
## Summary
- Expands biome transition rules for missed harsh boundaries across badlands, savanna variants, forests, taiga, and peak/lowland pairs.
- Aligns transition band width metadata with the 12-block edge detection radius.
- Adds tests for required transition categories and verifies transition micro-biomes remain edge-injected only.

## Verification
- `nix develop --command zig fmt modules/world-worldgen/src/biome_edge_detector.zig src/worldgen_tests.zig`
- `nix develop --command zig build test`

Fixes #658