### PR TITLE
revert: restore ZHIPU_API_KEY and use_github_token in opencode.yml (#765)

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -50,6 +50,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT }}
           GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
         with:
           model: zhipuai-coding-plan/glm-5.2
           variant: max
+          use_github_token: true


### PR DESCRIPTION
## Why revert

PR #765 removed `ZHIPU_API_KEY` and `use_github_token: true` based on a wrong theory that `zhipuai-coding-plan/glm-5.2` would fall back to an opencode-managed funded path. The re-trigger run (#746, run 28737814667) disproved this — it failed instantly:

```
Model not found: zhipuai-coding-plan/glm-5.2. Did you mean: glm-5.2?
```

The `zhipuai-coding-plan` provider **requires** a Zhipu API key to resolve. Removing `ZHIPU_API_KEY` unregisters the provider entirely; it does not switch billing paths. My third misdiagnosis in this thread.

## Actual root cause (now confirmed by logs)

The repo's `ZHIPU_API_KEY` secret points to an **unfunded Zhipu account** (`code 1113 余额不足`). Local sessions work because they use a **funded** Zhipu key from the local environment. Same provider, different keys, different wallet. The workflow config itself was correct.

## This revert

Restores `ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}` and `use_github_token: true`, returning `opencode.yml` to its post-#764 state (variant: max + serialized concurrency intact).

## Follow-up (separate from this revert)

Update the repo `ZHIPU_API_KEY` secret value to a funded Zhipu key. Config is not the problem; the secret's account balance is.