### PR TITLE
feat: add persistent LOD source store

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -273,6 +273,7 @@ pub fn build(b: *std.Build) void {
     world_lod.addImport("engine-rhi", engine_rhi);
     world_lod.addImport("world-meshing", world_meshing);
     world_lod.addImport("world-core", world_core);
+    world_lod.addImport("world-persistence", world_persistence);
     world_lod.addOptions("world_lod_options", world_lod_options);
     addSharedImports(world_persistence, zig_math, zig_noise, fs_module, sync_module, c_module, options);
     world_persistence.addImport("engine-core", engine_core);

--- a/modules/world-core/src/lod_data.zig
+++ b/modules/world-core/src/lod_data.zig
@@ -10,6 +10,16 @@ pub const LODDataVersion = enum(u16) {
     rich_v2 = 2,
 };
 
+pub const LODColumnProvenance = enum(u8) {
+    worldgen = 0,
+    chunk_derived = 1,
+    edited = 2,
+
+    pub fn canOverwrite(new: LODColumnProvenance, old: LODColumnProvenance) bool {
+        return @intFromEnum(new) >= @intFromEnum(old);
+    }
+};
+
 pub const MAX_LOD_VERTICAL_SPANS: usize = 4;
 
 pub const LODMaterialLayers = struct {
@@ -118,6 +128,7 @@ pub const LODSimplifiedData = struct {
     water: []LODWaterState,
     lighting: []LODLightingHint,
     vegetation: []LODVegetationHint,
+    provenance: []LODColumnProvenance,
     vertical_span_counts: ?[]u8,
     vertical_spans: ?[]LODVerticalSpan,
     allocator: std.mem.Allocator,
@@ -163,6 +174,8 @@ pub const LODSimplifiedData = struct {
         errdefer allocator.free(lighting);
         const vegetation = try allocator.alloc(LODVegetationHint, count);
         errdefer allocator.free(vegetation);
+        const provenance = try allocator.alloc(LODColumnProvenance, count);
+        errdefer allocator.free(provenance);
 
         @memset(heightmap, 0.0);
         @memset(biomes, .plains);
@@ -172,6 +185,7 @@ pub const LODSimplifiedData = struct {
         @memset(water, LODWaterState.empty);
         @memset(lighting, LODLightingHint.daylight);
         @memset(vegetation, LODVegetationHint.empty);
+        @memset(provenance, .worldgen);
 
         return .{
             .version = .rich_v2,
@@ -184,6 +198,7 @@ pub const LODSimplifiedData = struct {
             .water = water,
             .lighting = lighting,
             .vegetation = vegetation,
+            .provenance = provenance,
             .vertical_span_counts = null,
             .vertical_spans = null,
             .allocator = allocator,
@@ -206,6 +221,7 @@ pub const LODSimplifiedData = struct {
         self.allocator.free(self.water);
         self.allocator.free(self.lighting);
         self.allocator.free(self.vegetation);
+        self.allocator.free(self.provenance);
         if (self.vertical_span_counts) |counts| self.allocator.free(counts);
         if (self.vertical_spans) |spans| self.allocator.free(spans);
         self.* = undefined;
@@ -269,6 +285,16 @@ pub const LODSimplifiedData = struct {
         }
     }
 
+    pub fn setColumnProvenance(self: *LODSimplifiedData, gx: u32, gz: u32, provenance: LODColumnProvenance) void {
+        if (gx >= self.width or gz >= self.width) return;
+        self.provenance[gz * self.width + gx] = provenance;
+    }
+
+    pub fn getColumnProvenance(self: *const LODSimplifiedData, gx: u32, gz: u32) LODColumnProvenance {
+        if (gx >= self.width or gz >= self.width) return .worldgen;
+        return self.provenance[gz * self.width + gx];
+    }
+
     pub fn verticalSpanCount(self: *const LODSimplifiedData, gx: u32, gz: u32) u8 {
         if (gx >= self.width or gz >= self.width) return 0;
         const counts = self.vertical_span_counts orelse return 0;
@@ -304,7 +330,7 @@ pub const LODSimplifiedData = struct {
     pub fn totalMemoryBytes(self: *const LODSimplifiedData) usize {
         const count = self.width * self.width;
         const count_usize = @as(usize, @intCast(count));
-        var total: usize = count_usize * (@sizeOf(f32) + @sizeOf(world_core.BiomeId) + @sizeOf(world_core.BlockType) + @sizeOf(u32) + @sizeOf(LODMaterialLayers) + @sizeOf(LODWaterState) + @sizeOf(LODLightingHint) + @sizeOf(LODVegetationHint));
+        var total: usize = count_usize * (@sizeOf(f32) + @sizeOf(world_core.BiomeId) + @sizeOf(world_core.BlockType) + @sizeOf(u32) + @sizeOf(LODMaterialLayers) + @sizeOf(LODWaterState) + @sizeOf(LODLightingHint) + @sizeOf(LODVegetationHint) + @sizeOf(LODColumnProvenance));
         if (self.vertical_span_counts != null) total += count_usize * @sizeOf(u8);
         if (self.vertical_spans != null) total += @as(usize, @intCast(count)) * MAX_LOD_VERTICAL_SPANS * @sizeOf(LODVerticalSpan);
         return total;

--- a/modules/world-core/src/lod_data.zig
+++ b/modules/world-core/src/lod_data.zig
@@ -350,6 +350,13 @@ test "LODSimplifiedData initializes rich column defaults" {
     try std.testing.expectEqual(@as(f32, 0.0), data.vegetation[0].tree_coverage);
 }
 
+test "LODColumnProvenance orders overwrite authority" {
+    try std.testing.expect(LODColumnProvenance.chunk_derived.canOverwrite(.worldgen));
+    try std.testing.expect(LODColumnProvenance.edited.canOverwrite(.chunk_derived));
+    try std.testing.expect(!LODColumnProvenance.worldgen.canOverwrite(.chunk_derived));
+    try std.testing.expect(!LODColumnProvenance.chunk_derived.canOverwrite(.edited));
+}
+
 test "LODSimplifiedData setColumn stores rich representative data" {
     const allocator = std.testing.allocator;
     var data = try LODSimplifiedData.init(allocator, .lod2);

--- a/modules/world-core/src/root.zig
+++ b/modules/world-core/src/root.zig
@@ -53,6 +53,7 @@ pub const LODDataVersion = lod_data.LODDataVersion;
 pub const LODLightingHint = lod_data.LODLightingHint;
 pub const LODMaterialLayers = lod_data.LODMaterialLayers;
 pub const LODSimplifiedData = lod_data.LODSimplifiedData;
+pub const LODColumnProvenance = lod_data.LODColumnProvenance;
 pub const LODVegetationHint = lod_data.LODVegetationHint;
 pub const LODVerticalSpan = lod_data.LODVerticalSpan;
 pub const LODWaterState = lod_data.LODWaterState;

--- a/modules/world-lod/src/lod_cache.zig
+++ b/modules/world-lod/src/lod_cache.zig
@@ -39,11 +39,7 @@ pub const CacheError = error{
     ChecksumMismatch,
 };
 
-pub const ColumnProvenance = enum(u8) {
-    worldgen = 0,
-    chunk_derived = 1,
-    edited = 2,
-};
+pub const ColumnProvenance = world_core.LODColumnProvenance;
 
 const BIOME_COUNT: usize = @typeInfo(BiomeId).@"enum".fields.len;
 const BLOCK_COUNT: usize = @typeInfo(BlockType).@"enum".fields.len;
@@ -284,8 +280,10 @@ pub fn serialize(data: *const LODSimplifiedData, key: Key, allocator: std.mem.Al
     if (has_spans) {
         const counts = data.vertical_span_counts.?;
         const spans = data.vertical_spans.?;
-        @memset(buf[off..][0..count], @intFromEnum(ColumnProvenance.worldgen));
-        off += count;
+        for (data.provenance) |provenance| {
+            buf[off] = @intFromEnum(provenance);
+            off += 1;
+        }
         @memcpy(buf[off..][0..count], counts);
         off += count;
         for (spans) |span| {
@@ -389,7 +387,16 @@ pub fn deserialize(bytes: []const u8, key: Key, allocator: std.mem.Allocator) !L
         off += 1;
         if ((flags & ~@as(u8, 1)) != 0) return CacheError.InvalidSpanCount;
         if (has_spans) {
-            off += count; // provenance reserved for Phase 2; all v2 writes use worldgen.
+            for (data.provenance) |*provenance| {
+                const byte = bytes[off];
+                provenance.* = switch (byte) {
+                    0 => .worldgen,
+                    1 => .chunk_derived,
+                    2 => .edited,
+                    else => return CacheError.InvalidSpanCount,
+                };
+                off += 1;
+            }
             const counts = data.vertical_span_counts.?;
             @memcpy(counts, bytes[off..][0..count]);
             off += count;
@@ -493,6 +500,25 @@ test "LOD cache round-trip preserves vertical spans" {
     try testing.expectEqualSlices(u8, data.vertical_span_counts.?, decoded.vertical_span_counts.?);
     try testing.expectEqual(data.vertical_spans.?.len, decoded.vertical_spans.?.len);
     try testing.expectEqualSlices(u8, std.mem.sliceAsBytes(data.vertical_spans.?), std.mem.sliceAsBytes(decoded.vertical_spans.?));
+}
+
+test "LOD cache round-trip preserves column provenance" {
+    var data = try LODSimplifiedData.initWithVerticalSpans(testing.allocator, .lod1);
+    defer data.deinit();
+
+    data.setColumnProvenance(2, 3, .chunk_derived);
+    data.setColumnProvenance(4, 5, .edited);
+
+    const key = Key{ .seed = 1234, .generator_identity_hash = 99, .generator_version = 7, .rx = -2, .rz = 3, .lod = .lod1 };
+    const bytes = try serialize(&data, key, testing.allocator);
+    defer testing.allocator.free(bytes);
+
+    var decoded = try deserialize(bytes, key, testing.allocator);
+    defer decoded.deinit();
+
+    try testing.expectEqual(ColumnProvenance.chunk_derived, decoded.getColumnProvenance(2, 3));
+    try testing.expectEqual(ColumnProvenance.edited, decoded.getColumnProvenance(4, 5));
+    try testing.expectEqual(ColumnProvenance.worldgen, decoded.getColumnProvenance(0, 0));
 }
 
 test "LOD cache accepts v1 payload as span-less data" {

--- a/modules/world-lod/src/lod_manager.zig
+++ b/modules/world-lod/src/lod_manager.zig
@@ -62,6 +62,7 @@ const MeshMap = lod_gpu.MeshMap;
 const RegionMap = lod_gpu.RegionMap;
 const lod_scheduler = @import("lod_scheduler.zig");
 const lod_cache = @import("lod_cache.zig");
+const lod_store = @import("lod_store.zig");
 
 pub const MAX_LOD_REGIONS = 2048;
 const CHUNK_COVERAGE_PADDING: i32 = 1;
@@ -161,8 +162,9 @@ pub const LODManager = struct {
     // Type-erased renderer interface (replaces direct LODRenderer(RHI) field)
     renderer: LODRenderInterface,
 
-    // Optional on-disk cache for generated LOD source data.
+    // Optional save directory for generated LOD source data.
     cache_dir_path: ?[]const u8,
+    logged_legacy_cache_notice: bool,
 
     // Keep cleanup behavior testable, but allow the live world to opt out.
     cleanup_covered_regions: bool = true,
@@ -241,6 +243,7 @@ pub const LODManager = struct {
             .renderer = render_iface,
             .cleanup_covered_regions = true,
             .cache_dir_path = null,
+            .logged_legacy_cache_notice = false,
         };
 
         const cpu_count = std.Thread.getCpuCount() catch MIN_LOD_WORKERS;
@@ -326,10 +329,14 @@ pub const LODManager = struct {
     }
 
     pub fn enableCache(self: *Self, save_dir_path: []const u8) !void {
-        const cache_dir_path = try std.fs.path.join(self.allocator, &.{ save_dir_path, "lod_cache" });
+        const cache_dir_path = try self.allocator.dupe(u8, save_dir_path);
         errdefer self.allocator.free(cache_dir_path);
 
-        try fs.cwd().makePath(cache_dir_path);
+        try lod_store.writeHeader(self.allocator, save_dir_path, .{
+            .seed = self.generator.seed,
+            .generator_identity_hash = self.generator.identity_hash,
+            .generator_version = self.generator.version,
+        });
 
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -337,7 +344,8 @@ pub const LODManager = struct {
             self.allocator.free(old_path);
         }
         self.cache_dir_path = cache_dir_path;
-        log.log.info("LOD source cache enabled at '{s}'", .{cache_dir_path});
+        self.logged_legacy_cache_notice = false;
+        log.log.info("LOD source store enabled at '{s}/lod'", .{cache_dir_path});
     }
 
     /// Update LOD system with player position
@@ -1055,14 +1063,22 @@ pub const LODManager = struct {
         };
     }
 
-    fn cacheFilePath(self: *Self, cache_dir_path: []const u8, key: lod_cache.Key) ![]u8 {
+    fn legacyCacheFilePath(self: *Self, save_dir_path: []const u8, key: lod_cache.Key) ![]u8 {
         const filename = try std.fmt.allocPrint(
             self.allocator,
             "lod_{}_{}_{}_{}_{}_{}.dat",
             .{ key.seed, key.generator_identity_hash, key.generator_version, key.rx, key.rz, @intFromEnum(key.lod) },
         );
         defer self.allocator.free(filename);
-        return std.fs.path.join(self.allocator, &.{ cache_dir_path, filename });
+        return std.fs.path.join(self.allocator, &.{ save_dir_path, "lod_cache", filename });
+    }
+
+    fn logLegacyCacheNotice(self: *Self) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.logged_legacy_cache_notice) return;
+        self.logged_legacy_cache_notice = true;
+        log.log.warn("Using read-only legacy LOD cache fallback; new writes go to lod/ region store", .{});
     }
 
     fn cacheDirPathSnapshot(self: *Self) ?[]u8 {
@@ -1083,12 +1099,40 @@ pub const LODManager = struct {
     }
 
     fn loadCachedSourceData(self: *Self, key: LODRegionKey) ?LODSimplifiedData {
-        const cache_dir_path = self.cacheDirPathSnapshot() orelse return null;
-        defer self.allocator.free(cache_dir_path);
+        const save_dir_path = self.cacheDirPathSnapshot() orelse return null;
+        defer self.allocator.free(save_dir_path);
 
         const cache_key = self.cacheKey(key);
-        const path = self.cacheFilePath(cache_dir_path, cache_key) catch |err| {
-            log.log.warn("LOD cache path allocation failed: {}", .{err});
+
+        if (lod_store.readPayload(self.allocator, save_dir_path, cache_key) catch |err| switch (err) {
+            lod_store.StoreError.CorruptContainer => {
+                const path = lod_store.containerPath(self.allocator, save_dir_path, cache_key) catch null;
+                if (path) |container_path| {
+                    defer self.allocator.free(container_path);
+                    log.log.warn("Discarding corrupt LOD store container '{s}'", .{container_path});
+                    fs.cwd().deleteFile(container_path) catch |delete_err| {
+                        if (delete_err != error.FileNotFound) {
+                            log.log.warn("Failed to delete corrupt LOD store container '{s}': {}", .{ container_path, delete_err });
+                        }
+                    };
+                }
+                return null;
+            },
+            else => {
+                log.log.warn("Failed to read LOD store for LOD{} ({}, {}): {}", .{ @intFromEnum(key.lod), key.rx, key.rz, err });
+                return null;
+            },
+        }) |bytes| {
+            defer self.allocator.free(bytes);
+            return lod_cache.deserialize(bytes, cache_key, self.allocator) catch |err| {
+                log.log.warn("Discarding corrupt LOD store payload LOD{} ({}, {}): {}", .{ @intFromEnum(key.lod), key.rx, key.rz, err });
+                lod_store.deletePayload(self.allocator, save_dir_path, cache_key);
+                return null;
+            };
+        }
+
+        const path = self.legacyCacheFilePath(save_dir_path, cache_key) catch |err| {
+            log.log.warn("LOD legacy cache path allocation failed: {}", .{err});
             return null;
         };
         defer self.allocator.free(path);
@@ -1096,17 +1140,18 @@ pub const LODManager = struct {
         const bytes = fs.cwd().readFileAlloc(path, self.allocator, 16 * 1024 * 1024) catch |err| switch (err) {
             error.FileNotFound => return null,
             else => {
-                log.log.warn("Failed to read LOD cache '{s}': {}", .{ path, err });
+                log.log.warn("Failed to read legacy LOD cache '{s}': {}", .{ path, err });
                 return null;
             },
         };
         defer self.allocator.free(bytes);
+        self.logLegacyCacheNotice();
 
         return lod_cache.deserialize(bytes, cache_key, self.allocator) catch |err| {
-            log.log.warn("Discarding corrupt LOD cache '{s}': {}", .{ path, err });
+            log.log.warn("Discarding corrupt legacy LOD cache '{s}': {}", .{ path, err });
             fs.cwd().deleteFile(path) catch |delete_err| {
                 if (delete_err != error.FileNotFound) {
-                    log.log.warn("Failed to delete corrupt LOD cache '{s}': {}", .{ path, delete_err });
+                    log.log.warn("Failed to delete corrupt legacy LOD cache '{s}': {}", .{ path, delete_err });
                 }
             };
             return null;
@@ -1126,20 +1171,10 @@ pub const LODManager = struct {
     }
 
     fn saveCachedSourceData(self: *Self, key: LODRegionKey, data: *const LODSimplifiedData) void {
-        const cache_dir_path = self.cacheDirPathSnapshot() orelse return;
-        defer self.allocator.free(cache_dir_path);
+        const save_dir_path = self.cacheDirPathSnapshot() orelse return;
+        defer self.allocator.free(save_dir_path);
 
         const cache_key = self.cacheKey(key);
-        const path = self.cacheFilePath(cache_dir_path, cache_key) catch |err| {
-            log.log.warn("LOD cache path allocation failed: {}", .{err});
-            return;
-        };
-        defer self.allocator.free(path);
-        const tmp_path = std.fmt.allocPrint(self.allocator, "{s}.tmp", .{path}) catch |err| {
-            log.log.warn("LOD cache temp path allocation failed: {}", .{err});
-            return;
-        };
-        defer self.allocator.free(tmp_path);
 
         const bytes = lod_cache.serialize(data, cache_key, self.allocator) catch |err| {
             log.log.warn("Failed to serialize LOD{} cache ({}, {}): {}", .{ @intFromEnum(key.lod), key.rx, key.rz, err });
@@ -1147,22 +1182,8 @@ pub const LODManager = struct {
         };
         defer self.allocator.free(bytes);
 
-        const cwd = fs.cwd();
-        const file = cwd.createFile(tmp_path, .{ .truncate = true }) catch |err| {
-            log.log.warn("Failed to create LOD cache '{s}': {}", .{ tmp_path, err });
-            return;
-        };
-        file.writeAll(bytes) catch |err| {
-            log.log.warn("Failed to write LOD cache '{s}': {}", .{ tmp_path, err });
-            file.close();
-            cwd.deleteFile(tmp_path) catch {};
-            return;
-        };
-        file.close();
-
-        cwd.rename(tmp_path, path) catch |err| {
-            log.log.warn("Failed to publish LOD cache '{s}': {}", .{ path, err });
-            cwd.deleteFile(tmp_path) catch {};
+        lod_store.writePayload(self.allocator, save_dir_path, cache_key, bytes) catch |err| {
+            log.log.warn("Failed to write LOD{} store ({}, {}): {}", .{ @intFromEnum(key.lod), key.rx, key.rz, err });
         };
     }
 
@@ -1201,6 +1222,7 @@ pub const LODManager = struct {
             .deletion_timer = 0,
             .renderer = undefined,
             .cache_dir_path = cache_dir_path,
+            .logged_legacy_cache_notice = false,
             .cleanup_covered_regions = true,
         };
     }
@@ -1391,9 +1413,9 @@ test "LODManager cache helpers save and reload source data" {
 
     const dir = fs.Dir{ .inner = tmp_dir.dir };
     var path_buf: [fs.max_path_bytes]u8 = undefined;
-    const cache_dir_path = try dir.realpath(".", &path_buf);
+    const save_dir_path = try dir.realpath(".", &path_buf);
 
-    var manager = LODManager.initCacheTestManager(testing.allocator, cache_dir_path);
+    var manager = LODManager.initCacheTestManager(testing.allocator, save_dir_path);
     const key = LODRegionKey{ .rx = 2, .rz = -3, .lod = .lod1 };
 
     var data = try LODSimplifiedData.init(testing.allocator, .lod1);
@@ -1405,6 +1427,10 @@ test "LODManager cache helpers save and reload source data" {
     }, 0xFF112233, .empty, .daylight, .empty);
 
     manager.saveCachedSourceData(key, &data);
+
+    const store_path = try lod_store.containerPath(testing.allocator, save_dir_path, manager.cacheKey(key));
+    defer testing.allocator.free(store_path);
+    fs.cwd().access(store_path, .{}) catch return error.ExpectedStoreContainer;
 
     var loaded = manager.loadCachedSourceData(key) orelse return error.ExpectedCacheHit;
     defer loaded.deinit();
@@ -1421,11 +1447,14 @@ test "LODManager cache helpers delete corrupt cache files" {
 
     const dir = fs.Dir{ .inner = tmp_dir.dir };
     var path_buf: [fs.max_path_bytes]u8 = undefined;
-    const cache_dir_path = try dir.realpath(".", &path_buf);
+    const save_dir_path = try dir.realpath(".", &path_buf);
 
-    var manager = LODManager.initCacheTestManager(testing.allocator, cache_dir_path);
+    var manager = LODManager.initCacheTestManager(testing.allocator, save_dir_path);
     const key = LODRegionKey{ .rx = 0, .rz = 0, .lod = .lod2 };
-    const path = try manager.cacheFilePath(cache_dir_path, manager.cacheKey(key));
+    const legacy_dir = try fs.path.join(testing.allocator, &.{ save_dir_path, "lod_cache" });
+    defer testing.allocator.free(legacy_dir);
+    try fs.cwd().makePath(legacy_dir);
+    const path = try manager.legacyCacheFilePath(save_dir_path, manager.cacheKey(key));
     defer testing.allocator.free(path);
 
     const file = try fs.cwd().createFile(path, .{ .truncate = true });

--- a/modules/world-lod/src/lod_manager.zig
+++ b/modules/world-lod/src/lod_manager.zig
@@ -165,6 +165,7 @@ pub const LODManager = struct {
     // Optional save directory for generated LOD source data.
     cache_dir_path: ?[]const u8,
     logged_legacy_cache_notice: bool,
+    store_mutex: std.Thread.Mutex,
 
     // Keep cleanup behavior testable, but allow the live world to opt out.
     cleanup_covered_regions: bool = true,
@@ -244,6 +245,7 @@ pub const LODManager = struct {
             .cleanup_covered_regions = true,
             .cache_dir_path = null,
             .logged_legacy_cache_notice = false,
+            .store_mutex = .{},
         };
 
         const cpu_count = std.Thread.getCpuCount() catch MIN_LOD_WORKERS;
@@ -332,11 +334,20 @@ pub const LODManager = struct {
         const cache_dir_path = try self.allocator.dupe(u8, save_dir_path);
         errdefer self.allocator.free(cache_dir_path);
 
-        try lod_store.writeHeader(self.allocator, save_dir_path, .{
+        const live_header = lod_store.StoreHeader{
             .seed = self.generator.seed,
             .generator_identity_hash = self.generator.identity_hash,
             .generator_version = self.generator.version,
-        });
+        };
+
+        if (try lod_store.readHeader(self.allocator, save_dir_path)) |stored_header| {
+            if (!lod_store.headersMatch(stored_header, live_header)) {
+                log.log.warn("LOD store metadata mismatch; purging stale LOD source store", .{});
+                try lod_store.deleteStore(self.allocator, save_dir_path);
+            }
+        }
+
+        try lod_store.writeHeader(self.allocator, save_dir_path, live_header);
 
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -1098,23 +1109,47 @@ pub const LODManager = struct {
         return self.cache_dir_path != null;
     }
 
+    fn readStorePayload(self: *Self, save_dir_path: []const u8, cache_key: lod_cache.Key) !?[]u8 {
+        self.store_mutex.lock();
+        defer self.store_mutex.unlock();
+        return lod_store.readPayload(self.allocator, save_dir_path, cache_key);
+    }
+
+    fn writeStorePayload(self: *Self, save_dir_path: []const u8, cache_key: lod_cache.Key, bytes: []const u8) !void {
+        self.store_mutex.lock();
+        defer self.store_mutex.unlock();
+        try lod_store.writePayload(self.allocator, save_dir_path, cache_key, bytes);
+    }
+
+    fn deleteStorePayload(self: *Self, save_dir_path: []const u8, cache_key: lod_cache.Key) void {
+        self.store_mutex.lock();
+        defer self.store_mutex.unlock();
+        lod_store.deletePayload(self.allocator, save_dir_path, cache_key);
+    }
+
+    fn deleteStoreContainer(self: *Self, path: []const u8) void {
+        self.store_mutex.lock();
+        defer self.store_mutex.unlock();
+        fs.cwd().deleteFile(path) catch |delete_err| {
+            if (delete_err != error.FileNotFound) {
+                log.log.warn("Failed to delete corrupt LOD store container '{s}': {}", .{ path, delete_err });
+            }
+        };
+    }
+
     fn loadCachedSourceData(self: *Self, key: LODRegionKey) ?LODSimplifiedData {
         const save_dir_path = self.cacheDirPathSnapshot() orelse return null;
         defer self.allocator.free(save_dir_path);
 
         const cache_key = self.cacheKey(key);
 
-        if (lod_store.readPayload(self.allocator, save_dir_path, cache_key) catch |err| switch (err) {
+        if (self.readStorePayload(save_dir_path, cache_key) catch |err| switch (err) {
             lod_store.StoreError.CorruptContainer => {
                 const path = lod_store.containerPath(self.allocator, save_dir_path, cache_key) catch null;
                 if (path) |container_path| {
                     defer self.allocator.free(container_path);
                     log.log.warn("Discarding corrupt LOD store container '{s}'", .{container_path});
-                    fs.cwd().deleteFile(container_path) catch |delete_err| {
-                        if (delete_err != error.FileNotFound) {
-                            log.log.warn("Failed to delete corrupt LOD store container '{s}': {}", .{ container_path, delete_err });
-                        }
-                    };
+                    self.deleteStoreContainer(container_path);
                 }
                 return null;
             },
@@ -1126,7 +1161,7 @@ pub const LODManager = struct {
             defer self.allocator.free(bytes);
             return lod_cache.deserialize(bytes, cache_key, self.allocator) catch |err| {
                 log.log.warn("Discarding corrupt LOD store payload LOD{} ({}, {}): {}", .{ @intFromEnum(key.lod), key.rx, key.rz, err });
-                lod_store.deletePayload(self.allocator, save_dir_path, cache_key);
+                self.deleteStorePayload(save_dir_path, cache_key);
                 return null;
             };
         }
@@ -1182,7 +1217,7 @@ pub const LODManager = struct {
         };
         defer self.allocator.free(bytes);
 
-        lod_store.writePayload(self.allocator, save_dir_path, cache_key, bytes) catch |err| {
+        self.writeStorePayload(save_dir_path, cache_key, bytes) catch |err| {
             log.log.warn("Failed to write LOD{} store ({}, {}): {}", .{ @intFromEnum(key.lod), key.rx, key.rz, err });
         };
     }
@@ -1223,6 +1258,7 @@ pub const LODManager = struct {
             .renderer = undefined,
             .cache_dir_path = cache_dir_path,
             .logged_legacy_cache_notice = false,
+            .store_mutex = .{},
             .cleanup_covered_regions = true,
         };
     }

--- a/modules/world-lod/src/lod_store.zig
+++ b/modules/world-lod/src/lod_store.zig
@@ -7,6 +7,7 @@ const RegionFile = @import("world-persistence").RegionFile;
 const lod_cache = @import("lod_cache.zig");
 
 const REGION_GRID: i32 = 32;
+const MAX_CONTAINER_BYTES: usize = 256 * 1024 * 1024;
 
 pub const StoreHeader = struct {
     seed: u64,
@@ -18,6 +19,13 @@ pub const StoreHeader = struct {
 pub const StoreError = error{
     CorruptContainer,
 };
+
+pub fn headersMatch(a: StoreHeader, b: StoreHeader) bool {
+    return a.seed == b.seed and
+        a.generator_identity_hash == b.generator_identity_hash and
+        a.generator_version == b.generator_version and
+        a.lod_data_version == b.lod_data_version;
+}
 
 fn containerCoord(value: i32) i32 {
     return @divFloor(value, REGION_GRID);
@@ -75,6 +83,31 @@ pub fn writeHeader(allocator: std.mem.Allocator, save_dir_path: []const u8, head
     };
 }
 
+pub fn readHeader(allocator: std.mem.Allocator, save_dir_path: []const u8) !?StoreHeader {
+    const path = try fs.path.join(allocator, &.{ save_dir_path, "lod", "store.json" });
+    defer allocator.free(path);
+
+    const bytes = fs.cwd().readFileAlloc(path, allocator, 4096) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    defer allocator.free(bytes);
+
+    const parsed = try std.json.parseFromSlice(StoreHeader, allocator, bytes, .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+    return parsed.value;
+}
+
+pub fn deleteStore(allocator: std.mem.Allocator, save_dir_path: []const u8) !void {
+    const lod_root = try fs.path.join(allocator, &.{ save_dir_path, "lod" });
+    defer allocator.free(lod_root);
+
+    fs.cwd().deleteTree(lod_root) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
+}
+
 pub fn readPayload(allocator: std.mem.Allocator, save_dir_path: []const u8, key: lod_cache.Key) !?[]u8 {
     const path = try containerPath(allocator, save_dir_path, key);
     defer allocator.free(path);
@@ -98,14 +131,53 @@ pub fn writePayload(allocator: std.mem.Allocator, save_dir_path: []const u8, key
 
     const path = try containerPath(allocator, save_dir_path, key);
     defer allocator.free(path);
-
-    var region = RegionFile.open(allocator, path) catch |err| switch (err) {
-        error.FileNotFound => try RegionFile.create(allocator, path),
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{path});
+    defer allocator.free(tmp_path);
+    fs.cwd().deleteFile(tmp_path) catch |err| switch (err) {
+        error.FileNotFound => {},
         else => return err,
     };
-    defer region.close();
 
-    try region.writeChunk(localCoord(key.rx), localCoord(key.rz), bytes);
+    const use_existing = blk: {
+        var existing_region = RegionFile.open(allocator, path) catch |err| switch (err) {
+            error.FileNotFound => break :blk false,
+            else => break :blk false,
+        };
+        existing_region.close();
+        break :blk true;
+    };
+
+    if (use_existing) {
+        const existing = try fs.cwd().readFileAlloc(path, allocator, MAX_CONTAINER_BYTES);
+        defer allocator.free(existing);
+        const tmp_file = try fs.cwd().createFile(tmp_path, .{ .truncate = true });
+        tmp_file.writeAll(existing) catch |err| {
+            tmp_file.close();
+            fs.cwd().deleteFile(tmp_path) catch {};
+            return err;
+        };
+        tmp_file.close();
+    }
+
+    var region = (if (use_existing)
+        RegionFile.open(allocator, tmp_path)
+    else
+        RegionFile.create(allocator, tmp_path)) catch |err| {
+        fs.cwd().deleteFile(tmp_path) catch {};
+        return err;
+    };
+
+    region.writeChunk(localCoord(key.rx), localCoord(key.rz), bytes) catch |err| {
+        region.close();
+        fs.cwd().deleteFile(tmp_path) catch {};
+        return err;
+    };
+    region.close();
+
+    fs.cwd().rename(tmp_path, path) catch |err| {
+        fs.cwd().deleteFile(tmp_path) catch {};
+        return err;
+    };
 }
 
 pub fn deletePayload(allocator: std.mem.Allocator, save_dir_path: []const u8, key: lod_cache.Key) void {
@@ -152,6 +224,51 @@ test "LOD store overwrites existing payloads" {
     try testing.expectEqualStrings("larger replacement payload", loaded);
 }
 
+test "LOD store atomic overwrite preserves sibling entries" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const save_dir = try dir.realpath(".", &path_buf);
+
+    const key_a = lod_cache.Key{ .seed = 1, .generator_identity_hash = 2, .generator_version = 3, .rx = 0, .rz = 0, .lod = .lod1 };
+    const key_b = lod_cache.Key{ .seed = 1, .generator_identity_hash = 2, .generator_version = 3, .rx = 1, .rz = 0, .lod = .lod1 };
+    try writePayload(testing.allocator, save_dir, key_a, "payload-a");
+    try writePayload(testing.allocator, save_dir, key_b, "payload-b");
+    try writePayload(testing.allocator, save_dir, key_a, "payload-a-updated");
+
+    const loaded_a = (try readPayload(testing.allocator, save_dir, key_a)).?;
+    defer testing.allocator.free(loaded_a);
+    const loaded_b = (try readPayload(testing.allocator, save_dir, key_b)).?;
+    defer testing.allocator.free(loaded_b);
+    try testing.expectEqualStrings("payload-a-updated", loaded_a);
+    try testing.expectEqualStrings("payload-b", loaded_b);
+}
+
+test "LOD store write replaces corrupt containers" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const save_dir = try dir.realpath(".", &path_buf);
+    const key = lod_cache.Key{ .seed = 1, .generator_identity_hash = 2, .generator_version = 3, .rx = 0, .rz = 0, .lod = .lod1 };
+
+    const path = try containerPath(testing.allocator, save_dir, key);
+    defer testing.allocator.free(path);
+    const parent = fs.path.dirname(path).?;
+    try fs.cwd().makePath(parent);
+    const file = try fs.cwd().createFile(path, .{ .truncate = true });
+    try file.writeAll("bad");
+    file.close();
+
+    try writePayload(testing.allocator, save_dir, key, "replacement");
+    const loaded = (try readPayload(testing.allocator, save_dir, key)).?;
+    defer testing.allocator.free(loaded);
+    try testing.expectEqualStrings("replacement", loaded);
+}
+
 test "LOD store missing and corrupt containers are advisory misses" {
     var tmp_dir = testing.tmpDir(.{});
     defer tmp_dir.cleanup();
@@ -190,4 +307,21 @@ test "LOD store writes metadata header atomically" {
 
     try testing.expect(std.mem.indexOf(u8, bytes, "\"seed\": 123") != null);
     try testing.expect(std.mem.indexOf(u8, bytes, "\"lod_data_version\": 2") != null);
+}
+
+test "LOD store reads and deletes metadata store" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const save_dir = try dir.realpath(".", &path_buf);
+    const header = StoreHeader{ .seed = 123, .generator_identity_hash = 456, .generator_version = 7 };
+
+    try writeHeader(testing.allocator, save_dir, header);
+    const loaded = (try readHeader(testing.allocator, save_dir)).?;
+    try testing.expect(headersMatch(header, loaded));
+
+    try deleteStore(testing.allocator, save_dir);
+    try testing.expect((try readHeader(testing.allocator, save_dir)) == null);
 }

--- a/modules/world-lod/src/lod_store.zig
+++ b/modules/world-lod/src/lod_store.zig
@@ -1,0 +1,193 @@
+//! Persistent container store for serialized LOD source payloads.
+
+const std = @import("std");
+const fs = @import("fs");
+
+const RegionFile = @import("world-persistence").RegionFile;
+const lod_cache = @import("lod_cache.zig");
+
+const REGION_GRID: i32 = 32;
+
+pub const StoreHeader = struct {
+    seed: u64,
+    generator_identity_hash: u64,
+    generator_version: u32,
+    lod_data_version: u8 = lod_cache.CACHE_VERSION,
+};
+
+pub const StoreError = error{
+    CorruptContainer,
+};
+
+fn containerCoord(value: i32) i32 {
+    return @divFloor(value, REGION_GRID);
+}
+
+fn localCoord(value: i32) u5 {
+    return @intCast(@mod(value, REGION_GRID));
+}
+
+fn lodDirPath(allocator: std.mem.Allocator, save_dir_path: []const u8, lod: @import("lod_types.zig").LODLevel) ![]u8 {
+    const lod_name = try std.fmt.allocPrint(allocator, "{}", .{@intFromEnum(lod)});
+    defer allocator.free(lod_name);
+    return fs.path.join(allocator, &.{ save_dir_path, "lod", lod_name });
+}
+
+pub fn containerPath(allocator: std.mem.Allocator, save_dir_path: []const u8, key: lod_cache.Key) ![]u8 {
+    const dir_path = try lodDirPath(allocator, save_dir_path, key.lod);
+    defer allocator.free(dir_path);
+    const filename = try std.fmt.allocPrint(
+        allocator,
+        "r.{}.{}.zlod",
+        .{ containerCoord(key.rx), containerCoord(key.rz) },
+    );
+    defer allocator.free(filename);
+    return fs.path.join(allocator, &.{ dir_path, filename });
+}
+
+pub fn writeHeader(allocator: std.mem.Allocator, save_dir_path: []const u8, header: StoreHeader) !void {
+    const lod_root = try fs.path.join(allocator, &.{ save_dir_path, "lod" });
+    defer allocator.free(lod_root);
+    try fs.cwd().makePath(lod_root);
+
+    const path = try fs.path.join(allocator, &.{ lod_root, "store.json" });
+    defer allocator.free(path);
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{path});
+    defer allocator.free(tmp_path);
+
+    const bytes = try std.fmt.allocPrint(
+        allocator,
+        "{{\n  \"seed\": {},\n  \"generator_identity_hash\": {},\n  \"generator_version\": {},\n  \"lod_data_version\": {}\n}}\n",
+        .{ header.seed, header.generator_identity_hash, header.generator_version, header.lod_data_version },
+    );
+    defer allocator.free(bytes);
+
+    const file = try fs.cwd().createFile(tmp_path, .{ .truncate = true });
+    file.writeAll(bytes) catch |err| {
+        file.close();
+        fs.cwd().deleteFile(tmp_path) catch {};
+        return err;
+    };
+    file.close();
+    fs.cwd().rename(tmp_path, path) catch |err| {
+        fs.cwd().deleteFile(tmp_path) catch {};
+        return err;
+    };
+}
+
+pub fn readPayload(allocator: std.mem.Allocator, save_dir_path: []const u8, key: lod_cache.Key) !?[]u8 {
+    const path = try containerPath(allocator, save_dir_path, key);
+    defer allocator.free(path);
+
+    var region = RegionFile.open(allocator, path) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return StoreError.CorruptContainer,
+    };
+    defer region.close();
+
+    return region.readChunk(localCoord(key.rx), localCoord(key.rz), allocator) catch |err| switch (err) {
+        error.ChunkNotFound => return null,
+        else => return err,
+    };
+}
+
+pub fn writePayload(allocator: std.mem.Allocator, save_dir_path: []const u8, key: lod_cache.Key, bytes: []const u8) !void {
+    const dir_path = try lodDirPath(allocator, save_dir_path, key.lod);
+    defer allocator.free(dir_path);
+    try fs.cwd().makePath(dir_path);
+
+    const path = try containerPath(allocator, save_dir_path, key);
+    defer allocator.free(path);
+
+    var region = RegionFile.open(allocator, path) catch |err| switch (err) {
+        error.FileNotFound => try RegionFile.create(allocator, path),
+        else => return err,
+    };
+    defer region.close();
+
+    try region.writeChunk(localCoord(key.rx), localCoord(key.rz), bytes);
+}
+
+pub fn deletePayload(allocator: std.mem.Allocator, save_dir_path: []const u8, key: lod_cache.Key) void {
+    const path = containerPath(allocator, save_dir_path, key) catch return;
+    defer allocator.free(path);
+
+    var region = RegionFile.open(allocator, path) catch return;
+    defer region.close();
+    region.deleteChunk(localCoord(key.rx), localCoord(key.rz)) catch {};
+}
+
+const testing = std.testing;
+
+test "LOD store round-trips payloads through region containers" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const save_dir = try dir.realpath(".", &path_buf);
+
+    const key = lod_cache.Key{ .seed = 11, .generator_identity_hash = 22, .generator_version = 3, .rx = 34, .rz = -1, .lod = .lod2 };
+    try writePayload(testing.allocator, save_dir, key, "payload-a");
+
+    const loaded = (try readPayload(testing.allocator, save_dir, key)).?;
+    defer testing.allocator.free(loaded);
+    try testing.expectEqualStrings("payload-a", loaded);
+}
+
+test "LOD store overwrites existing payloads" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const save_dir = try dir.realpath(".", &path_buf);
+
+    const key = lod_cache.Key{ .seed = 1, .generator_identity_hash = 2, .generator_version = 3, .rx = -32, .rz = 63, .lod = .lod1 };
+    try writePayload(testing.allocator, save_dir, key, "small");
+    try writePayload(testing.allocator, save_dir, key, "larger replacement payload");
+
+    const loaded = (try readPayload(testing.allocator, save_dir, key)).?;
+    defer testing.allocator.free(loaded);
+    try testing.expectEqualStrings("larger replacement payload", loaded);
+}
+
+test "LOD store missing and corrupt containers are advisory misses" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const save_dir = try dir.realpath(".", &path_buf);
+    const key = lod_cache.Key{ .seed = 1, .generator_identity_hash = 2, .generator_version = 3, .rx = 0, .rz = 0, .lod = .lod1 };
+
+    try testing.expect((try readPayload(testing.allocator, save_dir, key)) == null);
+
+    const path = try containerPath(testing.allocator, save_dir, key);
+    defer testing.allocator.free(path);
+    const parent = fs.path.dirname(path).?;
+    try fs.cwd().makePath(parent);
+    const file = try fs.cwd().createFile(path, .{ .truncate = true });
+    try file.writeAll("bad");
+    file.close();
+
+    try testing.expectError(StoreError.CorruptContainer, readPayload(testing.allocator, save_dir, key));
+}
+
+test "LOD store writes metadata header atomically" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const save_dir = try dir.realpath(".", &path_buf);
+
+    try writeHeader(testing.allocator, save_dir, .{ .seed = 123, .generator_identity_hash = 456, .generator_version = 7 });
+    const header_path = try fs.path.join(testing.allocator, &.{ save_dir, "lod", "store.json" });
+    defer testing.allocator.free(header_path);
+    const bytes = try fs.cwd().readFileAlloc(header_path, testing.allocator, 4096);
+    defer testing.allocator.free(bytes);
+
+    try testing.expect(std.mem.indexOf(u8, bytes, "\"seed\": 123") != null);
+    try testing.expect(std.mem.indexOf(u8, bytes, "\"lod_data_version\": 2") != null);
+}

--- a/modules/world-lod/src/root.zig
+++ b/modules/world-lod/src/root.zig
@@ -12,6 +12,7 @@ pub const lod_streaming_coordinator = @import("lod_streaming_coordinator.zig");
 pub const lod_types = @import("lod_types.zig");
 pub const lod_upload_queue = @import("lod_upload_queue.zig");
 pub const lod_stats = @import("lod_stats.zig");
+pub const lod_store = @import("lod_store.zig");
 pub const world_lod = @import("world_lod.zig");
 
 pub const LODChunk = lod_chunk.LODChunk;


### PR DESCRIPTION
## Summary
- Add a persistent LOD region-container store under `<save>/lod/<lod>/r.X.Z.zlod` using `world-persistence.RegionFile` sector logic
- Move `LODManager` source-data save/load to the new store while retaining `lod_cache/` as a read-only legacy fallback
- Serialize store file access with a dedicated LOD store mutex outside the LODManager state mutex
- Publish container updates via temp-file + rename and recover corrupt containers on write
- Add conservative store metadata mismatch handling by purging stale stores before writing the live header
- Add in-memory column provenance and cache serialization round-trip coverage for `worldgen`/`chunk_derived`/`edited` provenance

## Tests
- `nix develop --command zig fmt modules/world-core/src/lod_data.zig modules/world-lod/src/lod_store.zig modules/world-lod/src/lod_manager.zig`
- `nix develop --command zig build test`

## Runtime Check
- Earlier `nix develop --command zig build run -Dskip-present -Dauto-world=normal -Dstartup-diagnostic-seconds=5` timed out after 30s and again after 60s after shader validation output, before startup diagnostics appeared; no crash output was captured.

Refs #754
