### PR TITLE
Fixed audio use-after-free (#683)

### DIFF
--- a/modules/engine-audio/src/backends/sdl_audio.zig
+++ b/modules/engine-audio/src/backends/sdl_audio.zig
@@ -215,6 +215,9 @@ const Mixer = struct {
 
         if (voice.active and voice.generation == handle.generation) {
             voice.active = false;
+            // Drop the reference to externally-owned SoundData so a subsequent
+            // free by SoundManager cannot leave us with a dangling pointer.
+            voice.sound_data = null;
         } else if (voice.active) {
             log.log.debug("stopVoice: generation mismatch (req: {}, act: {}), ignoring.", .{ handle.generation, voice.generation });
         }
@@ -377,6 +380,9 @@ const Mixer = struct {
 
         for (&self.voices) |*voice| {
             voice.active = false;
+            // Drop the reference to externally-owned SoundData so a subsequent
+            // free by SoundManager cannot leave us with a dangling pointer.
+            voice.sound_data = null;
         }
     }
 };
@@ -716,4 +722,81 @@ test "readSourceFrame handles large frame index without overflow overrun" {
         .length_samples = 1,
     };
     try testing.expect(readSourceFrame(&data, std.math.maxInt(usize)) == null);
+}
+
+// ---------------------------------------------------------------------------
+// Tests for dangling-pointer mitigation in Mixer voice lifecycle (Issue #683).
+//
+// Voices hold raw pointers to SoundData owned by SoundManager. stopAll() and
+// stopVoice() must clear those references so that a subsequent free by the
+// SoundManager cannot leave the mixer with dangling pointers. These tests do
+// not touch SDL: Mixer.init/stopAll/stopVoice only use the mutex.
+// ---------------------------------------------------------------------------
+
+fn dummySoundData() *const types.SoundData {
+    const S = struct {
+        var data: types.SoundData = .{
+            .buffer = &[_]u8{},
+            .frequency = 44100,
+            .channels = 1,
+            .format = .signed16,
+            .length_samples = 0,
+        };
+    };
+    return &S.data;
+}
+
+test "Mixer.stopAll clears sound_data pointers to avoid dangling refs" {
+    var mixer = Mixer.init();
+    defer mixer.stopAll();
+
+    // Set up two active voices referencing externally-owned SoundData.
+    const sd = dummySoundData();
+    mixer.voices[0] = .{ .active = true, .sound_data = sd, .generation = 10 };
+    mixer.voices[1] = .{ .active = true, .sound_data = sd, .generation = 11 };
+
+    mixer.stopAll();
+
+    // All voices must be inactive and must NOT retain any SoundData pointer.
+    for (mixer.voices) |v| {
+        try testing.expect(!v.active);
+        try testing.expect(v.sound_data == null);
+    }
+}
+
+test "Mixer.stopVoice clears sound_data pointer on matching generation" {
+    var mixer = Mixer.init();
+    defer mixer.stopAll();
+
+    const sd = dummySoundData();
+    const gen: u64 = 42;
+    mixer.voices[3] = .{ .active = true, .sound_data = sd, .generation = gen };
+
+    mixer.stopVoice(.{ .id = 3, .generation = gen });
+
+    try testing.expect(!mixer.voices[3].active);
+    try testing.expect(mixer.voices[3].sound_data == null);
+}
+
+test "Mixer.stopVoice does not clear a voice on generation mismatch" {
+    var mixer = Mixer.init();
+    defer mixer.stopAll();
+
+    const sd = dummySoundData();
+    mixer.voices[5] = .{ .active = true, .sound_data = sd, .generation = 7 };
+
+    // Wrong generation -> voice must remain untouched (still owned by caller).
+    mixer.stopVoice(.{ .id = 5, .generation = 999 });
+
+    try testing.expect(mixer.voices[5].active);
+    try testing.expect(mixer.voices[5].sound_data == sd);
+}
+
+test "Mixer.stopVoice ignores out-of-range voice id" {
+    var mixer = Mixer.init();
+    defer mixer.stopAll();
+
+    // Must not crash or panic on an id beyond the voice array.
+    mixer.stopVoice(.{ .id = MAX_VOICES + 1, .generation = 1 });
+    try testing.expect(true);
 }

--- a/modules/engine-audio/src/system.zig
+++ b/modules/engine-audio/src/system.zig
@@ -60,13 +60,21 @@ pub const AudioSystem = struct {
     }
 
     /// Shutdown the audio system and free resources.
+    ///
+    /// Ordering is critical: the backend (and its Mixer) holds pointers into
+    /// `SoundData` owned by `manager`. We must stop voices, tear down the
+    /// backend/Mixer (the consumer of those buffers), and only then free the
+    /// `SoundData` via `manager.deinit()`. Reversing this order leaves the
+    /// Mixer with dangling pointers to freed `SoundData` — a use-after-free
+    /// (CWE-416). See issue #683.
     pub fn deinit(self: *AudioSystem) void {
         self.stopAll();
-        self.manager.deinit();
         if (self.backend_ptr) |ptr| {
             const backend_inst: *sdl_backend.SDLAudioBackend = @ptrCast(@alignCast(ptr));
             backend_inst.destroy();
+            self.backend_ptr = null;
         }
+        self.manager.deinit();
         self.allocator.destroy(self);
     }
 


### PR DESCRIPTION
The fix is committed on the feature branch `opencode/issue683-20260706001142` (targeting `dev`).

## Summary

**Confirmed** the use-after-free vulnerability (CWE-416) in `AudioSystem.deinit()`:

`AudioSystem.deinit()` (`system.zig:65`) called `manager.deinit()` — which frees every `SoundData` buffer **and** the `ArrayList` backing store that stores the `SoundData` structs themselves — **before** destroying the SDL backend/Mixer (`system.zig:66-68`). The `Mixer`'s `Voice.sound_data` pointers point into that backing store, so they became dangling. The `if (voice.sound_data == null)` guard in `mix()` does not catch this since a freed pointer is non-null.

**Three-layer fix:**
1. `modules/engine-audio/src/system.zig` — Reordered `deinit()` so the backend (Mixer, the consumer of `SoundData`) is destroyed **before** `manager.deinit()` frees the buffers.
2. `modules/engine-audio/src/backends/sdl_audio.zig` — `Mixer.stopAll()` and `Mixer.stopVoice()` now clear `sound_data = null` so stopped voices never retain stale references.
3. Added regression tests for the clearing behavior.

**Verification:**
- `zig build` and `zig build test` (289/289) pass.
- Ran `zig test` directly on the `sdl_audio` module (the test runner doesn't collect module tests in this Zig 0.16 setup) — all 4 new `Mixer` tests pass, confirming `stopAll`/`stopVoice` clear pointers and that generation-mismatch voices are left intact.
- Runtime smoke test couldn't run (no Vulkan surface in this headless env) — unrelated environment constraint.

Closes #683

<a href="https://opencode.ai/s/arKhWJXO"><img width="200" alt="New%20session%20-%202026-07-06T00%3A11%3A42.065Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA2VDAwOjExOjQyLjA2NVo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=arKhWJXO" /></a>
[opencode session](https://opencode.ai/s/arKhWJXO)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28759757631)