### PR TITLE
refactor: add RHI compute facet

### DIFF
--- a/modules/engine-graphics/src/lpv_backend.zig
+++ b/modules/engine-graphics/src/lpv_backend.zig
@@ -1,7 +1,7 @@
 //! Backend binding for Light Propagation Volumes.
 //!
-//! LPV compute currently uses Vulkan resources directly. Keep that dependency
-//! explicit so LPVSystem does not pretend any RHI backend can satisfy it.
+//! LPV compute currently uses Vulkan resources directly. The backend context is
+//! retrieved through RHI native handles so callers do not downcast `RHI.ptr`.
 
 const rhi_pkg = @import("engine-rhi").rhi;
 const VulkanContext = @import("vulkan/rhi_context_types.zig").VulkanContext;
@@ -10,6 +10,6 @@ pub const LPVBackend = struct {
     vk_ctx: *VulkanContext,
 
     pub fn fromVulkanRHI(rhi: rhi_pkg.RHI) LPVBackend {
-        return .{ .vk_ctx = @ptrCast(@alignCast(rhi.ptr)) };
+        return .{ .vk_ctx = @ptrFromInt(rhi.nativeHandles().getBackendContext()) };
     }
 };

--- a/modules/engine-graphics/src/rhi_tests.zig
+++ b/modules/engine-graphics/src/rhi_tests.zig
@@ -240,6 +240,93 @@ const MockContext = struct {
         self.draw_depth_texture_called = true;
     }
 
