### PR TITLE


6 tests: swapchain recreate + abortFrame

### DIFF
--- a/modules/engine-graphics/src/vulkan/vulkan_frame_tests.zig
+++ b/modules/engine-graphics/src/vulkan/vulkan_frame_tests.zig
@@ -639,3 +639,150 @@ test "Post-process framebuffer index bounds check" {
     image_index = 3;
     try testing.expect(image_index >= framebuffers_len);
 }
+
+// ============================================================================
+// markSwapchainRecreateFailed tests - call real production function
+// ============================================================================
+
+test "markSwapchainRecreateFailed first call returns true and sets failure flags" {
+    const frame_orchestration = @import("rhi_frame_orchestration.zig");
+    const MockRecreateCtx = struct {
+        runtime: struct {
+            swapchain_recreate_failed: bool = false,
+            framebuffer_resized: bool = false,
+            pipeline_rebuild_needed: bool = false,
+        } = .{},
+    };
+
+    var ctx = MockRecreateCtx{};
+
+    const result = frame_orchestration.markSwapchainRecreateFailed(&ctx, "test stage", error.OutOfMemory);
+
+    try testing.expect(result);
+    try testing.expect(ctx.runtime.swapchain_recreate_failed);
+    try testing.expect(ctx.runtime.framebuffer_resized);
+    try testing.expect(ctx.runtime.pipeline_rebuild_needed);
+}
+
+test "markSwapchainRecreateFailed second call returns false and keeps flags set" {
+    const frame_orchestration = @import("rhi_frame_orchestration.zig");
+    const MockRecreateCtx = struct {
+        runtime: struct {
+            swapchain_recreate_failed: bool = false,
+            framebuffer_resized: bool = false,
+            pipeline_rebuild_needed: bool = false,
+        } = .{},
+    };
+
+    var ctx = MockRecreateCtx{};
+
+    _ = frame_orchestration.markSwapchainRecreateFailed(&ctx, "first", error.OutOfMemory);
+    const second_result = frame_orchestration.markSwapchainRecreateFailed(&ctx, "second", error.ValidationFailed);
+
+    try testing.expect(!second_result);
+    try testing.expect(ctx.runtime.swapchain_recreate_failed);
+    try testing.expect(ctx.runtime.framebuffer_resized);
+    try testing.expect(ctx.runtime.pipeline_rebuild_needed);
+}
+
+test "markSwapchainRecreateFailed different errors all set same failure state" {
+    const frame_orchestration = @import("rhi_frame_orchestration.zig");
+    const MockRecreateCtx = struct {
+        runtime: struct {
+            swapchain_recreate_failed: bool = false,
+            framebuffer_resized: bool = false,
+            pipeline_rebuild_needed: bool = false,
+        } = .{},
+    };
+
+    const errors = [_]anyerror{ error.OutOfMemory, error.GpuLost, error.InitializationFailed };
+
+    for (errors) |err| {
+        var ctx = MockRecreateCtx{};
+        _ = frame_orchestration.markSwapchainRecreateFailed(&ctx, "stage", err);
+        try testing.expect(ctx.runtime.swapchain_recreate_failed);
+        try testing.expect(ctx.runtime.framebuffer_resized);
+        try testing.expect(ctx.runtime.pipeline_rebuild_needed);
+    }
+}
+
+// ============================================================================
+// markSwapchainRecreateSucceeded tests - call real production function
+// ============================================================================
+
+test "markSwapchainRecreateSucceeded clears all failure flags" {
+    const frame_orchestration = @import("rhi_frame_orchestration.zig");
+    const MockRecreateCtx = struct {
+        runtime: struct {
+            swapchain_recreate_failed: bool = false,
+            framebuffer_resized: bool = false,
+            pipeline_rebuild_needed: bool = false,
+        } = .{},
+    };
+
+    var ctx = MockRecreateCtx{ .runtime = .{
+        .swapchain_recreate_failed = true,
+        .framebuffer_resized = true,
+        .pipeline_rebuild_needed = true,
+    } };
+
+    frame_orchestration.markSwapchainRecreateSucceeded(&ctx);
+
+    try testing.expect(!ctx.runtime.swapchain_recreate_failed);
+    try testing.expect(!ctx.runtime.framebuffer_resized);
+    try testing.expect(!ctx.runtime.pipeline_rebuild_needed);
+}
+
+// ============================================================================
+// FrameManager abortFrame tests - real production state transition
+// ============================================================================
+
+test "FrameManager abortFrame no-op when frame not in progress" {
+    const frame_manager = @import("frame_manager.zig");
+    const MockDevice = struct {
+        vk_device: c.VkDevice = null,
+    };
+
+    var device = MockDevice{};
+    var fm = frame_manager.FrameManager{
+        .vulkan_device = &device,
+        .command_pool = null,
+        .command_buffers = .{ null, null },
+        .image_available_semaphores = .{ null, null },
+        .render_finished_semaphores = .{ null, null },
+        .in_flight_fences = .{ null, null },
+        .current_frame = 0,
+        .current_image_index = 0,
+        .frame_in_progress = false,
+        .dry_run = true,
+    };
+
+    fm.abortFrame();
+
+    try testing.expect(!fm.frame_in_progress);
+}
+
+test "FrameManager abortFrame clears frame_in_progress when set" {
+    const frame_manager = @import("frame_manager.zig");
+    const MockDevice = struct {
+        vk_device: c.VkDevice = null,
+    };
+
+    var device = MockDevice{};
+    var fm = frame_manager.FrameManager{
+        .vulkan_device = &device,
+        .command_pool = null,
+        .command_buffers = .{ null, null },
+        .image_available_semaphores = .{ null, null },
+        .render_finished_semaphores = .{ null, null },
+        .in_flight_fences = .{ null, null },
+        .current_frame = 0,
+        .current_image_index = 0,
+        .frame_in_progress = true,
+        .dry_run = true,
+    };
+
+    fm.abortFrame();
+
+    try testing.expect(!fm.frame_in_progress);
+}


