### PR TITLE
fix(worldgen): correct underwater detection in V2 surface fill

### DIFF
--- a/modules/worldgen-overworld-v2/src/root.zig
+++ b/modules/worldgen-overworld-v2/src/root.zig
@@ -377,7 +377,7 @@ pub const OverworldV2Generator = struct {
             }
 
             if (layer_depth >= 0) {
-                const underwater = above == .water or y < self.params.sea_level - 1;
+                const underwater = above == .water;
                 chunk.blocks[idx] = if (layer_depth == 0)
                     surfaceBlock(sample.biome, sample.terrain_height, self.params.sea_level, underwater)
                 else if (layer_depth <= filler_depth)


### PR DESCRIPTION
## Summary

Fixes #740

The V2 generator's `applyBiomeSurfaceColumn` computed the `underwater` flag incorrectly:

```zig
// Before (buggy)
const underwater = above == .water or y < self.params.sea_level - 1;
```

The height-based fallback `y < sea_level - 1` marked **any** stone below sea level as underwater, regardless of whether water actually sat above it. This caused:

- **Mountains rising from the ocean**: stone inside an above-sea-level mountain (e.g. surface at y=80, but a block at y=62) got marked underwater and received sand/gravel surface instead of grass/dirt.
- **Cave-exposed stone below sea level**: when a cave carved an air pocket below sea level, the stone below it was treated as underwater and got sand/gravel even though it was exposed to air, not water.

## Fix

```zig
// After
const underwater = above == .water;
```

The loop in `applyBiomeSurfaceColumn` iterates top-to-bottom and the `above` variable already tracks what block sits directly on top of the current position. This makes the height-based fallback redundant and incorrect:
- If `above == .water`, the block is genuinely submerged.
- If `above` is air/stone/etc., there is no water above regardless of global height.

This matches the Luanti v7 mapgen reference logic.

## Location
- `modules/worldgen-overworld-v2/src/root.zig:380` — `applyBiomeSurfaceColumn`

## Verification
- [x] `zig fmt` clean
- [x] `zig build test` passes (unit tests + shader validation)
- [x] Genuinely underwater stone (ocean floor with water directly above) still gets sand/gravel via `above == .water`
- [x] Above-sea-level mountain stone below sea level now gets correct grass/dirt surface

## Acceptance Criteria (from issue)
- [x] Stone blocks inside above-sea-level mountains below `y=sea_level-1` get correct surface (grass/dirt) not sand/gravel
- [x] Stone blocks genuinely underwater still get correct underwater surface (sand/gravel)
- [x] `zig build test` passes