### PR TITLE
Removed unused AtmosphereSystem.resources field

### DIFF
--- a/modules/engine-graphics/src/atmosphere_system.zig
+++ b/modules/engine-graphics/src/atmosphere_system.zig
@@ -1,17 +1,14 @@
 const std = @import("std");
 const rhi = @import("engine-rhi");
-const ResourceManager = rhi.ResourceManager;
 const RenderContext = rhi.RenderContext;
 
 pub const AtmosphereSystem = struct {
     allocator: std.mem.Allocator,
-    resources: ResourceManager,
 
-    pub fn init(allocator: std.mem.Allocator, resources: ResourceManager) !*AtmosphereSystem {
+    pub fn init(allocator: std.mem.Allocator) !*AtmosphereSystem {
         const self = try allocator.create(AtmosphereSystem);
         self.* = .{
             .allocator = allocator,
-            .resources = resources,
         };
         return self;
     }

--- a/modules/engine-graphics/src/render_graph.zig
+++ b/modules/engine-graphics/src/render_graph.zig
@@ -143,7 +143,7 @@ pub const RenderGraph = struct {
     material_system: ?*MaterialSystem,
 
     pub fn init(allocator: std.mem.Allocator, rhi: rhi_pkg.RHI, lpv_config: LPVConfig) !RenderGraph {
-        const atmosphere_system = try AtmosphereSystem.init(allocator, rhi.resourceManager());
+        const atmosphere_system = try AtmosphereSystem.init(allocator);
         errdefer atmosphere_system.deinit();
 
         const lpv_system = try LPVSystem.init(

--- a/modules/engine-graphics/src/rhi_tests.zig
+++ b/modules/engine-graphics/src/rhi_tests.zig
@@ -638,7 +638,7 @@ test "AtmosphereSystem.renderSky with null handles" {
     const rhi_instance = rhi.RHI{ .ptr = &mock, .vtable = &MockContext.MOCK_VULKAN_RHI_VTABLE, .device = null };
 
     const AtmosphereSystem = @import("engine-atmosphere").AtmosphereSystem;
-    var system = try AtmosphereSystem.init(testing.allocator, rhi_instance.resourceManager());
+    var system = try AtmosphereSystem.init(testing.allocator);
     defer system.deinit();
 
     try testing.expectError(error.SkyPipelineNotReady, system.renderSky(rhi_instance.renderContext(), .{


### PR DESCRIPTION
Issue confirmed and fixed. The unused `resources: ResourceManager` field, its `init()` parameter, and the now-orphan `ResourceManager` import were removed from `AtmosphereSystem`, and both call sites (`render_graph.zig:146`, `rhi_tests.zig:641`) were updated to the new signature. `nix develop --command zig build test` passes (exit 0).

Summary of changes:
- `modules/engine-graphics/src/atmosphere_system.zig`: Removed `resources` field, `resources` init parameter, and `ResourceManager` import.
- `modules/engine-graphics/src/render_graph.zig:146`: Updated `AtmosphereSystem.init(allocator)` call.
- `modules/engine-graphics/src/rhi_tests.zig:641`: Updated test `AtmosphereSystem.init(testing.allocator)` call.

A PR will be created targeting `dev` automatically.

Closes #717

<a href="https://opencode.ai/s/A7ilDSFN"><img width="200" alt="New%20session%20-%202026-07-05T22%3A10%3A12.165Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDIyOjEwOjEyLjE2NVo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=A7ilDSFN" /></a>
[opencode session](https://opencode.ai/s/A7ilDSFN)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28756564596)