### PR TITLE
Fixed #720, PR to dev, 267 tests pass.

### DIFF
--- a/modules/engine-physics/src/collision.zig
+++ b/modules/engine-physics/src/collision.zig
@@ -39,8 +39,10 @@ pub const CollisionResult = struct {
 pub const CollisionConfig = struct {
     /// Small epsilon to prevent floating point issues at block boundaries
     epsilon: f32 = 0.001,
-    /// Maximum number of iterations for collision resolution
-    max_iterations: u32 = 4,
+    /// Maximum number of iterations for collision resolution binary search.
+    /// Higher values give more precise collision points at the cost of CPU;
+    /// lower values are faster but may stop further from the surface.
+    max_iterations: u32 = 16,
 };
 
 /// Move an AABB through the world, detecting and resolving collisions.
@@ -83,7 +85,7 @@ pub fn moveAndCollide(
 
         if (collidesWithWorld(world, test_aabb)) {
             // Find the exact collision point
-            const resolved_y = resolveAxis(world, pos, half_size, move.y, 1, config.epsilon);
+            const resolved_y = resolveAxis(world, pos, half_size, move.y, 1, config.epsilon, config.max_iterations);
             pos.y = resolved_y;
 
             if (move.y < 0) {
@@ -106,7 +108,7 @@ pub fn moveAndCollide(
         );
 
         if (collidesWithWorld(world, test_aabb)) {
-            const resolved_x = resolveAxis(world, pos, half_size, move.x, 0, config.epsilon);
+            const resolved_x = resolveAxis(world, pos, half_size, move.x, 0, config.epsilon, config.max_iterations);
             pos.x = resolved_x;
             vel.x = 0;
             result.hit_wall = true;
@@ -124,7 +126,7 @@ pub fn moveAndCollide(
         );
 
         if (collidesWithWorld(world, test_aabb)) {
-            const resolved_z = resolveAxis(world, pos, half_size, move.z, 2, config.epsilon);
+            const resolved_z = resolveAxis(world, pos, half_size, move.z, 2, config.epsilon, config.max_iterations);
             pos.z = resolved_z;
             vel.z = 0;
             result.hit_wall = true;
@@ -147,6 +149,7 @@ fn resolveAxis(
     movement: f32,
     axis: u2,
     epsilon: f32,
+    max_iterations: u32,
 ) f32 {
     var current = switch (axis) {
         0 => pos.x,
@@ -159,7 +162,7 @@ fn resolveAxis(
 
     // Binary search to find the furthest valid position
     var iterations: u32 = 0;
-    while (@abs(target - current) > epsilon and iterations < 16) : (iterations += 1) {
+    while (@abs(target - current) > epsilon and iterations < max_iterations) : (iterations += 1) {
         const mid = (current + target) * 0.5;
         const test_pos = switch (axis) {
             0 => Vec3.init(mid, pos.y, pos.z),

--- a/src/collision_tests.zig
+++ b/src/collision_tests.zig
@@ -1,0 +1,119 @@
+const std = @import("std");
+const testing = std.testing;
+const Vec3 = @import("zig-math").Vec3;
+const AABB = @import("zig-math").AABB;
+const collision = @import("engine-physics");
+const VoxelCollisionWorld = collision.VoxelCollisionWorld;
+const CollisionConfig = collision.CollisionConfig;
+
+pub const std_options: std.Options = .{ .log_level = .err };
+
+/// Mock voxel world used to drive collision resolution without a real World.
+///
+/// Geometry is configured declaratively:
+///   - `floor`: when true, every block with `y < 0` is solid (flat ground at y=0).
+///   - `wall_x`/`wall_z`: an optional full-height wall spanning the entire column
+///     at the given x or z coordinate (so wall collision can be tested in
+///     isolation from floor placement).
+const MockWorld = struct {
+    floor: bool = false,
+    wall_x: ?i32 = null,
+    wall_z: ?i32 = null,
+
+    fn interface(self: *MockWorld) VoxelCollisionWorld {
+        return .{ .ptr = self, .vtable = &VTABLE };
+    }
+
+    const VTABLE = VoxelCollisionWorld.VTable{ .isSolidAt = isSolidAt };
+
+    fn isSolidAt(ptr: *anyopaque, x: i32, y: i32, z: i32) bool {
+        const self: *MockWorld = @ptrCast(@alignCast(ptr));
+        if (self.floor and y < 0) return true;
+        if (self.wall_x) |wx| {
+            if (x == wx) return true;
+        }
+        if (self.wall_z) |wz| {
+            if (z == wz) return true;
+        }
+        return false;
+    }
+};
+
+test "moveAndCollide lands on floor with default config" {
+    var world = MockWorld{ .floor = true };
+    const aabb = AABB.fromCenterSize(Vec3.init(5, 5, 5), Vec3.init(1, 1, 1));
+
+    // Fall straight down at 5 blocks/sec for 1 second.
+    const result = collision.moveAndCollide(
+        world.interface(),
+        aabb,
+        Vec3.init(0, -5, 0),
+        1.0,
+        .{},
+    );
+
+    // AABB bottom rests on the floor surface (y=0), so center is at ~0.5.
+    try testing.expect(result.grounded);
+    try testing.expect(!result.hit_wall);
+    try testing.expect(!result.hit_ceiling);
+    try testing.expectApproxEqAbs(@as(f32, 0.5), result.position.y, 0.01);
+    try testing.expectEqual(@as(f32, 0), result.velocity.y);
+}
+
+test "moveAndCollide honors max_iterations for binary search precision" {
+    // Same scenario as above, but the binary search converges to the surface
+    // (y ~= 0.5) only when given enough iterations. With max_iterations = 2 it
+    // bails out far above the floor (y ~= 1.25), proving the field is consulted.
+    var world = MockWorld{ .floor = true };
+    const aabb = AABB.fromCenterSize(Vec3.init(5, 5, 5), Vec3.init(1, 1, 1));
+
+    const low_iter = collision.moveAndCollide(
+        world.interface(),
+        aabb,
+        Vec3.init(0, -5, 0),
+        1.0,
+        .{ .max_iterations = 2 },
+    );
+    const high_iter = collision.moveAndCollide(
+        world.interface(),
+        aabb,
+        Vec3.init(0, -5, 0),
+        1.0,
+        .{ .max_iterations = 16 },
+    );
+
+    // Low iteration count stops well short of the true surface.
+    try testing.expect(low_iter.grounded);
+    try testing.expect(low_iter.position.y > 1.0);
+
+    // High iteration count converges close to the surface.
+    try testing.expect(high_iter.grounded);
+    try testing.expectApproxEqAbs(@as(f32, 0.5), high_iter.position.y, 0.01);
+
+    // The two results must differ meaningfully.
+    try testing.expect(high_iter.position.y < low_iter.position.y);
+    try testing.expect((low_iter.position.y - high_iter.position.y) > 0.5);
+}
+
+test "moveAndCollide resolves X-axis wall collision" {
+    // Wall block at x=2 occupies x in [2,3], y in [0,1]. Player approaching
+    // from +x must stop with AABB min.x == block max.x (center_x ~= 3.5).
+    var world = MockWorld{ .wall_x = 2 };
+    const aabb = AABB.fromCenterSize(Vec3.init(5, 5, 5), Vec3.init(1, 1, 1));
+
+    const result = collision.moveAndCollide(
+        world.interface(),
+        aabb,
+        Vec3.init(-3, 0, 0),
+        1.0,
+        .{},
+    );
+
+    try testing.expect(result.hit_wall);
+    try testing.expect(!result.grounded);
+    try testing.expectEqual(@as(f32, 0), result.velocity.x);
+    try testing.expectApproxEqAbs(@as(f32, 3.5), result.position.x, 0.01);
+    // Y and Z should be unchanged.
+    try testing.expectApproxEqAbs(@as(f32, 5), result.position.y, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 5), result.position.z, 0.001);
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -20,6 +20,7 @@ test {
     _ = @import("shadow_cascade_tests.zig");
     _ = @import("interface_mock_tests.zig");
     _ = @import("world_inline_tests.zig");
+    _ = @import("collision_tests.zig");
 
     // ECS and engine tests
     _ = @import("ecs_tests.zig");


### PR DESCRIPTION
Committed as `cdd0207`. The fix is complete.

**Summary**

Confirmed the issue was still open: `cf537f9` (the previous claimed fix) is absent from every branch — it never landed.

**Fix** (`modules/engine-physics/src/collision.zig`):
- Added `max_iterations: u32` parameter to `resolveAxis` (collision.zig:152).
- Replaced the hardcoded `16` in the binary-search loop with the parameter (collision.zig:165).
- All three call sites in `moveAndCollide` (Y/X/Z at lines 88/110/128) now pass `config.max_iterations`.
- Bumped the default from `4` to `16` so existing callers using `.{}` keep the prior runtime behavior while the field is now genuinely tunable.

**Tests** (`src/collision_tests.zig`, +3): default floor landing, the precision gap between `max_iterations=2` vs `16` (proves the field is consulted), and X-axis wall resolution — using a mock `VoxelCollisionWorld` following the `interface_mock_tests.zig` pattern.

**Verification:** `zig build test` → exit 0, all 267 tests pass (was 264 baseline). Commit `cdd0207` is on branch `opencode/issue720-20260705143119` targeting `dev` — no direct push to `dev`.

Closes #720

<a href="https://opencode.ai/s/Nk0Bh1c8"><img width="200" alt="New%20session%20-%202026-07-05T14%3A31%3A18.574Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDE0OjMxOjE4LjU3NFo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=Nk0Bh1c8" /></a>
[opencode session](https://opencode.ai/s/Nk0Bh1c8)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28744072312)