### PR TITLE
Issue #705 is a false positive; `<=` is correct.

### DIFF
--- a/modules/world-meshing/src/chunk_mesh.zig
+++ b/modules/world-meshing/src/chunk_mesh.zig
@@ -158,7 +158,14 @@ pub const ChunkMesh = struct {
         const y0: i32 = @intCast(si * SUBCHUNK_SIZE);
         const y1: i32 = y0 + SUBCHUNK_SIZE;
 
-        // Mesh horizontal slices (top/bottom faces)
+        // Mesh horizontal slices (top/bottom faces).
+        // The loop iterates over boundary SLICES, not blocks: a subchunk of 16
+        // blocks has 17 horizontal boundaries (y0..y0+16). The top face of the
+        // topmost block (y=y1-1) lives at slice s=y1, so the bound is inclusive
+        // (`<=`). This mirrors the sx/sz loops below. boundary.isEmittingSubchunk
+        // assigns each face to exactly one subchunk, so there is no duplication.
+        // (Block-iterating meshers like flat_quad_mesher use `< y1` instead
+        // because they loop over 16 blocks, not 17 boundaries.)
         var sy: i32 = y0;
         while (sy <= y1) : (sy += 1) {
             try greedy_mesher.meshSlice(self.allocator, chunk, neighbors, .top, sy, si, solid_verts, cutout_verts, fluid_verts, atlas, mask);

--- a/src/world_inline_tests.zig
+++ b/src/world_inline_tests.zig
@@ -276,6 +276,55 @@ test "single block generates 6 faces" {
     try testing.expectEqual(@as(u32, 36), total_verts);
 }
 
+test "block at subchunk top boundary keeps its top face" {
+    // A stone cube at y=15 sits on the top layer of subchunk 0. Its top face
+    // lives at boundary slice s=16. buildSubchunk must iterate the horizontal
+    // slice loop inclusively (sy <= y1) to reach s=16; an off-by-one (`< y1`)
+    // would drop the top face and yield only 30 verts instead of 36.
+    var atlas: TextureAtlas = undefined;
+    @memset(std.mem.asBytes(&atlas.tile_mappings), 0);
+
+    var chunk = Chunk.init(0, 0);
+    chunk.setBlock(8, 15, 8, .stone);
+
+    var mesh = ChunkMesh.init(testing.allocator);
+    defer mesh.deinitWithoutRHI();
+    try mesh.buildWithNeighbors(&chunk, .empty, &atlas);
+
+    var total_verts: u32 = 0;
+    if (mesh.pending_solid) |v| total_verts += @intCast(v.len);
+    if (mesh.pending_fluid) |v| total_verts += @intCast(v.len);
+    try testing.expectEqual(@as(u32, 36), total_verts);
+
+    // The top face vertices sit at y=16 (slice above y=15).
+    if (mesh.pending_solid) |verts| {
+        var found_top = false;
+        for (verts) |v| {
+            if (v.pos[1] == 16.0) found_top = true;
+        }
+        try testing.expect(found_top);
+    }
+}
+
+test "block at world ceiling (y=255) keeps its top face" {
+    // Topmost subchunk (si=15): the top face of y=255 is at slice s=256, which
+    // queries above the world (air / full sky). This must still be emitted.
+    var atlas: TextureAtlas = undefined;
+    @memset(std.mem.asBytes(&atlas.tile_mappings), 0);
+
+    var chunk = Chunk.init(0, 0);
+    chunk.setBlock(8, 255, 8, .stone);
+
+    var mesh = ChunkMesh.init(testing.allocator);
+    defer mesh.deinitWithoutRHI();
+    try mesh.buildWithNeighbors(&chunk, .empty, &atlas);
+
+    var total_verts: u32 = 0;
+    if (mesh.pending_solid) |v| total_verts += @intCast(v.len);
+    if (mesh.pending_fluid) |v| total_verts += @intCast(v.len);
+    try testing.expectEqual(@as(u32, 36), total_verts);
+}
+
 test "adjacent blocks share face (no internal faces)" {
     var atlas: TextureAtlas = undefined;
     @memset(std.mem.asBytes(&atlas.tile_mappings), 0);


### PR DESCRIPTION
Done. Summary of my investigation:

**The issue is a false positive — the `<= y1` loop is correct and the proposed fix would break rendering.**

I confirmed this empirically by temporarily applying the proposed `while (sy < y1)` fix and running a regression test:
- A stone block at y=15 (top of subchunk 0) generated **30 verts instead of 36** — its **top face was dropped**.

**Why `<=` is correct:** `buildSubchunk` iterates over boundary **slices**, not blocks. 16 blocks ⇒ 17 horizontal boundaries (`y0..y0+16`). The top face of the topmost block (`y=y1-1`) lives at slice `s=y1`, requiring the inclusive bound — identical to the `sx`/`sz` loops in the same function. `boundary.isEmittingSubchunk` assigns each face to exactly one subchunk, so there's no duplication. The issue's comparison to `flat_quad_mesher` was apples-to-oranges: that mesher loops over 16 *blocks* (`< y1`), not 17 *boundaries*.

**Changes (PR targets `dev`):**
- `chunk_mesh.zig`: Added explanatory comment on the inclusive bound (no behavior change).
- `world_inline_tests.zig`: Two regression tests proving the top face is emitted at a subchunk boundary (y=15→slice 16) and the world ceiling (y=255→slice 256).

Closes #705

<a href="https://opencode.ai/s/CcrBINFC"><img width="200" alt="New%20session%20-%202026-07-06T00%3A36%3A03.915Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA3LTA2VDAwOjM2OjAzLjkxNVo=.png?model=zhipuai-coding-plan/glm-5.2&version=1.17.13&id=CcrBINFC" /></a>
[opencode session](https://opencode.ai/s/CcrBINFC)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/OpenStaticFish/ZigCraft/actions/runs/28760476356)