### PR TITLE
Fixed ImGui context leak with errdefer cleanup.

### DIFF
--- a/modules/engine-ui/src/imgui/imgui_backend.zig
+++ b/modules/engine-ui/src/imgui/imgui_backend.zig
@@ -19,12 +19,14 @@ pub const Backend = struct {
         if (!build_options.imgui) return error.ImguiDisabled;
 
         c.ZigCraft_ImGui_CreateContext();
+        errdefer c.ZigCraft_ImGui_DestroyContext();
         c.ZigCraft_ImGui_StyleColorsDark();
 
         if (!c.ZigCraft_ImGui_ImplSDL3_InitForVulkan(@ptrCast(window))) {
             log.log.err("Failed to initialize ImGui SDL3 backend", .{});
             return error.ImguiBackendInitFailed;
         }
+        errdefer c.ZigCraft_ImGui_ImplSDL3_Shutdown();
 
         const native = rhi_ptr.nativeHandles();
         const image_count = native.getSwapchainImageCount();
@@ -42,7 +44,6 @@ pub const Backend = struct {
             .msaa_samples = 1,
         };
         if (!c.ZigCraft_ImGui_ImplVulkan_Init(&init_info)) {
-            c.ZigCraft_ImGui_ImplSDL3_Shutdown();
             log.log.err("Failed to initialize ImGui Vulkan backend", .{});
             return error.ImguiBackendInitFailed;
         }


### PR DESCRIPTION
Confirmed and fixed the ImGui context leak in `modules/engine-ui/src/imgui/imgui_backend.zig`.

**Root cause:** `Backend.init` created the ImGui context at line 21 but never destroyed it if SDL3 init (line 24) or Vulkan init (line 44) failed, since `deinit()` is never called on init failure paths.

**Fix:** Added LIFO `errdefer` cleanup — one per successfully-initialized resource:
- After `CreateContext`: `errdefer DestroyContext()` (covers all subsequent failures)
- After `ImplSDL3_InitForVulkan` success: `errdefer ImplSDL3_Shutdown()` (covers Vulkan init failure)

This matches `deinit()`'s teardown order. I deliberately avoided the issue's proposed snippet, which had two overlapping `errdefer`s that would have double-destroyed the context and called `ImplSDL3_Shutdown` even when SDL3 was never initialized.

**Verification:** `nix develop --command zig build test` passes (exit 0). Branch `opencode/issue744-20260705160913` pushed; PR targeting `dev` will be created automatically by the opencode infrastructure.

Closes #744

<a href="https://opencode.ai/s/o3iEKpQP"><img width="200" alt="New%20session%20-%202026-07-05T16%3A09%3A12.997Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDE2OjA5OjEyLjk5N1o=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=o3iEKpQP" /></a>
[opencode session](https://opencode.ai/s/o3iEKpQP)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28746818075)