### PR TITLE
Fix SSAO swapchain recreate loop

### DIFF
--- a/modules/engine-graphics/src/rhi_vulkan.zig
+++ b/modules/engine-graphics/src/rhi_vulkan.zig
@@ -70,7 +70,7 @@ fn beginFrame(ctx_ptr: *anyopaque) void {
     if (ctx.runtime.gpu_fault_detected) return;
     if (ctx.frames.frame_in_progress) return;
 
-    if (ctx.runtime.framebuffer_resized or ctx.swapchain.framebuffer_resized) {
+    if ((ctx.runtime.framebuffer_resized or ctx.swapchain.framebuffer_resized) and !ctx.runtime.swapchain_recreate_failed) {
         log.log.info("beginFrame: triggering recreateSwapchainInternal (resize)", .{});
         frame_orchestration.recreateSwapchainInternal(ctx);
     }

--- a/modules/engine-graphics/src/vulkan/rhi_frame_orchestration.zig
+++ b/modules/engine-graphics/src/vulkan/rhi_frame_orchestration.zig
@@ -152,7 +152,12 @@ pub fn recreateSwapchainInternal(ctx: anytype) void {
 pub fn markSwapchainRecreateFailed(ctx: anytype, stage: []const u8, err: anyerror) bool {
     const already_failed = ctx.runtime.swapchain_recreate_failed;
     ctx.runtime.swapchain_recreate_failed = true;
-    ctx.runtime.framebuffer_resized = true;
+    // Consume the resize request instead of re-arming it. Re-arming here would
+    // cause beginFrame to retry the recreation every frame; if the failure is
+    // persistent (e.g. SSAO allocation under memory pressure) this loops
+    // forever. The swapchain_recreate_failed flag above gates retries until a
+    // fresh request (resize / vsync / msaa change) clears it.
+    ctx.runtime.framebuffer_resized = false;
     ctx.runtime.pipeline_rebuild_needed = true;
     if (!already_failed) {
         log.log.errWithTrace("Failed to recreate swapchain at {s}: {}", .{ stage, err });

--- a/modules/engine-graphics/src/vulkan/rhi_frame_orchestration_tests.zig
+++ b/modules/engine-graphics/src/vulkan/rhi_frame_orchestration_tests.zig
@@ -29,12 +29,15 @@ test "prepareFrameState texture binding needs_update detection" {
 
 test "markSwapchainRecreateFailed sets explicit retry state" {
     var ctx = MockSwapchainContext{};
+    ctx.runtime.framebuffer_resized = true;
 
     const logged = frame_orchestration.markSwapchainRecreateFailed(&ctx, "test stage", error.OutOfMemory);
 
     try testing.expect(logged);
     try testing.expect(ctx.runtime.swapchain_recreate_failed);
-    try testing.expect(ctx.runtime.framebuffer_resized);
+    // The resize request is consumed on failure so beginFrame does not retry
+    // every frame (which would loop when the failure is persistent).
+    try testing.expect(!ctx.runtime.framebuffer_resized);
     try testing.expect(ctx.runtime.pipeline_rebuild_needed);
 }
 
@@ -47,8 +50,35 @@ test "markSwapchainRecreateFailed logs only first failure" {
     try testing.expect(first_logged);
     try testing.expect(!second_logged);
     try testing.expect(ctx.runtime.swapchain_recreate_failed);
-    try testing.expect(ctx.runtime.framebuffer_resized);
+    try testing.expect(!ctx.runtime.framebuffer_resized);
     try testing.expect(ctx.runtime.pipeline_rebuild_needed);
+}
+
+test "beginFrame recreate guard blocks retry after persistent SSAO failure" {
+    // Simulates the swapchain-recreate loop fixed in issue #725:
+    //   frame 1: resize requested -> recreate attempted -> SSAO fails
+    //   frame 2+: beginFrame must NOT retry the recreation every frame
+    var ctx = MockSwapchainContext{};
+
+    // Resize requested by the windowing layer.
+    ctx.runtime.framebuffer_resized = true;
+    const attempt_frame1 = (ctx.runtime.framebuffer_resized) and !ctx.runtime.swapchain_recreate_failed;
+    try testing.expect(attempt_frame1);
+
+    // SSAO creation fails during recreateSwapchainInternal.
+    _ = frame_orchestration.markSwapchainRecreateFailed(&ctx, "SSAO resources", error.OutOfMemory);
+
+    // Subsequent frames: the guard condition must be false so no retry occurs.
+    const attempt_frame2 = (ctx.runtime.framebuffer_resized) and !ctx.runtime.swapchain_recreate_failed;
+    try testing.expect(!attempt_frame2);
+    try testing.expect(ctx.runtime.swapchain_recreate_failed);
+    try testing.expect(!ctx.runtime.framebuffer_resized);
+
+    // A fresh resize request clears the failed flag, allowing a new attempt.
+    ctx.runtime.framebuffer_resized = true;
+    ctx.runtime.swapchain_recreate_failed = false;
+    const attempt_after_new_resize = (ctx.runtime.framebuffer_resized) and !ctx.runtime.swapchain_recreate_failed;
+    try testing.expect(attempt_after_new_resize);
 }
 
 test "markSwapchainRecreateSucceeded clears failure state" {

--- a/modules/engine-graphics/src/vulkan/rhi_state_control.zig
+++ b/modules/engine-graphics/src/vulkan/rhi_state_control.zig
@@ -41,6 +41,7 @@ pub fn setViewport(ctx: anytype, width: u32, height: u32) void {
 
 pub fn requestSwapchainRecreate(ctx: anytype) void {
     ctx.runtime.framebuffer_resized = true;
+    ctx.runtime.swapchain_recreate_failed = false;
     ctx.swapchain.framebuffer_resized = true;
 }
 
@@ -145,6 +146,7 @@ pub fn setVSync(ctx: anytype, enabled: bool) void {
     }
 
     ctx.runtime.framebuffer_resized = true;
+    ctx.runtime.swapchain_recreate_failed = false;
 
     const mode_name: []const u8 = switch (ctx.options.present_mode) {
         c.VK_PRESENT_MODE_IMMEDIATE_KHR => "IMMEDIATE (VSync OFF)",
@@ -173,6 +175,7 @@ pub fn setMSAA(ctx: anytype, samples: u8) void {
     ctx.options.msaa_samples = clamped;
     ctx.swapchain.msaa_samples = clamped;
     ctx.runtime.framebuffer_resized = true;
+    ctx.runtime.swapchain_recreate_failed = false;
     ctx.runtime.pipeline_rebuild_needed = true;
     log.log.info("Vulkan MSAA set to {}x (pending swapchain recreation)", .{clamped});
 }

--- a/modules/engine-graphics/src/vulkan/rhi_state_control_tests.zig
+++ b/modules/engine-graphics/src/vulkan/rhi_state_control_tests.zig
@@ -45,6 +45,7 @@ const MockRuntime = struct {
     gpu_fault_detected: bool = false,
     framebuffer_resized: bool = false,
     pipeline_rebuild_needed: bool = false,
+    swapchain_recreate_failed: bool = false,
     main_pass_active: bool = false,
     g_pass_active: bool = false,
     ssao_pass_active: bool = false,
@@ -280,6 +281,19 @@ test "rhi_state_control.requestSwapchainRecreate sets both resize flags" {
     try testing.expect(ctx.swapchain.framebuffer_resized);
 }
 
+test "rhi_state_control.requestSwapchainRecreate clears prior recreate failure" {
+    // After a failed recreation, a fresh resize request must clear the failed
+    // flag so beginFrame is allowed to attempt recreation again (issue #725).
+    var ctx = MockSimpleContext{ .allocator = testing.allocator };
+    ctx.runtime.swapchain_recreate_failed = true;
+
+    rhi_state_control.requestSwapchainRecreate(&ctx);
+
+    try testing.expect(!ctx.runtime.swapchain_recreate_failed);
+    try testing.expect(ctx.runtime.framebuffer_resized);
+    try testing.expect(ctx.swapchain.framebuffer_resized);
+}
+
 // ============================================================================
 // MSAA State Tests
 // ============================================================================
@@ -289,6 +303,7 @@ test "rhi_state_control.setMSAA clamps to max samples" {
     ctx.vulkan_device.max_msaa_samples = 4;
     ctx.options.msaa_samples = 1;
     ctx.swapchain.msaa_samples = 1;
+    ctx.runtime.swapchain_recreate_failed = true;
 
     rhi_state_control.setMSAA(&ctx, 8);
 
@@ -297,6 +312,8 @@ test "rhi_state_control.setMSAA clamps to max samples" {
     try testing.expectEqual(@as(u8, 4), ctx.swapchain.msaa_samples);
     try testing.expect(ctx.runtime.framebuffer_resized);
     try testing.expect(ctx.runtime.pipeline_rebuild_needed);
+    // A settings change is a fresh recreate request, so it must clear a prior failure.
+    try testing.expect(!ctx.runtime.swapchain_recreate_failed);
 }
 
 test "rhi_state_control.setMSAA no-op when unchanged" {


### PR DESCRIPTION
## Confirmed: the issue still exists and is not covered by an existing fix

The bug is present in `markSwapchainRecreateFailed` (modules/engine-graphics/src/vulkan/rhi_frame_orchestration.zig:155). The loop mechanism:

1. Swapchain resize → `beginFrame` (rhi_vulkan.zig:73) calls `recreateSwapchainInternal`
2. Swapchain + G-Pass succeed (G-Pass correctly sets `g_pass_extent` at rhi_resource_setup.zig:350), but **SSAO fails** → `markSwapchainRecreateFailed` re-arms `framebuffer_resized = true`
3. Next frame, `beginFrame` sees `framebuffer_resized` → retries → SSAO fails again → **infinite loop**

The `swapchain_recreate_failed` flag already existed but was never read to gate retries.

## The fix

- **rhi_frame_orchestration.zig** — `markSwapchainRecreateFailed` now *consumes* the resize request (`framebuffer_resized = false`) instead of re-arming it. The persistent-failure state is tracked via `swapchain_recreate_failed`.
- **rhi_vulkan.zig** — `beginFrame` guard now also checks `and !swapchain_recreate_failed`, so a known-failed state won't be retried every frame (covers all failure points, not just SSAO).
- **rhi_state_control.zig** — fresh-request paths (`requestSwapchainRecreate`, `setVSync`, `setMSAA`) clear `swapchain_recreate_failed` so genuine new resize/settings events can still trigger a retry, enabling graceful degradation.
- Updated existing tests and added regression tests reproducing the no-loop scenario.

`zig build`, `zig build test`, and shader validation all pass. PR targets `dev`.

Closes #725

<a href="https://opencode.ai/s/mbTqC60h"><img width="200" alt="New%20session%20-%202026-07-05T13%3A13%3A15.878Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDEzOjEzOjE1Ljg3OFo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=mbTqC60h" /></a>
[opencode session](https://opencode.ai/s/mbTqC60h)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28741959706)