### PR TITLE
ci: upgrade opencode workflow models (M3, k2p7, glm-5.2)

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -4,7 +4,7 @@ name: opencode-audit
 # - OPENCODE_PAT: Classic PAT with `repo` scope OR fine-grained PAT with:
 #     Contents: Read, Issues: Read & Write, Pull requests: Read & Write
 #   Without proper scopes, gh issue create and label operations will fail.
-# - MINIMAX_API_KEY: API key for the MiniMax M2.7 model
+# - MINIMAX_API_KEY: API key for the MiniMax M3 model
 
 on:
   schedule:
@@ -80,7 +80,7 @@ jobs:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:
-          model: minimax-coding-plan/MiniMax-M2.7
+          model: minimax-coding-plan/MiniMax-M3
           use_github_token: true
           prompt: ${{ env.PROMPT }}
 

--- a/.github/workflows/opencode-pr.yml
+++ b/.github/workflows/opencode-pr.yml
@@ -81,7 +81,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
-          model: kimi-for-coding/k2p6
+          model: kimi-for-coding/k2p7
           use_github_token: true
           prompt: ${{ env.PROMPT }}
 

--- a/.github/workflows/opencode-test-writer.yml
+++ b/.github/workflows/opencode-test-writer.yml
@@ -4,7 +4,7 @@ name: opencode-test-writer
 # - OPENCODE_PAT: Classic PAT with `repo` scope OR fine-grained PAT with:
 #     Contents: Read & Write, Pull requests: Read & Write, Metadata: Read
 #   Without `repo` scope, git push will fail with 403 permission denied.
-# - MINIMAX_API_KEY: API key for the MiniMax M2.7 model
+# - MINIMAX_API_KEY: API key for the MiniMax M3 model
 
 on:
   schedule:
@@ -99,7 +99,7 @@ jobs:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           XDG_CACHE_HOME: /tmp/opencode-cache
         with:
-          model: minimax-coding-plan/MiniMax-M2.7
+          model: minimax-coding-plan/MiniMax-M3
           use_github_token: true
           prompt: ${{ env.PROMPT }}
 

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -65,6 +65,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         with:
-          model: minimax-coding-plan/MiniMax-M2.7
+          model: minimax-coding-plan/MiniMax-M3
           use_github_token: true
           prompt: ${{ env.PROMPT }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
-          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
         with:
-          model: minimax-coding-plan/MiniMax-M2.7
+          model: zhipuai-coding-plan/glm-5.2
           use_github_token: true

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -116,20 +116,20 @@ jobs:
 
       - name: Run opencode visual verification
         if: steps.convert.outputs.screenshot_exists == 'true'
-        uses: anomalyco/opencode/github@v1.3.13
+        uses: anomalyco/opencode/github@latest
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
-          KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         with:
-          model: kimi-for-coding/k2p5
+          model: minimax-coding-plan/MiniMax-M3
           prompt: ${{ env.VISUAL_VERIFY_PROMPT }}
 
       - name: Run opencode failure diagnosis
         if: failure() || steps.screenshot.outcome == 'failure' || steps.convert.outputs.screenshot_exists != 'true'
-        uses: anomalyco/opencode/github@v1.3.13
+        uses: anomalyco/opencode/github@latest
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
-          KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         with:
-          model: kimi-for-coding/k2p5
+          model: minimax-coding-plan/MiniMax-M3
           prompt: ${{ env.VISUAL_DIAGNOSE_PROMPT }}


### PR DESCRIPTION
## Summary

Upgrades the models used by the six `anomalyco/opencode/github` workflows to current generations.

| Workflow | Before | After |
|---|---|---|
| `opencode.yml` (slash-command runs) | `minimax-coding-plan/MiniMax-M2.7` | `zhipuai-coding-plan/glm-5.2` |
| `opencode-audit.yml` (scheduled audit) | `minimax-coding-plan/MiniMax-M2.7` | `minimax-coding-plan/MiniMax-M3` |
| `opencode-test-writer.yml` (auto tests) | `minimax-coding-plan/MiniMax-M2.7` | `minimax-coding-plan/MiniMax-M3` |
| `opencode-triage.yml` (issue triage) | `minimax-coding-plan/MiniMax-M2.7` | `minimax-coding-plan/MiniMax-M3` |
| `opencode-pr.yml` (PR review) | `kimi-for-coding/k2p6` | `kimi-for-coding/k2p7` |
| `visual-test.yml` (verify + diagnose) | `kimi-for-coding/k2p5` | `minimax-coding-plan/MiniMax-M3` |

### Related changes
- `opencode.yml`: swapped `MINIMAX_API_KEY` env for `ZHIPU_API_KEY` (`ZHIPU_API_KEY` secret already exists in repo secrets).
- `visual-test.yml`: swapped `KIMI_API_KEY` env for `MINIMAX_API_KEY` on both opencode steps, and bumped the action ref from `@v1.3.13` to `@latest` to match the other workflows.
- Updated the model-name comments in `opencode-audit.yml` and `opencode-test-writer.yml`.

### Secret usage after this change
- `MINIMAX_API_KEY`: audit, test-writer, triage, visual-test
- `KIMI_API_KEY`: opencode-pr (k2p7)
- `ZHIPU_API_KEY`: opencode.yml (glm-5.2)
- `OPENCODE_PAT`: unchanged
- No secrets added or removed.

### Validation
- All 12 workflow files pass `YAML.load_file` parse check (ruby psych).
- No source code or prompt files changed.

### Risk
- `visual-test.yml` action bump `@v1.3.13 \u2192 @latest` is the only behavioral risk beyond the model swap; the other five workflows already tracked `@latest`.
- Model identifiers are passed verbatim to the opencode action; any 4xx from the provider would surface as a failed run rather than a YAML error.