### PR TITLE
Issue #721 is a false positive; added tests.

### DIFF
--- a/modules/world-meshing/src/chunk_mesh_tests.zig
+++ b/modules/world-meshing/src/chunk_mesh_tests.zig
@@ -113,3 +113,55 @@ test "ChunkMesh emits custom stair fixture solid mesh" {
     try testing.expectEqual(null, mesh.pending_cutout);
     try testing.expectEqual(null, mesh.pending_fluid);
 }
+
+test "ChunkMesh tall_cross emits 2-block billboard from single block" {
+    var chunk = world_core.Chunk.init(0, 0);
+    chunk.setBlock(1, 5, 1, .tall_grass);
+
+    var atlas: TextureAtlas = undefined;
+    atlas.tile_mappings = [_]TextureAtlas.BlockTiles{TextureAtlas.BlockTiles.uniform(7)} ** 256;
+
+    var mesh = ChunkMesh.init(testing.allocator);
+    defer mesh.deinitWithoutRHI();
+
+    try mesh.buildWithNeighbors(&chunk, NeighborChunks.empty, &atlas);
+
+    // tall_cross emits 2 diagonal quads × 6 verts = 12 cutout vertices
+    try testing.expectEqual(@as(usize, 12), mesh.pending_cutout.?.len);
+    // The quad should span 2 blocks vertically (y=5 to y=7)
+    const verts = mesh.pending_cutout.?;
+    var found_y5 = false;
+    var found_y7 = false;
+    for (verts) |v| {
+        if (v.pos[1] == 5.0) found_y5 = true;
+        if (v.pos[1] == 7.0) found_y7 = true;
+    }
+    try testing.expect(found_y5);
+    try testing.expect(found_y7);
+}
+
+test "ChunkMesh tall_cross renders full height at subchunk top boundary" {
+    // Place tall_grass at the LAST y of subchunk 0 (y=15). The 2-block-tall
+    // billboard extends into subchunk 1's range but should still be fully meshed.
+    var chunk = world_core.Chunk.init(0, 0);
+    chunk.setBlock(1, 15, 1, .tall_grass);
+
+    var atlas: TextureAtlas = undefined;
+    atlas.tile_mappings = [_]TextureAtlas.BlockTiles{TextureAtlas.BlockTiles.uniform(7)} ** 256;
+
+    var mesh = ChunkMesh.init(testing.allocator);
+    defer mesh.deinitWithoutRHI();
+
+    try mesh.buildWithNeighbors(&chunk, NeighborChunks.empty, &atlas);
+
+    try testing.expectEqual(@as(usize, 12), mesh.pending_cutout.?.len);
+    const verts = mesh.pending_cutout.?;
+    var found_y15 = false;
+    var found_y17 = false;
+    for (verts) |v| {
+        if (v.pos[1] == 15.0) found_y15 = true;
+        if (v.pos[1] == 17.0) found_y17 = true;
+    }
+    try testing.expect(found_y15);
+    try testing.expect(found_y17);
+}

--- a/modules/world-meshing/src/meshing/tall_cross_mesher.zig
+++ b/modules/world-meshing/src/meshing/tall_cross_mesher.zig
@@ -2,6 +2,14 @@
 //!
 //! Emits the same two diagonal billboard planes as cross meshing, but stretches
 //! them across two vertical blocks from the bottom block position.
+//!
+//! Design note: unlike vanilla Minecraft which uses separate upper/lower block
+//! types for tall vegetation, this engine stores tall vegetation (tall_grass,
+//! tall_seagrass, kelp) as a SINGLE block whose billboard quad spans two
+//! vertical blocks (y to y+2). Each tall_cross block is therefore
+//! self-contained: it is found at its own Y position and renders the full
+//! 2-block height from there. There is no separate "top half" block to detect,
+//! so no look-back at the block below is needed.
 
 const std = @import("std");
 


### PR DESCRIPTION
Commit created on branch `opencode/issue721-20260705214826`.

## Summary

**Issue #721 is a FALSE POSITIVE.** After thorough investigation I confirmed the described bug does not exist and did not implement the proposed fix (which would cause duplicate rendering).

### Evidence

The issue assumes tall vegetation uses a **2-block-pair model** (separate bottom/top block types like vanilla Minecraft). This codebase does **not**:

1. **Single-block placement**: Both worldgen modules place ONE block per tall plant:
   - `worldgen-overworld/src/decoration_registry.zig:218` — `chunk.setBlock(local_x, place_y, local_z, simple.block)`
   - `worldgen-overworld-v2/src/root.zig:309` — `setDecorationBlock(chunk, x, place_y, z, ...)`

2. **No top-half block type exists**: Only `.tall_grass`, `.tall_seagrass`, `.kelp` are registered with `.tall_cross` (block_registry.zig:430). There is no `tall_grass_top`.

3. **The mesher stretches the single block 2-high**: `tall_cross_mesher.zig:60-61` emits quads from `yf` to `yf+2`, producing the full billboard from one block.

4. **Regression tests prove it** (both pass):
   - `tall_cross emits 2-block billboard from single block` — 12 cutout verts spanning y=5→7
   - `tall_cross renders full height at subchunk top boundary` — 12 cutout verts spanning y=15→17 (crosses subchunk boundary correctly)

### Changes in the PR
- Added 2 regression tests guarding the correct behavior
- Enhanced the module doc comment to document the single-block design and prevent future false-positive audits

Implementing the issue's proposed fix (checking the block below for `.tall_cross`) would cause **duplicate rendering** — every tall plant would emit overlapping quads — so it was deliberately not done.

Closes #721

<a href="https://opencode.ai/s/4DM85lSe"><img width="200" alt="New%20session%20-%202026-07-05T21%3A48%3A25.248Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDIxOjQ4OjI1LjI0OFo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=4DM85lSe" /></a>
[opencode session](https://opencode.ai/s/4DM85lSe)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28755989707)