### PR TITLE
fix: distinguish .key from .key_alt in InputBinding.eql

### DIFF
--- a/modules/engine-input/src/interfaces.zig
+++ b/modules/engine-input/src/interfaces.zig
@@ -75,18 +75,15 @@ pub const InputBinding = union(enum) {
     none: void,
 
     pub fn eql(self: InputBinding, other: InputBinding) bool {
-        const self_key = switch (self) {
-            .key, .key_alt => |k| k,
-            else => null,
-        };
-        const other_key = switch (other) {
-            .key, .key_alt => |k| k,
-            else => null,
-        };
-
-        if (self_key != null and other_key != null) return self_key.? == other_key.?;
-
         return switch (self) {
+            .key => |k| switch (other) {
+                .key => |ok| k == ok,
+                else => false,
+            },
+            .key_alt => |k| switch (other) {
+                .key_alt => |ok| k == ok,
+                else => false,
+            },
             .mouse_button => |mb| switch (other) {
                 .mouse_button => |omb| mb == omb,
                 else => false,
@@ -95,7 +92,6 @@ pub const InputBinding = union(enum) {
                 .none => true,
                 else => false,
             },
-            else => false,
         };
     }
 

--- a/modules/game-core/src/input_mapper.zig
+++ b/modules/game-core/src/input_mapper.zig
@@ -267,10 +267,12 @@ test "InputBinding equality" {
     const b1 = InputBinding{ .key = .w };
     const b2 = InputBinding{ .key_alt = .w };
     const b3 = InputBinding{ .key = .s };
+    const b4 = InputBinding{ .key_alt = .w };
 
-    try std.testing.expect(b1.eql(b2));
-    try std.testing.expect(b2.eql(b1));
+    try std.testing.expect(!b1.eql(b2));
+    try std.testing.expect(!b2.eql(b1));
     try std.testing.expect(!b1.eql(b3));
+    try std.testing.expect(b2.eql(b4));
 }
 
 test "InputMapper resetActionToDefault" {

--- a/src/game/input_mapper_tests.zig
+++ b/src/game/input_mapper_tests.zig
@@ -55,11 +55,28 @@ test "InputBinding.eql with .none values" {
     try testing.expect(b.eql(a));
 }
 
-test "InputBinding.eql key vs key_alt same key" {
+test "InputBinding.eql key vs key_alt same key are distinct" {
     const a = InputBinding{ .key = .w };
     const b = InputBinding{ .key_alt = .w };
+    try testing.expect(!a.eql(b));
+    try testing.expect(!b.eql(a));
+}
+
+test "InputBinding.eql key vs key_alt different keys are distinct" {
+    const a = InputBinding{ .key = .w };
+    const b = InputBinding{ .key_alt = .space };
+    try testing.expect(!a.eql(b));
+    try testing.expect(!b.eql(a));
+}
+
+test "InputBinding.eql same key variant equal" {
+    const a = InputBinding{ .key = .w };
+    const b = InputBinding{ .key = .w };
     try testing.expect(a.eql(b));
-    try testing.expect(b.eql(a));
+
+    const c = InputBinding{ .key_alt = .up };
+    const d = InputBinding{ .key_alt = .up };
+    try testing.expect(c.eql(d));
 }
 
 test "InputBinding.eql different key types" {


### PR DESCRIPTION
## Summary

Fixes #729

`InputBinding.eql()` collapsed the `.key` and `.key_alt` variants into a shared code path (`modules/engine-input/src/interfaces.zig:77-100`), comparing only the underlying `Key` value and discarding the variant tag. This made `InputBinding{ .key = .w }.eql(InputBinding{ .key_alt = .w })` return `true` when the variants are distinct.

## Impact

The input mapper's `isBindingStateActive`/`isBindingStatePressed`/`isBindingStateReleased` (`modules/game-core/src/input_mapper.zig:141-166`) all rely on `eql`, so querying a `.key` binding would incorrectly match a `.key_alt` binding with the same physical key. The `InputBinding` union explicitly defines `.key` and `.key_alt` as separate variants so an action can have both a primary binding (e.g. `W`) and an alternate binding (e.g. `Up Arrow`) — the old behavior defeated that distinction.

## Changes

- **`modules/engine-input/src/interfaces.zig`** — Rewrote `eql` to compare variant tags explicitly. `.key` only equals `.key`; `.key_alt` only equals `.key_alt`; matching requires both the variant and the underlying value to be equal.
- **`modules/game-core/src/input_mapper.zig`** — Updated the `InputBinding equality` test that previously asserted the buggy equality (now verifies `.key != .key_alt` with the same key, and `.key_alt == .key_alt`).
- **`src/game/input_mapper_tests.zig`** — Replaced the `key vs key_alt same key` test (which documented the bug) with tests asserting the variants are distinct, plus a positive test confirming same-variant equality.

## Verification

- `zig fmt src/ modules/` — clean
- `zig build test` — **277/277 tests pass**
- Confirmed the new test `InputBinding.eql key vs key_alt same key are distinct` **fails** against the old buggy `eql` (verified by temporarily reverting the fix) and **passes** with the fix in place, proving the test catches the regression.

## Acceptance Criteria (from issue)

- [x] `eql` returns `false` when comparing `.key` against `.key_alt` (same key)
- [x] New unit tests verify `.key` and `.key_alt` are treated as distinct
- [x] No regression in existing `eql` tests