### PR TITLE
fix(worldgen): log TreeHintCache OOM and preserve computed hints

### DIFF
--- a/modules/worldgen-overworld/src/overworld_generator.zig
+++ b/modules/worldgen-overworld/src/overworld_generator.zig
@@ -423,7 +423,9 @@ pub const OverworldGenerator = struct {
 
         const hints = self.computeChunkTreeHints(chunk_x, chunk_z);
         const result = hints[idx];
-        cache.put(key, hints) catch {};
+        cache.put(key, hints) catch |err| {
+            log.log.warn("TreeHintCache: failed to cache tree hints for chunk ({}, {}): {}", .{ chunk_x, chunk_z, err });
+        };
         return result;
     }
 
@@ -448,10 +450,14 @@ pub const OverworldGenerator = struct {
             var chunk_x = min_chunk_x;
             while (chunk_x <= max_chunk_x) : (chunk_x += 1) {
                 const key = treeHintCacheKey(chunk_x, chunk_z);
-                if (!cache.contains(key)) {
-                    cache.put(key, self.computeChunkTreeHints(chunk_x, chunk_z)) catch {};
-                }
-                const hints = cache.get(key) orelse continue;
+                const hints = blk: {
+                    if (cache.get(key)) |cached| break :blk cached;
+                    const computed = self.computeChunkTreeHints(chunk_x, chunk_z);
+                    cache.put(key, computed) catch |err| {
+                        log.log.warn("TreeHintCache: failed to cache tree hints for chunk ({}, {}): {}", .{ chunk_x, chunk_z, err });
+                    };
+                    break :blk computed;
+                };
                 const chunk_world_x = chunk_x * @as(i32, @intCast(CHUNK_SIZE_X));
                 const chunk_world_z = chunk_z * @as(i32, @intCast(CHUNK_SIZE_Z));
 


### PR DESCRIPTION
## Summary

Fixes #722.

Confirmed the issue still exists at `overworld_generator.zig:426` and `overworld_generator.zig:452` — both `TreeHintCache.put` call sites used `catch {}` to silently swallow `error.OutOfMemory`. No existing fix or duplicate issue was found in the codebase or recent history.

## Changes

**`actualTreeHintAtColumn` (line 426):** Replaced `catch {}` with a logged warning. The immediate caller already extracted its result before the put, so behavior is unchanged for the caller — this is purely observability.

**`actualTreeHintInArea` (lines 451-460):** This was the real bug. The original code was:
```zig
if (!cache.contains(key)) {
    cache.put(key, self.computeChunkTreeHints(chunk_x, chunk_z)) catch {};
}
const hints = cache.get(key) orelse continue;
```
When `put` failed, `cache.get` returned `null` and the loop `continue`d, discarding the just-computed chunk hints and silently degrading LOD vegetation for that chunk (falling through to `LODVegetationHint.empty`). The fix captures the computed hints and uses them directly even when cache insertion fails, so vegetation data is preserved. Also collapses the contains+get into a single get to remove a redundant lookup.

## Acceptance Criteria

- [x] Computed `TreeHintChunk` is preserved and used when cache put fails (no discarded computation)
- [x] No silent OOM — a warning is logged on cache insertion failure
- [x] LOD vegetation hints remain consistent even when cache insertion fails
- [x] `zig build test` passes (264/264 tests, all shaders validated)

## Notes

The issue's framing of a "memory leak" was slightly off — `TreeHintChunk` is a fixed-size value array (not heap-allocated), so the hints value itself never leaked. The genuine bug was the discarded computation and degraded vegetation coverage in `actualTreeHintInArea`, plus the lack of observability for cache failures. Note also that per the comment at lines 273-276, this path is currently dormant (`compute_tree_hints` is false for all LOD levels), but the fix is still worthwhile for correctness when the feature is re-enabled.

## Verification

```
zig build test
Build Summary: 36/36 steps succeeded; 264/264 tests passed
```