### PR TITLE
fix(ci): grant /home/runner external dir + bump timeout to 90m

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -18,7 +18,7 @@ jobs:
       contains(github.event.comment.body, ' /opencode') ||
       startsWith(github.event.comment.body, '/opencode')
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       id-token: write
       contents: write

--- a/opencode.json
+++ b/opencode.json
@@ -3,7 +3,8 @@
   "permission": {
     "external_directory": {
       "/tmp/**": "allow",
-      "/nix/**": "allow"
+      "/nix/**": "allow",
+      "/home/runner/**": "allow"
     }
   }
 }


### PR DESCRIPTION
Two fixes surfaced by the audit-issue batch run.

## 1. Grant /home/runner/** external_directory

Run for #740 hung 52 min then hit the 60-min job timeout, on a new external path:

```
asking { permission: "external_directory", patterns: ["/home/runner/work/ZigCraft/*"] }
##[error]The operation was canceled.
```

The runner workspace outside the repo subdir (`/home/runner/work/ZigCraft/*`) and opencode's own data dir (`/home/runner/.local/share/opencode/*\)) are external to the working directory and triggered the default `ask`. Granting `/home/runner/**` covers both. Keeps `/tmp/**` and `/nix/**` from #768.

## 2. Bump timeout-minutes 60 -> 90

#741 legitimately completed in 50 min (real work, no hang). The 60-min ceiling will keep clipping heavy-but-healthy runs under variant:max. 90 min gives headroom; the actual work still governs runtime.

## Scope
opencode.json + opencode.yml only. No model/agent change.