### PR TITLE
Fixed AABB.contains half-open interval

### DIFF
--- a/libs/zig-math/aabb.zig
+++ b/libs/zig-math/aabb.zig
@@ -24,10 +24,16 @@ pub const AABB = struct {
         return self.max.sub(self.min);
     }
 
+    /// Returns true if `point` lies within this AABB using a half-open
+    /// interval `[min, max)` on each axis. This matches the voxel convention
+    /// where a block AABB `init((x, y, z), (x+1, y+1, z+1))` owns its lower
+    /// corner but excludes the upper corner, avoiding double-counting shared
+    /// block boundaries. The `min` corner is therefore contained while the
+    /// `max` corner is not.
     pub fn contains(self: AABB, point: Vec3) bool {
-        return point.x >= self.min.x and point.x <= self.max.x and
-            point.y >= self.min.y and point.y <= self.max.y and
-            point.z >= self.min.z and point.z <= self.max.z;
+        return point.x >= self.min.x and point.x < self.max.x and
+            point.y >= self.min.y and point.y < self.max.y and
+            point.z >= self.min.z and point.z < self.max.z;
     }
 
     pub fn intersects(self: AABB, other: AABB) bool {

--- a/src/math_tests.zig
+++ b/src/math_tests.zig
@@ -236,11 +236,35 @@ test "AABB fromCenterSize" {
 test "AABB contains point" {
     const aabb = AABB.init(Vec3.init(0, 0, 0), Vec3.init(10, 10, 10));
 
+    // Interior and min corner are contained (half-open [min, max)).
     try testing.expect(aabb.contains(Vec3.init(5, 5, 5)));
     try testing.expect(aabb.contains(Vec3.init(0, 0, 0)));
-    try testing.expect(aabb.contains(Vec3.init(10, 10, 10)));
+
+    // Just-below-max on each axis is contained.
+    try testing.expect(aabb.contains(Vec3.init(9.999, 9.999, 9.999)));
+
+    // Max corner is excluded by the half-open upper bound.
+    try testing.expect(!aabb.contains(Vec3.init(10, 10, 10)));
+    try testing.expect(!aabb.contains(Vec3.init(10, 5, 5)));
+    try testing.expect(!aabb.contains(Vec3.init(5, 10, 5)));
+    try testing.expect(!aabb.contains(Vec3.init(5, 5, 10)));
+
+    // Points fully outside are excluded.
     try testing.expect(!aabb.contains(Vec3.init(-1, 5, 5)));
     try testing.expect(!aabb.contains(Vec3.init(11, 5, 5)));
+}
+
+test "AABB contains voxel-sized region" {
+    // Mirrors the common voxel pattern: a unit block at the origin.
+    const block = AABB.init(Vec3.init(0, 0, 0), Vec3.init(1, 1, 1));
+
+    // Lower corner and interior are inside the block.
+    try testing.expect(block.contains(Vec3.init(0, 0, 0)));
+    try testing.expect(block.contains(Vec3.init(0.5, 0.5, 0.5)));
+
+    // The upper corner belongs to the neighboring block, not this one.
+    try testing.expect(!block.contains(Vec3.init(1, 1, 1)));
+    try testing.expect(!block.contains(Vec3.init(1, 0.5, 0.5)));
 }
 
 test "AABB intersects" {


### PR DESCRIPTION
Issue confirmed and fixed. Summary:

**Issue confirmed** at `libs/zig-math/aabb.zig:27-31` — `AABB.contains` used closed `[min, max]` comparisons, reporting the max corner as contained.

**Impact analysis:** Grepping all 52 `.contains()` callsites confirmed the *only* `AABB.contains` caller is the unit test. Collision detection (`isOnGround`, `collidesWithWorld`) uses `intersects` (unchanged, correct closed-interval intersection logic), and all other `.contains()` calls are on hash maps, enum sets, or a separate `Rect` struct — none affected.

**Fix (`50a078e`):**
- `libs/zig-math/aabb.zig`: changed `<=` → `<` for the upper bound on each axis, giving half-open `[min, max)` semantics matching voxel conventions, plus a doc comment.
- `src/math_tests.zig`: updated the existing test to expect the max corner to be excluded, added per-axis boundary coverage, and added a new `"AABB contains voxel-sized region"` test mirroring the real `init((x,y,z),(x+1,y+1,z+1))` block pattern.

**Verification:** `nix develop --command zig fmt` clean; `nix develop --command zig build test` passes (exit 0, including shader validation).

Pushed to `opencode/issue710-20260705231035` for PR creation targeting `dev`.

Closes #710

<a href="https://opencode.ai/s/hf5BLtqx"><img width="200" alt="New%20session%20-%202026-07-05T23%3A10%3A34.229Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDIzOjEwOjM0LjIyOVo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=hf5BLtqx" /></a>
[opencode session](https://opencode.ai/s/hf5BLtqx)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28758129932)