### PR TITLE
False positive: pool isn't leaked; added docs.

### DIFF
--- a/modules/engine-core/src/job_system.zig
+++ b/modules/engine-core/src/job_system.zig
@@ -350,6 +350,15 @@ pub const WorkerPool = struct {
             .process_job_fn = process_fn,
         };
 
+        // Cleanup ordering on error: Zig errdefers run LIFO (last registered fires
+        // first), and each stays active for ALL subsequent failure points in scope:
+        //   1. this block  -> stop the queue, join already-spawned threads,
+        //   2. allocator.free(threads) (registered above),
+        //   3. allocator.destroy(pool)  (registered first, above).
+        // Because allocator.destroy(pool) is registered first, it remains active even
+        // for a Thread.spawn failure in the loop below, so the pool struct is never
+        // leaked on a partial/total thread-spawn failure.
+        //
         // Note: Partial Thread.spawn failure (where some threads spawn but others fail)
         // cannot be reliably tested in unit tests because Thread.spawn rarely fails
         // deterministically. The spawned_count tracking and errdefer cleanup logic


### PR DESCRIPTION
## Summary

**Confirmation: the issue does NOT exist — it is a false positive.**

I verified `WorkerPool.init` at `modules/engine-core/src/job_system.zig:339`:

- The `errdefer allocator.destroy(pool)` (line 341) is registered **first**, so by Zig's LIFO errdefer semantics it remains active for *every* subsequent failure point — including the `Thread.spawn` at line 374.
- On spawn failure, errdefers fire in reverse: stop/join → `free(threads)` → `destroy(pool)`. The pool is freed; no leak.
- The issue's claim that `destroy(pool)` "only fires if the thread array allocation fails" misreads how errdefer works.

**Verification:** `zig build test` → 285/285 passed; `zig fmt` clean.

**Change made:** Since there's no logic bug to fix but this same audit has recurred twice from confusion over the errdefer chain, I expanded the existing explanatory comment to document the cleanup order explicitly (docs-only, 9 insertions). Committed to `opencode/issue726-20260705214052` for a PR targeting `dev`.

Closes #726

<a href="https://opencode.ai/s/ROlRSn82"><img width="200" alt="New%20session%20-%202026-07-05T21%3A40%3A51.308Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDIxOjQwOjUxLjMwOFo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=ROlRSn82" /></a>
[opencode session](https://opencode.ai/s/ROlRSn82)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28755799450)