### PR TITLE


11 tests: boundary cross + block occluder checks

### DIFF
--- a/modules/world-core/src/block_registry_tests.zig
+++ b/modules/world-core/src/block_registry_tests.zig
@@ -181,6 +181,28 @@ test "core natural block pack registry properties" {
     try testing.expectEqual(block_registry.RenderPass.solid, block_registry.getBlockDefinition(.white_terracotta).render_pass);
 }
 
+test "BlockDefinition.isFullCubeOccluder true for solid cube blocks" {
+    try testing.expect(block_registry.getBlockDefinition(.stone).isFullCubeOccluder());
+    try testing.expect(block_registry.getBlockDefinition(.bedrock).isFullCubeOccluder());
+    try testing.expect(block_registry.getBlockDefinition(.cobblestone).isFullCubeOccluder());
+}
+
+test "BlockDefinition.isFullCubeOccluder false for transparent blocks" {
+    try testing.expect(!block_registry.getBlockDefinition(.glass).isFullCubeOccluder());
+    try testing.expect(!block_registry.getBlockDefinition(.ice).isFullCubeOccluder());
+}
+
+test "BlockDefinition.isFullCubeOccluder false for non-cube shapes" {
+    try testing.expect(!block_registry.getBlockDefinition(.torch).isFullCubeOccluder());
+    try testing.expect(!block_registry.getBlockDefinition(.tall_grass).isFullCubeOccluder());
+    try testing.expect(!block_registry.getBlockDefinition(.vine).isFullCubeOccluder());
+}
+
+test "BlockDefinition.isFullCubeOccluder false for solid but non-cube render shape" {
+    try testing.expect(!block_registry.getBlockDefinition(.stone_slab).isFullCubeOccluder());
+    try testing.expect(!block_registry.getBlockDefinition(.stone_stairs).isFullCubeOccluder());
+}
+
 test "aquatic vegetation blocks use cutout shapes" {
     const seagrass = block_registry.getBlockDefinition(.seagrass);
     try testing.expect(!seagrass.is_solid);

--- a/modules/world-meshing/src/meshing/boundary_cross_tests.zig
+++ b/modules/world-meshing/src/meshing/boundary_cross_tests.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+const testing = std.testing;
+const boundary = @import("boundary.zig");
+const NeighborChunks = boundary.NeighborChunks;
+const Chunk = @import("world-core").Chunk;
+
+test "getBlockCross cross-chunk east neighbor returns neighbor block" {
+    var chunk = Chunk.init(0, 0);
+    var east = Chunk.init(1, 0);
+    east.setBlock(0, 64, 8, .glowstone);
+    const neighbors = NeighborChunks{ .east = &east };
+    try testing.expectEqual(.glowstone, boundary.getBlockCross(&chunk, neighbors, 16, 64, 8));
+}
+
+test "getBlockCross cross-chunk north neighbor returns neighbor block" {
+    var chunk = Chunk.init(0, 1);
+    var north = Chunk.init(0, 0);
+    north.setBlock(8, 64, 15, .water);
+    const neighbors = NeighborChunks{ .north = &north };
+    try testing.expectEqual(.water, boundary.getBlockCross(&chunk, neighbors, 8, 64, -1));
+}
+
+test "getBlockCross null neighbor returns air" {
+    var chunk = Chunk.init(0, 0);
+    try testing.expectEqual(.air, boundary.getBlockCross(&chunk, .empty, 16, 64, 8));
+    try testing.expectEqual(.air, boundary.getBlockCross(&chunk, .empty, -1, 64, 8));
+    try testing.expectEqual(.air, boundary.getBlockCross(&chunk, .empty, 8, 64, 16));
+}
+
+test "getEntranceBounceCross cross-chunk west neighbor returns neighbor value" {
+    var chunk = Chunk.init(1, 0);
+    var west = Chunk.init(0, 0);
+    west.setEntranceBounce(15, 64, 8, 5);
+    const neighbors = NeighborChunks{ .west = &west };
+    try testing.expectEqual(@as(u4, 5), boundary.getEntranceBounceCross(&chunk, neighbors, -1, 64, 8));
+}
+
+test "getEntranceBounceCross out of Y range returns zero" {
+    var chunk = Chunk.init(0, 0);
+    try testing.expectEqual(@as(u4, 0), boundary.getEntranceBounceCross(&chunk, .empty, 5, -1, 10));
+    try testing.expectEqual(@as(u4, 0), boundary.getEntranceBounceCross(&chunk, .empty, 5, 256, 10));
+}
+
+test "getEntranceDirCross cross-chunk south neighbor returns neighbor value" {
+    var chunk = Chunk.init(0, 0);
+    var south = Chunk.init(0, 1);
+    south.setEntranceDir(8, 64, 0, 99);
+    const neighbors = NeighborChunks{ .south = &south };
+    try testing.expectEqual(@as(u8, 99), boundary.getEntranceDirCross(&chunk, neighbors, 8, 64, 16));
+}
+
+test "getEntranceDirCross null neighbor on boundary returns zero" {
+    var chunk = Chunk.init(0, 0);
+    try testing.expectEqual(@as(u8, 0), boundary.getEntranceDirCross(&chunk, .empty, 16, 64, 8));
+    try testing.expectEqual(@as(u8, 0), boundary.getEntranceDirCross(&chunk, .empty, -1, 64, 8));
+}

--- a/modules/world-meshing/src/root.zig
+++ b/modules/world-meshing/src/root.zig
@@ -13,6 +13,7 @@ pub const meshing = struct {
     pub const biome_color_sampler = @import("meshing/biome_color_sampler.zig");
     pub const boundary = @import("meshing/boundary.zig");
     pub const boundary_tests = @import("meshing/boundary_tests.zig");
+    pub const boundary_cross_tests = @import("meshing/boundary_cross_tests.zig");
     pub const cross_mesher = @import("meshing/cross_mesher.zig");
     pub const custom_mesh_mesher = @import("meshing/custom_mesh_mesher.zig");
     pub const greedy_mesher = @import("meshing/greedy_mesher.zig");

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -95,6 +95,7 @@ test {
     _ = @import("world-meshing").chunk_storage_interface_tests;
     _ = @import("world-core").biome_and_block_tests;
     _ = @import("world-core").packed_light_tests;
+    _ = @import("world-meshing").meshing.boundary_cross_tests;
     _ = @import("world-meshing").meshing.boundary_tests;
     _ = @import("world-core").world_coord_tests;
     _ = @import("world-core").world_block_fill_tests;


### PR DESCRIPTION


## Summary

**Tests added (11 total across 2 files):**

### `modules/world-meshing/src/meshing/boundary_cross_tests.zig` (7 new tests)
- `test "getBlockCross cross-chunk east neighbor returns neighbor block"` — validates `getBlockCross` crosses into east neighbor chunk at boundary
- `test "getBlockCross cross-chunk north neighbor returns neighbor block"` — validates north neighbor lookup at z=-1 boundary
- `test "getBlockCross null neighbor returns air"` — validates that missing neighbors return `.air`
- `test "getEntranceBounceCross cross-chunk west neighbor returns neighbor value"` — validates bounce data crosses west boundary
- `test "getEntranceBounceCross out of Y range returns zero"` — validates Y bounds clamping for entrance bounce
- `test "getEntranceDirCross cross-chunk south neighbor returns neighbor value"` — validates entrance dir crosses south boundary
- `test "getEntranceDirCross null neighbor on boundary returns zero"` — validates null neighbor returns zero for entrance dir

### `modules/world-core/src/block_registry_tests.zig` (4 new tests — added to existing file)
- `test "BlockDefinition.isFullCubeOccluder true for solid cube blocks"` — stone/bedrock/cobblestone fully occlude
- `test "BlockDefinition.isFullCubeOccluder false for transparent blocks"` — glass/ice don't fully occlude
- `test "BlockDefinition.isFullCubeOccluder false for non-cube shapes"` — torch/tall_grass/vine don't fully occlude
- `test "BlockDefinition.isFullCubeOccluder false for solid but non-cube render shape"` — stone_slab/stone_stairs don't fully occlude

**Verification:**
- `nix develop . --command zig build test` — **STATUS:0** (all tests pass)
- `nix develop . --command zig build test -- --test-filter "getBlockCross"` — **STATUS:0**

**Non-test files modified:** Only registration files (`root.zig`, `src/tests.zig`) as required.

**Remaining testing gaps:**
- `chunk_allocator.zig` — `GlobalVertexAllocator` requires real `ResourceManager`/`IDeviceQuery` with actual GPU buffers; would need mock injection infrastructure that doesn't exist. Skipped as per skill guidelines.
- `Chunk.pin/unpin` — removed after hitting the 8-test limit; can be added in a future PR when other boundary tests are also trimmed.

Triggered by scheduled workflow

<a href="https://opencode.ai/s/Ei21d2Ou"><img width="200" alt="New%20session%20-%202026-05-04T06%3A34%3A31.418Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA1LTA0VDA2OjM0OjMxLjQxOFo=.png?model=minimax-coding-plan/MiniMax-M2.7&version=1.14.33&id=Ei21d2Ou" /></a>
[opencode session](https://opencode.ai/s/Ei21d2Ou)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/25304636180)