### PR TITLE
Guard ECS remove() usize underflow + tests

### DIFF
--- a/modules/engine-ecs/src/storage.zig
+++ b/modules/engine-ecs/src/storage.zig
@@ -63,6 +63,22 @@ pub fn ComponentStorage(comptime T: type) type {
 
         pub fn remove(self: *Self, entity: EntityId) bool {
             if (self.map.get(entity)) |index| {
+                // Defensive guard: if the dense arrays are empty or the stored
+                // index is out of bounds, the sparse map and dense arrays have
+                // desynchronized. This cannot happen through correct API usage
+                // (set/remove/clear keep them in sync), but we guard against it
+                // to avoid usize underflow on `len - 1` and subsequent
+                // out-of-bounds access if internal state becomes corrupted.
+                if (self.components.items.len == 0 or
+                    self.entities.items.len == 0 or
+                    index >= self.components.items.len or
+                    index >= self.entities.items.len)
+                {
+                    // Repair state by dropping the stale map entry.
+                    _ = self.map.remove(entity);
+                    return false;
+                }
+
                 // Swap with last element to keep dense
                 const last_index = self.components.items.len - 1;
                 const last_entity = self.entities.items[last_index];
@@ -77,8 +93,8 @@ pub fn ComponentStorage(comptime T: type) type {
                 }
 
                 // Pop back
-                _ = self.components.pop(self.allocator);
-                _ = self.entities.pop(self.allocator);
+                _ = self.components.pop();
+                _ = self.entities.pop();
                 _ = self.map.remove(entity);
                 return true;
             }

--- a/src/ecs_tests.zig
+++ b/src/ecs_tests.zig
@@ -3,6 +3,8 @@ const testing = std.testing;
 const ecs_manager = @import("engine-ecs").manager;
 const ECSRegistry = ecs_manager.Registry;
 const ecs_components = @import("engine-ecs").components;
+const ComponentStorage = @import("engine-ecs").ComponentStorage;
+const EntityId = @import("engine-ecs").EntityId;
 const Vec3 = @import("zig-math").Vec3;
 
 test "ECS registry basic operations" {
@@ -90,4 +92,74 @@ test "ECS Serialization" {
 
     try testing.expect(registry3.transforms.has(e1));
     try testing.expectEqual(@as(f32, 10), registry3.transforms.get(e1).?.position.x);
+}
+
+test "ComponentStorage.remove returns false on empty storage" {
+    const allocator = testing.allocator;
+    var storage = ComponentStorage(ecs_components.Transform).init(allocator);
+    defer storage.deinit();
+
+    // Removing from a fresh (empty) storage must not crash and must report
+    // nothing was removed.
+    try testing.expect(!storage.remove(123));
+}
+
+test "ComponentStorage.remove handles stale map entry with empty arrays (desync)" {
+    // Simulate a desync condition where the sparse map still references an
+    // entity but the dense arrays have been drained. Previously this triggered
+    // a usize underflow on `len - 1` followed by an out-of-bounds access.
+    const allocator = testing.allocator;
+    var storage = ComponentStorage(ecs_components.Transform).init(allocator);
+    defer storage.deinit();
+
+    const entity: EntityId = 42;
+    // Inject a stale map entry while leaving the dense arrays empty.
+    try storage.map.put(entity, 0);
+    try testing.expect(storage.has(entity));
+    try testing.expectEqual(@as(usize, 0), storage.components.items.len);
+
+    // Should gracefully report not-found and repair the stale map entry.
+    try testing.expect(!storage.remove(entity));
+    try testing.expect(!storage.has(entity));
+}
+
+test "ComponentStorage.remove handles stale map entry with out-of-bounds index (desync)" {
+    // Simulate a desync where the stored index is beyond the dense array
+    // length. The defensive guard should drop the stale entry and return
+    // false instead of indexing out of bounds.
+    const allocator = testing.allocator;
+    var storage = ComponentStorage(ecs_components.Transform).init(allocator);
+    defer storage.deinit();
+
+    const entity: EntityId = 7;
+    try storage.set(entity, .{ .position = Vec3.init(1, 2, 3) });
+    // Corrupt the stored index to point past the end of the dense arrays.
+    try storage.map.put(entity, 999);
+
+    try testing.expect(!storage.remove(entity));
+    try testing.expect(!storage.has(entity));
+}
+
+test "ComponentStorage.remove keeps dense arrays consistent under normal use" {
+    // Regression coverage to ensure the defensive guard does not interfere
+    // with the normal swap-remove behavior.
+    const allocator = testing.allocator;
+    var storage = ComponentStorage(ecs_components.Transform).init(allocator);
+    defer storage.deinit();
+
+    const a: EntityId = 1;
+    const b: EntityId = 2;
+    const c: EntityId = 3;
+    try storage.set(a, .{ .position = Vec3.init(1, 0, 0) });
+    try storage.set(b, .{ .position = Vec3.init(2, 0, 0) });
+    try storage.set(c, .{ .position = Vec3.init(3, 0, 0) });
+
+    // Remove the middle entity; the remaining two must still be retrievable.
+    try testing.expect(storage.remove(b));
+    try testing.expect(!storage.has(b));
+    try testing.expect(storage.has(a));
+    try testing.expect(storage.has(c));
+    try testing.expectEqual(@as(f32, 1), storage.get(a).?.position.x);
+    try testing.expectEqual(@as(f32, 3), storage.get(c).?.position.x);
+    try testing.expectEqual(@as(usize, 2), storage.components.items.len);
 }


### PR DESCRIPTION
Issue confirmed and fixed.

**Root cause** (`modules/engine-ecs/src/storage.zig:67`): `self.components.items.len - 1` underflows to `usize.MAX` when arrays are empty but the sparse map still holds a stale entry, causing an out-of-bounds access on the next line.

**Fix applied:**
1. **Defensive bounds guard** in `ComponentStorage.remove()` — if dense arrays are empty or the stored index is out of bounds (desync), drops the stale map entry and returns `false` instead of crashing.
2. **Pre-existing `pop()` API bug** — `ArrayListUnmanaged.pop()` in Zig 0.16.0 takes no args; the existing `pop(self.allocator)` calls would have prevented `remove()` from ever compiling when invoked. This was latent because no prior test exercised `remove()`.
3. **4 new unit tests** in `src/ecs_tests.zig`: empty-storage remove, stale-map-with-empty-arrays (the exact issue scenario), stale-map-with-out-of-bounds index, and a normal swap-remove regression.

Verified by reverting the guard and confirming the desync test fails to build (proving the path is exercised); `zig build test` passes with the fix applied.

Commit `fbe1f5c` on branch `opencode/issue733-20260705183956`, targeting `dev`.

Closes #733

<a href="https://opencode.ai/s/LJ9yygwV"><img width="200" alt="New%20session%20-%202026-07-05T18%3A39%3A55.082Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDE4OjM5OjU1LjA4Mlo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=LJ9yygwV" /></a>
[opencode session](https://opencode.ai/s/LJ9yygwV)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28750925822)