### PR DESCRIPTION


## Tests Added (6 total)

1. **`test "markSwapchainRecreateFailed first call returns true and sets failure flags"`** — Calls `markSwapchainRecreateFailed` directly; verifies it returns `true` on first failure and sets all three runtime flags.

2. **`test "markSwapchainRecreateFailed second call returns false and keeps flags set"`** — Calls `markSwapchainRecreateFailed` twice; verifies it returns `false` on subsequent calls and maintains flags.

3. **`test "markSwapchainRecreateFailed different errors all set same failure state"`** — Calls `markSwapchainRecreateFailed` with multiple error types; proves error type doesn't affect the state machine logic.

4. **`test "markSwapchainRecreateSucceeded clears all failure flags"`** — Calls `markSwapchainRecreateSucceeded`; verifies it resets all three runtime flags atomically.

5. **`test "FrameManager abortFrame no-op when frame not in progress"`** — Calls `abortFrame()` on a `FrameManager` with `frame_in_progress=false`; verifies the field stays `false` (early return path).

6. **`test "FrameManager abortFrame clears frame_in_progress when set"`** — Calls `abortFrame()` on a `FrameManager` with `frame_in_progress=true`; verifies the field becomes `false`.

## Verification

- [x] `nix develop --command zig build test` passes (EXIT: 0)
- [x] `nix develop --command zig build test -- --test-filter "markSwapchainRecreateFailed"` passes
- [x] `nix develop --command zig build test -- --test-filter "abortFrame"` passes
- [x] No non-test source files were modified (only `modules/engine-graphics/src/vulkan/vulkan_frame_tests.zig`)
- [x] `nix develop --command zig fmt modules/engine-graphics/src/vulkan/vulkan_frame_tests.zig` applied

## Production Behavior Protected

- `markSwapchainRecreateFailed`: error-suppression logic (first-call vs. repeat-call behavior), flag-setting correctness, error-type independence
- `markSwapchainRecreateSucceeded`: atomic flag-reset logic
- `FrameManager.abortFrame`: no-op early return and state-clearing behavior

## Testing Gaps

- `beginFrame`/`endFrame` in `FrameManager` cannot be tested without a real GPU/Vulkan device (they call `vkWaitForFences`, `vkCreateSemaphore`, `vkBeginCommandBuffer`, etc. which require valid handles)
- `recreateSwapchainInternal` and pass orchestration functions (`beginGPassInternal`, etc.) require full Vulkan context mocks not currently in the codebase
- `RenderPassManager` create/destroy functions require valid `VkDevice` handles

Triggered by scheduled workflow

<a href="https://opencode.ai/s/lVpOhjsp"><img width="200" alt="New%20session%20-%202026-05-04T14%3A05%3A06.422Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA1LTA0VDE0OjA1OjA2LjQyMlo=.png?model=minimax-coding-plan/MiniMax-M2.7&version=1.14.33&id=lVpOhjsp" /></a>
[opencode session](https://opencode.ai/s/lVpOhjsp)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/25323555900)