### PR TITLE
fix(ci): pre-grant external_directory permissions for headless opencode runs

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "/tmp/**": "allow",
+      "/nix/**": "allow"
+    }
+  }
+}


### PR DESCRIPTION
## Root cause of the remaining CI hang

With the funded `ZHIPU_API_KEY` now working, the re-test run (`28738759852`) proved the model is fine — the agent completed 6 model turns (read issue, explored code, wrote a fix, ran tests) with **zero balance errors**. It then hung for 12 minutes on this:

```
11:12:53  asking { permission: "external_directory", patterns: ["/tmp/*"] }
11:24:51  ##[error]The operation was canceled.
```

Per the opencode docs, `external_directory` **defaults to `"ask"`**. The agent wrote test output to `/tmp/test_out.txt` and tried to read it back; opencode prompted for approval; there is no human to answer in a headless GitHub Actions runner; the run blocked until the 60-min timeout (or cancellation).

## Fix

Add a repo-level `opencode.json` pre-granting the external paths this Nix-based CI legitimately needs:

- `/tmp/**` — test output, temp files, and the workflow's `XDG_CACHE_HOME=/tmp/opencode-cache`.
- `/nix/**` — the read-only Nix toolchain store that `zig`/builds read from.

```json
{
  "$schema": "https://opencode.ai/config.json",
  "permission": {
    "external_directory": {
      "/tmp/**": "allow",
      "/nix/**": "allow"
    }
  }
}
```

Everything else stays at opencode's defaults (`read`/`edit`/`bash`/`glob`/`grep` allow within the workspace; `.env` denied). This is the minimal grant that lets the agent operate autonomously in CI without hanging on prompts.

## Why a repo config (not the action)

`opencode github run` does not run in `--auto` mode, and the action exposes no auto-approve input. The repo-level config is the supported lever — opencode auto-discovers `opencode.json` from the checked-out working directory.

## Scope

New file only. No workflow changes. Applies to all opencode invocations in this repo (CI + local), which is desirable — local sessions benefit from the same grants.

## Verification plan

After merge, re-trigger #746 and confirm the agent proceeds past `/tmp` access and completes (creates a branch/PR) without hanging.