### PR TITLE
refactor: move sky and water draws behind RHI

### DIFF
--- a/modules/engine-graphics/src/atmosphere_system.zig
+++ b/modules/engine-graphics/src/atmosphere_system.zig
@@ -2,8 +2,6 @@ const std = @import("std");
 const rhi = @import("engine-rhi");
 const ResourceManager = rhi.ResourceManager;
 const RenderContext = rhi.RenderContext;
-const c = @import("c").c;
-const log = @import("engine-core").log;
 
 pub const AtmosphereSystem = struct {
     allocator: std.mem.Allocator,
@@ -23,40 +21,6 @@ pub const AtmosphereSystem = struct {
     }
 
     pub fn renderSky(_: *AtmosphereSystem, ctx: RenderContext, params: rhi.SkyParams) rhi.RhiError!void {
-        const pipeline_u64 = ctx.getNativeSkyPipeline();
-        const layout_u64 = ctx.getNativeSkyPipelineLayout();
-        const descriptor_set_u64 = ctx.getNativeMainDescriptorSet();
-        const cmd_u64 = ctx.getNativeCommandBuffer();
-
-        if (pipeline_u64 == 0 or layout_u64 == 0 or cmd_u64 == 0) {
-            log.log.warn("AtmosphereSystem: Sky rendering skipped, native handles missing (pipeline={}, layout={}, cmd={})", .{ pipeline_u64 != 0, layout_u64 != 0, cmd_u64 != 0 });
-            if (pipeline_u64 == 0) return error.SkyPipelineNotReady;
-            if (layout_u64 == 0) return error.SkyPipelineLayoutNotReady;
-            if (cmd_u64 == 0) return error.CommandBufferNotReady;
-            return error.ResourceNotReady;
-        }
-
-        const pipeline = @as(c.VkPipeline, @ptrFromInt(pipeline_u64));
-        const layout = @as(c.VkPipelineLayout, @ptrFromInt(layout_u64));
-        const descriptor_set = @as(c.VkDescriptorSet, @ptrFromInt(descriptor_set_u64));
-        const cmd = @as(c.VkCommandBuffer, @ptrFromInt(cmd_u64));
-
-        const pc = rhi.SkyPushConstants{
-            .cam_forward = .{ params.cam_forward.x, params.cam_forward.y, params.cam_forward.z, 0.0 },
-            .cam_right = .{ params.cam_right.x, params.cam_right.y, params.cam_right.z, 0.0 },
-            .cam_up = .{ params.cam_up.x, params.cam_up.y, params.cam_up.z, 0.0 },
-            .sun_dir = .{ params.sun_dir.x, params.sun_dir.y, params.sun_dir.z, 0.0 },
-            .sky_color = .{ params.sky_color.x, params.sky_color.y, params.sky_color.z, 1.0 },
-            .horizon_color = .{ params.horizon_color.x, params.horizon_color.y, params.horizon_color.z, 1.0 },
-            .params = .{ params.aspect, params.tan_half_fov, params.sun_intensity, params.moon_intensity },
-            .time = .{ params.time, params.cam_pos.x, params.cam_pos.y, params.cam_pos.z },
-        };
-
-        c.vkCmdBindPipeline(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
-        if (descriptor_set_u64 != 0) {
-            c.vkCmdBindDescriptorSets(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0, 1, &descriptor_set, 0, null);
-        }
-        c.vkCmdPushConstants(cmd, layout, c.VK_SHADER_STAGE_VERTEX_BIT | c.VK_SHADER_STAGE_FRAGMENT_BIT, 0, @sizeOf(rhi.SkyPushConstants), &pc);
-        c.vkCmdDraw(cmd, 3, 1, 0, 0);
+        try ctx.drawSky(params);
     }
 };

--- a/modules/engine-graphics/src/render_graph.zig
+++ b/modules/engine-graphics/src/render_graph.zig
@@ -36,7 +36,6 @@
 //! parameters. This provides passes with everything needed for rendering.
 
 const std = @import("std");
-const c = @import("c").c;
 const build_options = @import("engine_graphics_options");
 const Camera = @import("engine-camera").Camera;
 const IWorldRenderView = @import("world_render_view.zig").IWorldRenderView;
@@ -635,32 +634,18 @@ pub const WaterPass = struct {
         const self: *WaterPass = @ptrCast(@alignCast(ptr));
         if (!self.enabled) return;
 
-        const pipeline_u64 = ctx.render_ctx.getNativeWaterPipeline();
-        const layout_u64 = ctx.render_ctx.getNativeWaterPipelineLayout();
-        const descriptor_set_u64 = ctx.render_ctx.getNativeMainDescriptorSet();
-        const cmd_u64 = ctx.render_ctx.getNativeCommandBuffer();
         const reflection_handle = ctx.water_ctx.getReflectionTextureHandle();
         const scene_depth_handle = ctx.water_ctx.getSceneDepthTextureHandle();
 
-        if (pipeline_u64 == 0 or layout_u64 == 0 or cmd_u64 == 0 or reflection_handle == 0 or scene_depth_handle == 0) return;
-
-        const pipeline = @as(c.VkPipeline, @ptrFromInt(pipeline_u64));
-        const layout = @as(c.VkPipelineLayout, @ptrFromInt(layout_u64));
-        const descriptor_set = @as(c.VkDescriptorSet, @ptrFromInt(descriptor_set_u64));
-        const cmd = @as(c.VkCommandBuffer, @ptrFromInt(cmd_u64));
+        if (!ctx.render_ctx.beginWaterDraw(reflection_handle, scene_depth_handle)) return;
+        defer ctx.render_ctx.endWaterDraw();
 
         ctx.render_ctx.bindTexture(reflection_handle, 14);
         ctx.render_ctx.bindTexture(scene_depth_handle, 15);
-        c.vkCmdBindPipeline(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
-        if (descriptor_set_u64 != 0) {
-            c.vkCmdBindDescriptorSets(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0, 1, &descriptor_set, 0, null);
-        }
-        ctx.render_ctx.setTerrainPipelineBound(true);
 
         const view_proj = ctx.camera.getJitteredProjectionMatrixReverseZ(ctx.aspect, ctx.viewport_width, ctx.viewport_height, ctx.taa_enabled).multiply(ctx.camera.getViewMatrixOriginCentered());
         const render_lod_water = engine_core.envFlag("ZIGCRAFT_LOD_WATER", true);
         ctx.world.renderFluid(view_proj, ctx.camera.position, render_lod_water);
-        ctx.render_ctx.setTerrainPipelineBound(false);
     }
 };
 

--- a/modules/engine-graphics/src/rhi_tests.zig
+++ b/modules/engine-graphics/src/rhi_tests.zig
@@ -11,6 +11,7 @@ const MockContext = struct {
     draw_called: bool = false,
     draw_depth_texture_called: bool = false,
     sky_pipeline_requested: bool = false,
+    sky_pipeline_ready: bool = false,
     dynamic_resolution_called: bool = false,
     dynamic_resolution_enabled: bool = false,
     dynamic_resolution_min_scale: f32 = 0.0,
@@ -138,6 +139,7 @@ const MockContext = struct {
         const self: *MockContext = @ptrCast(@alignCast(ptr));
         _ = params;
         self.sky_pipeline_requested = true;
+        if (!self.sky_pipeline_ready) return error.SkyPipelineNotReady;
     }
 
     fn beginWaterDraw(ptr: *anyopaque, reflection: rhi.TextureHandle, scene_depth: rhi.TextureHandle) bool {

--- a/modules/engine-graphics/src/rhi_tests.zig
+++ b/modules/engine-graphics/src/rhi_tests.zig
@@ -81,27 +81,6 @@ const MockContext = struct {
         _ = height;
     }
 
-    fn getNativeSkyPipeline(ptr: *anyopaque) u64 {
-        const self: *MockContext = @ptrCast(@alignCast(ptr));
-        self.sky_pipeline_requested = true;
-        return 0;
-    }
-    fn getNativeSkyPipelineLayout(ptr: *anyopaque) u64 {
-        _ = ptr;
-        return 0;
-    }
-    fn getNativeWaterPipeline(ptr: *anyopaque) u64 {
-        _ = ptr;
-        return 0;
-    }
-    fn getNativeWaterPipelineLayout(ptr: *anyopaque) u64 {
-        _ = ptr;
-        return 0;
-    }
-    fn getNativeMainDescriptorSet(ptr: *anyopaque) u64 {
-        _ = ptr;
-        return 0;
-    }
     fn getNativeCommandBuffer(ptr: *anyopaque) u64 {
         _ = ptr;
         return 0;
@@ -153,6 +132,21 @@ const MockContext = struct {
         _ = ptr;
         _ = cascade_index;
         _ = depth_map_handle;
+    }
+
+    fn drawSky(ptr: *anyopaque, params: rhi.SkyParams) rhi.RhiError!void {
+        const self: *MockContext = @ptrCast(@alignCast(ptr));
+        _ = params;
+        self.sky_pipeline_requested = true;
+    }
+
+    fn beginWaterDraw(ptr: *anyopaque, reflection: rhi.TextureHandle, scene_depth: rhi.TextureHandle) bool {
+        _ = ptr;
+        return reflection != 0 and scene_depth != 0;
+    }
+
+    fn endWaterDraw(ptr: *anyopaque) void {
+        _ = ptr;
     }
 
     fn getEncoder(ptr: *anyopaque) rhi.IGraphicsCommandEncoder {
@@ -268,12 +262,13 @@ const MockContext = struct {
         .computeDepthPyramid = undefined,
     };
 
+    const MOCK_EFFECTS_VTABLE = rhi.IRenderEffectsContext.VTable{
+        .drawSky = drawSky,
+        .beginWaterDraw = beginWaterDraw,
+        .endWaterDraw = endWaterDraw,
+    };
+
     const MOCK_NATIVE_VTABLE = rhi.INativeHandlesContext.VTable{
-        .getSkyPipeline = getNativeSkyPipeline,
-        .getSkyPipelineLayout = getNativeSkyPipelineLayout,
-        .getWaterPipeline = getNativeWaterPipeline,
-        .getWaterPipelineLayout = getNativeWaterPipelineLayout,
-        .getMainDescriptorSet = getNativeMainDescriptorSet,
         .getCommandBuffer = getNativeCommandBuffer,
         .getSwapchainExtent = getNativeSwapchainExtent,
         .getDevice = getNativeDevice,
@@ -423,6 +418,7 @@ const MockContext = struct {
         .render = MOCK_RENDER_VTABLE,
         .passes = MOCK_PASSES_VTABLE,
         .post_process = MOCK_POST_PROCESS_VTABLE,
+        .effects = MOCK_EFFECTS_VTABLE,
         .native = MOCK_NATIVE_VTABLE,
         .ssao = MOCK_SSAO_VTABLE,
         .debug_overlay = MOCK_DEBUG_OVERLAY_VTABLE,

--- a/modules/engine-graphics/src/rhi_vulkan.zig
+++ b/modules/engine-graphics/src/rhi_vulkan.zig
@@ -829,26 +829,6 @@ fn computeWaterReflectedViewProj(ctx_ptr: *anyopaque, view: Mat4, proj: Mat4, ca
     return water_bridge.computeWaterReflectedViewProj(ctx, view, proj, camera_pos);
 }
 
-fn getNativeSkyPipeline(ctx_ptr: *anyopaque) u64 {
-    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
-    return native_access.getNativeSkyPipeline(ctx);
-}
-fn getNativeSkyPipelineLayout(ctx_ptr: *anyopaque) u64 {
-    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
-    return native_access.getNativeSkyPipelineLayout(ctx);
-}
-fn getNativeWaterPipeline(ctx_ptr: *anyopaque) u64 {
-    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
-    return native_access.getNativeWaterPipeline(ctx);
-}
-fn getNativeWaterPipelineLayout(ctx_ptr: *anyopaque) u64 {
-    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
-    return native_access.getNativeWaterPipelineLayout(ctx);
-}
-fn getNativeMainDescriptorSet(ctx_ptr: *anyopaque) u64 {
-    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
-    return native_access.getNativeMainDescriptorSet(ctx);
-}
 fn getNativeCommandBuffer(ctx_ptr: *anyopaque) u64 {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
     return native_access.getNativeCommandBuffer(ctx);
@@ -901,6 +881,68 @@ fn computeSsao(ctx_ptr: *anyopaque, proj: Mat4, inv_proj: Mat4) void {
         inv_proj,
     );
 }
+
+fn drawSkyEffect(ctx_ptr: *anyopaque, params: rhi.SkyParams) rhi.RhiError!void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const pipeline = ctx.pipeline_manager.sky_pipeline;
+    const layout = ctx.pipeline_manager.sky_pipeline_layout;
+    const cmd = ctx.frames.command_buffers[ctx.frames.current_frame];
+
+    if (pipeline == null or layout == null or cmd == null) {
+        log.log.warn("Vulkan RHI: Sky rendering skipped, handles missing (pipeline={}, layout={}, cmd={})", .{ pipeline != null, layout != null, cmd != null });
+        if (pipeline == null) return error.SkyPipelineNotReady;
+        if (layout == null) return error.SkyPipelineLayoutNotReady;
+        if (cmd == null) return error.CommandBufferNotReady;
+        return error.ResourceNotReady;
+    }
+
+    const pc = rhi.SkyPushConstants{
+        .cam_forward = .{ params.cam_forward.x, params.cam_forward.y, params.cam_forward.z, 0.0 },
+        .cam_right = .{ params.cam_right.x, params.cam_right.y, params.cam_right.z, 0.0 },
+        .cam_up = .{ params.cam_up.x, params.cam_up.y, params.cam_up.z, 0.0 },
+        .sun_dir = .{ params.sun_dir.x, params.sun_dir.y, params.sun_dir.z, 0.0 },
+        .sky_color = .{ params.sky_color.x, params.sky_color.y, params.sky_color.z, 1.0 },
+        .horizon_color = .{ params.horizon_color.x, params.horizon_color.y, params.horizon_color.z, 1.0 },
+        .params = .{ params.aspect, params.tan_half_fov, params.sun_intensity, params.moon_intensity },
+        .time = .{ params.time, params.cam_pos.x, params.cam_pos.y, params.cam_pos.z },
+    };
+
+    c.vkCmdBindPipeline(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+    const descriptor_set = ctx.descriptors.descriptor_sets[ctx.frames.current_frame];
+    if (descriptor_set != null) {
+        c.vkCmdBindDescriptorSets(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0, 1, &descriptor_set, 0, null);
+    }
+    c.vkCmdPushConstants(cmd, layout, c.VK_SHADER_STAGE_VERTEX_BIT | c.VK_SHADER_STAGE_FRAGMENT_BIT, 0, @sizeOf(rhi.SkyPushConstants), &pc);
+    c.vkCmdDraw(cmd, 3, 1, 0, 0);
+}
+
+fn beginWaterDrawEffect(ctx_ptr: *anyopaque, reflection: rhi.TextureHandle, scene_depth: rhi.TextureHandle) bool {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const pipeline = ctx.water_system.water_pipeline;
+    const layout = ctx.water_system.water_pipeline_layout;
+    const cmd = ctx.frames.command_buffers[ctx.frames.current_frame];
+
+    if (pipeline == null or layout == null or cmd == null or reflection == 0 or scene_depth == 0) return false;
+
+    c.vkCmdBindPipeline(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+    const descriptor_set = ctx.descriptors.descriptor_sets[ctx.frames.current_frame];
+    if (descriptor_set != null) {
+        c.vkCmdBindDescriptorSets(cmd, c.VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0, 1, &descriptor_set, 0, null);
+    }
+    ctx.draw.terrain_pipeline_bound = true;
+    return true;
+}
+
+fn endWaterDrawEffect(ctx_ptr: *anyopaque) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    ctx.draw.terrain_pipeline_bound = false;
+}
+
+const VULKAN_RENDER_EFFECTS_VTABLE = rhi.IRenderEffectsContext.VTable{
+    .drawSky = drawSkyEffect,
+    .beginWaterDraw = beginWaterDrawEffect,
+    .endWaterDraw = endWaterDrawEffect,
+};
 
 fn drawDebugShadowMap(ctx_ptr: *anyopaque, cascade_index: usize, depth_map_handle: rhi.TextureHandle) void {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
@@ -997,12 +1039,8 @@ const VULKAN_RHI_VTABLE = rhi.RHI.VTable{
         .computeTAA = computeTAA,
         .computeDepthPyramid = computeDepthPyramid,
     },
+    .effects = VULKAN_RENDER_EFFECTS_VTABLE,
     .native = .{
-        .getSkyPipeline = getNativeSkyPipeline,
-        .getSkyPipelineLayout = getNativeSkyPipelineLayout,
-        .getWaterPipeline = getNativeWaterPipeline,
-        .getWaterPipelineLayout = getNativeWaterPipelineLayout,
-        .getMainDescriptorSet = getNativeMainDescriptorSet,
         .getCommandBuffer = getNativeCommandBuffer,
         .getSwapchainExtent = getNativeSwapchainExtent,
         .getDevice = getNativeDevice,

--- a/modules/engine-graphics/src/vulkan/rhi_native_access.zig
+++ b/modules/engine-graphics/src/vulkan/rhi_native_access.zig
@@ -1,23 +1,3 @@
-pub fn getNativeSkyPipeline(ctx: anytype) u64 {
-    return @intFromPtr(ctx.pipeline_manager.sky_pipeline);
-}
-
-pub fn getNativeSkyPipelineLayout(ctx: anytype) u64 {
-    return @intFromPtr(ctx.pipeline_manager.sky_pipeline_layout);
-}
-
-pub fn getNativeWaterPipeline(ctx: anytype) u64 {
-    return @intFromPtr(ctx.water_system.water_pipeline);
-}
-
-pub fn getNativeWaterPipelineLayout(ctx: anytype) u64 {
-    return @intFromPtr(ctx.water_system.water_pipeline_layout);
-}
-
-pub fn getNativeMainDescriptorSet(ctx: anytype) u64 {
-    return @intFromPtr(ctx.descriptors.descriptor_sets[ctx.frames.current_frame]);
-}
-
 pub fn getNativeCommandBuffer(ctx: anytype) u64 {
     return @intFromPtr(ctx.frames.command_buffers[ctx.frames.current_frame]);
 }

--- a/modules/engine-rhi/src/rhi.zig
+++ b/modules/engine-rhi/src/rhi.zig
@@ -234,6 +234,7 @@ pub const RenderContext = struct {
     render: IRenderContext,
     passes: IPassOrchestrationContext,
     post_process: IPostProcessContext,
+    effects: IRenderEffectsContext,
     native: INativeHandlesContext,
     encoder: IGraphicsCommandEncoder,
     state: IRenderStateContext,
@@ -282,29 +283,20 @@ pub const RenderContext = struct {
     pub fn computeDepthPyramid(self: RenderContext) void {
         self.post_process.computeDepthPyramid();
     }
+    pub fn drawSky(self: RenderContext, params: SkyParams) RhiError!void {
+        return self.effects.drawSky(params);
+    }
+    pub fn beginWaterDraw(self: RenderContext, reflection: TextureHandle, scene_depth: TextureHandle) bool {
+        return self.effects.beginWaterDraw(reflection, scene_depth);
+    }
+    pub fn endWaterDraw(self: RenderContext) void {
+        self.effects.endWaterDraw();
+    }
     pub fn requestSwapchainRecreate(self: RenderContext) void {
         self.render.requestSwapchainRecreate();
     }
     pub fn setClearColor(self: RenderContext, color: Vec3) void {
         self.render.vtable.setClearColor(self.render.ptr, color);
-    }
-    pub fn getNativeSkyPipeline(self: RenderContext) u64 {
-        return self.native.getSkyPipeline();
-    }
-    pub fn getNativeSkyPipelineLayout(self: RenderContext) u64 {
-        return self.native.getSkyPipelineLayout();
-    }
-    pub fn getNativeWaterPipeline(self: RenderContext) u64 {
-        return self.native.getWaterPipeline();
-    }
-    pub fn getNativeWaterPipelineLayout(self: RenderContext) u64 {
-        return self.native.getWaterPipelineLayout();
-    }
-    pub fn getNativeMainDescriptorSet(self: RenderContext) u64 {
-        return self.native.getMainDescriptorSet();
-    }
-    pub fn getNativeCommandBuffer(self: RenderContext) u64 {
-        return self.native.getCommandBuffer();
     }
     pub fn getNativeSwapchainExtent(self: RenderContext) [2]u32 {
         return self.native.getSwapchainExtent();
@@ -760,16 +752,32 @@ pub const IPostProcessContext = struct {
     }
 };
 
+pub const IRenderEffectsContext = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        drawSky: *const fn (ptr: *anyopaque, params: SkyParams) RhiError!void,
+        beginWaterDraw: *const fn (ptr: *anyopaque, reflection: TextureHandle, scene_depth: TextureHandle) bool,
+        endWaterDraw: *const fn (ptr: *anyopaque) void,
+    };
+
+    pub fn drawSky(self: IRenderEffectsContext, params: SkyParams) RhiError!void {
+        return self.vtable.drawSky(self.ptr, params);
+    }
+    pub fn beginWaterDraw(self: IRenderEffectsContext, reflection: TextureHandle, scene_depth: TextureHandle) bool {
+        return self.vtable.beginWaterDraw(self.ptr, reflection, scene_depth);
+    }
+    pub fn endWaterDraw(self: IRenderEffectsContext) void {
+        self.vtable.endWaterDraw(self.ptr);
+    }
+};
+
 pub const INativeHandlesContext = struct {
     ptr: *anyopaque,
     vtable: *const VTable,
 
     pub const VTable = struct {
-        getSkyPipeline: *const fn (ptr: *anyopaque) u64,
-        getSkyPipelineLayout: *const fn (ptr: *anyopaque) u64,
-        getWaterPipeline: *const fn (ptr: *anyopaque) u64,
-        getWaterPipelineLayout: *const fn (ptr: *anyopaque) u64,
-        getMainDescriptorSet: *const fn (ptr: *anyopaque) u64,
         getCommandBuffer: *const fn (ptr: *anyopaque) u64,
         getSwapchainExtent: *const fn (ptr: *anyopaque) [2]u32,
         getDevice: *const fn (ptr: *anyopaque) u64,
@@ -782,21 +790,6 @@ pub const INativeHandlesContext = struct {
         getSwapchainImageCount: *const fn (ptr: *anyopaque) u32,
     };
 
-    pub fn getSkyPipeline(self: INativeHandlesContext) u64 {
-        return self.vtable.getSkyPipeline(self.ptr);
-    }
-    pub fn getSkyPipelineLayout(self: INativeHandlesContext) u64 {
-        return self.vtable.getSkyPipelineLayout(self.ptr);
-    }
-    pub fn getWaterPipeline(self: INativeHandlesContext) u64 {
-        return self.vtable.getWaterPipeline(self.ptr);
-    }
-    pub fn getWaterPipelineLayout(self: INativeHandlesContext) u64 {
-        return self.vtable.getWaterPipelineLayout(self.ptr);
-    }
-    pub fn getMainDescriptorSet(self: INativeHandlesContext) u64 {
-        return self.vtable.getMainDescriptorSet(self.ptr);
-    }
     pub fn getCommandBuffer(self: INativeHandlesContext) u64 {
         return self.vtable.getCommandBuffer(self.ptr);
     }
@@ -1034,6 +1027,7 @@ pub const RHI = struct {
         render: IRenderContext.VTable,
         passes: IPassOrchestrationContext.VTable,
         post_process: IPostProcessContext.VTable,
+        effects: IRenderEffectsContext.VTable,
         native: INativeHandlesContext.VTable,
         ssao: ISSAOContext.VTable,
         debug_overlay: IDebugOverlayContext.VTable,
@@ -1060,6 +1054,7 @@ pub const RHI = struct {
             .render = rc,
             .passes = self.passOrchestration(),
             .post_process = self.postProcess(),
+            .effects = self.renderEffects(),
             .native = self.nativeHandles(),
             .encoder = rc.getEncoder(),
             .state = rc.getState(),
@@ -1070,6 +1065,9 @@ pub const RHI = struct {
     }
     pub fn postProcess(self: RHI) IPostProcessContext {
         return .{ .ptr = self.ptr, .vtable = &self.vtable.post_process };
+    }
+    pub fn renderEffects(self: RHI) IRenderEffectsContext {
+        return .{ .ptr = self.ptr, .vtable = &self.vtable.effects };
     }
     pub fn nativeHandles(self: RHI) INativeHandlesContext {
         return .{ .ptr = self.ptr, .vtable = &self.vtable.native };

--- a/modules/engine-rhi/src/root.zig
+++ b/modules/engine-rhi/src/root.zig
@@ -53,6 +53,7 @@ pub const IDebugOverlayContext = rhi.IDebugOverlayContext;
 pub const IRenderContext = rhi.IRenderContext;
 pub const IPassOrchestrationContext = rhi.IPassOrchestrationContext;
 pub const IPostProcessContext = rhi.IPostProcessContext;
+pub const IRenderEffectsContext = rhi.IRenderEffectsContext;
 pub const INativeHandlesContext = rhi.INativeHandlesContext;
 pub const IDeviceQuery = rhi.IDeviceQuery;
 pub const IDeviceTiming = rhi.IDeviceTiming;

--- a/src/engine/graphics/rhi.zig
+++ b/src/engine/graphics/rhi.zig
@@ -49,6 +49,7 @@ pub const IDebugOverlayContext = rhi.IDebugOverlayContext;
 pub const IRenderContext = rhi.IRenderContext;
 pub const IPassOrchestrationContext = rhi.IPassOrchestrationContext;
 pub const IPostProcessContext = rhi.IPostProcessContext;
+pub const IRenderEffectsContext = rhi.IRenderEffectsContext;
 pub const INativeHandlesContext = rhi.INativeHandlesContext;
 pub const IDeviceQuery = rhi.IDeviceQuery;
 pub const IDeviceTiming = rhi.IDeviceTiming;


### PR DESCRIPTION
## Summary
- Add an RHI render-effects context for sky and water draw orchestration
- Move sky pipeline binding, sky push constants, and water pipeline binding into the Vulkan backend
- Remove sky/water/native descriptor accessors from INativeHandlesContext and call sites

Part of #784

## Verification
- nix develop --command zig fmt modules/engine-rhi/src/rhi.zig modules/engine-rhi/src/root.zig src/engine/graphics/rhi.zig modules/engine-graphics/src/atmosphere_system.zig modules/engine-graphics/src/render_graph.zig modules/engine-graphics/src/rhi_vulkan.zig modules/engine-graphics/src/rhi_tests.zig modules/engine-graphics/src/vulkan/rhi_native_access.zig
- nix develop --command zig build test

## Notes
- This PR removes native handle exposure from sky/water draw paths only. Full INativeHandlesContext deletion and any remaining debug-shadow/native interop work should continue under #784/#776.
- Headless screenshot verification was attempted with `nix develop --command zig build run -Dskip-present -Dauto-world=normal -Dscreenshot-path=screenshots/issue-784-after.png -Dscreenshot-frame=120`, but the run timed out after 90s and did not produce a screenshot.
- Existing ImGui Vulkan interop still uses native handles; this PR avoids broadening the review scope.