### PR TITLE
fix: improve LOD cache correctness and observability

### DIFF
--- a/modules/world-lod/src/lod_cache.zig
+++ b/modules/world-lod/src/lod_cache.zig
@@ -9,11 +9,13 @@ const LODMaterialLayers = world_core.LODMaterialLayers;
 const LODWaterState = world_core.LODWaterState;
 const LODLightingHint = world_core.LODLightingHint;
 const LODVegetationHint = world_core.LODVegetationHint;
+const LODVerticalSpan = world_core.LODVerticalSpan;
 const BlockType = world_core.BlockType;
 const BiomeId = world_core.BiomeId;
 
 pub const MAGIC: u32 = 0x5A4C4F44; // "ZLOD"
-pub const CACHE_VERSION: u8 = 1;
+pub const CACHE_VERSION: u8 = 2;
+pub const CACHE_VERSION_V1: u8 = 1;
 pub const HEADER_SIZE: usize = 42;
 
 pub const Key = struct {
@@ -33,7 +35,14 @@ pub const CacheError = error{
     InvalidWidth,
     InvalidBiome,
     InvalidBlock,
+    InvalidSpanCount,
     ChecksumMismatch,
+};
+
+pub const ColumnProvenance = enum(u8) {
+    worldgen = 0,
+    chunk_derived = 1,
+    edited = 2,
 };
 
 const BIOME_COUNT: usize = @typeInfo(BiomeId).@"enum".fields.len;
@@ -47,6 +56,8 @@ const WATER_WIRE_SIZE: usize = @sizeOf(u8) + 3 * @sizeOf(f32);
 const LIGHTING_WIRE_SIZE: usize = 2 * @sizeOf(u8) + @sizeOf(f32);
 const VEGETATION_WIRE_SIZE: usize = 4 * @sizeOf(f32) + 2 * BLOCK_WIRE_SIZE;
 const CELL_WIRE_SIZE: usize = HEIGHT_WIRE_SIZE + BIOME_WIRE_SIZE + BLOCK_WIRE_SIZE + COLOR_WIRE_SIZE + MATERIAL_LAYERS_WIRE_SIZE + WATER_WIRE_SIZE + LIGHTING_WIRE_SIZE + VEGETATION_WIRE_SIZE;
+const SPAN_FLAGS_WIRE_SIZE: usize = @sizeOf(u8);
+const SPAN_WIRE_SIZE: usize = 2 * HEIGHT_WIRE_SIZE + BIOME_WIRE_SIZE + MATERIAL_LAYERS_WIRE_SIZE + COLOR_WIRE_SIZE + WATER_WIRE_SIZE + LIGHTING_WIRE_SIZE + VEGETATION_WIRE_SIZE;
 
 comptime {
     std.debug.assert(MATERIAL_LAYERS_WIRE_SIZE == 3);
@@ -54,6 +65,7 @@ comptime {
     std.debug.assert(LIGHTING_WIRE_SIZE == 6);
     std.debug.assert(VEGETATION_WIRE_SIZE == 18);
     std.debug.assert(CELL_WIRE_SIZE == 50);
+    std.debug.assert(SPAN_WIRE_SIZE == 53);
 }
 
 fn payloadSize(count: usize) usize {
@@ -62,7 +74,13 @@ fn payloadSize(count: usize) usize {
 
 pub fn serializedSize(data: *const LODSimplifiedData) usize {
     const count = @as(usize, @intCast(data.width)) * @as(usize, @intCast(data.width));
-    return HEADER_SIZE + payloadSize(count);
+    var total = HEADER_SIZE + payloadSize(count) + SPAN_FLAGS_WIRE_SIZE;
+    if (data.hasVerticalSpans()) {
+        total += count; // provenance bytes
+        total += count; // vertical span counts
+        total += count * world_core.MAX_LOD_VERTICAL_SPANS * SPAN_WIRE_SIZE;
+    }
+    return total;
 }
 
 fn writeF32(buf: []u8, value: f32) void {
@@ -87,6 +105,109 @@ fn readBiome(byte: u8) !BiomeId {
     return std.enums.fromInt(BiomeId, byte) orelse CacheError.InvalidBiome;
 }
 
+fn writeMaterialLayers(buf: []u8, layers: LODMaterialLayers) void {
+    writeBlock(buf[0..1], layers.surface);
+    writeBlock(buf[1..2], layers.subsurface);
+    writeBlock(buf[2..3], layers.foundation);
+}
+
+fn readMaterialLayers(buf: []const u8) !LODMaterialLayers {
+    return .{
+        .surface = try readBlock(buf[0]),
+        .subsurface = try readBlock(buf[1]),
+        .foundation = try readBlock(buf[2]),
+    };
+}
+
+fn writeWater(buf: []u8, water: LODWaterState) void {
+    buf[0] = if (water.is_surface) 1 else 0;
+    writeF32(buf[1..][0..4], water.surface_height);
+    writeF32(buf[5..][0..4], water.depth);
+    writeF32(buf[9..][0..4], water.coverage);
+}
+
+fn readWater(buf: []const u8) LODWaterState {
+    return .{
+        .is_surface = buf[0] != 0,
+        .surface_height = readF32(buf[1..][0..4]),
+        .depth = readF32(buf[5..][0..4]),
+        .coverage = readF32(buf[9..][0..4]),
+    };
+}
+
+fn writeLighting(buf: []u8, lighting: LODLightingHint) void {
+    buf[0] = lighting.sky_light;
+    buf[1] = lighting.block_light;
+    writeF32(buf[2..][0..4], lighting.ambient_occlusion);
+}
+
+fn readLighting(buf: []const u8) LODLightingHint {
+    return .{
+        .sky_light = buf[0],
+        .block_light = buf[1],
+        .ambient_occlusion = readF32(buf[2..][0..4]),
+    };
+}
+
+fn writeVegetation(buf: []u8, vegetation: LODVegetationHint) void {
+    writeF32(buf[0..][0..4], vegetation.tree_coverage);
+    writeF32(buf[4..][0..4], vegetation.avg_tree_height);
+    writeF32(buf[8..][0..4], vegetation.offset_x);
+    writeF32(buf[12..][0..4], vegetation.offset_z);
+    writeBlock(buf[16..17], vegetation.trunk);
+    writeBlock(buf[17..18], vegetation.leaves);
+}
+
+fn readVegetation(buf: []const u8) !LODVegetationHint {
+    return .{
+        .tree_coverage = readF32(buf[0..][0..4]),
+        .avg_tree_height = readF32(buf[4..][0..4]),
+        .offset_x = readF32(buf[8..][0..4]),
+        .offset_z = readF32(buf[12..][0..4]),
+        .trunk = try readBlock(buf[16]),
+        .leaves = try readBlock(buf[17]),
+    };
+}
+
+fn writeSpan(buf: []u8, span: LODVerticalSpan) void {
+    var off: usize = 0;
+    writeF32(buf[off..][0..4], span.min_height);
+    off += 4;
+    writeF32(buf[off..][0..4], span.max_height);
+    off += 4;
+    buf[off] = @intFromEnum(span.biome);
+    off += 1;
+    writeMaterialLayers(buf[off..][0..3], span.material_layers);
+    off += 3;
+    std.mem.writeInt(u32, buf[off..][0..4], span.color, .little);
+    off += 4;
+    writeWater(buf[off..][0..WATER_WIRE_SIZE], span.water);
+    off += WATER_WIRE_SIZE;
+    writeLighting(buf[off..][0..LIGHTING_WIRE_SIZE], span.lighting);
+    off += LIGHTING_WIRE_SIZE;
+    writeVegetation(buf[off..][0..VEGETATION_WIRE_SIZE], span.vegetation);
+}
+
+fn readSpan(buf: []const u8) !LODVerticalSpan {
+    var off: usize = 0;
+    const min_height = readF32(buf[off..][0..4]);
+    off += 4;
+    const max_height = readF32(buf[off..][0..4]);
+    off += 4;
+    const biome = try readBiome(buf[off]);
+    off += 1;
+    const material_layers = try readMaterialLayers(buf[off..][0..3]);
+    off += 3;
+    const color = std.mem.readInt(u32, buf[off..][0..4], .little);
+    off += 4;
+    const water = readWater(buf[off..][0..WATER_WIRE_SIZE]);
+    off += WATER_WIRE_SIZE;
+    const lighting = readLighting(buf[off..][0..LIGHTING_WIRE_SIZE]);
+    off += LIGHTING_WIRE_SIZE;
+    const vegetation = try readVegetation(buf[off..][0..VEGETATION_WIRE_SIZE]);
+    return .{ .min_height = min_height, .max_height = max_height, .biome = biome, .material_layers = material_layers, .color = color, .water = water, .lighting = lighting, .vegetation = vegetation };
+}
+
 fn computeCrc(bytes: []const u8) u32 {
     var crc = std.hash.Crc32.init();
     crc.update(bytes[0..6]);
@@ -98,7 +219,7 @@ fn computeCrc(bytes: []const u8) u32 {
 pub fn serialize(data: *const LODSimplifiedData, key: Key, allocator: std.mem.Allocator) ![]u8 {
     const width_usize = @as(usize, @intCast(data.width));
     const count = width_usize * width_usize;
-    const total_size = HEADER_SIZE + payloadSize(count);
+    const total_size = serializedSize(data);
     const buf = try allocator.alloc(u8, total_size);
     errdefer allocator.free(buf);
 
@@ -141,40 +262,36 @@ pub fn serialize(data: *const LODSimplifiedData, key: Key, allocator: std.mem.Al
         off += 4;
     }
     for (data.material_layers) |layers| {
-        writeBlock(buf[off..][0..1], layers.surface);
-        writeBlock(buf[off + 1 ..][0..1], layers.subsurface);
-        writeBlock(buf[off + 2 ..][0..1], layers.foundation);
+        writeMaterialLayers(buf[off..][0..3], layers);
         off += 3;
     }
     for (data.water) |water| {
-        buf[off] = if (water.is_surface) 1 else 0;
-        off += 1;
-        writeF32(buf[off..][0..4], water.surface_height);
-        off += 4;
-        writeF32(buf[off..][0..4], water.depth);
-        off += 4;
-        writeF32(buf[off..][0..4], water.coverage);
-        off += 4;
+        writeWater(buf[off..][0..WATER_WIRE_SIZE], water);
+        off += WATER_WIRE_SIZE;
     }
     for (data.lighting) |lighting| {
-        buf[off] = lighting.sky_light;
-        buf[off + 1] = lighting.block_light;
-        off += 2;
-        writeF32(buf[off..][0..4], lighting.ambient_occlusion);
-        off += 4;
+        writeLighting(buf[off..][0..LIGHTING_WIRE_SIZE], lighting);
+        off += LIGHTING_WIRE_SIZE;
     }
     for (data.vegetation) |vegetation| {
-        writeF32(buf[off..][0..4], vegetation.tree_coverage);
-        off += 4;
-        writeF32(buf[off..][0..4], vegetation.avg_tree_height);
-        off += 4;
-        writeF32(buf[off..][0..4], vegetation.offset_x);
-        off += 4;
-        writeF32(buf[off..][0..4], vegetation.offset_z);
-        off += 4;
-        writeBlock(buf[off..][0..1], vegetation.trunk);
-        writeBlock(buf[off + 1 ..][0..1], vegetation.leaves);
-        off += 2;
+        writeVegetation(buf[off..][0..VEGETATION_WIRE_SIZE], vegetation);
+        off += VEGETATION_WIRE_SIZE;
+    }
+
+    const has_spans = data.hasVerticalSpans();
+    buf[off] = if (has_spans) 1 else 0;
+    off += 1;
+    if (has_spans) {
+        const counts = data.vertical_span_counts.?;
+        const spans = data.vertical_spans.?;
+        @memset(buf[off..][0..count], @intFromEnum(ColumnProvenance.worldgen));
+        off += count;
+        @memcpy(buf[off..][0..count], counts);
+        off += count;
+        for (spans) |span| {
+            writeSpan(buf[off..][0..SPAN_WIRE_SIZE], span);
+            off += SPAN_WIRE_SIZE;
+        }
     }
 
     std.debug.assert(off == total_size);
@@ -190,7 +307,8 @@ pub fn deserialize(bytes: []const u8, key: Key, allocator: std.mem.Allocator) !L
     if (std.mem.readInt(u32, bytes[off..][0..4], .little) != MAGIC) return CacheError.InvalidMagic;
     off += 4;
 
-    if (bytes[off] != CACHE_VERSION) return CacheError.UnsupportedVersion;
+    const version = bytes[off];
+    if (version != CACHE_VERSION and version != CACHE_VERSION_V1) return CacheError.UnsupportedVersion;
     off += 1;
     const lod_byte = bytes[off];
     off += 1;
@@ -217,10 +335,20 @@ pub fn deserialize(bytes: []const u8, key: Key, allocator: std.mem.Allocator) !L
     if (width != LODSimplifiedData.getGridSize(key.lod)) return CacheError.InvalidWidth;
 
     const count = @as(usize, @intCast(width)) * @as(usize, @intCast(width));
-    const expected = HEADER_SIZE + payloadSize(count);
+    const v1_expected = HEADER_SIZE + payloadSize(count);
+    if (bytes.len < v1_expected) return CacheError.DataTooShort;
+
+    var has_spans = false;
+    var expected = v1_expected;
+    if (version == CACHE_VERSION) {
+        if (bytes.len < v1_expected + SPAN_FLAGS_WIRE_SIZE) return CacheError.DataTooShort;
+        has_spans = bytes[v1_expected] != 0;
+        expected = v1_expected + SPAN_FLAGS_WIRE_SIZE;
+        if (has_spans) expected += count + count + count * world_core.MAX_LOD_VERTICAL_SPANS * SPAN_WIRE_SIZE;
+    }
     if (bytes.len < expected) return CacheError.DataTooShort;
 
-    var data = try LODSimplifiedData.init(allocator, key.lod);
+    var data = if (has_spans) try LODSimplifiedData.initWithVerticalSpans(allocator, key.lod) else try LODSimplifiedData.init(allocator, key.lod);
     errdefer data.deinit();
 
     for (data.heightmap) |*height| {
@@ -240,40 +368,40 @@ pub fn deserialize(bytes: []const u8, key: Key, allocator: std.mem.Allocator) !L
         off += 4;
     }
     for (data.material_layers) |*layers| {
-        layers.* = LODMaterialLayers{
-            .surface = try readBlock(bytes[off]),
-            .subsurface = try readBlock(bytes[off + 1]),
-            .foundation = try readBlock(bytes[off + 2]),
-        };
+        layers.* = try readMaterialLayers(bytes[off..][0..3]);
         off += 3;
     }
     for (data.water) |*water| {
-        water.* = LODWaterState{
-            .is_surface = bytes[off] != 0,
-            .surface_height = readF32(bytes[off + 1 ..][0..4]),
-            .depth = readF32(bytes[off + 5 ..][0..4]),
-            .coverage = readF32(bytes[off + 9 ..][0..4]),
-        };
+        water.* = readWater(bytes[off..][0..WATER_WIRE_SIZE]);
         off += 13;
     }
     for (data.lighting) |*lighting| {
-        lighting.* = LODLightingHint{
-            .sky_light = bytes[off],
-            .block_light = bytes[off + 1],
-            .ambient_occlusion = readF32(bytes[off + 2 ..][0..4]),
-        };
+        lighting.* = readLighting(bytes[off..][0..LIGHTING_WIRE_SIZE]);
         off += 6;
     }
     for (data.vegetation) |*vegetation| {
-        vegetation.* = LODVegetationHint{
-            .tree_coverage = readF32(bytes[off..][0..4]),
-            .avg_tree_height = readF32(bytes[off + 4 ..][0..4]),
-            .offset_x = readF32(bytes[off + 8 ..][0..4]),
-            .offset_z = readF32(bytes[off + 12 ..][0..4]),
-            .trunk = try readBlock(bytes[off + 16]),
-            .leaves = try readBlock(bytes[off + 17]),
-        };
+        vegetation.* = try readVegetation(bytes[off..][0..VEGETATION_WIRE_SIZE]);
         off += 18;
+    }
+
+    if (version == CACHE_VERSION) {
+        const flags = bytes[off];
+        off += 1;
+        if ((flags & ~@as(u8, 1)) != 0) return CacheError.InvalidSpanCount;
+        if (has_spans) {
+            off += count; // provenance reserved for Phase 2; all v2 writes use worldgen.
+            const counts = data.vertical_span_counts.?;
+            @memcpy(counts, bytes[off..][0..count]);
+            off += count;
+            for (counts) |span_count| {
+                if (span_count > world_core.MAX_LOD_VERTICAL_SPANS) return CacheError.InvalidSpanCount;
+            }
+            const spans = data.vertical_spans.?;
+            for (spans) |*span| {
+                span.* = try readSpan(bytes[off..][0..SPAN_WIRE_SIZE]);
+                off += SPAN_WIRE_SIZE;
+            }
+        }
     }
 
     std.debug.assert(off == expected);
@@ -324,6 +452,72 @@ test "LOD cache round-trip preserves source data" {
     try testing.expectEqual(data.water[idx].depth, decoded.water[idx].depth);
     try testing.expectEqual(data.lighting[idx].sky_light, decoded.lighting[idx].sky_light);
     try testing.expectEqual(data.vegetation[idx].leaves, decoded.vegetation[idx].leaves);
+}
+
+test "LOD cache round-trip preserves vertical spans" {
+    var data = try LODSimplifiedData.initWithVerticalSpans(testing.allocator, .lod1);
+    defer data.deinit();
+
+    const lower = LODVerticalSpan{
+        .min_height = 12.0,
+        .max_height = 48.0,
+        .biome = .forest,
+        .material_layers = .{ .surface = .grass, .subsurface = .dirt, .foundation = .stone },
+        .color = 0xFF112233,
+        .water = .empty,
+        .lighting = .{ .sky_light = 9, .block_light = 1, .ambient_occlusion = 0.7 },
+        .vegetation = .{ .tree_coverage = 0.5, .avg_tree_height = 7.0, .offset_x = 0.25, .offset_z = -0.25, .trunk = .wood, .leaves = .leaves },
+    };
+    const upper = LODVerticalSpan{
+        .min_height = 49.0,
+        .max_height = 92.0,
+        .biome = .mountains,
+        .material_layers = .{ .surface = .stone, .subsurface = .stone, .foundation = .stone },
+        .color = 0xFF8899AA,
+        .water = .{ .is_surface = true, .surface_height = 64.0, .depth = 2.0, .coverage = 0.25 },
+        .lighting = .daylight,
+        .vegetation = .empty,
+    };
+    try testing.expect(data.setVerticalSpan(2, 3, 0, lower));
+    try testing.expect(data.setVerticalSpan(2, 3, 1, upper));
+
+    const key = Key{ .seed = 1234, .generator_identity_hash = 99, .generator_version = 7, .rx = -2, .rz = 3, .lod = .lod1 };
+    const bytes = try serialize(&data, key, testing.allocator);
+    defer testing.allocator.free(bytes);
+
+    var decoded = try deserialize(bytes, key, testing.allocator);
+    defer decoded.deinit();
+
+    try testing.expect(decoded.hasVerticalSpans());
+    try testing.expectEqual(data.vertical_span_counts.?.len, decoded.vertical_span_counts.?.len);
+    try testing.expectEqualSlices(u8, data.vertical_span_counts.?, decoded.vertical_span_counts.?);
+    try testing.expectEqual(data.vertical_spans.?.len, decoded.vertical_spans.?.len);
+    try testing.expectEqualSlices(u8, std.mem.sliceAsBytes(data.vertical_spans.?), std.mem.sliceAsBytes(decoded.vertical_spans.?));
+}
+
+test "LOD cache accepts v1 payload as span-less data" {
+    var data = try LODSimplifiedData.init(testing.allocator, .lod2);
+    defer data.deinit();
+    data.setColumn(1, 1, 91.0, .mountains, .{ .surface = .stone, .subsurface = .dirt, .foundation = .stone }, 0xFF445566, .empty, .daylight, .empty);
+
+    const key = Key{ .seed = 4, .generator_identity_hash = 5, .generator_version = 6, .rx = -1, .rz = -2, .lod = .lod2 };
+    const v2_bytes = try serialize(&data, key, testing.allocator);
+    defer testing.allocator.free(v2_bytes);
+    const count = @as(usize, @intCast(data.width)) * @as(usize, @intCast(data.width));
+    const v1_size = HEADER_SIZE + payloadSize(count);
+    const v1_bytes = try testing.allocator.dupe(u8, v2_bytes[0..v1_size]);
+    defer testing.allocator.free(v1_bytes);
+    v1_bytes[4] = CACHE_VERSION_V1;
+    std.mem.writeInt(u32, v1_bytes[6..][0..4], 0, .little);
+    std.mem.writeInt(u32, v1_bytes[6..][0..4], computeCrc(v1_bytes), .little);
+
+    var decoded = try deserialize(v1_bytes, key, testing.allocator);
+    defer decoded.deinit();
+
+    try testing.expect(!decoded.hasVerticalSpans());
+    const idx = 1 + data.width;
+    try testing.expectEqual(data.heightmap[idx], decoded.heightmap[idx]);
+    try testing.expectEqual(data.biomes[idx], decoded.biomes[idx]);
 }
 
 test "LOD cache rejects checksum mismatch" {

--- a/modules/world-lod/src/lod_chunk.zig
+++ b/modules/world-lod/src/lod_chunk.zig
@@ -162,6 +162,9 @@ pub const LODChunk = struct {
     min_height: f32,
     max_height: f32,
 
+    /// Number of direct 2x2 finer child regions currently renderable.
+    ready_children: u8,
+
     /// Dirty flag for re-meshing
     dirty: bool,
 
@@ -177,6 +180,7 @@ pub const LODChunk = struct {
             .mesh_handle = 0,
             .min_height = 0.0,
             .max_height = @floatFromInt(CHUNK_SIZE_Y),
+            .ready_children = 0,
             .dirty = false,
         };
     }

--- a/modules/world-lod/src/lod_chunk.zig
+++ b/modules/world-lod/src/lod_chunk.zig
@@ -54,6 +54,30 @@ pub const LODRegionKey = struct {
         return a.rx == b.rx and a.rz == b.rz and a.lod == b.lod;
     }
 
+    pub fn parentKey(self: LODRegionKey) ?LODRegionKey {
+        const lod_idx = @intFromEnum(self.lod);
+        if (lod_idx + 1 >= LODLevel.count) return null;
+        return .{
+            .rx = @divFloor(self.rx, 2),
+            .rz = @divFloor(self.rz, 2),
+            .lod = @enumFromInt(@as(u3, @intCast(lod_idx + 1))),
+        };
+    }
+
+    pub fn childKeys(self: LODRegionKey) ?[4]LODRegionKey {
+        const lod_idx = @intFromEnum(self.lod);
+        if (lod_idx == 0) return null;
+        const child_lod: LODLevel = @enumFromInt(@as(u3, @intCast(lod_idx - 1)));
+        const base_x = self.rx * 2;
+        const base_z = self.rz * 2;
+        return .{
+            .{ .rx = base_x, .rz = base_z, .lod = child_lod },
+            .{ .rx = base_x + 1, .rz = base_z, .lod = child_lod },
+            .{ .rx = base_x, .rz = base_z + 1, .lod = child_lod },
+            .{ .rx = base_x + 1, .rz = base_z + 1, .lod = child_lod },
+        };
+    }
+
     /// Get the chunk coordinates that this region covers
     pub fn chunkBounds(self: LODRegionKey) ChunkBounds {
         const scale: i32 = @intCast(self.lod.chunksPerSide());
@@ -134,6 +158,10 @@ pub const LODChunk = struct {
     /// Mesh handle (0 = no mesh)
     mesh_handle: u32,
 
+    /// Actual source-data height bounds in world block coordinates.
+    min_height: f32,
+    max_height: f32,
+
     /// Dirty flag for re-meshing
     dirty: bool,
 
@@ -147,6 +175,8 @@ pub const LODChunk = struct {
             .pin_count = std.atomic.Value(u32).init(0),
             .data = .{ .empty = {} },
             .mesh_handle = 0,
+            .min_height = 0.0,
+            .max_height = @floatFromInt(CHUNK_SIZE_Y),
             .dirty = false,
         };
     }
@@ -179,6 +209,8 @@ pub const LODChunk = struct {
         min_z: i32,
         max_x: i32,
         max_z: i32,
+        min_y: f32,
+        max_y: f32,
     };
 
     /// Get the world-space bounds of this LOD region
@@ -190,7 +222,39 @@ pub const LODChunk = struct {
             .min_z = self.region_z * size,
             .max_x = self.region_x * size + size,
             .max_z = self.region_z * size + size,
+            .min_y = self.min_height,
+            .max_y = self.max_height,
         };
+    }
+
+    pub fn updateHeightBoundsFromData(self: *LODChunk) void {
+        switch (self.data) {
+            .simplified => |*data| {
+                var min_height: f32 = std.math.floatMax(f32);
+                var max_height: f32 = -std.math.floatMax(f32);
+                if (data.hasVerticalSpans()) {
+                    const counts = data.vertical_span_counts.?;
+                    const spans = data.vertical_spans.?;
+                    for (counts, 0..) |span_count, column_idx| {
+                        var span_idx: usize = 0;
+                        while (span_idx < span_count) : (span_idx += 1) {
+                            const span = spans[column_idx * world_core.MAX_LOD_VERTICAL_SPANS + span_idx];
+                            min_height = @min(min_height, span.min_height);
+                            max_height = @max(max_height, span.max_height);
+                        }
+                    }
+                }
+                for (data.heightmap) |height| {
+                    min_height = @min(min_height, height);
+                    max_height = @max(max_height, height);
+                }
+                if (min_height <= max_height) {
+                    self.min_height = min_height;
+                    self.max_height = max_height;
+                }
+            },
+            else => {},
+        }
     }
 
     pub fn chunkBounds(self: *const LODChunk) ChunkBounds {
@@ -225,6 +289,7 @@ pub const ILODConfig = struct {
         getMeshPath: *const fn (ptr: *anyopaque) LODMeshPath,
         getFogStartPercent: *const fn (ptr: *anyopaque, lod: LODLevel) f32,
         getFallbackMissingChildThreshold: *const fn (ptr: *anyopaque) f32,
+        getMemoryBudgetMB: *const fn (ptr: *anyopaque) u32,
     };
 
     pub fn getRadii(self: ILODConfig) [LODLevel.count]i32 {
@@ -284,6 +349,10 @@ pub const ILODConfig = struct {
 
     pub fn getFallbackMissingChildThreshold(self: ILODConfig) f32 {
         return self.vtable.getFallbackMissingChildThreshold(self.ptr);
+    }
+
+    pub fn getMemoryBudgetMB(self: ILODConfig) u32 {
+        return self.vtable.getMemoryBudgetMB(self.ptr);
     }
 };
 
@@ -390,6 +459,7 @@ pub const LODConfig = struct {
         .getMeshPath = getMeshPathWrapper,
         .getFogStartPercent = getFogStartPercentWrapper,
         .getFallbackMissingChildThreshold = getFallbackMissingChildThresholdWrapper,
+        .getMemoryBudgetMB = getMemoryBudgetMBWrapper,
     };
 
     fn getRadiiWrapper(ptr: *anyopaque) [LODLevel.count]i32 {
@@ -459,6 +529,10 @@ pub const LODConfig = struct {
         const self: *LODConfig = @ptrCast(@alignCast(ptr));
         return std.math.clamp(self.fallback_missing_child_threshold, 0.0, 1.0);
     }
+    fn getMemoryBudgetMBWrapper(ptr: *anyopaque) u32 {
+        const self: *LODConfig = @ptrCast(@alignCast(ptr));
+        return self.memory_budget_mb;
+    }
 };
 
 // Tests
@@ -482,6 +556,18 @@ test "LODRegionKey from chunk coords" {
     const key2 = LODRegionKey.fromChunkCoords(-3, -5, .lod2);
     try std.testing.expectEqual(@as(i32, -1), key2.rx); // -3 / 8 = -1
     try std.testing.expectEqual(@as(i32, -1), key2.rz); // -5 / 8 = -1
+}
+
+test "LODRegionKey parent and child keys handle negative coordinates" {
+    const child = LODRegionKey{ .rx = -1, .rz = -3, .lod = .lod1 };
+    const parent = child.parentKey().?;
+    try std.testing.expectEqual(LODRegionKey{ .rx = -1, .rz = -2, .lod = .lod2 }, parent);
+
+    const children = parent.childKeys().?;
+    try std.testing.expectEqual(LODRegionKey{ .rx = -2, .rz = -4, .lod = .lod1 }, children[0]);
+    try std.testing.expectEqual(LODRegionKey{ .rx = -1, .rz = -4, .lod = .lod1 }, children[1]);
+    try std.testing.expectEqual(LODRegionKey{ .rx = -2, .rz = -3, .lod = .lod1 }, children[2]);
+    try std.testing.expectEqual(LODRegionKey{ .rx = -1, .rz = -3, .lod = .lod1 }, children[3]);
 }
 
 test "LODConfig distance calculation" {

--- a/modules/world-lod/src/lod_manager.zig
+++ b/modules/world-lod/src/lod_manager.zig
@@ -584,10 +584,45 @@ pub const LODManager = struct {
                             continue;
                         };
                     }
-                    chunk.state = .renderable;
+                    self.markRegionRenderable(key, chunk);
                     uploads += 1;
                 }
             }
+        }
+    }
+
+    fn countRenderableChildren(self: *Self, key: LODRegionKey) u8 {
+        const children = key.childKeys() orelse return 0;
+        const child_idx = @intFromEnum(children[0].lod);
+        var count: u8 = 0;
+        for (children) |child_key| {
+            const child = self.regions[child_idx].get(child_key) orelse continue;
+            if (child.state == .renderable) count += 1;
+        }
+        return count;
+    }
+
+    fn adjustParentReadyChildren(self: *Self, key: LODRegionKey, delta: i8) void {
+        const parent = key.parentKey() orelse return;
+        const parent_chunk = self.regions[@intFromEnum(parent.lod)].get(parent) orelse return;
+        if (delta > 0) {
+            parent_chunk.ready_children = @min(parent_chunk.ready_children + @as(u8, @intCast(delta)), 4);
+        } else if (delta < 0) {
+            const amount: u8 = @intCast(-delta);
+            parent_chunk.ready_children = if (amount >= parent_chunk.ready_children) 0 else parent_chunk.ready_children - amount;
+        }
+    }
+
+    fn markRegionRenderable(self: *Self, key: LODRegionKey, chunk: *LODChunk) void {
+        if (chunk.state == .renderable) return;
+        chunk.ready_children = self.countRenderableChildren(key);
+        chunk.state = .renderable;
+        self.adjustParentReadyChildren(key, 1);
+    }
+
+    fn noteRegionRemoved(self: *Self, key: LODRegionKey, chunk: *const LODChunk) void {
+        if (chunk.state == .renderable) {
+            self.adjustParentReadyChildren(key, -1);
         }
     }
 
@@ -637,14 +672,11 @@ pub const LODManager = struct {
                     const meshes = &self.meshes[@intFromEnum(lod)];
                     if (meshes.get(key)) |mesh| {
                         // Push to deferred deletion queue instead of deleting immediately
-                        self.deletion_queue.append(self.allocator, mesh) catch {
-                            // Fallback if allocation fails: delete immediately (slow but safe)
-                            self.gpu_bridge.destroy(mesh);
-                            self.allocator.destroy(mesh);
-                        };
+                        self.queueMeshDeletion(mesh);
                         _ = meshes.remove(key);
                     }
 
+                    self.noteRegionRemoved(key, chunk);
                     chunk.deinit(self.allocator);
                     self.allocator.destroy(chunk);
                     _ = storage.remove(key);
@@ -690,6 +722,8 @@ pub const LODManager = struct {
                 const key = entry.key_ptr.*;
                 const chunk = entry.value_ptr.*;
                 if (chunk.state != .renderable or chunk.isPinned()) continue;
+                // Coarsest active LOD regions have no renderable parent fallback and are
+                // intentionally excluded so eviction never opens horizon holes.
                 const parent = key.parentKey() orelse continue;
                 const parent_idx = @intFromEnum(parent.lod);
                 const parent_chunk = self.regions[parent_idx].get(parent) orelse continue;
@@ -717,6 +751,7 @@ pub const LODManager = struct {
                 self.queueMeshDeletion(m);
                 _ = self.meshes[idx].remove(candidate.key);
             }
+            self.noteRegionRemoved(candidate.key, chunk);
             chunk.deinit(self.allocator);
             self.allocator.destroy(chunk);
             _ = self.regions[idx].remove(candidate.key);
@@ -888,12 +923,10 @@ pub const LODManager = struct {
             for (to_remove.items) |rem_key| {
                 if (meshes.fetchRemove(rem_key)) |mesh_entry| {
                     // Queue for deferred deletion to avoid waitIdle stutter
-                    self.deletion_queue.append(self.allocator, mesh_entry.value) catch {
-                        self.gpu_bridge.destroy(mesh_entry.value);
-                        self.allocator.destroy(mesh_entry.value);
-                    };
+                    self.queueMeshDeletion(mesh_entry.value);
                 }
                 if (storage.fetchRemove(rem_key)) |chunk_entry| {
+                    self.noteRegionRemoved(rem_key, chunk_entry.value);
                     chunk_entry.value.deinit(self.allocator);
                     self.allocator.destroy(chunk_entry.value);
                 }
@@ -1391,4 +1424,132 @@ test "LODManager cache helpers delete corrupt cache files" {
 
     try testing.expect(manager.loadCachedSourceData(key) == null);
     try testing.expectError(error.FileNotFound, fs.cwd().openFile(path, .{}));
+}
+
+fn initEvictionTestManager(allocator: std.mem.Allocator, config: *LODConfig) !LODManager {
+    var manager = LODManager.initCacheTestManager(allocator, "");
+    manager.config = config.interface();
+    for (0..LODLevel.count) |i| {
+        manager.regions[i] = RegionMap.init(allocator);
+        manager.meshes[i] = MeshMap.init(allocator);
+    }
+    var bridge_ctx: u8 = 0;
+    manager.gpu_bridge = .{
+        .on_upload = struct {
+            fn f(_: *LODMesh, _: *anyopaque) @import("engine-rhi").RhiError!void {}
+        }.f,
+        .on_destroy = struct {
+            fn f(_: *LODMesh, _: *anyopaque) void {}
+        }.f,
+        .on_wait_idle = struct {
+            fn f(_: *anyopaque) void {}
+        }.f,
+        .ctx = @ptrCast(&bridge_ctx),
+    };
+    return manager;
+}
+
+fn deinitEvictionTestManager(manager: *LODManager) void {
+    for (0..LODLevel.count) |i| {
+        var region_iter = manager.regions[i].iterator();
+        while (region_iter.next()) |entry| {
+            entry.value_ptr.*.deinit(manager.allocator);
+            manager.allocator.destroy(entry.value_ptr.*);
+        }
+        manager.regions[i].deinit();
+
+        var mesh_iter = manager.meshes[i].iterator();
+        while (mesh_iter.next()) |entry| {
+            manager.allocator.destroy(entry.value_ptr.*);
+        }
+        manager.meshes[i].deinit();
+    }
+    for (manager.deletion_queue.items) |mesh| {
+        manager.allocator.destroy(mesh);
+    }
+    manager.deletion_queue.deinit(manager.allocator);
+}
+
+fn putTestRegion(manager: *LODManager, key: LODRegionKey, state: LODState) !*LODChunk {
+    const chunk = try manager.allocator.create(LODChunk);
+    chunk.* = LODChunk.init(key.rx, key.rz, key.lod);
+    chunk.state = state;
+    try manager.regions[@intFromEnum(key.lod)].put(key, chunk);
+    return chunk;
+}
+
+fn putTestMesh(manager: *LODManager, key: LODRegionKey, capacity: u32) !*LODMesh {
+    const mesh = try manager.allocator.create(LODMesh);
+    mesh.* = LODMesh.init(manager.allocator, key.lod);
+    mesh.ready = true;
+    mesh.vertex_count = 1;
+    mesh.capacity = capacity;
+    try manager.meshes[@intFromEnum(key.lod)].put(key, mesh);
+    return mesh;
+}
+
+test "LODManager ready child counters update on renderable transitions and removal" {
+    var config = LODConfig{};
+    var manager = try initEvictionTestManager(testing.allocator, &config);
+    defer deinitEvictionTestManager(&manager);
+
+    const child_key = LODRegionKey{ .rx = 2, .rz = 0, .lod = .lod1 };
+    const child = try putTestRegion(&manager, child_key, .mesh_ready);
+    manager.markRegionRenderable(child_key, child);
+
+    const parent_key = child_key.parentKey().?;
+    const parent = try putTestRegion(&manager, parent_key, .mesh_ready);
+    manager.markRegionRenderable(parent_key, parent);
+    try testing.expectEqual(@as(u8, 1), parent.ready_children);
+
+    manager.noteRegionRemoved(child_key, child);
+    try testing.expectEqual(@as(u8, 0), parent.ready_children);
+}
+
+test "LODManager memory budget eviction skips unsafe regions and evicts farthest first" {
+    var config = LODConfig{ .memory_budget_mb = 1 };
+    var manager = try initEvictionTestManager(testing.allocator, &config);
+    defer deinitEvictionTestManager(&manager);
+
+    const budget_bytes = @as(usize, config.memory_budget_mb) * 1024 * 1024;
+    const eviction_bytes = 600 * 1024;
+    const mesh_capacity: u32 = @intCast(@max(eviction_bytes / @sizeOf(Vertex), 1));
+    const mesh_bytes = @as(usize, mesh_capacity) * @sizeOf(Vertex);
+
+    const near_key = LODRegionKey{ .rx = 2, .rz = 0, .lod = .lod1 };
+    const far_key = LODRegionKey{ .rx = 20, .rz = 0, .lod = .lod1 };
+    const pinned_key = LODRegionKey{ .rx = 40, .rz = 0, .lod = .lod1 };
+    const no_parent_key = LODRegionKey{ .rx = 60, .rz = 0, .lod = .lod1 };
+    const in_flight_key = LODRegionKey{ .rx = 80, .rz = 0, .lod = .lod1 };
+
+    _ = try putTestRegion(&manager, near_key.parentKey().?, .renderable);
+    _ = try putTestRegion(&manager, far_key.parentKey().?, .renderable);
+    _ = try putTestRegion(&manager, pinned_key.parentKey().?, .renderable);
+    _ = try putTestRegion(&manager, in_flight_key.parentKey().?, .renderable);
+
+    _ = try putTestRegion(&manager, near_key, .renderable);
+    _ = try putTestRegion(&manager, far_key, .renderable);
+    const pinned_chunk = try putTestRegion(&manager, pinned_key, .renderable);
+    pinned_chunk.pin();
+    _ = try putTestRegion(&manager, no_parent_key, .renderable);
+    _ = try putTestRegion(&manager, in_flight_key, .generating);
+
+    _ = try putTestMesh(&manager, near_key, mesh_capacity);
+    _ = try putTestMesh(&manager, far_key, mesh_capacity);
+    _ = try putTestMesh(&manager, pinned_key, mesh_capacity);
+    _ = try putTestMesh(&manager, no_parent_key, mesh_capacity);
+    _ = try putTestMesh(&manager, in_flight_key, mesh_capacity);
+
+    manager.memory_used_bytes = budget_bytes + mesh_bytes;
+    try manager.enforceMemoryBudget();
+
+    try testing.expect(!manager.regions[1].contains(far_key));
+    try testing.expect(!manager.meshes[1].contains(far_key));
+    try testing.expect(manager.regions[1].contains(near_key));
+    try testing.expect(manager.regions[1].contains(pinned_key));
+    try testing.expect(manager.regions[1].contains(no_parent_key));
+    try testing.expect(manager.regions[1].contains(in_flight_key));
+    try testing.expect(manager.memory_used_bytes <= budget_bytes);
+    try testing.expectEqual(@as(u32, 1), manager.stats.evictions);
+    try testing.expectEqual(@as(u32, 1), manager.deletion_queue.items.len);
 }

--- a/modules/world-lod/src/lod_manager.zig
+++ b/modules/world-lod/src/lod_manager.zig
@@ -416,19 +416,23 @@ pub const LODManager = struct {
 
         // Update stats
         self.updateStats();
+        self.enforceMemoryBudget() catch |err| {
+            log.log.warn("LOD memory budget eviction error: {} (non-fatal)", .{err});
+        };
 
         // Periodic WARN-level LOD stats so logs/zigcraft.log shows LOD fill
         // progress by default (no env vars needed). update_tick counts frames;
         // every ~180 frames (~3s @ 60fps) gives a trend over a 20s diagnostic run.
         if (self.update_tick % 180 == 0) {
             const s = self.stats;
-            log.log.warn("LOD_STATS: loaded=[L1:{},L2:{},L3:{}] generating=[{},{},{}] meshing=[{},{},{}] genQ3={} uploadQ=[{},{},{}] meshes=[{},{},{}] cache_hit/miss={}/{}", .{
+            log.log.warn("LOD_STATS: loaded=[L1:{},L2:{},L3:{}] generating=[{},{},{}] meshing=[{},{},{}] genQ3={} uploadQ=[{},{},{}] meshes=[{},{},{}] cache_hit/miss={}/{} store_hit/miss={}/{} evictions={}", .{
                 s.loaded[1],                           s.loaded[2],             s.loaded[3],
                 s.generating[1],                       s.generating[2],         s.generating[3],
                 s.meshing[1],                          s.meshing[2],            s.meshing[3],
                 s.gen_queue_depth[LODLevel.count - 1], s.upload_queue_depth[1], s.upload_queue_depth[2],
                 s.upload_queue_depth[3],               s.mesh_count[1],         s.mesh_count[2],
                 s.mesh_count[3],                       s.cache_hits,            s.cache_misses,
+                s.store_hits,                          s.store_misses,          s.evictions,
             });
         }
 
@@ -649,6 +653,79 @@ pub const LODManager = struct {
         }
     }
 
+    fn queueMeshDeletion(self: *Self, mesh: *LODMesh) void {
+        self.deletion_queue.append(self.allocator, mesh) catch {
+            self.gpu_bridge.destroy(mesh);
+            self.allocator.destroy(mesh);
+        };
+    }
+
+    fn regionMemoryBytes(chunk: *const LODChunk, mesh: ?*LODMesh) usize {
+        var total: usize = 0;
+        switch (chunk.data) {
+            .simplified => |*s| total += s.totalMemoryBytes(),
+            else => {},
+        }
+        if (mesh) |m| total += m.capacity * @sizeOf(Vertex);
+        return total;
+    }
+
+    fn enforceMemoryBudget(self: *Self) !void {
+        const budget_mb = self.config.getMemoryBudgetMB();
+        if (budget_mb == 0) return;
+        const budget_bytes = @as(usize, budget_mb) * 1024 * 1024;
+        if (self.memory_used_bytes <= budget_bytes) return;
+
+        const Candidate = struct { key: LODRegionKey, distance_sq: i64 };
+        var candidates = std.ArrayListUnmanaged(Candidate).empty;
+        defer candidates.deinit(self.allocator);
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const active_lod_count = lod_chunk.activeLODCount(self.config);
+        for (1..active_lod_count) |i| {
+            var iter = self.regions[i].iterator();
+            while (iter.next()) |entry| {
+                const key = entry.key_ptr.*;
+                const chunk = entry.value_ptr.*;
+                if (chunk.state != .renderable or chunk.isPinned()) continue;
+                const parent = key.parentKey() orelse continue;
+                const parent_idx = @intFromEnum(parent.lod);
+                const parent_chunk = self.regions[parent_idx].get(parent) orelse continue;
+                if (parent_chunk.state != .renderable) continue;
+                const bounds = key.chunkBounds();
+                try candidates.append(self.allocator, .{ .key = key, .distance_sq = bounds.distanceSquaredToPoint(self.player_cx, self.player_cz) });
+            }
+        }
+
+        std.mem.sort(Candidate, candidates.items, {}, struct {
+            fn lt(_: void, a: Candidate, b: Candidate) bool {
+                return a.distance_sq > b.distance_sq;
+            }
+        }.lt);
+
+        var used = self.memory_used_bytes;
+        for (candidates.items) |candidate| {
+            if (used <= budget_bytes) break;
+            const idx = @intFromEnum(candidate.key.lod);
+            const chunk = self.regions[idx].get(candidate.key) orelse continue;
+            if (chunk.state != .renderable or chunk.isPinned()) continue;
+            const mesh = self.meshes[idx].get(candidate.key);
+            const bytes = regionMemoryBytes(chunk, mesh);
+            if (mesh) |m| {
+                self.queueMeshDeletion(m);
+                _ = self.meshes[idx].remove(candidate.key);
+            }
+            chunk.deinit(self.allocator);
+            self.allocator.destroy(chunk);
+            _ = self.regions[idx].remove(candidate.key);
+            used = if (bytes >= used) 0 else used - bytes;
+            self.memory_used_bytes = used;
+            self.stats.evictions += 1;
+        }
+    }
+
     /// Update statistics
     fn updateStats(self: *Self) void {
         self.stats.reset();
@@ -686,6 +763,8 @@ pub const LODManager = struct {
         }
 
         self.stats.addMemory(mem_usage);
+        self.stats.store_hits = self.cache_hits;
+        self.stats.store_misses = self.cache_misses;
         self.stats.cache_hits = self.cache_hits;
         self.stats.cache_misses = self.cache_misses;
         self.memory_used_bytes = mem_usage;
@@ -696,7 +775,7 @@ pub const LODManager = struct {
             };
             S.counter += 1;
             if (S.counter % 120 == 1) {
-                log.log.info("LOD_STATS_DIAG gen_q={any} upload_q={any} meshes={any} verts={any} cache_hits={} cache_misses={} cache_hit_rate={d:.2} mem_mb={} upload_failures={}", .{
+                log.log.info("LOD_STATS_DIAG gen_q={any} upload_q={any} meshes={any} verts={any} cache_hits={} cache_misses={} cache_hit_rate={d:.2} mem_mb={} upload_failures={} store_hits={} store_misses={} evictions={} ingestion_backlog={} drawn={any} instances={any}", .{
                     self.stats.gen_queue_depth,
                     self.stats.upload_queue_depth,
                     self.stats.mesh_count,
@@ -706,6 +785,12 @@ pub const LODManager = struct {
                     self.stats.cacheHitRate(),
                     self.stats.memory_used_mb,
                     self.stats.upload_failures,
+                    self.stats.store_hits,
+                    self.stats.store_misses,
+                    self.stats.evictions,
+                    self.stats.ingestion_backlog,
+                    self.stats.drawn,
+                    self.stats.instances,
                 });
             }
         }
@@ -764,7 +849,7 @@ pub const LODManager = struct {
         self.mutex.lockShared();
         defer self.mutex.unlockShared();
 
-        self.renderer.render(&self.meshes, &self.regions, self.config, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks);
+        self.renderer.render(&self.meshes, &self.regions, self.config, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, &self.stats);
     }
 
     fn pointDistanceSquared(x0: i32, z0: i32, x1: i32, z1: i32) i64 {
@@ -1157,13 +1242,20 @@ pub const LODManager = struct {
                 // Initialize simplified data if needed
                 if (needs_data_init) {
                     const cache_enabled = self.cacheEnabled();
-                    const cached_data = if (cache_enabled) self.loadCachedSourceData(key) else null;
+                    const want_spans = self.config.getVerticalSpanBudget() > 0;
+                    var cached_data = if (cache_enabled) self.loadCachedSourceData(key) else null;
+                    if (cached_data) |*cached| {
+                        if (want_spans and !cached.hasVerticalSpans()) {
+                            cached.deinit();
+                            cached_data = null;
+                        }
+                    }
                     const data = if (cached_data) |cached| blk: {
                         self.recordCacheHit();
                         break :blk cached;
                     } else blk: {
                         if (cache_enabled) self.recordCacheMiss();
-                        var generated = if (self.config.getVerticalSpanBudget() > 0)
+                        var generated = if (want_spans)
                             LODSimplifiedData.initWithVerticalSpans(self.allocator, lod_level) catch {
                                 new_state = .missing;
                                 chunk.unpin();
@@ -1209,6 +1301,7 @@ pub const LODManager = struct {
                     // Acquire lock to update chunk data
                     self.mutex.lock();
                     chunk.data = .{ .simplified = data };
+                    chunk.updateHeightBoundsFromData();
                     self.mutex.unlock();
                 }
                 success = true;

--- a/modules/world-lod/src/lod_manager.zig
+++ b/modules/world-lod/src/lod_manager.zig
@@ -597,9 +597,15 @@ pub const LODManager = struct {
         var count: u8 = 0;
         for (children) |child_key| {
             const child = self.regions[child_idx].get(child_key) orelse continue;
-            if (child.state == .renderable) count += 1;
+            if (self.regionContributesGeometry(child_key, child)) count += 1;
         }
         return count;
+    }
+
+    fn regionContributesGeometry(self: *Self, key: LODRegionKey, chunk: *const LODChunk) bool {
+        if (chunk.state != .renderable) return false;
+        const mesh = self.meshes[@intFromEnum(key.lod)].get(key) orelse return false;
+        return mesh.ready and mesh.vertex_count > 0;
     }
 
     fn adjustParentReadyChildren(self: *Self, key: LODRegionKey, delta: i8) void {
@@ -617,11 +623,13 @@ pub const LODManager = struct {
         if (chunk.state == .renderable) return;
         chunk.ready_children = self.countRenderableChildren(key);
         chunk.state = .renderable;
-        self.adjustParentReadyChildren(key, 1);
+        if (self.regionContributesGeometry(key, chunk)) {
+            self.adjustParentReadyChildren(key, 1);
+        }
     }
 
     fn noteRegionRemoved(self: *Self, key: LODRegionKey, chunk: *const LODChunk) void {
-        if (chunk.state == .renderable) {
+        if (self.regionContributesGeometry(key, chunk)) {
             self.adjustParentReadyChildren(key, -1);
         }
     }
@@ -670,13 +678,13 @@ pub const LODManager = struct {
                 if (storage.get(key)) |chunk| {
                     // Clean up mesh before removing chunk
                     const meshes = &self.meshes[@intFromEnum(lod)];
+                    self.noteRegionRemoved(key, chunk);
                     if (meshes.get(key)) |mesh| {
                         // Push to deferred deletion queue instead of deleting immediately
                         self.queueMeshDeletion(mesh);
                         _ = meshes.remove(key);
                     }
 
-                    self.noteRegionRemoved(key, chunk);
                     chunk.deinit(self.allocator);
                     self.allocator.destroy(chunk);
                     _ = storage.remove(key);
@@ -747,11 +755,11 @@ pub const LODManager = struct {
             if (chunk.state != .renderable or chunk.isPinned()) continue;
             const mesh = self.meshes[idx].get(candidate.key);
             const bytes = regionMemoryBytes(chunk, mesh);
+            self.noteRegionRemoved(candidate.key, chunk);
             if (mesh) |m| {
                 self.queueMeshDeletion(m);
                 _ = self.meshes[idx].remove(candidate.key);
             }
-            self.noteRegionRemoved(candidate.key, chunk);
             chunk.deinit(self.allocator);
             self.allocator.destroy(chunk);
             _ = self.regions[idx].remove(candidate.key);
@@ -921,12 +929,14 @@ pub const LODManager = struct {
             }
 
             for (to_remove.items) |rem_key| {
+                if (storage.get(rem_key)) |chunk| {
+                    self.noteRegionRemoved(rem_key, chunk);
+                }
                 if (meshes.fetchRemove(rem_key)) |mesh_entry| {
                     // Queue for deferred deletion to avoid waitIdle stutter
                     self.queueMeshDeletion(mesh_entry.value);
                 }
                 if (storage.fetchRemove(rem_key)) |chunk_entry| {
-                    self.noteRegionRemoved(rem_key, chunk_entry.value);
                     chunk_entry.value.deinit(self.allocator);
                     self.allocator.destroy(chunk_entry.value);
                 }
@@ -1482,7 +1492,7 @@ fn putTestMesh(manager: *LODManager, key: LODRegionKey, capacity: u32) !*LODMesh
     const mesh = try manager.allocator.create(LODMesh);
     mesh.* = LODMesh.init(manager.allocator, key.lod);
     mesh.ready = true;
-    mesh.vertex_count = 1;
+    mesh.vertex_count = capacity;
     mesh.capacity = capacity;
     try manager.meshes[@intFromEnum(key.lod)].put(key, mesh);
     return mesh;
@@ -1495,6 +1505,7 @@ test "LODManager ready child counters update on renderable transitions and remov
 
     const child_key = LODRegionKey{ .rx = 2, .rz = 0, .lod = .lod1 };
     const child = try putTestRegion(&manager, child_key, .mesh_ready);
+    _ = try putTestMesh(&manager, child_key, 1);
     manager.markRegionRenderable(child_key, child);
 
     const parent_key = child_key.parentKey().?;
@@ -1503,6 +1514,23 @@ test "LODManager ready child counters update on renderable transitions and remov
     try testing.expectEqual(@as(u8, 1), parent.ready_children);
 
     manager.noteRegionRemoved(child_key, child);
+    try testing.expectEqual(@as(u8, 0), parent.ready_children);
+}
+
+test "LODManager ready child counters ignore renderable children without geometry" {
+    var config = LODConfig{};
+    var manager = try initEvictionTestManager(testing.allocator, &config);
+    defer deinitEvictionTestManager(&manager);
+
+    const child_key = LODRegionKey{ .rx = 2, .rz = 0, .lod = .lod1 };
+    const child = try putTestRegion(&manager, child_key, .mesh_ready);
+    _ = try putTestMesh(&manager, child_key, 0);
+    manager.markRegionRenderable(child_key, child);
+
+    const parent_key = child_key.parentKey().?;
+    const parent = try putTestRegion(&manager, parent_key, .mesh_ready);
+    manager.markRegionRenderable(parent_key, parent);
+
     try testing.expectEqual(@as(u8, 0), parent.ready_children);
 }
 

--- a/modules/world-lod/src/lod_manager_tests.zig
+++ b/modules/world-lod/src/lod_manager_tests.zig
@@ -93,7 +93,7 @@ test "LODManager initialization" {
 
     const mock_render = LODRenderInterface{
         .render_fn = struct {
-            fn f(_: *anyopaque, _: *const [LODLevel.count]MeshMap, _: *const [LODLevel.count]RegionMap, _: ILODConfig, _: Mat4, _: Vec3, _: ?LODManager.ChunkChecker, _: ?*anyopaque, _: bool, _: ?i32) void {}
+            fn f(_: *anyopaque, _: *const [LODLevel.count]MeshMap, _: *const [LODLevel.count]RegionMap, _: ILODConfig, _: Mat4, _: Vec3, _: ?LODManager.ChunkChecker, _: ?*anyopaque, _: bool, _: ?i32, _: ?*LODStats) void {}
         }.f,
         .deinit_fn = struct {
             fn f(_: *anyopaque) void {}
@@ -188,7 +188,7 @@ test "LODManager end-to-end covered cleanup" {
 
     const mock_render = LODRenderInterface{
         .render_fn = struct {
-            fn f(_: *anyopaque, _: *const [LODLevel.count]MeshMap, _: *const [LODLevel.count]RegionMap, _: ILODConfig, _: Mat4, _: Vec3, _: ?LODManager.ChunkChecker, _: ?*anyopaque, _: bool, _: ?i32) void {}
+            fn f(_: *anyopaque, _: *const [LODLevel.count]MeshMap, _: *const [LODLevel.count]RegionMap, _: ILODConfig, _: Mat4, _: Vec3, _: ?LODManager.ChunkChecker, _: ?*anyopaque, _: bool, _: ?i32, _: ?*LODStats) void {}
         }.f,
         .deinit_fn = struct {
             fn f(_: *anyopaque) void {}

--- a/modules/world-lod/src/lod_renderer.zig
+++ b/modules/world-lod/src/lod_renderer.zig
@@ -226,7 +226,7 @@ pub fn LODRenderer(comptime RHI: type) type {
                         diag.bad_state += 1;
                         continue;
                     }
-                    if (self.isCoveredByFinerLOD(entry.key_ptr.*, all_meshes, all_regions, config)) {
+                    if (self.isCoveredByFinerLOD(chunk, config)) {
                         diag.covered_finer_lod += 1;
                         continue;
                     }
@@ -347,41 +347,12 @@ pub fn LODRenderer(comptime RHI: type) type {
 
         fn isCoveredByFinerLOD(
             _: *Self,
-            key: LODRegionKey,
-            all_meshes: *const [LODLevel.count]MeshMap,
-            all_regions: *const [LODLevel.count]RegionMap,
+            chunk: *const LODChunk,
             config: ILODConfig,
         ) bool {
-            if (key.lod == .lod1) return false;
-
-            const children = key.childKeys() orelse return false;
-            const finer_index = @intFromEnum(children[0].lod);
-            var total_children: u32 = 0;
-            var missing_children: u32 = 0;
-
-            for (children) |finer_key| {
-                total_children += 1;
-                const finer_chunk = all_regions[finer_index].get(finer_key) orelse {
-                    missing_children += 1;
-                    continue;
-                };
-                if (finer_chunk.state != .renderable) {
-                    missing_children += 1;
-                    continue;
-                }
-
-                const finer_mesh = all_meshes[finer_index].get(finer_key) orelse {
-                    missing_children += 1;
-                    continue;
-                };
-                if (!finer_mesh.ready or finer_mesh.vertex_count == 0) {
-                    missing_children += 1;
-                }
-            }
-
-            if (total_children == 0) return false;
-
-            const missing_fraction = @as(f32, @floatFromInt(missing_children)) / @as(f32, @floatFromInt(total_children));
+            if (chunk.lod_level == .lod1) return false;
+            const missing_children = 4 - @min(chunk.ready_children, 4);
+            const missing_fraction = @as(f32, @floatFromInt(missing_children)) / 4.0;
             return missing_fraction <= config.getFallbackMissingChildThreshold();
         }
 
@@ -1009,6 +980,7 @@ test "LODRenderer skips coarse LOD when finer coverage is ready" {
 
     var coarse_chunk = LODChunk.init(2, 0, .lod2);
     coarse_chunk.state = .renderable;
+    coarse_chunk.ready_children = 4;
     const coarse_key = LODRegionKey{ .rx = 2, .rz = 0, .lod = .lod2 };
     try meshes[2].put(coarse_key, &coarse_mesh);
     try regions[2].put(coarse_key, &coarse_chunk);
@@ -1094,6 +1066,7 @@ test "LODRenderer keeps coarse LOD when a finer child is missing" {
     coarse_mesh.ready = true;
     var coarse_chunk = LODChunk.init(2, 0, .lod2);
     coarse_chunk.state = .renderable;
+    coarse_chunk.ready_children = 3;
     const coarse_key = LODRegionKey{ .rx = 2, .rz = 0, .lod = .lod2 };
     try meshes[2].put(coarse_key, &coarse_mesh);
     try regions[2].put(coarse_key, &coarse_chunk);
@@ -1177,6 +1150,7 @@ test "LODRenderer resolves finer coverage across negative region boundaries" {
     coarse_mesh.ready = true;
     var coarse_chunk = LODChunk.init(-1, -1, .lod2);
     coarse_chunk.state = .renderable;
+    coarse_chunk.ready_children = 4;
     const coarse_key = LODRegionKey{ .rx = -1, .rz = -1, .lod = .lod2 };
     try meshes[2].put(coarse_key, &coarse_mesh);
     try regions[2].put(coarse_key, &coarse_chunk);

--- a/modules/world-lod/src/lod_renderer.zig
+++ b/modules/world-lod/src/lod_renderer.zig
@@ -47,6 +47,7 @@ const LODRenderInterface = lod_gpu.LODRenderInterface;
 const MeshMap = lod_gpu.MeshMap;
 const RegionMap = lod_gpu.RegionMap;
 const ChunkChecker = lod_gpu.ChunkChecker;
+const LODStats = @import("lod_stats.zig").LODStats;
 
 const Vec3 = @import("engine-math").Vec3;
 const Mat4 = @import("engine-math").Mat4;
@@ -138,6 +139,7 @@ pub fn LODRenderer(comptime RHI: type) type {
             checker_ctx: ?*anyopaque,
             use_frustum: bool,
             max_distance_chunks: ?i32,
+            stats: ?*LODStats,
         ) void {
             // Update frame index
             const query = if (@hasDecl(RHI, "query")) self.rhi.query() else self.rhi;
@@ -156,13 +158,17 @@ pub fn LODRenderer(comptime RHI: type) type {
 
             self.instance_data.clearRetainingCapacity();
             self.draw_list.clearRetainingCapacity();
+            if (stats) |s| {
+                s.drawn = [_]u32{0} ** LODLevel.count;
+                s.instances = [_]u32{0} ** LODLevel.count;
+            }
 
             // Collect visible meshes from coarsest active LOD down. Some presets
             // intentionally disable coarser levels to avoid low-quality slabs.
             var i: usize = lod_chunk.activeLODCount(config) - 1;
             while (i > 0) : (i -= 1) {
                 const lod: LODLevel = @enumFromInt(@as(u3, @intCast(i)));
-                self.collectVisibleMeshes(meshes, regions, lod, config, view_proj, camera_pos, frustum, lod_y_offset, chunk_checker, checker_ctx, use_frustum, max_distance_chunks) catch |err| {
+                self.collectVisibleMeshes(meshes, regions, lod, config, view_proj, camera_pos, frustum, lod_y_offset, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, stats) catch |err| {
                     log.log.errWithTrace("Failed to collect visible meshes for LOD{}: {}", .{ i, err });
                 };
             }
@@ -190,6 +196,7 @@ pub fn LODRenderer(comptime RHI: type) type {
             checker_ctx: ?*anyopaque,
             use_frustum: bool,
             max_distance_chunks: ?i32,
+            stats: ?*LODStats,
         ) !void {
             const meshes = &all_meshes[@intFromEnum(lod)];
             const regions = &all_regions[@intFromEnum(lod)];
@@ -279,6 +286,11 @@ pub fn LODRenderer(comptime RHI: type) type {
                     });
                     try self.draw_list.append(self.allocator, mesh);
                     diag.drawn += 1;
+                    if (stats) |s| {
+                        const lod_idx = @intFromEnum(lod);
+                        s.drawn[lod_idx] = diag.drawn;
+                        s.instances[lod_idx] = diag.drawn;
+                    }
                 } else {
                     diag.missing_region += 1;
                 }
@@ -342,40 +354,28 @@ pub fn LODRenderer(comptime RHI: type) type {
         ) bool {
             if (key.lod == .lod1) return false;
 
-            const finer_lod: LODLevel = @enumFromInt(@as(u3, @intCast(@intFromEnum(key.lod) - 1)));
-            const finer_index = @intFromEnum(finer_lod);
-            const finer_scale: i32 = @intCast(finer_lod.chunksPerSide());
-            const bounds = key.chunkBounds();
-            const finer_min_rx = @divFloor(bounds.min_x, finer_scale);
-            const finer_max_rx = @divFloor(bounds.max_x, finer_scale);
-            const finer_min_rz = @divFloor(bounds.min_z, finer_scale);
-            const finer_max_rz = @divFloor(bounds.max_z, finer_scale);
-
+            const children = key.childKeys() orelse return false;
+            const finer_index = @intFromEnum(children[0].lod);
             var total_children: u32 = 0;
             var missing_children: u32 = 0;
 
-            var rz = finer_min_rz;
-            while (rz <= finer_max_rz) : (rz += 1) {
-                var rx = finer_min_rx;
-                while (rx <= finer_max_rx) : (rx += 1) {
-                    total_children += 1;
-                    const finer_key = LODRegionKey{ .rx = rx, .rz = rz, .lod = finer_lod };
-                    const finer_chunk = all_regions[finer_index].get(finer_key) orelse {
-                        missing_children += 1;
-                        continue;
-                    };
-                    if (finer_chunk.state != .renderable) {
-                        missing_children += 1;
-                        continue;
-                    }
+            for (children) |finer_key| {
+                total_children += 1;
+                const finer_chunk = all_regions[finer_index].get(finer_key) orelse {
+                    missing_children += 1;
+                    continue;
+                };
+                if (finer_chunk.state != .renderable) {
+                    missing_children += 1;
+                    continue;
+                }
 
-                    const finer_mesh = all_meshes[finer_index].get(finer_key) orelse {
-                        missing_children += 1;
-                        continue;
-                    };
-                    if (!finer_mesh.ready or finer_mesh.vertex_count == 0) {
-                        missing_children += 1;
-                    }
+                const finer_mesh = all_meshes[finer_index].get(finer_key) orelse {
+                    missing_children += 1;
+                    continue;
+                };
+                if (!finer_mesh.ready or finer_mesh.vertex_count == 0) {
+                    missing_children += 1;
                 }
             }
 
@@ -489,9 +489,10 @@ pub fn LODRenderer(comptime RHI: type) type {
                     checker_ctx: ?*anyopaque,
                     use_frustum: bool,
                     max_distance_chunks: ?i32,
+                    stats: ?*LODStats,
                 ) void {
                     const renderer: *Self = @ptrCast(@alignCast(self_ptr));
-                    renderer.render(meshes, regions, config, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks);
+                    renderer.render(meshes, regions, config, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, stats);
                 }
                 fn deinitFn(self_ptr: *anyopaque) void {
                     const renderer: *Self = @ptrCast(@alignCast(self_ptr));
@@ -517,15 +518,18 @@ fn isRegionInFrustum(frustum: Frustum, bounds: LODChunk.WorldBounds, camera_pos:
     const min_z: f32 = @floatFromInt(bounds.min_z);
     const max_x: f32 = @floatFromInt(bounds.max_x);
     const max_z: f32 = @floatFromInt(bounds.max_z);
+    const min_y = bounds.min_y;
+    const max_y = bounds.max_y;
 
     const center = Vec3.init(
         (min_x + max_x) * 0.5 - camera_pos.x,
-        128.0 - camera_pos.y,
+        (min_y + max_y) * 0.5 - camera_pos.y,
         (min_z + max_z) * 0.5 - camera_pos.z,
     );
     const half_x = (max_x - min_x) * 0.5;
+    const half_y = @max((max_y - min_y) * 0.5, 1.0);
     const half_z = (max_z - min_z) * 0.5;
-    const radius = @sqrt(half_x * half_x + half_z * half_z + 128.0 * 128.0);
+    const radius = @sqrt(half_x * half_x + half_y * half_y + half_z * half_z);
     return frustum.intersectsSphere(center, radius);
 }
 
@@ -645,14 +649,18 @@ test "LODRenderer render draw path" {
     const view_proj = Mat4.identity;
     const camera_pos = Vec3.zero;
 
+    var stats = LODStats{};
+
     // Call render with explicit parameters
-    renderer.render(&meshes, &regions, mock_config.interface(), view_proj, camera_pos, null, null, false, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), view_proj, camera_pos, null, null, false, null, &stats);
 
     // Verify draw was called with correct parameters
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);
     try std.testing.expectEqual(@as(u32, 1), mock_state.set_matrix_calls);
     try std.testing.expectEqual(@as(u32, 42), mock_state.last_buffer_handle);
     try std.testing.expectEqual(@as(u32, 100), mock_state.last_vertex_count);
+    try std.testing.expectEqual(@as(u32, 1), stats.drawn[1]);
+    try std.testing.expectEqual(@as(u32, 1), stats.instances[1]);
 }
 
 test "LODRenderer keeps coarse LOD visible while finer bands stream" {
@@ -721,7 +729,7 @@ test "LODRenderer keeps coarse LOD visible while finer bands stream" {
         .radii = .{ 16, 32, 64, 100 },
     };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, null);
 
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);
     try std.testing.expectEqual(@as(u32, 1), mock_state.set_matrix_calls);
@@ -795,7 +803,7 @@ test "LODRenderer disables mask when chunks are missing inside LOD0 radius" {
         }
     };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.missingInRadius, &checker_ctx, false, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.missingInRadius, &checker_ctx, false, null, null);
 
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);
     try std.testing.expectEqual(LOD_UNMASKED_SENTINEL, mock_state.last_mask_radius);
@@ -869,7 +877,7 @@ test "LODRenderer keeps mask when only outside-radius chunks are uncovered" {
         }
     };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.loaded, &checker_ctx, false, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.loaded, &checker_ctx, false, null, null);
 
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);
     try std.testing.expectEqual(mock_config.interface().calculateMaskRadius(), mock_state.last_mask_radius);
@@ -943,7 +951,7 @@ test "LODRenderer keeps mask for partially covered chunk regions" {
         }
     };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.partiallyLoaded, &checker_ctx, false, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.partiallyLoaded, &checker_ctx, false, null, null);
 
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);
     try std.testing.expectEqual(mock_config.interface().calculateMaskRadius(), mock_state.last_mask_radius);
@@ -1028,7 +1036,7 @@ test "LODRenderer skips coarse LOD when finer coverage is ready" {
         .radii = .{ 16, 32, 64, 100 },
     };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, null);
 
     try std.testing.expectEqual(@as(u32, 4), mock_state.draw_calls);
 }
@@ -1110,7 +1118,7 @@ test "LODRenderer keeps coarse LOD when a finer child is missing" {
 
     var mock_config = LODConfig{ .radii = .{ 16, 32, 64, 100 } };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, null);
 
     try std.testing.expectEqual(@as(u32, 4), mock_state.draw_calls);
     try std.testing.expectEqual(@as(u32, 106), mock_state.handle_sum);
@@ -1194,7 +1202,7 @@ test "LODRenderer resolves finer coverage across negative region boundaries" {
 
     var mock_config = LODConfig{ .radii = .{ 16, 32, 64, 100 } };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, null);
 
     try std.testing.expectEqual(@as(u32, 4), mock_state.draw_calls);
     try std.testing.expectEqual(@as(u32, 10), mock_state.handle_sum);
@@ -1292,7 +1300,7 @@ test "LODRenderer createGPUBridge and toInterface round-trip" {
     var mock_config = LODConfig{};
 
     // Render through the type-erased interface
-    iface.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null);
+    iface.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, null);
 
     // Verify the real renderer's draw was invoked through the interface
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);

--- a/modules/world-lod/src/lod_stats.zig
+++ b/modules/world-lod/src/lod_stats.zig
@@ -18,8 +18,14 @@ pub const LODStats = struct {
     mesh_vertices: [LODLevel.count]u32 = [_]u32{0} ** LODLevel.count,
     gen_queue_depth: [LODLevel.count]u32 = [_]u32{0} ** LODLevel.count,
     upload_queue_depth: [LODLevel.count]u32 = [_]u32{0} ** LODLevel.count,
+    store_hits: u32 = 0,
+    store_misses: u32 = 0,
     cache_hits: u32 = 0,
     cache_misses: u32 = 0,
+    evictions: u32 = 0,
+    drawn: [LODLevel.count]u32 = [_]u32{0} ** LODLevel.count,
+    instances: [LODLevel.count]u32 = [_]u32{0} ** LODLevel.count,
+    ingestion_backlog: u32 = 0,
     upgrades_pending: u32 = 0,
     downgrades_pending: u32 = 0,
     upload_failures: u32 = 0,
@@ -48,9 +54,12 @@ pub const LODStats = struct {
         self.mesh_vertices = [_]u32{0} ** LODLevel.count;
         self.gen_queue_depth = [_]u32{0} ** LODLevel.count;
         self.upload_queue_depth = [_]u32{0} ** LODLevel.count;
+        self.drawn = [_]u32{0} ** LODLevel.count;
+        self.instances = [_]u32{0} ** LODLevel.count;
         self.upgrades_pending = 0;
         self.downgrades_pending = 0;
         self.upload_failures = 0;
+        self.ingestion_backlog = 0;
     }
 
     pub fn recordState(self: *LODStats, lod_idx: usize, state: LODState) void {
@@ -71,9 +80,9 @@ pub const LODStats = struct {
     }
 
     pub fn cacheHitRate(self: *const LODStats) f32 {
-        const total = self.cache_hits + self.cache_misses;
+        const total = self.store_hits + self.store_misses;
         if (total == 0) return 0.0;
-        return @as(f32, @floatFromInt(self.cache_hits)) / @as(f32, @floatFromInt(total));
+        return @as(f32, @floatFromInt(self.store_hits)) / @as(f32, @floatFromInt(total));
     }
 };
 
@@ -83,7 +92,7 @@ test "LODStats reports cache hit rate" {
     var stats = LODStats{};
     try std.testing.expectEqual(@as(f32, 0.0), stats.cacheHitRate());
 
-    stats.cache_hits = 3;
-    stats.cache_misses = 1;
+    stats.store_hits = 3;
+    stats.store_misses = 1;
     try std.testing.expectEqual(@as(f32, 0.75), stats.cacheHitRate());
 }

--- a/modules/world-lod/src/lod_stats.zig
+++ b/modules/world-lod/src/lod_stats.zig
@@ -18,6 +18,8 @@ pub const LODStats = struct {
     mesh_vertices: [LODLevel.count]u32 = [_]u32{0} ** LODLevel.count,
     gen_queue_depth: [LODLevel.count]u32 = [_]u32{0} ** LODLevel.count,
     upload_queue_depth: [LODLevel.count]u32 = [_]u32{0} ** LODLevel.count,
+    /// On-disk LOD source store counters. cache_* below are retained as
+    /// compatibility aliases for existing diagnostics consumers.
     store_hits: u32 = 0,
     store_misses: u32 = 0,
     cache_hits: u32 = 0,

--- a/modules/world-lod/src/lod_upload_queue.zig
+++ b/modules/world-lod/src/lod_upload_queue.zig
@@ -11,6 +11,7 @@ const LODChunk = lod_chunk.LODChunk;
 const LODRegionKey = lod_chunk.LODRegionKey;
 const LODRegionKeyContext = lod_chunk.LODRegionKeyContext;
 const ILODConfig = lod_chunk.ILODConfig;
+const LODStats = @import("lod_stats.zig").LODStats;
 const LODMesh = @import("lod_mesh.zig").LODMesh;
 const Vec3 = @import("engine-math").Vec3;
 const Mat4 = @import("engine-math").Mat4;
@@ -87,6 +88,7 @@ pub const LODRenderInterface = struct {
         checker_ctx: ?*anyopaque,
         use_frustum: bool,
         max_distance_chunks: ?i32,
+        stats: ?*LODStats,
     ) void,
     /// Destroy renderer resources.
     deinit_fn: *const fn (self_ptr: *anyopaque) void,
@@ -104,8 +106,9 @@ pub const LODRenderInterface = struct {
         checker_ctx: ?*anyopaque,
         use_frustum: bool,
         max_distance_chunks: ?i32,
+        stats: ?*LODStats,
     ) void {
-        self.render_fn(self.ptr, meshes, regions, config, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks);
+        self.render_fn(self.ptr, meshes, regions, config, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, stats);
     }
 
     pub fn deinit(self: LODRenderInterface) void {


### PR DESCRIPTION
## Summary
- add v2 LOD cache serialization for vertical spans while preserving v1 reads
- add real LOD height bounds for frustum culling
- add parent/child hierarchy helpers, budget eviction, and extended LOD diagnostics

## Verification
- nix develop --command zig fmt modules/world-lod/src/lod_cache.zig modules/world-lod/src/lod_chunk.zig modules/world-lod/src/lod_manager.zig modules/world-lod/src/lod_renderer.zig modules/world-lod/src/lod_stats.zig
- nix develop --command zig fmt modules/world-lod/src/lod_upload_queue.zig modules/world-lod/src/lod_renderer.zig modules/world-lod/src/lod_manager.zig modules/world-lod/src/lod_manager_tests.zig
- nix develop --command zig build test

Refs #753