### PR TITLE
ci: reduce scheduled workflow frequency

### DIFF
--- a/.github/workflows/model-update-checker.yml
+++ b/.github/workflows/model-update-checker.yml
@@ -2,7 +2,7 @@ name: Model Update Checker
 
 on:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 8 * * 1'
   workflow_dispatch:
     inputs:
       model_id:

--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -8,8 +8,7 @@ name: opencode-audit
 
 on:
   schedule:
-    - cron: '0 6 * * *'
-    - cron: '0 18 * * *'
+    - cron: '0 6 * * 1'
   workflow_dispatch:
     inputs:
       module:

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -8,9 +8,7 @@ name: opencode-test-writer
 
 on:
   schedule:
-    - cron: '0 4 * * *'
-    - cron: '0 12 * * *'
-    - cron: '0 20 * * *'
+    - cron: '0 4 * * 2'
   workflow_dispatch:
     inputs:
       module:

--- a/.github/workflows/stale-branch-cleanup.yml
+++ b/.github/workflows/stale-branch-cleanup.yml
@@ -2,7 +2,7 @@ name: Stale Branch Cleanup
 
 on:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 3 * * 0"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- reduce model update checker from daily to weekly
- reduce opencode audit from twice daily to weekly
- reduce opencode test writer from three times daily to weekly
- reduce stale branch cleanup from daily to weekly

## Verification
- git diff --check