### PR TITLE
fix(ci): configure git identity without API call (use GITHUB_ACTOR)

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -32,12 +32,8 @@ jobs:
 
       - name: Configure git identity
         run: |
-          PAT_USER_ID="$(gh api user --jq '.id')"
-          PAT_USER_LOGIN="$(gh api user --jq '.login')"
-          git config user.name "$PAT_USER_LOGIN"
-          git config user.email "${PAT_USER_ID}+${PAT_USER_LOGIN}@users.noreply.github.com"
-        env:
-          GH_TOKEN: ${{ secrets.OPENCODE_PAT }}
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix


### PR DESCRIPTION
## Problem

The `Configure git identity` step in `opencode.yml` calls `gh api user` twice per run to derive the PAT owner's login + numeric id for the commit noreply email. This consumes 2 GitHub API requests on every run and **fails the entire run when the token is rate-limited** — exactly what killed today's verification run (`28738008309`):

```
Run PAT_USER_ID="$(gh api user --jq '.id')"
gh: API rate limit exceeded for user ID 91565606 ... (HTTP 403)
Error: Process completed with exit code 1.
```

The run died at step 3 and never reached `Run opencode`, so the model never got invoked.

## Fix

Use the built-in `GITHUB_ACTOR` context var (the user/app that triggered the run) instead of querying the API. Zero API calls, no `GH_TOKEN` needed on the step, and structurally identical to how `opencode-pr.yml` configures identity via static values.

```yaml
- name: Configure git identity
  run: |
    git config user.name "${GITHUB_ACTOR}"
    git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
```

`GITHUB_ACTOR` is always populated for `issue_comment`/`pull_request_review_comment` events. The `${GITHUB_ACTOR}@users.noreply.github.com` email is a valid GitHub noreply format that attributes commits to the correct account.

## Scope

Only `opencode.yml`. No change to `Run opencode`, the model, the secret, or `variant: max`. This is purely a robustness fix for the identity step.

## Why now

This step was the blocker preventing verification of the funded `ZHIPU_API_KEY` fix — every test run died here on rate-limit before reaching the model. Removing the API dependency lets the run proceed to `Run opencode` regardless of API quota.