### PR TITLE
Fixed lookAt degenerate up vector (#728)

### DIFF
--- a/libs/zig-math/mat4.zig
+++ b/libs/zig-math/mat4.zig
@@ -78,7 +78,17 @@ pub const Mat4 = extern struct {
 
     pub fn lookAt(eye: Vec3, target: Vec3, world_up: Vec3) Mat4 {
         const f = target.sub(eye).normalize();
-        const r = f.cross(world_up).normalize();
+
+        // Handle degenerate case where f is parallel (or anti-parallel) to world_up.
+        // In that case f x world_up is zero, which normalize() collapses to Vec3.zero,
+        // producing an invalid view matrix with degenerate axes. Fall back to an
+        // alternate reference axis that is not aligned with f.
+        var up = world_up;
+        const cross_len_sq = f.cross(world_up).lengthSquared();
+        if (cross_len_sq < 1e-8) {
+            up = if (@abs(f.y) > 0.9) Vec3.right else Vec3.up;
+        }
+        const r = f.cross(up).normalize();
         const u = r.cross(f);
 
         var result = Mat4.identity;

--- a/modules/engine-math/src/mat4_tests.zig
+++ b/modules/engine-math/src/mat4_tests.zig
@@ -45,6 +45,57 @@ test "Mat4 lookAt preserves length" {
     try testing.expectApproxEqAbs(@as(f32, 1), rotated.length(), 0.0001);
 }
 
+test "Mat4 lookAt handles looking straight up (+Y)" {
+    const view = Mat4.lookAt(
+        Vec3.init(0, 0, 0),
+        Vec3.init(0, 5, 0),
+        Vec3.init(0, 1, 0),
+    );
+    // Forward axis (Z column) should map the +Y forward to -Z, not collapse to zero.
+    const fwd_col = Vec3.init(view.data[0][2], view.data[1][2], view.data[2][2]);
+    try testing.expectApproxEqAbs(@as(f32, 1), fwd_col.length(), 0.0001);
+    // Right axis (X column) should be a unit-length vector.
+    const right_col = Vec3.init(view.data[0][0], view.data[1][0], view.data[2][0]);
+    try testing.expectApproxEqAbs(@as(f32, 1), right_col.length(), 0.0001);
+    // Up axis (Y column) should be a unit-length vector.
+    const up_col = Vec3.init(view.data[0][1], view.data[1][1], view.data[2][1]);
+    try testing.expectApproxEqAbs(@as(f32, 1), up_col.length(), 0.0001);
+}
+
+test "Mat4 lookAt handles looking straight down (-Y)" {
+    const view = Mat4.lookAt(
+        Vec3.init(0, 5, 0),
+        Vec3.init(0, 0, 0),
+        Vec3.init(0, 1, 0),
+    );
+    const fwd_col = Vec3.init(view.data[0][2], view.data[1][2], view.data[2][2]);
+    try testing.expectApproxEqAbs(@as(f32, 1), fwd_col.length(), 0.0001);
+    const right_col = Vec3.init(view.data[0][0], view.data[1][0], view.data[2][0]);
+    try testing.expectApproxEqAbs(@as(f32, 1), right_col.length(), 0.0001);
+    const up_col = Vec3.init(view.data[0][1], view.data[1][1], view.data[2][1]);
+    try testing.expectApproxEqAbs(@as(f32, 1), up_col.length(), 0.0001);
+}
+
+test "Mat4 lookAt degenerate produces orthonormal axes" {
+    // Forward parallel to world_up should still produce an orthonormal basis.
+    const view = Mat4.lookAt(
+        Vec3.init(1, 2, 3),
+        Vec3.init(1, 5, 3),
+        Vec3.init(0, 1, 0),
+    );
+    const right_col = Vec3.init(view.data[0][0], view.data[1][0], view.data[2][0]);
+    const up_col = Vec3.init(view.data[0][1], view.data[1][1], view.data[2][1]);
+    const fwd_col = Vec3.init(view.data[0][2], view.data[1][2], view.data[2][2]);
+    // Each axis should be unit-length.
+    try testing.expectApproxEqAbs(@as(f32, 1), right_col.length(), 0.0001);
+    try testing.expectApproxEqAbs(@as(f32, 1), up_col.length(), 0.0001);
+    try testing.expectApproxEqAbs(@as(f32, 1), fwd_col.length(), 0.0001);
+    // Axes should be mutually orthogonal.
+    try testing.expectApproxEqAbs(@as(f32, 0), right_col.dot(up_col), 0.0001);
+    try testing.expectApproxEqAbs(@as(f32, 0), right_col.dot(fwd_col), 0.0001);
+    try testing.expectApproxEqAbs(@as(f32, 0), up_col.dot(fwd_col), 0.0001);
+}
+
 test "Mat4 orthographic creates correct matrix" {
     const ortho = Mat4.orthographic(-10, 10, -10, 10, -100, 100);
     try testing.expectEqual(@as(f32, 0.1), ortho.data[0][0]);


### PR DESCRIPTION
Confirmed the issue still exists at `libs/zig-math/mat4.zig:79` (no existing PR/issue covers it — only #728 itself), and fixed it.

**Summary of changes:**
- `libs/zig-math/mat4.zig:79` — `Mat4.lookAt` now detects when `f × world_up` is near-zero (forward parallel to up) and falls back to an alternate reference axis (`Vec3.right` when looking along Y, otherwise `Vec3.up`), preventing the degenerate zero-length axes.
- `modules/engine-math/src/mat4_tests.zig` — added 3 tests: looking straight up (+Y), straight down (-Y), and full orthonormality verification of the fallback basis.

`zig build test` passes (exit 0). Commit `3cc7b1d` on `opencode/issue728-20260705132958`, targeting `dev`.

Closes #728

<a href="https://opencode.ai/s/lD6MjNcs"><img width="200" alt="New%20session%20-%202026-07-05T13%3A29%3A58.052Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDEzOjI5OjU4LjA1Mlo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=lD6MjNcs" /></a>
[opencode session](https://opencode.ai/s/lD6MjNcs)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28742406572)