### PR TITLE
Fix generator deinit contract leak

### DIFF
--- a/modules/worldgen-overworld/src/overworld_generator.zig
+++ b/modules/worldgen-overworld/src/overworld_generator.zig
@@ -83,6 +83,15 @@ pub const OverworldGenerator = struct {
         };
     }
 
+    /// Release owned resources before the struct is destroyed.
+    ///
+    /// All fields of `OverworldGenerator` are inline value types with no heap
+    /// allocations (`classification_cache` is a fixed 256x256 inline grid,
+    /// `cache_mutex` is an inline primitive, and `terrain_shape` /
+    /// `biome_decorator` own no heap memory), so there is nothing to free here
+    /// today. This hook is still invoked by `deinitWrapper` so that any future
+    /// heap-owning field is cleaned up through the erased `Generator` interface
+    /// instead of leaking silently.
     pub fn deinit(self: *OverworldGenerator) void {
         _ = self;
     }
@@ -802,6 +811,7 @@ pub const OverworldGenerator = struct {
 
     fn deinitWrapper(ptr: *anyopaque, allocator: std.mem.Allocator) void {
         const self: *OverworldGenerator = @ptrCast(@alignCast(ptr));
+        self.deinit();
         allocator.destroy(self);
     }
 };


### PR DESCRIPTION
## Summary

**Confirmed the issue** (with nuance from the issue comment): the real bug is in `deinitWrapper` (`overworld_generator.zig:811`), which destroyed the struct through the erased `Generator` interface pointer **without** calling `self.deinit()` first — violating the `Generator` contract and leaving `deinit()` as dead code.

I verified all `OverworldGenerator` fields are inline value types (`ClassificationCache` is a fixed 256×256 inline grid, `cache_mutex`/`TerrainShapeGenerator`/`BiomeDecorator` own no heap memory), so this is a **latent leak** rather than an active ~16KB leak today. However, the contract violation is real, and any future heap-owning field would leak silently whenever a world unloads or a generator is replaced.

**Fix** (`modules/worldgen-overworld/src/overworld_generator.zig`):
- `deinitWrapper` now calls `self.deinit()` before `allocator.destroy(self)` — honoring the interface contract.
- Documented `deinit()` explaining why it's currently a no-op while remaining the hook the contract depends on.

**Verified**: `zig fmt` clean, `zig build test` passes (`EXIT_CODE=0`, includes shader validation).

Commit `cbdb23a` on `opencode/issue706-20260705235127` — the push and PR creation targeting `dev` are handled automatically by the infrastructure.

Note: The same `deinitWrapper`-skips-`deinit()` pattern exists in the flat, overworld-v2, and test generators (`modules/worldgen-flat/src/root.zig:162`, `modules/worldgen-overworld-v2/src/root.zig:391`, `modules/worldgen-test/src/root.zig:259`), but those generators currently have no `deinit()` method and only inline fields, so they're out of scope for this issue (#706 is scoped to `OverworldGenerator`). Worth a follow-up to add the same contract discipline there.

Closes #706

<a href="https://opencode.ai/s/nubxWNcT"><img width="200" alt="New%20session%20-%202026-07-05T23%3A51%3A26.540Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA1VDIzOjUxOjI2LjU0MFo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=nubxWNcT" /></a>
[opencode session](https://opencode.ai/s/nubxWNcT)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28759185409)