### PR TITLE
Fixed double-cleanup OOM bug in JobQueue

### DIFF
--- a/modules/engine-core/src/job_system.zig
+++ b/modules/engine-core/src/job_system.zig
@@ -40,6 +40,11 @@
 //! creating generic jobs with heap-allocated context pointers MUST provide a
 //! `cleanup_fn` to avoid memory leaks.
 //!
+//! `Job.cleanup()` is idempotent: after invoking `cleanup_fn` it nullifies the
+//! pointer, so subsequent calls are no-ops. This defends against double-free if
+//! a job is dropped on an error path (e.g. OOM in `doReprioritize`) and the
+//! same `Job` value is later re-added to a queue that is eventually drained.
+//!
 //! ## WorkerPool
 //!
 //! Worker threads pull jobs from a shared JobQueue and invoke the appropriate
@@ -97,11 +102,17 @@ pub const Job = struct {
         cleanup_fn: ?*const fn (*anyopaque) void = null,
     };
 
-    pub fn cleanup(self: Job) void {
+    /// Invoke this job's `cleanup_fn` (if any) and nullify it so subsequent
+    /// calls become no-ops. This defends against double-cleanup if a job is
+    /// dropped on an error path (e.g. OOM in `doReprioritize`) and the same
+    /// `Job` value is later re-added to a queue that is eventually drained by
+    /// `clear()`, `setPaused(true)`, or `stop()`.
+    pub fn cleanup(self: *Job) void {
         switch (self.type) {
             .generic => {
                 if (self.data.generic.cleanup_fn) |cleanup_fn| {
                     cleanup_fn(self.data.generic.context);
+                    self.data.generic.cleanup_fn = null;
                 }
             },
             .chunk_generation, .chunk_meshing => {},
@@ -247,8 +258,8 @@ pub const JobQueue = struct {
         }
 
         // Re-add with updated priorities
-        for (temp.items) |job| {
-            self.jobs.push(self.allocator, job) catch {
+        for (temp.items) |*job| {
+            self.jobs.push(self.allocator, job.*) catch {
                 log.log.warn("Job queue: failed to re-add job after priority update", .{});
                 job.cleanup();
                 continue;
@@ -283,7 +294,8 @@ pub const JobQueue = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
         while (self.jobs.pop()) |job| {
-            job.cleanup();
+            var j = job;
+            j.cleanup();
         }
     }
 
@@ -294,7 +306,8 @@ pub const JobQueue = struct {
         self.abort_worker = paused or self.stopped;
         if (paused) {
             while (self.jobs.pop()) |job| {
-                job.cleanup();
+                var j = job;
+                j.cleanup();
             }
         } else {
             self.cond.broadcast();
@@ -306,7 +319,8 @@ pub const JobQueue = struct {
         self.stopped = true;
         self.abort_worker = true;
         while (self.jobs.pop()) |job| {
-            job.cleanup();
+            var j = job;
+            j.cleanup();
         }
         self.mutex.unlock();
         self.cond.broadcast();
@@ -443,13 +457,55 @@ test "Job.cleanup is no-op for generic jobs without cleanup_fn" {
 
 test "Job.cleanup is no-op for chunk jobs" {
     cleanup_count = 0;
-    const job = Job{
+    var job = Job{
         .type = .chunk_generation,
         .dist_sq = 0,
         .data = .{ .chunk = .{ .x = 0, .z = 0, .job_token = 1 } },
     };
     job.cleanup();
     try testing.expectEqual(@as(usize, 0), cleanup_count);
+}
+
+test "Job.cleanup nullifies cleanup_fn to prevent double-cleanup" {
+    // Regression for the doReprioritize OOM double-cleanup issue: after
+    // cleanup() runs, cleanup_fn must be cleared so any subsequent call
+    // (e.g. if the same Job value is later re-added and the queue is
+    // drained) is a no-op rather than a double-free.
+    cleanup_count = 0;
+    var job = makeGenericJob();
+    job.cleanup();
+    try testing.expectEqual(@as(usize, 1), cleanup_count);
+    try testing.expect(job.data.generic.cleanup_fn == null);
+    // Subsequent cleanup must not re-invoke the cleanup function.
+    job.cleanup();
+    try testing.expectEqual(@as(usize, 1), cleanup_count);
+}
+
+test "Job.cleanup idempotency survives queue drain after OOM-style drop" {
+    // Simulates the doReprioritize OOM pattern at the Job level: a job is
+    // dropped via the OOM catch arm (cleanup invoked), then the same Job
+    // value is later re-added to a queue that is drained via stop(). With
+    // the fix, cleanup_fn is null after the first cleanup, so the queue
+    // drain must not trigger a second invocation.
+    cleanup_count = 0;
+    var job = makeGenericJob();
+
+    // Emulate the doReprioritize OOM drop: cleanup is invoked on the job
+    // that failed to be re-added.
+    job.cleanup();
+    try testing.expectEqual(@as(usize, 1), cleanup_count);
+
+    // The caller still holds the (now-cleaned) Job value and re-adds it.
+    // Without the fix, cleanup_fn would still be set here.
+    try testing.expect(job.data.generic.cleanup_fn == null);
+
+    var queue = JobQueue.init(testing.allocator);
+    defer queue.deinit();
+    queue.push(job) catch unreachable;
+
+    // Draining the queue must not double-invoke cleanup.
+    queue.stop();
+    try testing.expectEqual(@as(usize, 1), cleanup_count);
 }
 
 test "JobQueue reprioritizes region-scaled chunk jobs" {

--- a/src/job_system_tests.zig
+++ b/src/job_system_tests.zig
@@ -1,0 +1,111 @@
+//! Regression tests for engine-core job_system.
+//!
+//! These live under src/ (rather than alongside modules/engine-core/src/
+//! job_system.zig) because Zig 0.16 lazy compilation does not collect test
+//! blocks from module sub-files reached only through namespace references
+//! like `_ = @import("engine-core").job_system;`. Importing the public API
+//! types into a local src/ test file forces analysis and ensures these
+//! regressions actually execute under `zig build test`.
+
+const std = @import("std");
+const testing = std.testing;
+const engine_core = @import("engine-core");
+const Job = engine_core.Job;
+const JobQueue = engine_core.JobQueue;
+const JobType = engine_core.JobType;
+
+// --- Test helpers -----------------------------------------------------------
+
+var test_cleanup_count: usize = 0;
+
+fn testNopProcess(ctx: *anyopaque) void {
+    _ = ctx;
+}
+
+fn testCountingCleanup(ctx: *anyopaque) void {
+    _ = ctx;
+    test_cleanup_count += 1;
+}
+
+fn makeCountingCleanupJob() Job {
+    return Job{
+        .type = .generic,
+        .priority = 0,
+        .data = .{
+            .generic = .{
+                .context = undefined,
+                .process_fn = testNopProcess,
+                .cleanup_fn = testCountingCleanup,
+            },
+        },
+    };
+}
+
+// --- Regression tests for the doReprioritize double-cleanup fix ------------
+
+test "Job.cleanup nullifies cleanup_fn to prevent double-cleanup" {
+    // Regression for the doReprioritize OOM double-cleanup issue: after
+    // cleanup() runs, cleanup_fn must be cleared so any subsequent call
+    // (e.g. if the same Job value is later re-added and the queue is
+    // drained) is a no-op rather than a double-free.
+    test_cleanup_count = 0;
+    var job = makeCountingCleanupJob();
+    job.cleanup();
+    try testing.expectEqual(@as(usize, 1), test_cleanup_count);
+    try testing.expect(job.data.generic.cleanup_fn == null);
+    // Subsequent cleanup must not re-invoke the cleanup function.
+    job.cleanup();
+    try testing.expectEqual(@as(usize, 1), test_cleanup_count);
+}
+
+test "Job.cleanup idempotency survives queue drain after OOM-style drop" {
+    // Simulates the doReprioritize OOM pattern at the Job level: a job is
+    // dropped via the OOM catch arm (cleanup invoked), then the same Job
+    // value is later re-added to a queue that is drained via stop(). With
+    // the fix, cleanup_fn is null after the first cleanup, so the queue
+    // drain must not trigger a second invocation.
+    test_cleanup_count = 0;
+    var job = makeCountingCleanupJob();
+
+    // Emulate the doReprioritize OOM drop: cleanup is invoked on the job
+    // that failed to be re-added.
+    job.cleanup();
+    try testing.expectEqual(@as(usize, 1), test_cleanup_count);
+
+    // The caller still holds the (now-cleaned) Job value and re-adds it.
+    // Without the fix, cleanup_fn would still be set here.
+    try testing.expect(job.data.generic.cleanup_fn == null);
+
+    var queue = JobQueue.init(testing.allocator);
+    defer queue.deinit();
+    queue.push(job) catch unreachable;
+
+    // Draining the queue must not double-invoke cleanup.
+    queue.stop();
+    try testing.expectEqual(@as(usize, 1), test_cleanup_count);
+}
+
+test "JobQueue.stop calls cleanup exactly once per generic job" {
+    test_cleanup_count = 0;
+    var queue = JobQueue.init(testing.allocator);
+    defer queue.deinit();
+
+    queue.push(makeCountingCleanupJob()) catch unreachable;
+    queue.push(makeCountingCleanupJob()) catch unreachable;
+
+    queue.stop();
+    try testing.expectEqual(@as(usize, 2), test_cleanup_count);
+}
+
+test "Job.cleanup is no-op for chunk jobs (signature change)" {
+    // Sanity check that the *Job signature change for cleanup() compiles
+    // and works for chunk-type jobs (which have no cleanup_fn).
+    test_cleanup_count = 0;
+    var job = Job{
+        .type = .chunk_generation,
+        .dist_sq = 0,
+        .data = .{ .chunk = .{ .x = 0, .z = 0, .job_token = 1 } },
+    };
+    job.cleanup();
+    try testing.expectEqual(@as(usize, 0), test_cleanup_count);
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -24,6 +24,7 @@ test {
 
     // ECS and engine tests
     _ = @import("ecs_tests.zig");
+    _ = @import("job_system_tests.zig");
     _ = @import("engine-graphics").vulkan_device;
     _ = @import("engine-graphics").vulkan_device_tests;
     _ = @import("engine-graphics").vulkan_device_internal_tests;


### PR DESCRIPTION
## Summary

**Issue confirmed.** In `doReprioritize` (`modules/engine-core/src/job_system.zig:213`), both OOM catch arms called `Job.cleanup()` without nullifying `cleanup_fn`. If a dropped `Job` value was later re-added and the queue drained via `stop()`/`clear()`, cleanup would fire twice → double-free on heap-allocated generic job contexts.

**Fix** (commit `92fb30a` on branch `opencode/issue727-20260705192729`, targets `dev`):
- `Job.cleanup()` now takes `*Job` and nullifies `cleanup_fn` after invoking it — making cleanup idempotent. Updated all in-file callers.
- Added regression tests in a new `src/job_system_tests.zig` (local file, because module-namespace test imports are dead under Zig 0.16 lazy compilation — a pre-existing repo-wide gap I documented in the file header).
- Verified the new tests **fail** when the fix is reverted, and **pass** with it applied. Full suite: 279/279 pass.

PR creation/push is handled automatically by the opencode infrastructure.

Closes #727

<a href="https://opencode.ai/s/3tvKUhR9"><img width="200" alt="New%20session%20-%202026-07-05T19%3A27%3A28.513Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDE5OjI3OjI4LjUxM1o=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=3tvKUhR9" /></a>
[opencode session](https://opencode.ai/s/3tvKUhR9)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28752200499)