+    fn bindComputePipeline(ptr: *anyopaque, pipeline: u64) void {
+        _ = ptr;
+        _ = pipeline;
+    }
+    fn bindDescriptorSet(ptr: *anyopaque, pipeline_layout: u64, descriptor_set: u64) void {
+        _ = ptr;
+        _ = pipeline_layout;
+        _ = descriptor_set;
+    }
+    fn createComputeBuffer(ptr: *anyopaque, size: usize, host_visible: bool) rhi.RhiError!rhi.ComputeBuffer {
+        _ = ptr;
+        _ = size;
+        _ = host_visible;
+        return .{};
+    }
+    fn destroyComputeBuffer(ptr: *anyopaque, buffer: *rhi.ComputeBuffer) void {
+        _ = ptr;
+        buffer.* = .{};
+    }
+    fn createComputePipeline(ptr: *anyopaque, allocator: std.mem.Allocator, shader_path: []const u8, storage_binding_count: u32, push_constant_size: u32) anyerror!rhi.ComputePipeline {
+        _ = ptr;
+        _ = allocator;
+        _ = shader_path;
+        _ = storage_binding_count;
+        _ = push_constant_size;
+        return .{};
+    }
+    fn updateComputeDescriptors(ptr: *anyopaque, pipeline: rhi.ComputePipeline, frame_index: usize, buffers: []const u64) void {
+        _ = ptr;
+        _ = pipeline;
+        _ = frame_index;
+        _ = buffers;
+    }
+    fn destroyComputePipeline(ptr: *anyopaque, pipeline: *rhi.ComputePipeline) void {
+        _ = ptr;
+        pipeline.* = .{};
+    }
+    fn dispatchCompute(ptr: *anyopaque, group_count_x: u32, group_count_y: u32, group_count_z: u32) void {
+        _ = ptr;
+        _ = group_count_x;
+        _ = group_count_y;
+        _ = group_count_z;
+    }
+    fn pushComputeConstants(ptr: *anyopaque, pipeline_layout: u64, offset: u32, size: u32, data: *const anyopaque) void {
+        _ = ptr;
+        _ = pipeline_layout;
+        _ = offset;
+        _ = size;
+        _ = data;
+    }
+    fn fillComputeBuffer(ptr: *anyopaque, buffer: u64, offset: u64, size: u64, data: u32) void {
+        _ = ptr;
+        _ = buffer;
+        _ = offset;
+        _ = size;
+        _ = data;
+    }
+    fn copyComputeBuffer(ptr: *anyopaque, src_buffer: u64, dst_buffer: u64, src_offset: u64, dst_offset: u64, size: u64) void {
+        _ = ptr;
+        _ = src_buffer;
+        _ = dst_buffer;
+        _ = src_offset;
+        _ = dst_offset;
+        _ = size;
+    }
+    fn computePipelineBarrier(ptr: *anyopaque, src_stage: rhi.PipelineStageFlags, dst_stage: rhi.PipelineStageFlags, src_access: rhi.AccessFlags, dst_access: rhi.AccessFlags) void {
+        _ = ptr;
+        _ = src_stage;
+        _ = dst_stage;
+        _ = src_access;
+        _ = dst_access;
+    }
+    fn waitForFrameFence(ptr: *anyopaque, frame_index: usize) bool {
+        _ = ptr;
+        _ = frame_index;
+        return true;
+    }
+    fn getNativeBuffer(ptr: *anyopaque, handle: rhi.BufferHandle) u64 {
+        _ = ptr;
+        _ = handle;
+        return 0;
+    }
+    fn hasCommandBuffer(ptr: *anyopaque) bool {
+        _ = ptr;
+        return true;
+    }
+
     const MOCK_RENDER_VTABLE = rhi.IRenderContext.VTable{
         .beginFrame = undefined,
         .endFrame = undefined,
@@ -431,15 +518,21 @@ const MockContext = struct {
         .shadow = MOCK_SHADOW_VTABLE,
         .water = MOCK_WATER_VTABLE,
         .compute = .{
-            .bindComputePipeline = undefined,
-            .bindDescriptorSet = undefined,
-            .dispatch = undefined,
-            .pushConstants = undefined,
-            .fillBuffer = undefined,
-            .copyBuffer = undefined,
-            .pipelineBarrier = undefined,
-            .waitForFrameFence = undefined,
-            .getNativeBuffer = undefined,
+            .bindComputePipeline = bindComputePipeline,
+            .bindDescriptorSet = bindDescriptorSet,
+            .createComputeBuffer = createComputeBuffer,
+            .destroyComputeBuffer = destroyComputeBuffer,
+            .createComputePipeline = createComputePipeline,
+            .updateComputeDescriptors = updateComputeDescriptors,
+            .destroyComputePipeline = destroyComputePipeline,
+            .dispatch = dispatchCompute,
+            .pushConstants = pushComputeConstants,
+            .fillBuffer = fillComputeBuffer,
+            .copyBuffer = copyComputeBuffer,
+            .pipelineBarrier = computePipelineBarrier,
+            .waitForFrameFence = waitForFrameFence,
+            .getNativeBuffer = getNativeBuffer,
+            .hasCommandBuffer = hasCommandBuffer,
         },
         .ui = MOCK_UI_VTABLE,
         .query = MOCK_QUERY_VTABLE,

--- a/modules/engine-graphics/src/rhi_tests.zig
+++ b/modules/engine-graphics/src/rhi_tests.zig
@@ -312,6 +312,16 @@ const MockContext = struct {
         _ = src_access;
         _ = dst_access;
     }
+    fn computeBufferBarrier(ptr: *anyopaque, buffer: u64, src_stage: rhi.PipelineStageFlags, dst_stage: rhi.PipelineStageFlags, src_access: rhi.AccessFlags, dst_access: rhi.AccessFlags, offset: u64, size: u64) void {
+        _ = ptr;
+        _ = buffer;
+        _ = src_stage;
+        _ = dst_stage;
+        _ = src_access;
+        _ = dst_access;
+        _ = offset;
+        _ = size;
+    }
     fn waitForFrameFence(ptr: *anyopaque, frame_index: usize) bool {
         _ = ptr;
         _ = frame_index;
@@ -530,6 +540,7 @@ const MockContext = struct {
             .fillBuffer = fillComputeBuffer,
             .copyBuffer = copyComputeBuffer,
             .pipelineBarrier = computePipelineBarrier,
+            .bufferBarrier = computeBufferBarrier,
             .waitForFrameFence = waitForFrameFence,
             .getNativeBuffer = getNativeBuffer,
             .hasCommandBuffer = hasCommandBuffer,

--- a/modules/engine-graphics/src/rhi_tests.zig
+++ b/modules/engine-graphics/src/rhi_tests.zig
@@ -122,6 +122,9 @@ const MockContext = struct {
         _ = ptr;
         return 2;
     }
+    fn getNativeBackendContext(ptr: *anyopaque) u64 {
+        return @intFromPtr(ptr);
+    }
 
     fn computeSsao(ptr: *anyopaque, proj: Mat4, inv_proj: Mat4) void {
         _ = ptr;
@@ -281,6 +284,7 @@ const MockContext = struct {
         .getDescriptorPool = getNativeDescriptorPool,
         .getUiRenderPass = getNativeUiRenderPass,
         .getSwapchainImageCount = getNativeSwapchainImageCount,
+        .getBackendContext = getNativeBackendContext,
     };
 
     const MOCK_SSAO_VTABLE = rhi.ISSAOContext.VTable{
@@ -426,6 +430,17 @@ const MockContext = struct {
         .debug_overlay = MOCK_DEBUG_OVERLAY_VTABLE,
         .shadow = MOCK_SHADOW_VTABLE,
         .water = MOCK_WATER_VTABLE,
+        .compute = .{
+            .bindComputePipeline = undefined,
+            .bindDescriptorSet = undefined,
+            .dispatch = undefined,
+            .pushConstants = undefined,
+            .fillBuffer = undefined,
+            .copyBuffer = undefined,
+            .pipelineBarrier = undefined,
+            .waitForFrameFence = undefined,
+            .getNativeBuffer = undefined,
+        },
         .ui = MOCK_UI_VTABLE,
         .query = MOCK_QUERY_VTABLE,
         .timing = .{

--- a/modules/engine-graphics/src/rhi_vulkan.zig
+++ b/modules/engine-graphics/src/rhi_vulkan.zig
@@ -869,6 +869,9 @@ fn getNativeSwapchainImageCount(ctx_ptr: *anyopaque) u32 {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
     return native_access.getNativeSwapchainImageCount(ctx);
 }
+fn getNativeBackendContext(ctx_ptr: *anyopaque) u64 {
+    return @intFromPtr(ctx_ptr);
+}
 
 fn computeSsao(ctx_ptr: *anyopaque, proj: Mat4, inv_proj: Mat4) void {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
@@ -998,6 +1001,86 @@ const VULKAN_COMMAND_ENCODER_VTABLE = rhi.IGraphicsCommandEncoder.VTable{
     .setViewport = setViewport,
 };
 
+fn currentCommandBuffer(ctx: *VulkanContext) ?c.VkCommandBuffer {
+    return ctx.frames.command_buffers[ctx.frames.current_frame];
+}
+
+fn bindComputePipeline(ctx_ptr: *anyopaque, pipeline: u64) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const cmd = currentCommandBuffer(ctx) orelse return;
+    c.vkCmdBindPipeline(cmd, c.VK_PIPELINE_BIND_POINT_COMPUTE, @ptrFromInt(pipeline));
+}
+
+fn bindComputeDescriptorSet(ctx_ptr: *anyopaque, pipeline_layout: u64, descriptor_set: u64) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const cmd = currentCommandBuffer(ctx) orelse return;
+    const set: c.VkDescriptorSet = @ptrFromInt(descriptor_set);
+    c.vkCmdBindDescriptorSets(cmd, c.VK_PIPELINE_BIND_POINT_COMPUTE, @ptrFromInt(pipeline_layout), 0, 1, &set, 0, null);
+}
+
+fn dispatchCompute(ctx_ptr: *anyopaque, group_count_x: u32, group_count_y: u32, group_count_z: u32) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const cmd = currentCommandBuffer(ctx) orelse return;
+    c.vkCmdDispatch(cmd, group_count_x, group_count_y, group_count_z);
+}
+
+fn pushComputeConstants(ctx_ptr: *anyopaque, pipeline_layout: u64, offset: u32, size: u32, data: *const anyopaque) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const cmd = currentCommandBuffer(ctx) orelse return;
+    c.vkCmdPushConstants(cmd, @ptrFromInt(pipeline_layout), c.VK_SHADER_STAGE_COMPUTE_BIT, offset, size, data);
+}
+
+fn fillComputeBuffer(ctx_ptr: *anyopaque, buffer: u64, offset: u64, size: u64, data: u32) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const cmd = currentCommandBuffer(ctx) orelse return;
+    c.vkCmdFillBuffer(cmd, @ptrFromInt(buffer), offset, size, data);
+}
+
+fn copyComputeBuffer(ctx_ptr: *anyopaque, src_buffer: u64, dst_buffer: u64, src_offset: u64, dst_offset: u64, size: u64) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const cmd = currentCommandBuffer(ctx) orelse return;
+    var region = std.mem.zeroes(c.VkBufferCopy);
+    region.srcOffset = src_offset;
+    region.dstOffset = dst_offset;
+    region.size = size;
+    c.vkCmdCopyBuffer(cmd, @ptrFromInt(src_buffer), @ptrFromInt(dst_buffer), 1, &region);
+}
+
+fn computePipelineBarrier(ctx_ptr: *anyopaque, src_stage: rhi.PipelineStageFlags, dst_stage: rhi.PipelineStageFlags, src_access: rhi.AccessFlags, dst_access: rhi.AccessFlags) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const cmd = currentCommandBuffer(ctx) orelse return;
+    var barrier = std.mem.zeroes(c.VkMemoryBarrier);
+    barrier.sType = c.VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    barrier.srcAccessMask = src_access;
+    barrier.dstAccessMask = dst_access;
+    c.vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 1, &barrier, 0, null, 0, null);
+}
+
+fn waitForFrameFence(ctx_ptr: *anyopaque, frame_index: usize) bool {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const fence = ctx.frames.in_flight_fences[frame_index] orelse return false;
+    _ = c.vkWaitForFences(ctx.vulkan_device.vk_device, 1, &fence, c.VK_TRUE, std.math.maxInt(u64));
+    return true;
+}
+
+fn getNativeBuffer(ctx_ptr: *anyopaque, handle: rhi.BufferHandle) u64 {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const buffer = ctx.resources.buffers.get(handle) orelse return 0;
+    return @intFromPtr(buffer.buffer);
+}
+
+const VULKAN_COMPUTE_CONTEXT_VTABLE = rhi.IComputeContext.VTable{
+    .bindComputePipeline = bindComputePipeline,
+    .bindDescriptorSet = bindComputeDescriptorSet,
+    .dispatch = dispatchCompute,
+    .pushConstants = pushComputeConstants,
+    .fillBuffer = fillComputeBuffer,
+    .copyBuffer = copyComputeBuffer,
+    .pipelineBarrier = computePipelineBarrier,
+    .waitForFrameFence = waitForFrameFence,
+    .getNativeBuffer = getNativeBuffer,
+};
+
 const VULKAN_RHI_VTABLE = rhi.RHI.VTable{
     .init = initContext,
     .deinit = deinit,
@@ -1051,11 +1134,13 @@ const VULKAN_RHI_VTABLE = rhi.RHI.VTable{
         .getDescriptorPool = getNativeDescriptorPool,
         .getUiRenderPass = getNativeUiRenderPass,
         .getSwapchainImageCount = getNativeSwapchainImageCount,
+        .getBackendContext = getNativeBackendContext,
     },
     .ssao = VULKAN_SSAO_VTABLE,
     .debug_overlay = VULKAN_DEBUG_OVERLAY_VTABLE,
     .shadow = VULKAN_SHADOW_CONTEXT_VTABLE,
     .water = VULKAN_WATER_CONTEXT_VTABLE,
+    .compute = VULKAN_COMPUTE_CONTEXT_VTABLE,
     .ui = VULKAN_UI_CONTEXT_VTABLE,
     .query = .{
         .getFrameIndex = getFrameIndex,

--- a/modules/engine-graphics/src/rhi_vulkan.zig
+++ b/modules/engine-graphics/src/rhi_vulkan.zig
@@ -1118,10 +1118,21 @@ fn createComputePipeline(ctx_ptr: *anyopaque, allocator: std.mem.Allocator, shad
 
 fn updateComputeDescriptors(ctx_ptr: *anyopaque, pipeline: rhi.ComputePipeline, frame_index: usize, buffers: []const u64) void {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
-    var infos: [8]c.VkDescriptorBufferInfo = undefined;
-    var writes: [8]c.VkWriteDescriptorSet = undefined;
-    const count = @min(buffers.len, infos.len);
-    for (buffers[0..count], 0..) |buffer, i| {
+    if (frame_index >= rhi.MAX_FRAMES_IN_FLIGHT or buffers.len == 0) return;
+
+    const infos = ctx.allocator.alloc(c.VkDescriptorBufferInfo, buffers.len) catch |err| {
+        log.log.err("Failed to allocate compute descriptor buffer infos: {}", .{err});
+        return;
+    };
+    defer ctx.allocator.free(infos);
+
+    const writes = ctx.allocator.alloc(c.VkWriteDescriptorSet, buffers.len) catch |err| {
+        log.log.err("Failed to allocate compute descriptor writes: {}", .{err});
+        return;
+    };
+    defer ctx.allocator.free(writes);
+
+    for (buffers, 0..) |buffer, i| {
         infos[i] = .{ .buffer = @ptrFromInt(buffer), .offset = 0, .range = c.VK_WHOLE_SIZE };
         writes[i] = std.mem.zeroes(c.VkWriteDescriptorSet);
         writes[i].sType = c.VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -1131,7 +1142,7 @@ fn updateComputeDescriptors(ctx_ptr: *anyopaque, pipeline: rhi.ComputePipeline, 
         writes[i].descriptorCount = 1;
         writes[i].pBufferInfo = &infos[i];
     }
-    c.vkUpdateDescriptorSets(ctx.vulkan_device.vk_device, @intCast(count), &writes[0], 0, null);
+    c.vkUpdateDescriptorSets(ctx.vulkan_device.vk_device, @intCast(writes.len), writes.ptr, 0, null);
 }
 
 fn destroyComputePipeline(ctx_ptr: *anyopaque, pipeline: *rhi.ComputePipeline) void {

--- a/modules/engine-graphics/src/rhi_vulkan.zig
+++ b/modules/engine-graphics/src/rhi_vulkan.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const fs = @import("fs");
 const c = @import("c").c;
 const rhi = @import("engine-rhi").rhi;
 const log = @import("engine-core").log;
@@ -19,6 +20,7 @@ const render_state = @import("vulkan/rhi_render_state.zig");
 const init_deinit = @import("vulkan/rhi_init_deinit.zig");
 const rhi_timing = @import("vulkan/rhi_timing.zig");
 const screenshot = @import("vulkan/screenshot.zig");
+const Utils = @import("vulkan/utils.zig");
 const CullingSystem = @import("vulkan/culling_system.zig").CullingSystem;
 
 const QUERY_COUNT_PER_FRAME = rhi_timing.QUERY_COUNT_PER_FRAME;
@@ -1018,6 +1020,130 @@ fn bindComputeDescriptorSet(ctx_ptr: *anyopaque, pipeline_layout: u64, descripto
     c.vkCmdBindDescriptorSets(cmd, c.VK_PIPELINE_BIND_POINT_COMPUTE, @ptrFromInt(pipeline_layout), 0, 1, &set, 0, null);
 }
 
+fn createComputeBuffer(ctx_ptr: *anyopaque, size: usize, host_visible: bool) rhi.RhiError!rhi.ComputeBuffer {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const properties: c.VkMemoryPropertyFlags = if (host_visible)
+        c.VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | c.VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
+    else
+        c.VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+    const buffer = try Utils.createVulkanBuffer(&ctx.vulkan_device, size, c.VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | c.VK_BUFFER_USAGE_TRANSFER_DST_BIT, properties);
+    return .{ .buffer = @intFromPtr(buffer.buffer), .memory = @intFromPtr(buffer.memory), .mapped_ptr = buffer.mapped_ptr };
+}
+
+fn destroyComputeBuffer(ctx_ptr: *anyopaque, buffer: *rhi.ComputeBuffer) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const vk = ctx.vulkan_device.vk_device;
+    const vk_buffer: c.VkBuffer = @ptrFromInt(buffer.buffer);
+    const vk_memory: c.VkDeviceMemory = @ptrFromInt(buffer.memory);
+    if (buffer.mapped_ptr != null) c.vkUnmapMemory(vk, vk_memory);
+    if (vk_buffer != null) c.vkDestroyBuffer(vk, vk_buffer, null);
+    if (vk_memory != null) c.vkFreeMemory(vk, vk_memory, null);
+    buffer.* = .{};
+}
+
+fn createComputePipeline(ctx_ptr: *anyopaque, allocator: std.mem.Allocator, shader_path: []const u8, storage_binding_count: u32, push_constant_size: u32) anyerror!rhi.ComputePipeline {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const vk = ctx.vulkan_device.vk_device;
+    var result = rhi.ComputePipeline{};
+    errdefer destroyComputePipeline(ctx_ptr, &result);
+
+    var pool_size = c.VkDescriptorPoolSize{ .type = c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = storage_binding_count * rhi.MAX_FRAMES_IN_FLIGHT };
+    var pool_info = std.mem.zeroes(c.VkDescriptorPoolCreateInfo);
+    pool_info.sType = c.VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    pool_info.maxSets = rhi.MAX_FRAMES_IN_FLIGHT;
+    pool_info.poolSizeCount = 1;
+    pool_info.pPoolSizes = &pool_size;
+    var descriptor_pool: c.VkDescriptorPool = null;
+    try Utils.checkVk(c.vkCreateDescriptorPool(vk, &pool_info, null, &descriptor_pool));
+    result.descriptor_pool = @intFromPtr(descriptor_pool);
+
+    const bindings = try allocator.alloc(c.VkDescriptorSetLayoutBinding, storage_binding_count);
+    defer allocator.free(bindings);
+    for (bindings, 0..) |*binding, i| {
+        binding.* = .{ .binding = @intCast(i), .descriptorType = c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 1, .stageFlags = c.VK_SHADER_STAGE_COMPUTE_BIT, .pImmutableSamplers = null };
+    }
+
+    var layout_info = std.mem.zeroes(c.VkDescriptorSetLayoutCreateInfo);
+    layout_info.sType = c.VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    layout_info.bindingCount = storage_binding_count;
+    layout_info.pBindings = bindings.ptr;
+    var descriptor_set_layout: c.VkDescriptorSetLayout = null;
+    try Utils.checkVk(c.vkCreateDescriptorSetLayout(vk, &layout_info, null, &descriptor_set_layout));
+    result.descriptor_set_layout = @intFromPtr(descriptor_set_layout);
+
+    var layouts = std.mem.zeroes([rhi.MAX_FRAMES_IN_FLIGHT]c.VkDescriptorSetLayout);
+    for (&layouts) |*layout| layout.* = descriptor_set_layout;
+    var alloc_info = std.mem.zeroes(c.VkDescriptorSetAllocateInfo);
+    alloc_info.sType = c.VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    alloc_info.descriptorPool = descriptor_pool;
+    alloc_info.descriptorSetCount = rhi.MAX_FRAMES_IN_FLIGHT;
+    alloc_info.pSetLayouts = &layouts;
+    var descriptor_sets = std.mem.zeroes([rhi.MAX_FRAMES_IN_FLIGHT]c.VkDescriptorSet);
+    try Utils.checkVk(c.vkAllocateDescriptorSets(vk, &alloc_info, &descriptor_sets));
+    for (descriptor_sets, 0..) |set, i| result.descriptor_sets[i] = @intFromPtr(set);
+
+    var pc_range = std.mem.zeroes(c.VkPushConstantRange);
+    pc_range.stageFlags = c.VK_SHADER_STAGE_COMPUTE_BIT;
+    pc_range.size = push_constant_size;
+    var pipeline_layout_info = std.mem.zeroes(c.VkPipelineLayoutCreateInfo);
+    pipeline_layout_info.sType = c.VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    pipeline_layout_info.setLayoutCount = 1;
+    pipeline_layout_info.pSetLayouts = &descriptor_set_layout;
+    pipeline_layout_info.pushConstantRangeCount = if (push_constant_size == 0) 0 else 1;
+    pipeline_layout_info.pPushConstantRanges = if (push_constant_size == 0) null else &pc_range;
+    var pipeline_layout: c.VkPipelineLayout = null;
+    try Utils.checkVk(c.vkCreatePipelineLayout(vk, &pipeline_layout_info, null, &pipeline_layout));
+    result.layout = @intFromPtr(pipeline_layout);
+
+    const bytes = try fs.cwd().readFileAlloc(shader_path, allocator, 16 * 1024 * 1024);
+    defer allocator.free(bytes);
+    if (bytes.len % 4 != 0) return error.InvalidShader;
+    const shader_module = try Utils.createShaderModule(vk, bytes);
+    defer c.vkDestroyShaderModule(vk, shader_module, null);
+
+    var stage = std.mem.zeroes(c.VkPipelineShaderStageCreateInfo);
+    stage.sType = c.VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stage.stage = c.VK_SHADER_STAGE_COMPUTE_BIT;
+    stage.module = shader_module;
+    stage.pName = "main";
+    var pipeline_info = std.mem.zeroes(c.VkComputePipelineCreateInfo);
+    pipeline_info.sType = c.VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+    pipeline_info.stage = stage;
+    pipeline_info.layout = pipeline_layout;
+    var pipeline: c.VkPipeline = null;
+    try Utils.checkVk(c.vkCreateComputePipelines(vk, null, 1, &pipeline_info, null, &pipeline));
+    result.pipeline = @intFromPtr(pipeline);
+    return result;
+}
+
+fn updateComputeDescriptors(ctx_ptr: *anyopaque, pipeline: rhi.ComputePipeline, frame_index: usize, buffers: []const u64) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    var infos: [8]c.VkDescriptorBufferInfo = undefined;
+    var writes: [8]c.VkWriteDescriptorSet = undefined;
+    const count = @min(buffers.len, infos.len);
+    for (buffers[0..count], 0..) |buffer, i| {
+        infos[i] = .{ .buffer = @ptrFromInt(buffer), .offset = 0, .range = c.VK_WHOLE_SIZE };
+        writes[i] = std.mem.zeroes(c.VkWriteDescriptorSet);
+        writes[i].sType = c.VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[i].dstSet = @ptrFromInt(pipeline.descriptor_sets[frame_index]);
+        writes[i].dstBinding = @intCast(i);
+        writes[i].descriptorType = c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[i].descriptorCount = 1;
+        writes[i].pBufferInfo = &infos[i];
+    }
+    c.vkUpdateDescriptorSets(ctx.vulkan_device.vk_device, @intCast(count), &writes[0], 0, null);
+}
+
+fn destroyComputePipeline(ctx_ptr: *anyopaque, pipeline: *rhi.ComputePipeline) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const vk = ctx.vulkan_device.vk_device;
+    if (pipeline.pipeline != 0) c.vkDestroyPipeline(vk, @ptrFromInt(pipeline.pipeline), null);
+    if (pipeline.layout != 0) c.vkDestroyPipelineLayout(vk, @ptrFromInt(pipeline.layout), null);
+    if (pipeline.descriptor_set_layout != 0) c.vkDestroyDescriptorSetLayout(vk, @ptrFromInt(pipeline.descriptor_set_layout), null);
+    if (pipeline.descriptor_pool != 0) c.vkDestroyDescriptorPool(vk, @ptrFromInt(pipeline.descriptor_pool), null);
+    pipeline.* = .{};
+}
+
 fn dispatchCompute(ctx_ptr: *anyopaque, group_count_x: u32, group_count_y: u32, group_count_z: u32) void {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
     const cmd = currentCommandBuffer(ctx) orelse return;
@@ -1058,9 +1184,9 @@ fn computePipelineBarrier(ctx_ptr: *anyopaque, src_stage: rhi.PipelineStageFlags
 
 fn waitForFrameFence(ctx_ptr: *anyopaque, frame_index: usize) bool {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    if (frame_index >= rhi.MAX_FRAMES_IN_FLIGHT) return false;
     const fence = ctx.frames.in_flight_fences[frame_index] orelse return false;
-    _ = c.vkWaitForFences(ctx.vulkan_device.vk_device, 1, &fence, c.VK_TRUE, std.math.maxInt(u64));
-    return true;
+    return c.vkWaitForFences(ctx.vulkan_device.vk_device, 1, &fence, c.VK_TRUE, 5_000_000_000) == c.VK_SUCCESS;
 }
 
 fn getNativeBuffer(ctx_ptr: *anyopaque, handle: rhi.BufferHandle) u64 {
@@ -1069,9 +1195,19 @@ fn getNativeBuffer(ctx_ptr: *anyopaque, handle: rhi.BufferHandle) u64 {
     return @intFromPtr(buffer.buffer);
 }
 
+fn hasComputeCommandBuffer(ctx_ptr: *anyopaque) bool {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    return currentCommandBuffer(ctx) != null;
+}
+
 const VULKAN_COMPUTE_CONTEXT_VTABLE = rhi.IComputeContext.VTable{
     .bindComputePipeline = bindComputePipeline,
     .bindDescriptorSet = bindComputeDescriptorSet,
+    .createComputeBuffer = createComputeBuffer,
+    .destroyComputeBuffer = destroyComputeBuffer,
+    .createComputePipeline = createComputePipeline,
+    .updateComputeDescriptors = updateComputeDescriptors,
+    .destroyComputePipeline = destroyComputePipeline,
     .dispatch = dispatchCompute,
     .pushConstants = pushComputeConstants,
     .fillBuffer = fillComputeBuffer,
@@ -1079,6 +1215,7 @@ const VULKAN_COMPUTE_CONTEXT_VTABLE = rhi.IComputeContext.VTable{
     .pipelineBarrier = computePipelineBarrier,
     .waitForFrameFence = waitForFrameFence,
     .getNativeBuffer = getNativeBuffer,
+    .hasCommandBuffer = hasComputeCommandBuffer,
 };
 
 const VULKAN_RHI_VTABLE = rhi.RHI.VTable{

--- a/modules/engine-graphics/src/rhi_vulkan.zig
+++ b/modules/engine-graphics/src/rhi_vulkan.zig
@@ -1193,6 +1193,24 @@ fn computePipelineBarrier(ctx_ptr: *anyopaque, src_stage: rhi.PipelineStageFlags
     c.vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 1, &barrier, 0, null, 0, null);
 }
 
+fn computeBufferBarrier(ctx_ptr: *anyopaque, buffer: u64, src_stage: rhi.PipelineStageFlags, dst_stage: rhi.PipelineStageFlags, src_access: rhi.AccessFlags, dst_access: rhi.AccessFlags, offset: u64, size: u64) void {
+    const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
+    const cmd = currentCommandBuffer(ctx) orelse return;
+    if (buffer == 0 or size == 0) return;
+
+    var barrier = std.mem.zeroes(c.VkBufferMemoryBarrier);
+    barrier.sType = c.VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+    barrier.srcAccessMask = src_access;
+    barrier.dstAccessMask = dst_access;
+    barrier.srcQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = c.VK_QUEUE_FAMILY_IGNORED;
+    barrier.buffer = @ptrFromInt(buffer);
+    barrier.offset = offset;
+    barrier.size = size;
+
+    c.vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, null, 1, &barrier, 0, null);
+}
+
 fn waitForFrameFence(ctx_ptr: *anyopaque, frame_index: usize) bool {
     const ctx: *VulkanContext = @ptrCast(@alignCast(ctx_ptr));
     if (frame_index >= rhi.MAX_FRAMES_IN_FLIGHT) return false;
@@ -1224,6 +1242,7 @@ const VULKAN_COMPUTE_CONTEXT_VTABLE = rhi.IComputeContext.VTable{
     .fillBuffer = fillComputeBuffer,
     .copyBuffer = copyComputeBuffer,
     .pipelineBarrier = computePipelineBarrier,
+    .bufferBarrier = computeBufferBarrier,
     .waitForFrameFence = waitForFrameFence,
     .getNativeBuffer = getNativeBuffer,
     .hasCommandBuffer = hasComputeCommandBuffer,

--- a/modules/engine-rhi/src/rhi.zig
+++ b/modules/engine-rhi/src/rhi.zig
@@ -702,6 +702,7 @@ pub const IComputeContext = struct {
         fillBuffer: *const fn (ptr: *anyopaque, buffer: u64, offset: u64, size: u64, data: u32) void,
         copyBuffer: *const fn (ptr: *anyopaque, src_buffer: u64, dst_buffer: u64, src_offset: u64, dst_offset: u64, size: u64) void,
         pipelineBarrier: *const fn (ptr: *anyopaque, src_stage: PipelineStageFlags, dst_stage: PipelineStageFlags, src_access: AccessFlags, dst_access: AccessFlags) void,
+        bufferBarrier: *const fn (ptr: *anyopaque, buffer: u64, src_stage: PipelineStageFlags, dst_stage: PipelineStageFlags, src_access: AccessFlags, dst_access: AccessFlags, offset: u64, size: u64) void,
         waitForFrameFence: *const fn (ptr: *anyopaque, frame_index: usize) bool,
         getNativeBuffer: *const fn (ptr: *anyopaque, handle: BufferHandle) u64,
         hasCommandBuffer: *const fn (ptr: *anyopaque) bool,
@@ -742,6 +743,9 @@ pub const IComputeContext = struct {
     }
     pub fn pipelineBarrier(self: IComputeContext, src_stage: PipelineStageFlags, dst_stage: PipelineStageFlags, src_access: AccessFlags, dst_access: AccessFlags) void {
         self.vtable.pipelineBarrier(self.ptr, src_stage, dst_stage, src_access, dst_access);
+    }
+    pub fn bufferBarrier(self: IComputeContext, buffer: u64, src_stage: PipelineStageFlags, dst_stage: PipelineStageFlags, src_access: AccessFlags, dst_access: AccessFlags, offset: u64, size: u64) void {
+        self.vtable.bufferBarrier(self.ptr, buffer, src_stage, dst_stage, src_access, dst_access, offset, size);
     }
     pub fn waitForFrameFence(self: IComputeContext, frame_index: usize) bool {
         return self.vtable.waitForFrameFence(self.ptr, frame_index);

--- a/modules/engine-rhi/src/rhi.zig
+++ b/modules/engine-rhi/src/rhi.zig
@@ -656,6 +656,54 @@ pub const IDebugOverlayContext = struct {
     }
 };
 
+pub const PipelineStageFlags = u32;
+pub const AccessFlags = u32;
+
+pub const IComputeContext = struct {
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        bindComputePipeline: *const fn (ptr: *anyopaque, pipeline: u64) void,
+        bindDescriptorSet: *const fn (ptr: *anyopaque, pipeline_layout: u64, descriptor_set: u64) void,
+        dispatch: *const fn (ptr: *anyopaque, group_count_x: u32, group_count_y: u32, group_count_z: u32) void,
+        pushConstants: *const fn (ptr: *anyopaque, pipeline_layout: u64, offset: u32, size: u32, data: *const anyopaque) void,
+        fillBuffer: *const fn (ptr: *anyopaque, buffer: u64, offset: u64, size: u64, data: u32) void,
+        copyBuffer: *const fn (ptr: *anyopaque, src_buffer: u64, dst_buffer: u64, src_offset: u64, dst_offset: u64, size: u64) void,
+        pipelineBarrier: *const fn (ptr: *anyopaque, src_stage: PipelineStageFlags, dst_stage: PipelineStageFlags, src_access: AccessFlags, dst_access: AccessFlags) void,
+        waitForFrameFence: *const fn (ptr: *anyopaque, frame_index: usize) bool,
+        getNativeBuffer: *const fn (ptr: *anyopaque, handle: BufferHandle) u64,
+    };
+
+    pub fn bindComputePipeline(self: IComputeContext, pipeline: u64) void {
+        self.vtable.bindComputePipeline(self.ptr, pipeline);
+    }
+    pub fn bindDescriptorSet(self: IComputeContext, pipeline_layout: u64, descriptor_set: u64) void {
+        self.vtable.bindDescriptorSet(self.ptr, pipeline_layout, descriptor_set);
+    }
+    pub fn dispatch(self: IComputeContext, group_count_x: u32, group_count_y: u32, group_count_z: u32) void {
+        self.vtable.dispatch(self.ptr, group_count_x, group_count_y, group_count_z);
+    }
+    pub fn pushConstants(self: IComputeContext, pipeline_layout: u64, offset: u32, size: u32, data: *const anyopaque) void {
+        self.vtable.pushConstants(self.ptr, pipeline_layout, offset, size, data);
+    }
+    pub fn fillBuffer(self: IComputeContext, buffer: u64, offset: u64, size: u64, data: u32) void {
+        self.vtable.fillBuffer(self.ptr, buffer, offset, size, data);
+    }
+    pub fn copyBuffer(self: IComputeContext, src_buffer: u64, dst_buffer: u64, src_offset: u64, dst_offset: u64, size: u64) void {
+        self.vtable.copyBuffer(self.ptr, src_buffer, dst_buffer, src_offset, dst_offset, size);
+    }
+    pub fn pipelineBarrier(self: IComputeContext, src_stage: PipelineStageFlags, dst_stage: PipelineStageFlags, src_access: AccessFlags, dst_access: AccessFlags) void {
+        self.vtable.pipelineBarrier(self.ptr, src_stage, dst_stage, src_access, dst_access);
+    }
+    pub fn waitForFrameFence(self: IComputeContext, frame_index: usize) bool {
+        return self.vtable.waitForFrameFence(self.ptr, frame_index);
+    }
+    pub fn getNativeBuffer(self: IComputeContext, handle: BufferHandle) u64 {
+        return self.vtable.getNativeBuffer(self.ptr, handle);
+    }
+};
+
 pub const IRenderContext = struct {
     ptr: *anyopaque,
     vtable: *const VTable,
@@ -788,6 +836,7 @@ pub const INativeHandlesContext = struct {
         getDescriptorPool: *const fn (ptr: *anyopaque) u64,
         getUiRenderPass: *const fn (ptr: *anyopaque) u64,
         getSwapchainImageCount: *const fn (ptr: *anyopaque) u32,
+        getBackendContext: *const fn (ptr: *anyopaque) u64,
     };
 
     pub fn getCommandBuffer(self: INativeHandlesContext) u64 {
@@ -819,6 +868,9 @@ pub const INativeHandlesContext = struct {
     }
     pub fn getSwapchainImageCount(self: INativeHandlesContext) u32 {
         return self.vtable.getSwapchainImageCount(self.ptr);
+    }
+    pub fn getBackendContext(self: INativeHandlesContext) u64 {
+        return self.vtable.getBackendContext(self.ptr);
     }
 };
 
@@ -1033,6 +1085,7 @@ pub const RHI = struct {
         debug_overlay: IDebugOverlayContext.VTable,
         shadow: IShadowContext.VTable,
         water: IWaterContext.VTable,
+        compute: IComputeContext.VTable,
         ui: IUIContext.VTable,
         query: IDeviceQuery.VTable,
         timing: IDeviceTiming.VTable,
@@ -1095,6 +1148,9 @@ pub const RHI = struct {
     }
     pub fn water(self: RHI) IWaterContext {
         return .{ .ptr = self.ptr, .vtable = &self.vtable.water };
+    }
+    pub fn compute(self: RHI) IComputeContext {
+        return .{ .ptr = self.ptr, .vtable = &self.vtable.compute };
     }
     pub fn ui(self: RHI) IUIContext {
         return .{ .ptr = self.ptr, .vtable = &self.vtable.ui };

--- a/modules/engine-rhi/src/rhi.zig
+++ b/modules/engine-rhi/src/rhi.zig
@@ -659,6 +659,32 @@ pub const IDebugOverlayContext = struct {
 pub const PipelineStageFlags = u32;
 pub const AccessFlags = u32;
 
+pub const PIPELINE_STAGE_HOST_BIT: PipelineStageFlags = 0x00004000;
+pub const PIPELINE_STAGE_TRANSFER_BIT: PipelineStageFlags = 0x00001000;
+pub const PIPELINE_STAGE_COMPUTE_SHADER_BIT: PipelineStageFlags = 0x00000800;
+pub const PIPELINE_STAGE_VERTEX_INPUT_BIT: PipelineStageFlags = 0x00000004;
+
+pub const ACCESS_HOST_READ_BIT: AccessFlags = 0x00002000;
+pub const ACCESS_TRANSFER_READ_BIT: AccessFlags = 0x00000800;
+pub const ACCESS_TRANSFER_WRITE_BIT: AccessFlags = 0x00001000;
+pub const ACCESS_SHADER_READ_BIT: AccessFlags = 0x00000020;
+pub const ACCESS_SHADER_WRITE_BIT: AccessFlags = 0x00000040;
+pub const ACCESS_VERTEX_ATTRIBUTE_READ_BIT: AccessFlags = 0x00000004;
+
+pub const ComputeBuffer = struct {
+    buffer: u64 = 0,
+    memory: u64 = 0,
+    mapped_ptr: ?*anyopaque = null,
+};
+
+pub const ComputePipeline = struct {
+    pipeline: u64 = 0,
+    layout: u64 = 0,
+    descriptor_pool: u64 = 0,
+    descriptor_set_layout: u64 = 0,
+    descriptor_sets: [MAX_FRAMES_IN_FLIGHT]u64 = .{0} ** MAX_FRAMES_IN_FLIGHT,
+};
+
 pub const IComputeContext = struct {
     ptr: *anyopaque,
     vtable: *const VTable,
@@ -666,6 +692,11 @@ pub const IComputeContext = struct {
     pub const VTable = struct {
         bindComputePipeline: *const fn (ptr: *anyopaque, pipeline: u64) void,
         bindDescriptorSet: *const fn (ptr: *anyopaque, pipeline_layout: u64, descriptor_set: u64) void,
+        createComputeBuffer: *const fn (ptr: *anyopaque, size: usize, host_visible: bool) RhiError!ComputeBuffer,
+        destroyComputeBuffer: *const fn (ptr: *anyopaque, buffer: *ComputeBuffer) void,
+        createComputePipeline: *const fn (ptr: *anyopaque, allocator: Allocator, shader_path: []const u8, storage_binding_count: u32, push_constant_size: u32) anyerror!ComputePipeline,
+        updateComputeDescriptors: *const fn (ptr: *anyopaque, pipeline: ComputePipeline, frame_index: usize, buffers: []const u64) void,
+        destroyComputePipeline: *const fn (ptr: *anyopaque, pipeline: *ComputePipeline) void,
         dispatch: *const fn (ptr: *anyopaque, group_count_x: u32, group_count_y: u32, group_count_z: u32) void,
         pushConstants: *const fn (ptr: *anyopaque, pipeline_layout: u64, offset: u32, size: u32, data: *const anyopaque) void,
         fillBuffer: *const fn (ptr: *anyopaque, buffer: u64, offset: u64, size: u64, data: u32) void,
@@ -673,6 +704,7 @@ pub const IComputeContext = struct {
         pipelineBarrier: *const fn (ptr: *anyopaque, src_stage: PipelineStageFlags, dst_stage: PipelineStageFlags, src_access: AccessFlags, dst_access: AccessFlags) void,
         waitForFrameFence: *const fn (ptr: *anyopaque, frame_index: usize) bool,
         getNativeBuffer: *const fn (ptr: *anyopaque, handle: BufferHandle) u64,
+        hasCommandBuffer: *const fn (ptr: *anyopaque) bool,
     };
 
     pub fn bindComputePipeline(self: IComputeContext, pipeline: u64) void {
@@ -680,6 +712,21 @@ pub const IComputeContext = struct {
     }
     pub fn bindDescriptorSet(self: IComputeContext, pipeline_layout: u64, descriptor_set: u64) void {
         self.vtable.bindDescriptorSet(self.ptr, pipeline_layout, descriptor_set);
+    }
+    pub fn createComputeBuffer(self: IComputeContext, size: usize, host_visible: bool) RhiError!ComputeBuffer {
+        return self.vtable.createComputeBuffer(self.ptr, size, host_visible);
+    }
+    pub fn destroyComputeBuffer(self: IComputeContext, buffer: *ComputeBuffer) void {
+        self.vtable.destroyComputeBuffer(self.ptr, buffer);
+    }
+    pub fn createComputePipeline(self: IComputeContext, allocator: Allocator, shader_path: []const u8, storage_binding_count: u32, push_constant_size: u32) anyerror!ComputePipeline {
+        return self.vtable.createComputePipeline(self.ptr, allocator, shader_path, storage_binding_count, push_constant_size);
+    }
+    pub fn updateComputeDescriptors(self: IComputeContext, pipeline: ComputePipeline, frame_index: usize, buffers: []const u64) void {
+        self.vtable.updateComputeDescriptors(self.ptr, pipeline, frame_index, buffers);
+    }
+    pub fn destroyComputePipeline(self: IComputeContext, pipeline: *ComputePipeline) void {
+        self.vtable.destroyComputePipeline(self.ptr, pipeline);
     }
     pub fn dispatch(self: IComputeContext, group_count_x: u32, group_count_y: u32, group_count_z: u32) void {
         self.vtable.dispatch(self.ptr, group_count_x, group_count_y, group_count_z);
@@ -701,6 +748,9 @@ pub const IComputeContext = struct {
     }
     pub fn getNativeBuffer(self: IComputeContext, handle: BufferHandle) u64 {
         return self.vtable.getNativeBuffer(self.ptr, handle);
+    }
+    pub fn hasCommandBuffer(self: IComputeContext) bool {
+        return self.vtable.hasCommandBuffer(self.ptr);
     }
 };
 

--- a/modules/world-runtime/src/gpu_mesher.zig
+++ b/modules/world-runtime/src/gpu_mesher.zig
@@ -3,12 +3,8 @@
 
 const std = @import("std");
 const fs = @import("fs");
-const c = @import("c").c;
 const log = @import("engine-core").log;
 const rhi_pkg = @import("engine-rhi").rhi;
-const graphics = @import("engine-graphics");
-const VulkanContext = graphics.VulkanContext;
-const Utils = graphics.vulkan_utils;
 const TextureAtlas = @import("engine-assets").TextureAtlas;
 const GpuBlockBuffer = @import("world-meshing").GpuBlockBuffer;
 const ChunkStorage = @import("world-meshing").ChunkStorage;
@@ -59,18 +55,13 @@ pub const GpuMesher = struct {
     rhi: rhi_pkg.RHI,
     rm: rhi_pkg.ResourceManager,
     compute: rhi_pkg.IComputeContext,
-    vk_ctx: *VulkanContext,
     available: bool,
 
-    descriptor_pool: c.VkDescriptorPool = null,
-    descriptor_set_layout: c.VkDescriptorSetLayout = null,
-    descriptor_sets: [MAX_FRAMES_IN_FLIGHT]c.VkDescriptorSet,
-    pipeline_layout: c.VkPipelineLayout = null,
-    pipeline: c.VkPipeline = null,
+    pipeline: rhi_pkg.ComputePipeline = .{},
 
     output_handles: [MAX_FRAMES_IN_FLIGHT]rhi_pkg.BufferHandle,
-    result_buffers: [MAX_FRAMES_IN_FLIGHT]Utils.VulkanBuffer,
-    block_props_buffer: Utils.VulkanBuffer,
+    result_buffers: [MAX_FRAMES_IN_FLIGHT]rhi_pkg.ComputeBuffer,
+    block_props_buffer: rhi_pkg.ComputeBuffer,
 
     mesh_queue: std.ArrayListUnmanaged(ChunkMeshRequest),
     submitted: [MAX_FRAMES_IN_FLIGHT]std.ArrayListUnmanaged(ChunkMeshRequest),
@@ -87,7 +78,6 @@ pub const GpuMesher = struct {
         errdefer allocator.destroy(self);
 
         const rm = rhi.resourceManager();
-        const vk_ctx: *VulkanContext = @ptrFromInt(rhi.nativeHandles().getBackendContext());
         const output_size = @as(usize, MAX_GPU_MESH_BATCH) * @as(usize, MAX_VERTICES_PER_CHUNK) * @as(usize, VERTEX_SIZE);
         const result_size = MAX_GPU_MESH_BATCH * @sizeOf(MeshBuildResult);
 
@@ -96,11 +86,9 @@ pub const GpuMesher = struct {
             .rhi = rhi,
             .rm = rm,
             .compute = rhi.compute(),
-            .vk_ctx = vk_ctx,
             .available = false,
-            .descriptor_sets = std.mem.zeroes([MAX_FRAMES_IN_FLIGHT]c.VkDescriptorSet),
             .output_handles = .{ 0, 0 },
-            .result_buffers = std.mem.zeroes([MAX_FRAMES_IN_FLIGHT]Utils.VulkanBuffer),
+            .result_buffers = .{rhi_pkg.ComputeBuffer{}} ** MAX_FRAMES_IN_FLIGHT,
             .block_props_buffer = .{},
             .mesh_queue = .empty,
             .submitted = .{ .empty, .empty },
@@ -111,12 +99,7 @@ pub const GpuMesher = struct {
 
         for (0..MAX_FRAMES_IN_FLIGHT) |i| {
             self.output_handles[i] = try rm.createBuffer(output_size, .storage);
-            self.result_buffers[i] = try Utils.createVulkanBuffer(
-                &vk_ctx.vulkan_device,
-                result_size,
-                c.VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | c.VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-                c.VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | c.VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-            );
+            self.result_buffers[i] = try self.compute.createComputeBuffer(result_size, true);
         }
 
         try self.createBlockPropsBuffer(atlas);
@@ -133,8 +116,8 @@ pub const GpuMesher = struct {
         for (self.output_handles) |handle| {
             if (handle != 0) self.rm.destroyBuffer(handle);
         }
-        for (&self.result_buffers) |*buf| destroyVulkanBuffer(self.vk_ctx.vulkan_device.vk_device, buf);
-        destroyVulkanBuffer(self.vk_ctx.vulkan_device.vk_device, &self.block_props_buffer);
+        for (&self.result_buffers) |*buf| self.compute.destroyComputeBuffer(buf);
+        self.compute.destroyComputeBuffer(&self.block_props_buffer);
         self.mesh_queue.deinit(self.allocator);
         for (&self.submitted) |*items| items.deinit(self.allocator);
         self.allocator.destroy(self);
@@ -163,7 +146,7 @@ pub const GpuMesher = struct {
     }
 
     fn finalizeCompletedMeshes(self: *GpuMesher, vertex_allocator: *GlobalVertexAllocator, storage: *ChunkStorage) void {
-        const fi = self.vk_ctx.frames.current_frame;
+        const fi = self.rhi.query().getFrameIndex();
         const prev_fi = (fi + MAX_FRAMES_IN_FLIGHT - 1) % MAX_FRAMES_IN_FLIGHT;
         if (self.submitted[prev_fi].items.len == 0) return;
 
@@ -172,8 +155,7 @@ pub const GpuMesher = struct {
             return;
         }
 
-        const cmd = self.vk_ctx.frames.command_buffers[fi];
-        if (cmd == null) return;
+        if (!self.compute.hasCommandBuffer()) return;
 
         const src = self.compute.getNativeBuffer(self.output_handles[prev_fi]);
         const dst = self.compute.getNativeBuffer(vertex_allocator.buffer);
@@ -251,29 +233,28 @@ pub const GpuMesher = struct {
         }
 
         if (copied_any) {
-            self.compute.pipelineBarrier(c.VK_PIPELINE_STAGE_TRANSFER_BIT, c.VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, c.VK_ACCESS_TRANSFER_WRITE_BIT, c.VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT);
+            self.compute.pipelineBarrier(rhi_pkg.PIPELINE_STAGE_TRANSFER_BIT, rhi_pkg.PIPELINE_STAGE_VERTEX_INPUT_BIT, rhi_pkg.ACCESS_TRANSFER_WRITE_BIT, rhi_pkg.ACCESS_VERTEX_ATTRIBUTE_READ_BIT);
         }
 
         self.submitted[prev_fi].clearRetainingCapacity();
     }
 
     fn dispatchQueuedMeshes(self: *GpuMesher, gpu_block_buffer: *GpuBlockBuffer) void {
-        const fi = self.vk_ctx.frames.current_frame;
+        const fi = self.rhi.query().getFrameIndex();
         self.submitted[fi].clearRetainingCapacity();
 
         if (self.mesh_queue.items.len == 0) return;
-        const cmd = self.vk_ctx.frames.command_buffers[fi];
-        if (cmd == null) return;
+        if (!self.compute.hasCommandBuffer()) return;
 
         self.submitted[fi].appendSlice(self.allocator, self.mesh_queue.items) catch return;
 
-        const result_buf = @intFromPtr(self.result_buffers[fi].buffer);
-        const result_size: c.VkDeviceSize = MAX_GPU_MESH_BATCH * @sizeOf(MeshBuildResult);
+        const result_buf = self.result_buffers[fi].buffer;
+        const result_size: u64 = MAX_GPU_MESH_BATCH * @sizeOf(MeshBuildResult);
         self.compute.fillBuffer(result_buf, 0, result_size, 0);
-        self.compute.pipelineBarrier(c.VK_PIPELINE_STAGE_TRANSFER_BIT, c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, c.VK_ACCESS_TRANSFER_WRITE_BIT, c.VK_ACCESS_SHADER_READ_BIT | c.VK_ACCESS_SHADER_WRITE_BIT);
+        self.compute.pipelineBarrier(rhi_pkg.PIPELINE_STAGE_TRANSFER_BIT, rhi_pkg.PIPELINE_STAGE_COMPUTE_SHADER_BIT, rhi_pkg.ACCESS_TRANSFER_WRITE_BIT, rhi_pkg.ACCESS_SHADER_READ_BIT | rhi_pkg.ACCESS_SHADER_WRITE_BIT);
 
-        self.compute.bindComputePipeline(@intFromPtr(self.pipeline));
-        self.compute.bindDescriptorSet(@intFromPtr(self.pipeline_layout), @intFromPtr(self.descriptor_sets[fi]));
+        self.compute.bindComputePipeline(self.pipeline.pipeline);
+        self.compute.bindDescriptorSet(self.pipeline.layout, self.pipeline.descriptor_sets[fi]);
 
         for (self.mesh_queue.items, 0..) |req, idx| {
             const n_slot = gpu_block_buffer.getSlotForChunk(req.cx, req.cz - 1);
@@ -289,11 +270,11 @@ pub const GpuMesher = struct {
                 .neighbor_east_slot = slotOrMissing(e_slot),
                 .neighbor_west_slot = slotOrMissing(w_slot),
             };
-            self.compute.pushConstants(@intFromPtr(self.pipeline_layout), 0, @sizeOf(MeshPushConstants), &push);
+            self.compute.pushConstants(self.pipeline.layout, 0, @sizeOf(MeshPushConstants), &push);
             self.compute.dispatch(CHUNK_Y, 1, 1);
         }
 
-        self.compute.pipelineBarrier(c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, c.VK_PIPELINE_STAGE_HOST_BIT | c.VK_PIPELINE_STAGE_TRANSFER_BIT, c.VK_ACCESS_SHADER_WRITE_BIT, c.VK_ACCESS_HOST_READ_BIT | c.VK_ACCESS_TRANSFER_READ_BIT);
+        self.compute.pipelineBarrier(rhi_pkg.PIPELINE_STAGE_COMPUTE_SHADER_BIT, rhi_pkg.PIPELINE_STAGE_HOST_BIT | rhi_pkg.PIPELINE_STAGE_TRANSFER_BIT, rhi_pkg.ACCESS_SHADER_WRITE_BIT, rhi_pkg.ACCESS_HOST_READ_BIT | rhi_pkg.ACCESS_TRANSFER_READ_BIT);
 
         self.stats.chunks_dispatched = @intCast(self.mesh_queue.items.len);
         self.mesh_queue.clearRetainingCapacity();
@@ -322,12 +303,7 @@ pub const GpuMesher = struct {
         const tile_array_size = MAX_BLOCK_TYPES * @sizeOf(u32);
         const total_size = packed_size + (channel_size * 3) + (tile_array_size * 3);
 
-        self.block_props_buffer = try Utils.createVulkanBuffer(
-            &self.vk_ctx.vulkan_device,
-            total_size,
-            c.VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
-            c.VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | c.VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-        );
+        self.block_props_buffer = try self.compute.createComputeBuffer(total_size, true);
 
         if (self.block_props_buffer.mapped_ptr) |ptr| {
             const base: [*]u8 = @ptrCast(ptr);
@@ -376,117 +352,23 @@ pub const GpuMesher = struct {
     }
 
     fn initComputeResources(self: *GpuMesher, gpu_block_buffer: *GpuBlockBuffer) !void {
-        const vk = self.vk_ctx.vulkan_device.vk_device;
-
-        var pool_sizes = [_]c.VkDescriptorPoolSize{
-            .{ .type = c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 4 * MAX_FRAMES_IN_FLIGHT },
-        };
-
-        var pool_info = std.mem.zeroes(c.VkDescriptorPoolCreateInfo);
-        pool_info.sType = c.VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-        pool_info.maxSets = MAX_FRAMES_IN_FLIGHT;
-        pool_info.poolSizeCount = pool_sizes.len;
-        pool_info.pPoolSizes = &pool_sizes;
-        try Utils.checkVk(c.vkCreateDescriptorPool(vk, &pool_info, null, &self.descriptor_pool));
-
-        const bindings = [_]c.VkDescriptorSetLayoutBinding{
-            .{ .binding = 0, .descriptorType = c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 1, .stageFlags = c.VK_SHADER_STAGE_COMPUTE_BIT, .pImmutableSamplers = null },
-            .{ .binding = 1, .descriptorType = c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 1, .stageFlags = c.VK_SHADER_STAGE_COMPUTE_BIT, .pImmutableSamplers = null },
-            .{ .binding = 2, .descriptorType = c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 1, .stageFlags = c.VK_SHADER_STAGE_COMPUTE_BIT, .pImmutableSamplers = null },
-            .{ .binding = 3, .descriptorType = c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 1, .stageFlags = c.VK_SHADER_STAGE_COMPUTE_BIT, .pImmutableSamplers = null },
-        };
-
-        var layout_info = std.mem.zeroes(c.VkDescriptorSetLayoutCreateInfo);
-        layout_info.sType = c.VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-        layout_info.bindingCount = bindings.len;
-        layout_info.pBindings = &bindings;
-        try Utils.checkVk(c.vkCreateDescriptorSetLayout(vk, &layout_info, null, &self.descriptor_set_layout));
-
-        var layouts = std.mem.zeroes([MAX_FRAMES_IN_FLIGHT]c.VkDescriptorSetLayout);
-        for (&layouts) |*layout| layout.* = self.descriptor_set_layout;
-
-        var alloc_info = std.mem.zeroes(c.VkDescriptorSetAllocateInfo);
-        alloc_info.sType = c.VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        alloc_info.descriptorPool = self.descriptor_pool;
-        alloc_info.descriptorSetCount = MAX_FRAMES_IN_FLIGHT;
-        alloc_info.pSetLayouts = &layouts;
-        try Utils.checkVk(c.vkAllocateDescriptorSets(vk, &alloc_info, &self.descriptor_sets));
-
+        self.pipeline = try self.compute.createComputePipeline(self.allocator, MESH_SHADER_PATH, 4, @sizeOf(MeshPushConstants));
         self.updateDescriptorSets(gpu_block_buffer);
-
-        var pc_range = std.mem.zeroes(c.VkPushConstantRange);
-        pc_range.stageFlags = c.VK_SHADER_STAGE_COMPUTE_BIT;
-        pc_range.offset = 0;
-        pc_range.size = @sizeOf(MeshPushConstants);
-
-        var pipeline_layout_info = std.mem.zeroes(c.VkPipelineLayoutCreateInfo);
-        pipeline_layout_info.sType = c.VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-        pipeline_layout_info.setLayoutCount = 1;
-        pipeline_layout_info.pSetLayouts = &self.descriptor_set_layout;
-        pipeline_layout_info.pushConstantRangeCount = 1;
-        pipeline_layout_info.pPushConstantRanges = &pc_range;
-        try Utils.checkVk(c.vkCreatePipelineLayout(vk, &pipeline_layout_info, null, &self.pipeline_layout));
-
-        const shader_module = try loadShaderModule(vk, MESH_SHADER_PATH, self.allocator);
-        defer c.vkDestroyShaderModule(vk, shader_module, null);
-
-        var stage = std.mem.zeroes(c.VkPipelineShaderStageCreateInfo);
-        stage.sType = c.VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        stage.stage = c.VK_SHADER_STAGE_COMPUTE_BIT;
-        stage.module = shader_module;
-        stage.pName = "main";
-
-        var pipeline_info = std.mem.zeroes(c.VkComputePipelineCreateInfo);
-        pipeline_info.sType = c.VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-        pipeline_info.stage = stage;
-        pipeline_info.layout = self.pipeline_layout;
-        try Utils.checkVk(c.vkCreateComputePipelines(vk, null, 1, &pipeline_info, null, &self.pipeline));
     }
 
     fn updateDescriptorSets(self: *GpuMesher, gpu_block_buffer: *GpuBlockBuffer) void {
-        const vk = self.vk_ctx.vulkan_device.vk_device;
         const block_buf_handle = gpu_block_buffer.getBufferHandle();
-        const native_block_buf: c.VkBuffer = if (self.vk_ctx.resources.buffers.get(block_buf_handle)) |vb| vb.buffer else null;
-
-        var writes: [4 * MAX_FRAMES_IN_FLIGHT]c.VkWriteDescriptorSet = undefined;
-        var block_infos: [MAX_FRAMES_IN_FLIGHT]c.VkDescriptorBufferInfo = undefined;
-        var props_infos: [MAX_FRAMES_IN_FLIGHT]c.VkDescriptorBufferInfo = undefined;
-        var output_infos: [MAX_FRAMES_IN_FLIGHT]c.VkDescriptorBufferInfo = undefined;
-        var result_infos: [MAX_FRAMES_IN_FLIGHT]c.VkDescriptorBufferInfo = undefined;
-        var n: usize = 0;
+        const native_block_buf = self.compute.getNativeBuffer(block_buf_handle);
 
         for (0..MAX_FRAMES_IN_FLIGHT) |i| {
-            const output_vk = self.vk_ctx.resources.buffers.get(self.output_handles[i]) orelse continue;
-
-            block_infos[i] = .{ .buffer = native_block_buf, .offset = 0, .range = c.VK_WHOLE_SIZE };
-            props_infos[i] = .{ .buffer = self.block_props_buffer.buffer, .offset = 0, .range = c.VK_WHOLE_SIZE };
-            output_infos[i] = .{ .buffer = output_vk.buffer, .offset = 0, .range = c.VK_WHOLE_SIZE };
-            result_infos[i] = .{ .buffer = self.result_buffers[i].buffer, .offset = 0, .range = c.VK_WHOLE_SIZE };
-
-            const set = self.descriptor_sets[i];
-            writes[n] = descriptorWrite(set, 0, &block_infos[i]);
-            n += 1;
-            writes[n] = descriptorWrite(set, 1, &props_infos[i]);
-            n += 1;
-            writes[n] = descriptorWrite(set, 2, &output_infos[i]);
-            n += 1;
-            writes[n] = descriptorWrite(set, 3, &result_infos[i]);
-            n += 1;
+            const output_buf = self.compute.getNativeBuffer(self.output_handles[i]);
+            const buffers = [_]u64{ native_block_buf, self.block_props_buffer.buffer, output_buf, self.result_buffers[i].buffer };
+            self.compute.updateComputeDescriptors(self.pipeline, i, &buffers);
         }
-
-        c.vkUpdateDescriptorSets(vk, @intCast(n), &writes[0], 0, null);
     }
 
     fn deinitComputeResources(self: *GpuMesher) void {
-        const vk = self.vk_ctx.vulkan_device.vk_device;
-        if (self.pipeline != null) c.vkDestroyPipeline(vk, self.pipeline, null);
-        if (self.pipeline_layout != null) c.vkDestroyPipelineLayout(vk, self.pipeline_layout, null);
-        if (self.descriptor_set_layout != null) c.vkDestroyDescriptorSetLayout(vk, self.descriptor_set_layout, null);
-        if (self.descriptor_pool != null) c.vkDestroyDescriptorPool(vk, self.descriptor_pool, null);
-        self.pipeline = null;
-        self.pipeline_layout = null;
-        self.descriptor_set_layout = null;
-        self.descriptor_pool = null;
+        self.compute.destroyComputePipeline(&self.pipeline);
     }
 };
 
@@ -508,42 +390,6 @@ fn copyVertexRange(self: *GpuMesher, src_buffer: u64, dst_buffer: u64, src_verte
 
 fn slotOrMissing(slot: ?usize) i32 {
     return if (slot) |s| @intCast(s) else -1;
-}
-
-fn descriptorWrite(set: c.VkDescriptorSet, binding: u32, info: *const c.VkDescriptorBufferInfo) c.VkWriteDescriptorSet {
-    var write = std.mem.zeroes(c.VkWriteDescriptorSet);
-    write.sType = c.VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    write.dstSet = set;
-    write.dstBinding = binding;
-    write.descriptorType = c.VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    write.descriptorCount = 1;
-    write.pBufferInfo = info;
-    return write;
-}
-
-fn destroyVulkanBuffer(vk: c.VkDevice, buf: *Utils.VulkanBuffer) void {
-    if (buf.mapped_ptr != null) {
-        c.vkUnmapMemory(vk, buf.memory);
-        buf.mapped_ptr = null;
-    }
-    if (buf.buffer != null) c.vkDestroyBuffer(vk, buf.buffer, null);
-    if (buf.memory != null) c.vkFreeMemory(vk, buf.memory, null);
-    buf.* = .{};
-}
-
-fn loadShaderModule(vk: c.VkDevice, path: []const u8, allocator: std.mem.Allocator) !c.VkShaderModule {
-    const bytes = try fs.cwd().readFileAlloc(path, allocator, 16 * 1024 * 1024);
-    defer allocator.free(bytes);
-    if (bytes.len % 4 != 0) return error.InvalidShader;
-
-    var info = std.mem.zeroes(c.VkShaderModuleCreateInfo);
-    info.sType = c.VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    info.codeSize = bytes.len;
-    info.pCode = @ptrCast(@alignCast(bytes.ptr));
-
-    var module: c.VkShaderModule = null;
-    try Utils.checkVk(c.vkCreateShaderModule(vk, &info, null, &module));
-    return module;
 }
 
 fn ensureShaderFileExists(path: []const u8) !void {

--- a/modules/world-runtime/src/gpu_mesher.zig
+++ b/modules/world-runtime/src/gpu_mesher.zig
@@ -151,7 +151,7 @@ pub const GpuMesher = struct {
         if (self.submitted[prev_fi].items.len == 0) return;
 
         if (!self.compute.waitForFrameFence(prev_fi)) {
-            log.log.warn("GPU_MESHER: in_flight_fences[{}] is null (FrameManager fences not yet initialized); deferring finalize this frame", .{prev_fi});
+            log.log.warn("GPU_MESHER: frame fence wait failed for frame {} (missing fence, timeout, or GPU/device error); deferring finalize this frame", .{prev_fi});
             return;
         }
 

--- a/modules/world-runtime/src/gpu_mesher.zig
+++ b/modules/world-runtime/src/gpu_mesher.zig
@@ -58,6 +58,7 @@ pub const GpuMesher = struct {
     allocator: std.mem.Allocator,
     rhi: rhi_pkg.RHI,
     rm: rhi_pkg.ResourceManager,
+    compute: rhi_pkg.IComputeContext,
     vk_ctx: *VulkanContext,
     available: bool,
 
@@ -86,7 +87,7 @@ pub const GpuMesher = struct {
         errdefer allocator.destroy(self);
 
         const rm = rhi.resourceManager();
-        const vk_ctx: *VulkanContext = @ptrCast(@alignCast(rhi.ptr));
+        const vk_ctx: *VulkanContext = @ptrFromInt(rhi.nativeHandles().getBackendContext());
         const output_size = @as(usize, MAX_GPU_MESH_BATCH) * @as(usize, MAX_VERTICES_PER_CHUNK) * @as(usize, VERTEX_SIZE);
         const result_size = MAX_GPU_MESH_BATCH * @sizeOf(MeshBuildResult);
 
@@ -94,6 +95,7 @@ pub const GpuMesher = struct {
             .allocator = allocator,
             .rhi = rhi,
             .rm = rm,
+            .compute = rhi.compute(),
             .vk_ctx = vk_ctx,
             .available = false,
             .descriptor_sets = std.mem.zeroes([MAX_FRAMES_IN_FLIGHT]c.VkDescriptorSet),
@@ -165,18 +167,17 @@ pub const GpuMesher = struct {
         const prev_fi = (fi + MAX_FRAMES_IN_FLIGHT - 1) % MAX_FRAMES_IN_FLIGHT;
         if (self.submitted[prev_fi].items.len == 0) return;
 
-        const fence = self.vk_ctx.frames.in_flight_fences[prev_fi];
-        if (fence == null) {
+        if (!self.compute.waitForFrameFence(prev_fi)) {
             log.log.warn("GPU_MESHER: in_flight_fences[{}] is null (FrameManager fences not yet initialized); deferring finalize this frame", .{prev_fi});
             return;
         }
-        _ = c.vkWaitForFences(self.vk_ctx.vulkan_device.vk_device, 1, &fence, c.VK_TRUE, std.math.maxInt(u64));
 
         const cmd = self.vk_ctx.frames.command_buffers[fi];
         if (cmd == null) return;
 
-        const src = self.vk_ctx.resources.buffers.get(self.output_handles[prev_fi]) orelse return;
-        const dst = self.vk_ctx.resources.buffers.get(vertex_allocator.buffer) orelse return;
+        const src = self.compute.getNativeBuffer(self.output_handles[prev_fi]);
+        const dst = self.compute.getNativeBuffer(vertex_allocator.buffer);
+        if (src == 0 or dst == 0) return;
         const results = self.getMappedResults(prev_fi) orelse {
             log.log.warn("GPU_MESHER_FINALIZE: no mapped results for prev_fi={}", .{prev_fi});
             return;
@@ -230,15 +231,15 @@ pub const GpuMesher = struct {
                 const request_base_vertices = @as(u64, @intCast(idx)) * @as(u64, MAX_VERTICES_PER_CHUNK);
 
                 if (solid_alloc) |alloc| {
-                    copyVertexRange(cmd, src.buffer, dst.buffer, request_base_vertices, alloc.offset, result.solid_count);
+                    copyVertexRange(self, src, dst, request_base_vertices, alloc.offset, result.solid_count);
                     copied_any = true;
                 }
                 if (cutout_alloc) |alloc| {
-                    copyVertexRange(cmd, src.buffer, dst.buffer, request_base_vertices + MAX_PASS_VERTICES, alloc.offset, result.cutout_count);
+                    copyVertexRange(self, src, dst, request_base_vertices + MAX_PASS_VERTICES, alloc.offset, result.cutout_count);
                     copied_any = true;
                 }
                 if (fluid_alloc) |alloc| {
-                    copyVertexRange(cmd, src.buffer, dst.buffer, request_base_vertices + (MAX_PASS_VERTICES * 2), alloc.offset, result.fluid_count);
+                    copyVertexRange(self, src, dst, request_base_vertices + (MAX_PASS_VERTICES * 2), alloc.offset, result.fluid_count);
                     copied_any = true;
                 }
 
@@ -250,22 +251,7 @@ pub const GpuMesher = struct {
         }
 
         if (copied_any) {
-            var barrier = std.mem.zeroes(c.VkMemoryBarrier);
-            barrier.sType = c.VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-            barrier.srcAccessMask = c.VK_ACCESS_TRANSFER_WRITE_BIT;
-            barrier.dstAccessMask = c.VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT;
-            c.vkCmdPipelineBarrier(
-                cmd,
-                c.VK_PIPELINE_STAGE_TRANSFER_BIT,
-                c.VK_PIPELINE_STAGE_VERTEX_INPUT_BIT,
-                0,
-                1,
-                &barrier,
-                0,
-                null,
-                0,
-                null,
-            );
+            self.compute.pipelineBarrier(c.VK_PIPELINE_STAGE_TRANSFER_BIT, c.VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, c.VK_ACCESS_TRANSFER_WRITE_BIT, c.VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT);
         }
 
         self.submitted[prev_fi].clearRetainingCapacity();
@@ -281,19 +267,13 @@ pub const GpuMesher = struct {
 
         self.submitted[fi].appendSlice(self.allocator, self.mesh_queue.items) catch return;
 
-        const result_buf = self.result_buffers[fi].buffer;
+        const result_buf = @intFromPtr(self.result_buffers[fi].buffer);
         const result_size: c.VkDeviceSize = MAX_GPU_MESH_BATCH * @sizeOf(MeshBuildResult);
-        c.vkCmdFillBuffer(cmd, result_buf, 0, result_size, 0);
-        {
-            var fill_barrier = std.mem.zeroes(c.VkMemoryBarrier);
-            fill_barrier.sType = c.VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-            fill_barrier.srcAccessMask = c.VK_ACCESS_TRANSFER_WRITE_BIT;
-            fill_barrier.dstAccessMask = c.VK_ACCESS_SHADER_READ_BIT | c.VK_ACCESS_SHADER_WRITE_BIT;
-            c.vkCmdPipelineBarrier(cmd, c.VK_PIPELINE_STAGE_TRANSFER_BIT, c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &fill_barrier, 0, null, 0, null);
-        }
+        self.compute.fillBuffer(result_buf, 0, result_size, 0);
+        self.compute.pipelineBarrier(c.VK_PIPELINE_STAGE_TRANSFER_BIT, c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, c.VK_ACCESS_TRANSFER_WRITE_BIT, c.VK_ACCESS_SHADER_READ_BIT | c.VK_ACCESS_SHADER_WRITE_BIT);
 
-        c.vkCmdBindPipeline(cmd, c.VK_PIPELINE_BIND_POINT_COMPUTE, self.pipeline);
-        c.vkCmdBindDescriptorSets(cmd, c.VK_PIPELINE_BIND_POINT_COMPUTE, self.pipeline_layout, 0, 1, &self.descriptor_sets[fi], 0, null);
+        self.compute.bindComputePipeline(@intFromPtr(self.pipeline));
+        self.compute.bindDescriptorSet(@intFromPtr(self.pipeline_layout), @intFromPtr(self.descriptor_sets[fi]));
 
         for (self.mesh_queue.items, 0..) |req, idx| {
             const n_slot = gpu_block_buffer.getSlotForChunk(req.cx, req.cz - 1);
@@ -309,26 +289,11 @@ pub const GpuMesher = struct {
                 .neighbor_east_slot = slotOrMissing(e_slot),
                 .neighbor_west_slot = slotOrMissing(w_slot),
             };
-            c.vkCmdPushConstants(cmd, self.pipeline_layout, c.VK_SHADER_STAGE_COMPUTE_BIT, 0, @sizeOf(MeshPushConstants), &push);
-            c.vkCmdDispatch(cmd, CHUNK_Y, 1, 1);
+            self.compute.pushConstants(@intFromPtr(self.pipeline_layout), 0, @sizeOf(MeshPushConstants), &push);
+            self.compute.dispatch(CHUNK_Y, 1, 1);
         }
 
-        var barrier = std.mem.zeroes(c.VkMemoryBarrier);
-        barrier.sType = c.VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-        barrier.srcAccessMask = c.VK_ACCESS_SHADER_WRITE_BIT;
-        barrier.dstAccessMask = c.VK_ACCESS_HOST_READ_BIT | c.VK_ACCESS_TRANSFER_READ_BIT;
-        c.vkCmdPipelineBarrier(
-            cmd,
-            c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-            c.VK_PIPELINE_STAGE_HOST_BIT | c.VK_PIPELINE_STAGE_TRANSFER_BIT,
-            0,
-            1,
-            &barrier,
-            0,
-            null,
-            0,
-            null,
-        );
+        self.compute.pipelineBarrier(c.VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, c.VK_PIPELINE_STAGE_HOST_BIT | c.VK_PIPELINE_STAGE_TRANSFER_BIT, c.VK_ACCESS_SHADER_WRITE_BIT, c.VK_ACCESS_HOST_READ_BIT | c.VK_ACCESS_TRANSFER_READ_BIT);
 
         self.stats.chunks_dispatched = @intCast(self.mesh_queue.items.len);
         self.mesh_queue.clearRetainingCapacity();
@@ -536,13 +501,9 @@ fn freeTempAllocations(vertex_allocator: *GlobalVertexAllocator, solid: ?VertexA
     if (fluid) |alloc| vertex_allocator.free(alloc);
 }
 
-fn copyVertexRange(cmd: c.VkCommandBuffer, src_buffer: c.VkBuffer, dst_buffer: c.VkBuffer, src_vertex_offset: u64, dst_byte_offset: usize, count: u32) void {
+fn copyVertexRange(self: *GpuMesher, src_buffer: u64, dst_buffer: u64, src_vertex_offset: u64, dst_byte_offset: usize, count: u32) void {
     if (count == 0) return;
-    var region = std.mem.zeroes(c.VkBufferCopy);
-    region.srcOffset = src_vertex_offset * VERTEX_SIZE;
-    region.dstOffset = dst_byte_offset;
-    region.size = @as(u64, count) * VERTEX_SIZE;
-    c.vkCmdCopyBuffer(cmd, src_buffer, dst_buffer, 1, &region);
+    self.compute.copyBuffer(src_buffer, dst_buffer, src_vertex_offset * VERTEX_SIZE, dst_byte_offset, @as(u64, count) * VERTEX_SIZE);
 }
 
 fn slotOrMissing(slot: ?usize) i32 {

--- a/modules/world-runtime/src/gpu_mesher.zig
+++ b/modules/world-runtime/src/gpu_mesher.zig
@@ -165,8 +165,6 @@ pub const GpuMesher = struct {
             return;
         };
 
-        var copied_any = false;
-
         storage.chunks_mutex.lock();
         defer storage.chunks_mutex.unlock();
 
@@ -214,15 +212,15 @@ pub const GpuMesher = struct {
 
                 if (solid_alloc) |alloc| {
                     copyVertexRange(self, src, dst, request_base_vertices, alloc.offset, result.solid_count);
-                    copied_any = true;
+                    vertexReadBarrier(self, dst, alloc.offset, result.solid_count);
                 }
                 if (cutout_alloc) |alloc| {
                     copyVertexRange(self, src, dst, request_base_vertices + MAX_PASS_VERTICES, alloc.offset, result.cutout_count);
-                    copied_any = true;
+                    vertexReadBarrier(self, dst, alloc.offset, result.cutout_count);
                 }
                 if (fluid_alloc) |alloc| {
                     copyVertexRange(self, src, dst, request_base_vertices + (MAX_PASS_VERTICES * 2), alloc.offset, result.fluid_count);
-                    copied_any = true;
+                    vertexReadBarrier(self, dst, alloc.offset, result.fluid_count);
                 }
 
                 data.render.mesh.replaceAllocations(vertex_allocator, solid_alloc, cutout_alloc, fluid_alloc);
@@ -230,10 +228,6 @@ pub const GpuMesher = struct {
                 data.chunk.dirty = false;
                 self.stats.vertices_produced += result.solid_count + result.cutout_count + result.fluid_count;
             }
-        }
-
-        if (copied_any) {
-            self.compute.pipelineBarrier(rhi_pkg.PIPELINE_STAGE_TRANSFER_BIT, rhi_pkg.PIPELINE_STAGE_VERTEX_INPUT_BIT, rhi_pkg.ACCESS_TRANSFER_WRITE_BIT, rhi_pkg.ACCESS_VERTEX_ATTRIBUTE_READ_BIT);
         }
 
         self.submitted[prev_fi].clearRetainingCapacity();
@@ -251,7 +245,7 @@ pub const GpuMesher = struct {
         const result_buf = self.result_buffers[fi].buffer;
         const result_size: u64 = MAX_GPU_MESH_BATCH * @sizeOf(MeshBuildResult);
         self.compute.fillBuffer(result_buf, 0, result_size, 0);
-        self.compute.pipelineBarrier(rhi_pkg.PIPELINE_STAGE_TRANSFER_BIT, rhi_pkg.PIPELINE_STAGE_COMPUTE_SHADER_BIT, rhi_pkg.ACCESS_TRANSFER_WRITE_BIT, rhi_pkg.ACCESS_SHADER_READ_BIT | rhi_pkg.ACCESS_SHADER_WRITE_BIT);
+        self.compute.bufferBarrier(result_buf, rhi_pkg.PIPELINE_STAGE_TRANSFER_BIT, rhi_pkg.PIPELINE_STAGE_COMPUTE_SHADER_BIT, rhi_pkg.ACCESS_TRANSFER_WRITE_BIT, rhi_pkg.ACCESS_SHADER_READ_BIT | rhi_pkg.ACCESS_SHADER_WRITE_BIT, 0, result_size);
 
         self.compute.bindComputePipeline(self.pipeline.pipeline);
         self.compute.bindDescriptorSet(self.pipeline.layout, self.pipeline.descriptor_sets[fi]);
@@ -274,7 +268,8 @@ pub const GpuMesher = struct {
             self.compute.dispatch(CHUNK_Y, 1, 1);
         }
 
-        self.compute.pipelineBarrier(rhi_pkg.PIPELINE_STAGE_COMPUTE_SHADER_BIT, rhi_pkg.PIPELINE_STAGE_HOST_BIT | rhi_pkg.PIPELINE_STAGE_TRANSFER_BIT, rhi_pkg.ACCESS_SHADER_WRITE_BIT, rhi_pkg.ACCESS_HOST_READ_BIT | rhi_pkg.ACCESS_TRANSFER_READ_BIT);
+        self.compute.bufferBarrier(self.result_buffers[fi].buffer, rhi_pkg.PIPELINE_STAGE_COMPUTE_SHADER_BIT, rhi_pkg.PIPELINE_STAGE_HOST_BIT, rhi_pkg.ACCESS_SHADER_WRITE_BIT, rhi_pkg.ACCESS_HOST_READ_BIT, 0, result_size);
+        self.compute.bufferBarrier(self.compute.getNativeBuffer(self.output_handles[fi]), rhi_pkg.PIPELINE_STAGE_COMPUTE_SHADER_BIT, rhi_pkg.PIPELINE_STAGE_TRANSFER_BIT, rhi_pkg.ACCESS_SHADER_WRITE_BIT, rhi_pkg.ACCESS_TRANSFER_READ_BIT, 0, outputBufferSize());
 
         self.stats.chunks_dispatched = @intCast(self.mesh_queue.items.len);
         self.mesh_queue.clearRetainingCapacity();
@@ -386,6 +381,15 @@ fn freeTempAllocations(vertex_allocator: *GlobalVertexAllocator, solid: ?VertexA
 fn copyVertexRange(self: *GpuMesher, src_buffer: u64, dst_buffer: u64, src_vertex_offset: u64, dst_byte_offset: usize, count: u32) void {
     if (count == 0) return;
     self.compute.copyBuffer(src_buffer, dst_buffer, src_vertex_offset * VERTEX_SIZE, dst_byte_offset, @as(u64, count) * VERTEX_SIZE);
+}
+
+fn vertexReadBarrier(self: *GpuMesher, buffer: u64, dst_byte_offset: usize, count: u32) void {
+    if (count == 0) return;
+    self.compute.bufferBarrier(buffer, rhi_pkg.PIPELINE_STAGE_TRANSFER_BIT, rhi_pkg.PIPELINE_STAGE_VERTEX_INPUT_BIT, rhi_pkg.ACCESS_TRANSFER_WRITE_BIT, rhi_pkg.ACCESS_VERTEX_ATTRIBUTE_READ_BIT, dst_byte_offset, @as(u64, count) * VERTEX_SIZE);
+}
+
+fn outputBufferSize() u64 {
+    return @as(u64, MAX_GPU_MESH_BATCH) * @as(u64, MAX_VERTICES_PER_CHUNK) * @as(u64, VERTEX_SIZE);
 }
 
 fn slotOrMissing(slot: ?usize) i32 {


### PR DESCRIPTION
## Summary
- add an RHI compute context for compute buffer creation, compute pipeline/descriptor setup, dispatch, push constants, buffer fill/copy, scoped buffer barriers, fence waits, and native buffer lookup
- route gpu_mesher compute resources and dispatch/copy/barrier/fence calls through the RHI compute facet
- remove the direct engine-graphics/VulkanContext dependency and raw Vulkan calls from world-runtime gpu_mesher
- scope gpu_mesher synchronization with Vulkan `VkBufferMemoryBarrier` via `IComputeContext.bufferBarrier`
- move LPV backend context lookup behind RHI native handles instead of directly downcasting RHI.ptr
- harden frame-fence waits with a finite timeout and replace mock compute undefined pointers with safe stubs
- update compute descriptors using dynamically sized scratch arrays so future pipelines are not capped at 8 bindings

## Verification
- nix develop --command zig fmt modules/engine-rhi/src/rhi.zig modules/engine-graphics/src/rhi_vulkan.zig modules/engine-graphics/src/rhi_tests.zig modules/world-runtime/src/gpu_mesher.zig
- nix develop --command zig build test
- nix develop --command zig build
- git diff --check
- verified no engine-graphics/VulkanContext/raw Vulkan references remain in modules/world-runtime/src/gpu_mesher.zig

## Runtime Check
- nix develop --command zig build run -Dskip-present -Dauto-world=normal -Dscreenshot-path=screenshots/rhi-compute-783.png -Dscreenshot-frame=120 timed out at 300s before runtime logs/screenshot. No screenshot file was produced.
- LIBGL_ALWAYS_SOFTWARE=1 WLR_RENDERER=pixman nix develop --command zig build run -Dskip-present -Dauto-world=normal -Dscreenshot-path=screenshots/rhi-compute-783.png -Dscreenshot-frame=120 timed out at 180s before runtime logs/screenshot. No screenshot file was produced.
- No Vulkan ICD JSON was available at /run/opengl-driver/share/vulkan/icd.d/*.json in this environment. Review also reports no available video device. Screenshot baseline should be rerun in an environment with a working offscreen/software Vulkan setup such as lavapipe/swiftshader or a display server.
- Earlier compile errors found by this path were fixed, and plain zig build now succeeds.

Closes #783
Closes #816