### PR TITLE
fix(app): gracefully handle pending world launch failure instead of crashing

### DIFF
--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -329,7 +329,18 @@ pub const App = struct {
         }
 
         log.log.info("PENDING WORLD LAUNCH: creating world after swapchain settled at {}x{}", .{ swapchain_extent[0], swapchain_extent[1] });
-        const world_screen = try WorldScreen.init(self.allocator, self.engineContext(), pending.seed, pending.generator_index);
+        const world_screen = WorldScreen.init(self.allocator, self.engineContext(), pending.seed, pending.generator_index) catch |err| {
+            log.log.err("PENDING WORLD LAUNCH FAILED (seed={}, generator_index={}): {} - returning to home screen", .{ pending.seed, pending.generator_index, err });
+            self.pending_world_launch = null;
+            self.direct_launch_resize_guard_frames = 0;
+            self.resize_debounce_frames = 0;
+            const home_screen = HomeScreen.init(self.allocator, self.engineContext()) catch |home_err| {
+                log.log.err("Failed to initialize home screen after world launch failure: {}", .{home_err});
+                return home_err;
+            };
+            self.screen_manager.setScreen(home_screen.screen());
+            return;
+        };
         self.screen_manager.setScreen(world_screen.screen());
         self.pending_world_launch = null;
         self.direct_launch_resize_guard_frames = 0;


### PR DESCRIPTION
## Summary

Fixes #724.

Confirmed the issue still exists: `maybeLaunchPendingWorld` (src/game/app.zig) used `try WorldScreen.init(...)`, so any world-initialization failure (OOM, RHI/GPU resource exhaustion, generator error) propagated through `runSingleFrame` → `run` (app.zig:475-478), terminating the application. No existing open PR covers this (#770 covers the separate #723 `InputSettings.saveFromMapper` pattern).

## Changes

In `maybeLaunchPendingWorld`, the `WorldScreen.init` `try` is replaced with `catch`:

- **Logs the error with context** (seed, generator_index) via `log.log.err`
- **Clears `pending_world_launch`** and related resize guard state so the launcher doesn't retry every frame
- **Falls back to `HomeScreen`** so the app remains in a usable state (the user can retry or adjust settings) — reuses the existing `HomeScreen.init` + `setScreen` pattern already used in `App.init`
- If even `HomeScreen.init` fails (catastrophic OOM), that error still propagates — there's genuinely nothing left to recover with

The success path is byte-identical to before.

## Acceptance Criteria

- [x] World load failure in `maybeLaunchPendingWorld` does not crash the app
- [x] Error is logged with context about what failed (seed, generator_index, error)
- [x] `pending_world_launch` is cleared on failure
- [x] App remains on the home screen after failure
- [x] Benchmark/smoke test modes still exit cleanly — smoke-test/screenshot-no-delay exit by frame count (unaffected); screenshot-with-delay now proceeds instead of hanging because `pending_world_launch` is cleared
- [x] `zig build test` passes (unit tests + shader validation)

## Verification

- `nix develop --command zig fmt src/` — clean
- `nix develop --command zig build test` — exit 0 (unit tests + SPIR-V shader validation)
- Runtime smoke test could not be executed in this CI environment (no Vulkan-capable device — fails earlier at `WindowManager.init`), but the success path is unchanged and the failure path follows existing patterns in the same file (`saveAllSettings` catch at app.zig:304-306, `HomeScreen` fallback at app.zig:240-241).

## References

- `saveAllSettings` (app.zig:302-307) — same catch-log-continue pattern
- `HomeScreen.init` fallback — already used in `App.init` (app.zig:240-241, 256-257)
- Issue #723 / PR #770 — related error-handling pattern (separate fix)