### PR TITLE
perf(meshing): O(1) chunk-to-slot lookup in GpuBlockBuffer

### DIFF
--- a/modules/world-meshing/src/gpu_block_buffer.zig
+++ b/modules/world-meshing/src/gpu_block_buffer.zig
@@ -42,6 +42,7 @@ pub const GpuBlockBuffer = struct {
     slot_size: usize,
     free_list: std.ArrayListUnmanaged(usize),
     slot_to_chunk: std.AutoArrayHashMapUnmanaged(usize, ChunkSlot),
+    chunk_to_slot: std.AutoArrayHashMapUnmanaged(ChunkSlot, usize),
 
     pub const ChunkSlot = struct {
         cx: i32,
@@ -65,6 +66,7 @@ pub const GpuBlockBuffer = struct {
             .slot_size = SLOT_SIZE,
             .free_list = .empty,
             .slot_to_chunk = .empty,
+            .chunk_to_slot = .empty,
         };
 
         try buffer.free_list.ensureTotalCapacity(allocator, capacity);
@@ -79,34 +81,33 @@ pub const GpuBlockBuffer = struct {
         self.rm.destroyBuffer(self.buffer);
         self.free_list.deinit(self.allocator);
         self.slot_to_chunk.deinit(self.allocator);
+        self.chunk_to_slot.deinit(self.allocator);
         self.allocator.destroy(self);
     }
 
     pub fn allocate(self: *GpuBlockBuffer, cx: i32, cz: i32) !usize {
         if (self.free_list.pop()) |slot| {
-            try self.slot_to_chunk.put(self.allocator, slot, ChunkSlot{ .cx = cx, .cz = cz });
+            const chunk_key = ChunkSlot{ .cx = cx, .cz = cz };
+            try self.slot_to_chunk.put(self.allocator, slot, chunk_key);
+            errdefer _ = self.slot_to_chunk.swapRemove(slot);
+            try self.chunk_to_slot.put(self.allocator, chunk_key, slot);
             return slot;
         }
         return error.OutOfMemory;
     }
 
     pub fn free(self: *GpuBlockBuffer, slot: usize) void {
-        if (self.slot_to_chunk.swapRemove(slot)) {
-            self.free_list.append(self.allocator, slot) catch {};
-        }
+        const chunk_key = self.slot_to_chunk.get(slot) orelse return;
+        _ = self.slot_to_chunk.swapRemove(slot);
+        _ = self.chunk_to_slot.swapRemove(chunk_key);
+        self.free_list.append(self.allocator, slot) catch {};
     }
 
     pub fn freeByChunk(self: *GpuBlockBuffer, cx: i32, cz: i32) ?usize {
-        var it = self.slot_to_chunk.iterator();
-        while (it.next()) |entry| {
-            if (entry.value_ptr.cx == cx and entry.value_ptr.cz == cz) {
-                const slot = entry.key_ptr.*;
-                _ = self.slot_to_chunk.swapRemove(slot);
-                self.free_list.append(self.allocator, slot) catch {};
-                return slot;
-            }
-        }
-        return null;
+        const chunk_key = ChunkSlot{ .cx = cx, .cz = cz };
+        const slot = self.chunk_to_slot.get(chunk_key) orelse return null;
+        self.free(slot);
+        return slot;
     }
 
     pub fn upload(self: *GpuBlockBuffer, slot: usize, blocks: []const u8) !void {
@@ -129,13 +130,7 @@ pub const GpuBlockBuffer = struct {
     }
 
     pub fn getSlotForChunk(self: *GpuBlockBuffer, cx: i32, cz: i32) ?usize {
-        var it = self.slot_to_chunk.iterator();
-        while (it.next()) |entry| {
-            if (entry.value_ptr.cx == cx and entry.value_ptr.cz == cz) {
-                return entry.key_ptr.*;
-            }
-        }
-        return null;
+        return self.chunk_to_slot.get(ChunkSlot{ .cx = cx, .cz = cz });
     }
 
     pub fn getBufferHandle(self: *GpuBlockBuffer) BufferHandle {

--- a/modules/world-meshing/src/gpu_block_buffer_tests.zig
+++ b/modules/world-meshing/src/gpu_block_buffer_tests.zig
@@ -1,0 +1,246 @@
+const std = @import("std");
+const testing = std.testing;
+const GpuBlockBuffer = @import("gpu_block_buffer.zig").GpuBlockBuffer;
+const rhi = @import("engine-rhi").rhi;
+
+/// Minimal mock `ResourceManager` for exercising `GpuBlockBuffer` without a GPU.
+///
+/// Only the buffer lifecycle hooks (`createBuffer`, `updateBuffer`, `destroyBuffer`)
+/// are exercised by `GpuBlockBuffer`; the remaining `IResourceFactory` vtable entries
+/// are stubbed so the `ResourceManager` can be constructed in tests.
+const MockRm = struct {
+    buffer_count: usize = 0,
+    update_count: usize = 0,
+    destroy_count: usize = 0,
+
+    fn resourceManager(self: *MockRm) rhi.ResourceManager {
+        return .{ .factory = .{
+            .ptr = self,
+            .vtable = &.{
+                .createBuffer = createBuffer,
+                .uploadBuffer = uploadBuffer,
+                .updateBuffer = updateBuffer,
+                .destroyBuffer = destroyBuffer,
+                .createTexture = createTexture,
+                .createTexture3D = createTexture3D,
+                .destroyTexture = destroyTexture,
+                .updateTexture = updateTexture,
+                .createShader = createShader,
+                .destroyShader = destroyShader,
+                .mapBuffer = mapBuffer,
+                .unmapBuffer = unmapBuffer,
+            },
+        } };
+    }
+
+    fn createBuffer(ptr: *anyopaque, size: usize, usage: rhi.BufferUsage) rhi.RhiError!rhi.BufferHandle {
+        _ = size;
+        _ = usage;
+        const self: *MockRm = @ptrCast(@alignCast(ptr));
+        self.buffer_count += 1;
+        return 1;
+    }
+    fn uploadBuffer(ptr: *anyopaque, handle: rhi.BufferHandle, data: []const u8) rhi.RhiError!void {
+        _ = ptr;
+        _ = handle;
+        _ = data;
+    }
+    fn updateBuffer(ptr: *anyopaque, handle: rhi.BufferHandle, offset: usize, data: []const u8) rhi.RhiError!void {
+        _ = handle;
+        _ = offset;
+        _ = data;
+        const self: *MockRm = @ptrCast(@alignCast(ptr));
+        self.update_count += 1;
+    }
+    fn destroyBuffer(ptr: *anyopaque, handle: rhi.BufferHandle) void {
+        _ = handle;
+        const self: *MockRm = @ptrCast(@alignCast(ptr));
+        self.destroy_count += 1;
+    }
+    fn createTexture(ptr: *anyopaque, width: u32, height: u32, format: rhi.TextureFormat, config: rhi.TextureConfig, data: ?[]const u8) rhi.RhiError!rhi.TextureHandle {
+        _ = ptr;
+        _ = width;
+        _ = height;
+        _ = format;
+        _ = config;
+        _ = data;
+        return error.Unknown;
+    }
+    fn createTexture3D(ptr: *anyopaque, width: u32, height: u32, depth: u32, format: rhi.TextureFormat, config: rhi.TextureConfig, data: ?[]const u8) rhi.RhiError!rhi.TextureHandle {
+        _ = ptr;
+        _ = width;
+        _ = height;
+        _ = depth;
+        _ = format;
+        _ = config;
+        _ = data;
+        return error.Unknown;
+    }
+    fn destroyTexture(ptr: *anyopaque, handle: rhi.TextureHandle) void {
+        _ = ptr;
+        _ = handle;
+    }
+    fn updateTexture(ptr: *anyopaque, handle: rhi.TextureHandle, data: []const u8) rhi.RhiError!void {
+        _ = ptr;
+        _ = handle;
+        _ = data;
+    }
+    fn createShader(ptr: *anyopaque, vertex_src: [*c]const u8, fragment_src: [*c]const u8) rhi.RhiError!rhi.ShaderHandle {
+        _ = ptr;
+        _ = vertex_src;
+        _ = fragment_src;
+        return error.Unknown;
+    }
+    fn destroyShader(ptr: *anyopaque, handle: rhi.ShaderHandle) void {
+        _ = ptr;
+        _ = handle;
+    }
+    fn mapBuffer(ptr: *anyopaque, handle: rhi.BufferHandle) rhi.RhiError!?*anyopaque {
+        _ = ptr;
+        _ = handle;
+        return null;
+    }
+    fn unmapBuffer(ptr: *anyopaque, handle: rhi.BufferHandle) void {
+        _ = ptr;
+        _ = handle;
+    }
+};
+
+test "GpuBlockBuffer.getSlotForChunk returns allocated slot" {
+    var mock = MockRm{};
+    const buf = try GpuBlockBuffer.init(testing.allocator, mock.resourceManager(), 16);
+    defer buf.deinit();
+
+    const slot = try buf.allocate(3, -7);
+    try testing.expectEqual(slot, buf.getSlotForChunk(3, -7).?);
+}
+
+test "GpuBlockBuffer.getSlotForChunk returns null for unallocated chunk" {
+    var mock = MockRm{};
+    const buf = try GpuBlockBuffer.init(testing.allocator, mock.resourceManager(), 16);
+    defer buf.deinit();
+
+    _ = try buf.allocate(1, 1);
+    try testing.expectEqual(null, buf.getSlotForChunk(2, 2));
+}
+
+test "GpuBlockBuffer.getSlotForChunk distinguishes distinct chunks" {
+    var mock = MockRm{};
+    const buf = try GpuBlockBuffer.init(testing.allocator, mock.resourceManager(), 16);
+    defer buf.deinit();
+
+    const a = try buf.allocate(0, 0);
+    const b = try buf.allocate(0, 1);
+    const c = try buf.allocate(1, 0);
+    try testing.expect(a != b);
+    try testing.expect(a != c);
+    try testing.expect(b != c);
+
+    try testing.expectEqual(a, buf.getSlotForChunk(0, 0).?);
+    try testing.expectEqual(b, buf.getSlotForChunk(0, 1).?);
+    try testing.expectEqual(c, buf.getSlotForChunk(1, 0).?);
+}
+
+test "GpuBlockBuffer.freeByChunk removes slot and returns it" {
+    var mock = MockRm{};
+    const buf = try GpuBlockBuffer.init(testing.allocator, mock.resourceManager(), 16);
+    defer buf.deinit();
+
+    const slot = try buf.allocate(-4, 9);
+    const freed = buf.freeByChunk(-4, 9);
+    try testing.expectEqual(slot, freed.?);
+    try testing.expectEqual(null, buf.getSlotForChunk(-4, 9));
+    try testing.expectEqual(null, buf.freeByChunk(-4, 9));
+}
+
+test "GpuBlockBuffer.freeByChunk only frees the matching chunk" {
+    var mock = MockRm{};
+    const buf = try GpuBlockBuffer.init(testing.allocator, mock.resourceManager(), 16);
+    defer buf.deinit();
+
+    _ = try buf.allocate(5, 5);
+    const keep = try buf.allocate(5, 6);
+
+    const freed = buf.freeByChunk(5, 5);
+    try testing.expect(freed != null);
+
+    try testing.expectEqual(keep, buf.getSlotForChunk(5, 6).?);
+    try testing.expectEqual(null, buf.getSlotForChunk(5, 5));
+}
+
+test "GpuBlockBuffer.free by slot clears reverse lookup" {
+    var mock = MockRm{};
+    const buf = try GpuBlockBuffer.init(testing.allocator, mock.resourceManager(), 16);
+    defer buf.deinit();
+
+    const slot = try buf.allocate(12, -3);
+    buf.free(slot);
+    try testing.expectEqual(null, buf.getSlotForChunk(12, -3));
+    try testing.expectEqual(null, buf.freeByChunk(12, -3));
+}
+
+test "GpuBlockBuffer.free by invalid slot is a no-op" {
+    var mock = MockRm{};
+    const buf = try GpuBlockBuffer.init(testing.allocator, mock.resourceManager(), 16);
+    defer buf.deinit();
+
+    _ = try buf.allocate(1, 1);
+    buf.free(9999);
+    try testing.expectEqual(@as(usize, 1), buf.allocatedCount());
+}
+
+test "GpuBlockBuffer reuses freed slot for reallocated chunk" {
+    var mock = MockRm{};
+    const buf = try GpuBlockBuffer.init(testing.allocator, mock.resourceManager(), 4);
+    defer buf.deinit();
+
+    const slot = try buf.allocate(2, 2);
+    _ = buf.freeByChunk(2, 2);
+    const reused = try buf.allocate(2, 2);
+    try testing.expectEqual(slot, reused);
+    try testing.expectEqual(slot, buf.getSlotForChunk(2, 2).?);
+}
+
+test "GpuBlockBuffer keeps reverse index consistent after many alloc/free cycles" {
+    var mock = MockRm{};
+    const buf = try GpuBlockBuffer.init(testing.allocator, mock.resourceManager(), 32);
+    defer buf.deinit();
+
+    var i: i32 = 0;
+    while (i < 16) : (i += 1) {
+        _ = try buf.allocate(i, -i);
+    }
+    _ = buf.freeByChunk(3, -3);
+    _ = buf.freeByChunk(7, -7);
+
+    try testing.expectEqual(null, buf.getSlotForChunk(3, -3));
+    try testing.expectEqual(null, buf.getSlotForChunk(7, -7));
+
+    var j: i32 = 0;
+    while (j < 16) : (j += 1) {
+        if (j == 3 or j == 7) continue;
+        try testing.expect(buf.getSlotForChunk(j, -j) != null);
+    }
+
+    const re3 = try buf.allocate(3, -3);
+    try testing.expectEqual(re3, buf.getSlotForChunk(3, -3).?);
+}
+
+test "GpuBlockBuffer.updateBlock hits RHI for allocated chunk" {
+    var mock = MockRm{};
+    const buf = try GpuBlockBuffer.init(testing.allocator, mock.resourceManager(), 8);
+    defer buf.deinit();
+
+    _ = try buf.allocate(1, 1);
+    try buf.updateBlock(1, 1, 0, 0, 0, 1);
+    try testing.expectEqual(@as(usize, 1), mock.update_count);
+}
+
+test "GpuBlockBuffer.updateBlock skips RHI for unallocated chunk" {
+    var mock = MockRm{};
+    const buf = try GpuBlockBuffer.init(testing.allocator, mock.resourceManager(), 8);
+    defer buf.deinit();
+
+    try buf.updateBlock(99, 99, 0, 0, 0, 1);
+    try testing.expectEqual(@as(usize, 0), mock.update_count);
+}

--- a/modules/world-meshing/src/root.zig
+++ b/modules/world-meshing/src/root.zig
@@ -6,6 +6,7 @@ pub const chunk_storage_extended_tests = @import("chunk_storage_extended_tests.z
 pub const chunk_storage_interface_tests = @import("chunk_storage_interface_tests.zig");
 pub const chunk_storage_tests = @import("chunk_storage_tests.zig");
 pub const gpu_block_buffer = @import("gpu_block_buffer.zig");
+pub const gpu_block_buffer_tests = @import("gpu_block_buffer_tests.zig");
 pub const world_interface_vtable_tests = @import("world_interface_vtable_tests.zig");
 pub const world_tests = @import("world_tests.zig");
 pub const meshing = struct {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -86,6 +86,7 @@ test {
     _ = @import("world-meshing").meshing.quadric_simplifier;
     _ = @import("world-meshing").chunk_storage_tests;
     _ = @import("world-meshing").chunk_storage_extended_tests;
+    _ = @import("world-meshing").gpu_block_buffer_tests;
     _ = @import("world-core").block_tests;
     _ = @import("world-core").block_registry_tests;
     _ = @import("world-core").block_biome_tests;


### PR DESCRIPTION
## Summary

Fixes #739.

Replaces the O(n) linear scans in `GpuBlockBuffer.getSlotForChunk` and `freeByChunk` with a reverse index (`chunk_to_slot` hashmap) enabling O(1) average-case lookup by chunk coordinates.

## Problem

`GpuBlockBuffer` stored only `slot_to_chunk: AutoArrayHashMap(usize, ChunkSlot)`, indexed by slot. Looking up a slot by chunk coordinates required iterating all entries (up to 16,384). This was a measurable bottleneck in the GPU meshing pipeline, where `gpu_mesher.zig:299-302` performs **four** neighbor `getSlotForChunk` queries per chunk, and `gpu_acceleration_coordinator.zig:72` queries it on every chunk upload.

## Changes

- **`modules/world-meshing/src/gpu_block_buffer.zig`**: Added `chunk_to_slot: AutoArrayHashMapUnmanaged(ChunkSlot, usize)` reverse index.
  - `allocate()` inserts into both maps (with `errdefer` rollback for consistency).
  - `free()` resolves the chunk key from `slot_to_chunk`, then removes from both maps.
  - `freeByChunk()` is now a single `chunk_to_slot.get()` + `free()`.
  - `getSlotForChunk()` is now a single `chunk_to_slot.get()`.
  - Memory overhead: one additional `usize` per allocated slot (~64KB at the 16K-chunk cap).
- **`modules/world-meshing/src/gpu_block_buffer_tests.zig`** (new): Unit tests with a mock `ResourceManager` covering allocation, free-by-slot, free-by-chunk, slot reuse, reverse-index consistency across alloc/free cycles, and `updateBlock` RHI dispatch.
- **`modules/world-meshing/src/root.zig`** / **`src/tests.zig`**: Register the new test module.

## Verification

- [x] `nix develop --command zig fmt src/ modules/`
- [x] `nix develop --command zig build test` (full suite passes, including new tests)
- [x] `getSlotForChunk` performs a single hashmap lookup (O(1))
- [x] `freeByChunk` performs a single hashmap lookup (O(1))
- [x] Memory overhead is minimal: one additional `usize` per allocated slot
- [x] Verified with Zig 0.16.0 + SDL3 Dev Environment