### PR TITLE
Fixed screenshot queue submit race.

### DIFF
--- a/modules/engine-graphics/src/vulkan/screenshot.zig
+++ b/modules/engine-graphics/src/vulkan/screenshot.zig
@@ -154,8 +154,8 @@ pub fn captureScreenshot(ctx: *VulkanContext, path: []const u8) bool {
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &cmd_buffer;
 
-    Utils.checkVk(c.vkQueueSubmit(device.queue, 1, &submit_info, fence)) catch {
-        log.log.err("screenshot: failed to submit command buffer", .{});
+    device.submitGuarded(submit_info, fence) catch |err| {
+        log.log.err("screenshot: vkQueueSubmit failed: {}", .{err});
         return false;
     };
     const fence_result = c.vkWaitForFences(vk, 1, &fence, c.VK_TRUE, 5_000_000_000);


### PR DESCRIPTION
Committed. The push and PR creation will be handled automatically by the opencode infrastructure.

## Summary

**Confirmed the issue** at `modules/engine-graphics/src/vulkan/screenshot.zig:157` — `captureScreenshot` was calling `vkQueueSubmit(device.queue, ...)` directly, bypassing the `device.mutex` serialization that all other submissions use via `submitGuarded`. This violated Vulkan's external synchronization requirement for queue submissions and would race with `FrameManager.endFrame()` if called concurrently. It also swallowed all errors with a generic catch.

**Fix:** Replaced the direct `vkQueueSubmit` + catch-all with `device.submitGuarded(submit_info, fence)`, matching the established pattern at `frame_manager.zig:195`. This satisfies all acceptance criteria:

- ✅ Acquires `device.mutex` before `vkQueueSubmit` (internally via `submitGuarded`)
- ✅ Handles `VK_ERROR_DEVICE_LOST` specially with `VK_EXT_device_fault` diagnostics
- ✅ Returns a typed error that is now logged with the specific error value (`{}`) instead of being swallowed
- ✅ Verified with `nix develop --command zig build test` (exit code 0)

I kept the `bool` return signature since it's part of the RHI vtable contract (`rhi.zig:1034`, `captureFrame`), avoiding ripple effects across the interface — the typed error is now logged with its specific value rather than swallowed.

Closes #709

<a href="https://opencode.ai/s/XWL0CHqx"><img width="200" alt="New%20session%20-%202026-07-05T23%3A19%3A29.823Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDIzOjE5OjI5LjgyM1o=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=XWL0CHqx" /></a>
[opencode session](https://opencode.ai/s/XWL0CHqx)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28758358593)