### PR TITLE
Fix input key state inconsistency on OOM

### DIFF
--- a/modules/engine-input/src/input.zig
+++ b/modules/engine-input/src/input.zig
@@ -98,15 +98,11 @@ pub const Input = struct {
             },
             c.SDL_EVENT_KEY_DOWN => {
                 if (!event.key.repeat) {
-                    const key = Key.fromSDL(event.key.key);
-                    self.keys_down.put(key, {}) catch {};
-                    self.keys_pressed.put(key, {}) catch {};
+                    self.recordKeyDown(Key.fromSDL(event.key.key));
                 }
             },
             c.SDL_EVENT_KEY_UP => {
-                const key = Key.fromSDL(event.key.key);
-                _ = self.keys_down.remove(key);
-                self.keys_released.put(key, {}) catch {};
+                self.recordKeyUp(Key.fromSDL(event.key.key));
             },
             c.SDL_EVENT_MOUSE_MOTION => {
                 self.mouse_x = @intFromFloat(event.motion.x);
@@ -147,6 +143,26 @@ pub const Input = struct {
             },
             else => {},
         }
+    }
+
+    /// Record a key press, keeping `keys_pressed` and `keys_down` consistent.
+    /// `keys_pressed` is updated first; if it fails the press is dropped entirely.
+    /// If `keys_down` then fails, `keys_pressed` is rolled back so `isKeyDown`
+    /// and `isKeyPressed` never disagree for the same key.
+    pub fn recordKeyDown(self: *Input, key: Key) void {
+        self.keys_pressed.put(key, {}) catch return;
+        self.keys_down.put(key, {}) catch {
+            _ = self.keys_pressed.remove(key);
+        };
+    }
+
+    /// Record a key release, keeping `keys_released` and `keys_down` consistent.
+    /// `keys_released` is updated first; if it fails `keys_down` is left
+    /// untouched so the key does not disappear from held state without a
+    /// matching release signal.
+    pub fn recordKeyUp(self: *Input, key: Key) void {
+        self.keys_released.put(key, {}) catch return;
+        _ = self.keys_down.remove(key);
     }
 
     // ========================================================================

--- a/src/input_tests.zig
+++ b/src/input_tests.zig
@@ -1,0 +1,73 @@
+//! Tests for Input key state consistency, including allocation-failure paths.
+//!
+//! Covers the fix for the issue where `keys_down` and `keys_pressed` could
+//! disagree when `put()` failed mid-operation, leaving a key reported as held
+//! but not pressed (or vice versa). The release path had the same problem
+//! between `keys_down` and `keys_released`.
+
+const std = @import("std");
+const testing = std.testing;
+const Input = @import("engine-input").Input;
+
+test "recordKeyDown registers key as both pressed and down" {
+    var input = Input.init(testing.allocator);
+    defer input.deinit();
+
+    input.recordKeyDown(.w);
+
+    try testing.expect(input.isKeyDown(.w));
+    try testing.expect(input.isKeyPressed(.w));
+}
+
+test "recordKeyDown stays consistent when keys_pressed put fails" {
+    // fail_index = 0 -> the very first allocation (keys_pressed.put) fails.
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    var input = Input.init(failing.allocator());
+    defer input.deinit();
+
+    input.recordKeyDown(.w);
+
+    // Press could not be recorded: neither held nor pressed, and no stuck key.
+    try testing.expect(!input.isKeyDown(.w));
+    try testing.expect(!input.isKeyPressed(.w));
+}
+
+test "recordKeyDown rolls back keys_pressed when keys_down put fails" {
+    // fail_index = 1 -> keys_pressed.put succeeds (alloc 0), keys_down.put fails (alloc 1).
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 1 });
+    var input = Input.init(failing.allocator());
+    defer input.deinit();
+
+    input.recordKeyDown(.w);
+
+    try testing.expect(!input.isKeyDown(.w));
+    try testing.expect(!input.isKeyPressed(.w));
+}
+
+test "recordKeyUp keeps key held when keys_released put fails" {
+    // fail_index = 2 -> key down allocates keys_pressed (0) and keys_down (1);
+    // the key-up keys_released.put (alloc 2) then fails.
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 2 });
+    var input = Input.init(failing.allocator());
+    defer input.deinit();
+
+    input.recordKeyDown(.w);
+    input.beginFrame();
+    input.recordKeyUp(.w);
+
+    // Release could not be recorded: key remains held and is not marked released.
+    try testing.expect(input.isKeyDown(.w));
+    try testing.expect(!input.isKeyReleased(.w));
+}
+
+test "recordKeyUp clears down and marks released on success" {
+    var input = Input.init(testing.allocator);
+    defer input.deinit();
+
+    input.recordKeyDown(.w);
+    input.beginFrame();
+    input.recordKeyUp(.w);
+
+    try testing.expect(!input.isKeyDown(.w));
+    try testing.expect(input.isKeyReleased(.w));
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -102,4 +102,5 @@ test {
     _ = @import("world-core").world_block_fill_tests;
     _ = @import("world-meshing").world_interface_vtable_tests;
     _ = @import("world-runtime").world_mutation;
+    _ = @import("input_tests.zig");
 }


### PR DESCRIPTION
## Summary

**Confirmed the issue** in `modules/engine-input/src/input.zig:99-110`: `keys_down.put()` succeeded (line 102) while `keys_pressed.put()` (line 103) could fail silently via `catch {}`, leaving `isKeyDown=true` but `isKeyPressed=false`. The release path had the same inconsistency between `keys_down` and `keys_released`.

### Fix (`modules/engine-input/src/input.zig`)
Refactored the key down/up handling into two helpers that order operations so the maps can never disagree:
- `recordKeyDown`: inserts into `keys_pressed` first; on failure the press is dropped entirely. If `keys_down` then fails, `keys_pressed` is rolled back — so `isKeyDown`/`isKeyPressed` always agree.
- `recordKeyUp`: inserts into `keys_released` first; on failure `keys_down` is left untouched, so a key can't vanish from held state without a matching release signal.

This also closes a gap in the issue's proposed fix, which only handled `keys_pressed` failure and would still go inconsistent if `keys_down.put` itself failed.

### Tests (`src/input_tests.zig`)
5 unit tests covering success paths and every allocation-failure rollback path, using `std.testing.FailingAllocator` with controlled `fail_index` values.

### Verification
- `nix develop --command zig fmt src/ modules/engine-input/src/` — clean
- `nix develop --command zig build test` — **272/272 tests pass** (267 existing + 5 new)
- Filtered run for `recordKeyUp keeps key held` confirms discoverability

### Note on test placement
During implementation I discovered that in this project's Zig 0.16 setup, test blocks in `modules/` (module-imported) are *not* collected by the test runner — only `src/` relative-imported test files execute. I verified this empirically by probing, then placed the tests in `src/input_tests.zig` where they actually run (confirmed: 272 total with the 5 new tests counted). This is worth noting as a broader project finding, since many existing `modules/.../*_tests.zig` registrations in `src/tests.zig` may not be executing.

Committed to `opencode/issue742-20260705152728` (targets `dev`).

Closes #742

<a href="https://opencode.ai/s/Kmq9YJJg"><img width="200" alt="New%20session%20-%202026-07-05T15%3A27%3A27.551Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDE1OjI3OjI3LjU1MVo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=Kmq9YJJg" /></a>
[opencode session](https://opencode.ai/s/Kmq9YJJg)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28745629698)