### PR TITLE
Fixed font measureTextWidth off-by-scale bug

### DIFF
--- a/modules/engine-ui/src/font.zig
+++ b/modules/engine-ui/src/font.zig
@@ -59,7 +59,25 @@ pub fn measureTextWidth(text: []const u8, scale: f32) f32 {
     }
 
     if (text.len == 0) return 0;
-    return @as(f32, @floatFromInt(text.len)) * 6.0 * scale - scale;
+    return @as(f32, @floatFromInt(text.len)) * 6.0 * scale;
+}
+
+test "font measureTextWidth matches drawText advance (fallback path)" {
+    const scale: f32 = 2.0;
+    const cases = [_][]const u8{ "", "A", "AB", "ABC", "12345" };
+    for (cases) |t| {
+        const expected: f32 = @as(f32, @floatFromInt(t.len)) * 6.0 * scale;
+        try std.testing.expectEqual(expected, measureTextWidth(t, scale));
+    }
+    try std.testing.expectEqual(@as(f32, 0), measureTextWidth("", 1.0));
+}
+
+test "font measureTextWidth fallback scales linearly" {
+    const text = "HELLO";
+    try std.testing.expectEqual(
+        measureTextWidth(text, 1.0) * 3.0,
+        measureTextWidth(text, 3.0),
+    );
 }
 
 pub fn drawTextCentered(u: *UISystem, text: []const u8, cx: f32, y: f32, scale: f32, color: Color) void {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -106,4 +106,5 @@ test {
     _ = @import("world-runtime").world_mutation;
     _ = @import("engine-audio").sdl_audio;
     _ = @import("input_tests.zig");
+    _ = @import("engine-ui").font;
 }


### PR DESCRIPTION
Confirmed the bug and implemented the fix.

**Root cause** (`modules/engine-ui/src/font.zig:62`): The bitmap fallback returned `N * 6.0 * scale - scale`, but its own `drawText` advances the cursor by `6.0 * scale` per char (total `N * 6.0 * scale`), and the atlas path (`font_atlas.zig:104-112`) also returns the full accumulated advance. The `- scale` made the fallback inconsistent with both, causing text position to shift when the atlas was loaded/unloaded — affecting `drawTextCentered`, `drawTextCenteredFit`, widget caret positioning, and right-aligned timing overlays.

**Fix:** Removed the erroneous `- scale`, added unit tests (empty/single/multi-char + linear scaling), and wired `engine-ui.font` into the test aggregator.

**Verification:**
- `zig fmt` clean
- `zig build test -- --test-filter "font measureTextWidth"` → exit 0
- Full `zig build test` → exit 0 (no regressions)

Commit `f4cc3d4` on branch `opencode/issue714-20260705225136`, targeting `dev`.

Closes #714

<a href="https://opencode.ai/s/2hE2sWDc"><img width="200" alt="New%20session%20-%202026-07-05T22%3A51%3A35.102Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDIyOjUxOjM1LjEwMlo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=2hE2sWDc" /></a>
[opencode session](https://opencode.ai/s/2hE2sWDc)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28757630886)