### PR TITLE
ci: serialize opencode runs and set GLM-5.2 variant to max

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -7,8 +7,8 @@ on:
     types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.comment.id }}
-  cancel-in-progress: true
+  group: opencode-serial
+  cancel-in-progress: false
 
 jobs:
   opencode:
@@ -53,4 +53,5 @@ jobs:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
         with:
           model: zhipuai-coding-plan/glm-5.2
+          variant: max
           use_github_token: true


### PR DESCRIPTION
## Context

8 parallel `opencode.yml` runs hung simultaneously on the `Run opencode` step for ~17+ minutes after `MichaelFisher1997` batch-commented `/oc` on 8 pre-existing audit issues (#720, #722, #723, #725, #728, #736, #746, +1) within ~90 seconds. All 8 entered the `opencode github run` step inside a 60s window and froze — `updated_at` went stale on every run. Root cause: a burst of 8 simultaneous GLM-5.2 sessions against a single `ZHIPU_API_KEY` with no concurrency serialization, hitting provider-side throttling.

The 8 hung runs were cancelled manually before opening this PR.

## Changes

**1. Serialize parallel bursts** — `.github/workflows/opencode.yml:9-11`

The old concurrency group was keyed per-comment (`github.event.comment.id`), so each `/oc` invocation got its own group and they all ran in parallel. Switched to a fixed group (`opencode-serial`) with `cancel-in-progress: false` so runs **queue one-at-a-time** instead of clobbering the provider. Distinct issues keep their work; no cancellation of in-flight runs.

**2. Set GLM-5.2 reasoning to `max`** — `.github/workflows/opencode.yml:56`

Added `variant: max` to the `with:` block. The `anomalyco/opencode/github` action exposes `variant` as the provider-specific reasoning effort (high / max / minimal). GLM-5.2 honors it; this is the only workflow using GLM.

## Not changed

- `opencode-pr.yml` (Kimi `k2p7`), `opencode-triage.yml`, `opencode-audit.yml`, `opencode-test-writer.yml` (MiniMax `M3`) — left alone. `variant` is provider-specific and these models don't use it the same way GLM does.

## Trade-off

With serialized concurrency + `max` reasoning, batch-triggering N issues will process sequentially and each run may take 10–20+ min (confirm-bug → search-dupes → implement → PR). 8 issues back-to-back could mean ~2–3 hours of queue. This is the robust choice for provider stability; the alternative (parallel + rate-limit errors) is what caused today's hang.

## Validation

- [x] YAML structure verified
- [ ] actionlint via CI (`workflow-validation.yml`)

## Follow-up

After merge, re-comment `/oc` on the affected audit issues to re-trigger. The cancelled runs do not auto-resume.