### PR TITLE
ci: route opencode GLM via managed provider instead of direct key

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -50,8 +50,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
-          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
         with:
           model: zhipuai-coding-plan/glm-5.2
           variant: max
-          use_github_token: true


### PR DESCRIPTION
## Root cause of the GLM hangs

The `opencode.yml` runs were hanging because of an **auth-path mismatch**, not parallelism or reasoning level.

- **Local opencode sessions work** because `zhipuai-coding-plan/glm-5.2` routes through opencode's **managed provider**, authenticated via the opencode account login — billed to the opencode subscription, no personal Zhipu balance involved.
- **The CI run hung** because the workflow set `ZHIPU_API_KEY` (a direct Zhipu account key) **and** `use_github_token: true` (which skips the OIDC exchange that authenticates CI to the opencode account). With OIDC skipped and a raw key present, opencode bypassed the managed provider and called Zhipu's API directly with that key. That Zhipu account has zero balance → API returns `code 1113 余额不足或无可用资源包` (insufficient balance) wrapped in HTTP 429 → opencode flags 429 as `isRetryable` → infinite retry loop → the 60-minute "hang".

Captured from run #28726053520 logs (cancelled to capture):
```
url: https://open.bigmodel.cn/api/coding/paas/v4/chat/completions
statusCode: 429
responseBody: {"error":{"code":"1113","message":"余额不足或无可用资源包,请充值。"}}
isRetryable: true
```

Same model, different wallet. PR #764 (variant + serialization) did not address this — my earlier parallel-throttling diagnosis was wrong.

## Change

Remove the two lines that forced the direct-key path:
- `ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}` — gone, so opencode falls back to the managed `zhipuai-coding-plan` provider.
- `use_github_token: true` — gone (defaults to `false`), so the OIDC exchange runs and CI authenticates to the opencode account, unlocking the funded managed provider.

`variant: max` (from #764) is kept. `id-token: write` (already present) is required for OIDC.

## Side effect

With `use_github_token` off, opencode uses the **opencode GitHub App installation token** for git push / PR / comment operations instead of `GITHUB_TOKEN`/`OPENCODE_PAT`. This is the default, supported path per the opencode docs. The `Configure git identity` step and `OPENCODE_PAT`-based `gh api user` lookup are unaffected. Requires the `opencode-agent` GitHub App to be installed on the repo.

## Verification plan

After merge, re-trigger **one** issue (#746) and confirm via logs that it now reaches GLM through the managed provider and produces output (not a 1113 loop). If green, re-trigger the remaining 7 audit issues.