### PR TITLE
Issue #715 invalid; added docs + tests.

### DIFF
--- a/libs/zig-math/vec3.zig
+++ b/libs/zig-math/vec3.zig
@@ -84,6 +84,24 @@ pub const Vec3 = struct {
         return .{ self.x, self.y, self.z };
     }
 
+    /// Decode an sRGB-encoded color to linear light via the sRGB
+    /// Electro-Optical Transfer Function (EOTF), using the standard 2.2 gamma
+    /// approximation. `self` holds sRGB *signal* values (e.g. an 8-bit color
+    /// picked as `byte/255.0`); the result is physical linear intensity.
+    ///
+    /// This DARKENS the input (exponent > 1) because sRGB 8-bit values are
+    /// perceptual signals, not linear intensities. This matches every other
+    /// sRGB→linear conversion in the engine:
+    ///   - `srgbByteToLinear` in `texture_atlas.zig` (precise 2.4 EOTF)
+    ///   - `agxEotf` in `assets/shaders/vulkan/post_process.frag` (pow 2.2)
+    ///   - `pow(vColor.rgb, vec3(2.2))` in `assets/shaders/vulkan/ui.frag`
+    ///   - `pow(vec3(0.9,0.9,1.0), vec3(2.2))` for the moon in `sky.frag`
+    ///
+    /// The swapchain is `VK_FORMAT_B8G8R8A8_SRGB`, so the GPU encodes
+    /// linear→sRGB on presentation; all shading happens in linear space and
+    /// CPU-side sRGB color constants must be decoded with this function.
+    ///
+    /// The inverse (linear→sRGB encoding / OETF) is exponent `1.0/2.2`.
     pub fn toLinear(self: Vec3) Vec3 {
         return .{
             .x = std.math.pow(f32, self.x, 2.2),

--- a/src/math_tests.zig
+++ b/src/math_tests.zig
@@ -422,3 +422,53 @@ test "Frustum intersectsChunkRelative matches independent circumscribed sphere" 
     // implication above would hold vacuously.
     try testing.expect(ref_visible_count > 0);
 }
+
+// Regression guard for issue #715 (atmosphere sky-palette gamma audit).
+//
+// The audit claimed `Vec3.toLinear()` (which applies `pow(x, 2.2)`) was the
+// wrong direction and proposed `pow(x, 1/2.2)` instead. That proposal is
+// backwards. `pow(x, 2.2)` is the sRGB Electro-Optical Transfer Function
+// (signal -> linear light) and matches every other sRGB->linear conversion in
+// the engine:
+//   - `srgbByteToLinear` in modules/engine-graphics/src/texture_atlas.zig (pow 2.4)
+//   - `agxEotf` in assets/shaders/vulkan/post_process.frag (pow 2.2, commented
+//     "sRGB IEC 61966-2-1 2.2 Exponent Reference EOTF Display")
+//   - `pow(vColor.rgb, vec3(2.2))` in assets/shaders/vulkan/ui.frag
+//   - the moon color `pow(vec3(0.9,0.9,1.0), vec3(2.2))` in sky.frag
+// The swapchain is VK_FORMAT_B8G8R8A8_SRGB, so shading happens in linear space
+// and CPU-side sRGB color constants must be decoded with `toLinear()`.
+//
+// These tests pin the correct direction so the audit mistake is not reintroduced.
+
+test "Vec3.toLinear decodes sRGB to linear via the EOTF (darkens, exponent 2.2)" {
+    // A mid-tone sRGB signal (e.g. 97/255, the day-sky red channel).
+    const srgb_r = 97.0 / 255.0;
+
+    // Decoding sRGB signal to linear light darkens mid-tones (exponent > 1).
+    const decoded = Vec3.init(srgb_r, srgb_r, srgb_r).toLinear();
+    try testing.expect(decoded.x < srgb_r);
+
+    // The proposed-but-incorrect direction (pow 1/2.2) would *brighten*; make
+    // sure we are not doing that.
+    const wrong = std.math.pow(f32, srgb_r, 1.0 / 2.2);
+    try testing.expect(decoded.x < wrong);
+
+    // toLinear must apply pow(x, 2.2), matching the engine's other EOTFs.
+    try testing.expectApproxEqAbs(decoded.x, std.math.pow(f32, srgb_r, 2.2), 0.0001);
+
+    // Round-trip: applying the inverse OETF (pow 1/2.2) recovers the signal.
+    const recovered = std.math.pow(f32, decoded.x, 1.0 / 2.2);
+    try testing.expectApproxEqAbs(srgb_r, recovered, 0.001);
+}
+
+test "Vec3.toLinear matches the absolute linear-light value of sRGB day-sky blue" {
+    // day_sky is the sRGB triple (97, 181, 245). Its correct linear intensity is
+    // obtained by the sRGB EOTF (pow 2.2): approx (0.119, 0.471, 0.916). Assert
+    // absolute values so that flipping the exponent is caught independently of
+    // how the expectation is computed. (A pow 1/2.2 mistake would yield the
+    // much-too-bright approx (0.645, 0.855, 0.982) and wash the sky out.)
+    const day_sky = Vec3.init(97.0 / 255.0, 181.0 / 255.0, 245.0 / 255.0).toLinear();
+    try testing.expectApproxEqAbs(@as(f32, 0.119), day_sky.x, 0.01);
+    try testing.expectApproxEqAbs(@as(f32, 0.471), day_sky.y, 0.01);
+    try testing.expectApproxEqAbs(@as(f32, 0.916), day_sky.z, 0.01);
+}


### PR DESCRIPTION
Committed on branch `opencode/issue715-20260705221733`. Summary:

## Investigation result: the issue is **INVALID**

I could not confirm the issue — the reporter has the gamma direction backwards. `pow(x, 2.2)` **is** the correct sRGB→linear decoding (the EOTF), not the encoding. The issue's proposed `pow(x, 1/2.2)` is the inverse (OETF) and would double-brighten sRGB sky-blue `(97,181,245)` to roughly `(177,230,247)`, washing out the sky.

**Decisive evidence from the codebase itself:**
- `texture_atlas.zig:580` `srgbByteToLinear` uses `pow((c+0.055)/1.055, 2.4)` (the accurate EOTF)
- `post_process.frag:82-83` `agxEotf` — commented *"sRGB IEC 61966-2-1 2.2 Exponent Reference EOTF Display"* — applies `pow(x, 2.2)`
- `ui.frag:8-11` — *"convert to linear… `pow(vColor, 2.2)`"*
- `sky.frag:183` moon color `pow(..., 2.2)`
- `vulkan_swapchain.zig` uses `VK_FORMAT_B8G8R8A8_SRGB` → working space is linear, so CPU sRGB constants **must** be decoded with `pow(x, 2.2)`

So I did **not** implement the proposed change (it would be a regression). Instead, the commit:
1. Documents `Vec3.toLinear` as the sRGB EOTF (no behavior change).
2. Adds two regression tests in `src/math_tests.zig` pinning the correct direction — verified to **fail** when the exponent is flipped to `1/2.2` (285/287), so the audit's mistake can't be reintroduced.

**Side discovery worth a separate ticket:** tests in module-reexported files (e.g. `atmosphere/tests.zig`, `engine-math/utils_tests.zig`) reached via `_ = @import("module").tests` are **not executed** by `zig build test` under Zig 0.16 — so the existing atmosphere tests are silently dead. That's why the tests went in `src/math_tests.zig` (which runs, 287/287). `zig build test` passes.

Closes #715

<a href="https://opencode.ai/s/l8KQdh9T"><img width="200" alt="New%20session%20-%202026-07-05T22%3A17%3A33.050Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDIyOjE3OjMzLjA1MFo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=l8KQdh9T" /></a>
[opencode session](https://opencode.ai/s/l8KQdh9T)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28756753111)