### PR TITLE
fix(settings): propagate persistence save errors instead of swallowing

### DIFF
--- a/modules/game-core/src/input_settings.zig
+++ b/modules/game-core/src/input_settings.zig
@@ -104,7 +104,9 @@ pub const InputSettings = struct {
         }
 
         if (healed) {
-            settings.save() catch {};
+            settings.save() catch |err| {
+                log.log.err("Failed to persist healed input settings: {}", .{err});
+            };
         }
 
         log.log.info("InputSettings: toggle_shadow_debug_vis is bound to {s}", .{settings.input_mapper.getBinding(.toggle_shadow_debug_vis).primary.getName()});

--- a/modules/game-core/src/settings/persistence.zig
+++ b/modules/game-core/src/settings/persistence.zig
@@ -107,45 +107,32 @@ pub fn setEnvironmentMap(settings: *Settings, allocator: std.mem.Allocator, name
 }
 
 /// Save settings to ~/.config/zigcraft/settings.json
-pub fn save(settings: *const Settings, allocator: std.mem.Allocator) void {
-    const home = getenv("HOME") orelse {
-        log.log.warn("Cannot save settings: HOME not set", .{});
-        return;
-    };
+///
+/// Errors are propagated to the caller so they can be reported to the user.
+/// Returns error.NoHomeDir if the HOME environment variable is not set.
+pub fn save(settings: *const Settings, allocator: std.mem.Allocator) !void {
+    const home = getenv("HOME") orelse return error.NoHomeDir;
 
     // Open home directory
-    var home_dir = fs.openDirAbsolute(home, .{}) catch |err| {
-        log.log.warn("Cannot open home directory: {}", .{err});
-        return;
-    };
+    var home_dir = try fs.openDirAbsolute(home, .{});
     defer home_dir.close();
 
-    // Create config directory if it doesn't exist
-    home_dir.makePath(CONFIG_DIR) catch |err| {
-        log.log.warn("Failed to create config directory: {}", .{err});
-        return;
+    // Create config directory if it doesn't exist (idempotent).
+    home_dir.makePath(CONFIG_DIR) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
     };
 
     // Open/create the settings file
     const config_path = CONFIG_DIR ++ "/" ++ CONFIG_FILE;
-    const file = home_dir.createFile(config_path, .{}) catch |err| {
-        log.log.warn("Failed to create settings file: {}", .{err});
-        return;
-    };
+    const file = try home_dir.createFile(config_path, .{});
     defer file.close();
 
     // Serialize settings to JSON and write to file
-    const json_str = std.json.Stringify.valueAlloc(allocator, settings.*, .{ .whitespace = .indent_2 }) catch |err| {
-        log.log.warn("Failed to serialize settings: {}", .{err});
-        return;
-    };
+    const json_str = try std.json.Stringify.valueAlloc(allocator, settings.*, .{ .whitespace = .indent_2 });
     defer allocator.free(json_str);
 
-    // Write to file
-    _ = file.writeAll(json_str) catch |err| {
-        log.log.warn("Failed to write settings: {}", .{err});
-        return;
-    };
+    try file.writeAll(json_str);
 
     log.log.info("Settings saved to ~/{s}", .{config_path});
 }

--- a/modules/game-core/src/settings_manager.zig
+++ b/modules/game-core/src/settings_manager.zig
@@ -28,8 +28,8 @@ pub const SettingsManager = struct {
         settings_pkg.deinitPresets(self.allocator);
     }
 
-    pub fn save(self: *const SettingsManager) void {
-        settings_pkg.persistence.save(&self.settings, self.allocator);
+    pub fn save(self: *const SettingsManager) !void {
+        try settings_pkg.persistence.save(&self.settings, self.allocator);
     }
 
     pub fn applyToRHI(self: *const SettingsManager, rhi: *RHI) void {

--- a/modules/game-ui/src/screen.zig
+++ b/modules/game-ui/src/screen.zig
@@ -172,7 +172,9 @@ pub const WorldContext = struct {
 };
 
 fn saveSettingsShared(allocator: std.mem.Allocator, settings: *Settings, input_mapper: IInputMapper) void {
-    settings_pkg.persistence.save(settings, allocator);
+    settings_pkg.persistence.save(settings, allocator) catch |err| {
+        @import("engine-core").log.log.err("Failed to save game settings: {}", .{err});
+    };
     @import("game-core").InputSettings.saveFromMapper(allocator, input_mapper) catch |err| {
         @import("engine-core").log.log.err("Failed to save input settings: {}", .{err});
     };

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -300,7 +300,9 @@ pub const App = struct {
     }
 
     pub fn saveAllSettings(self: *const App) void {
-        self.settings_manager.save();
+        self.settings_manager.save() catch |err| {
+            log.log.errWithTrace("Failed to save game settings: {}", .{err});
+        };
         InputSettings.saveFromMapper(self.allocator, self.input_mapper.interface()) catch |err| {
             log.log.errWithTrace("Failed to save input settings: {}", .{err});
         };


### PR DESCRIPTION
## Summary

Fixes #723.

The audit flagged the settings save path for silently swallowing errors. The issue title pointed at `InputSettings.saveFromMapper`, but as the [bot review noted](https://github.com/OpenStaticFish/ZigCraft/issues/723#issuecomment-), `saveFromMapper` already propagates errors correctly via `try`. The **real** silent swallowing lived in `settings/persistence.save`, which returned `void` and discarded every I/O error (disk full, permission denied, etc.) with internal `log.warn` calls — so callers like `App.saveAllSettings` had no way to know a save failed. There was also an empty `catch {}` in the `InputSettings.load` healing path.

I confirmed this is still the case on the current `dev` (522629e) and that no other fix covers it.

## Changes
- `settings/persistence.save` now returns `!void` and propagates errors (returns `error.NoHomeDir` when `HOME` is unset).
- `SettingsManager.save` propagates errors to its caller.
- `App.saveAllSettings` (`src/game/app.zig`) catches and logs game-settings save errors via `errWithTrace`, matching the existing input-settings handling.
- `screen.zig` `saveSettingsShared` catches and logs game-settings save errors, matching the existing input-settings handling.
- Replaced the empty `catch {}` in `InputSettings.load` (healing path) with a logged error.

## Acceptance criteria (from #723)
- [x] `saveFromMapper` propagates errors from `save` to its caller (already true; verified)
- [x] `saveAllSettings` receives and logs errors when input settings save fails (already true; now also logs game-settings errors)
- [x] No empty `catch {}` blocks in the save path
- [x] `zig build test` passes

## Verification
- `nix develop --command zig build` — succeeds
- `nix develop --command zig build test` — passes (exit 0), including shader validation
- `nix develop --command zig fmt src/ modules/` — clean

The user-facing `saveAllSettings`/`saveSettingsShared` entry points intentionally remain `void` (they're called from UI callbacks at shutdown), but they now log failures as errors instead of silently discarding them.