### PR TITLE
fix(audit): resolve 11 open [Audit] bug issues (#702-#747)

### DIFF
--- a/modules/engine-graphics/src/camera.zig
+++ b/modules/engine-graphics/src/camera.zig
@@ -3,34 +3,9 @@
 const std = @import("std");
 const Vec3 = @import("engine-math").Vec3;
 const Mat4 = @import("engine-math").Mat4;
-const Input = @import("engine-input").Input;
-const Key = @import("engine-core").interfaces.Key;
 
 pub const Camera = struct {
     pub const MovementVector = struct { x: f32, z: f32 };
-
-    pub const InputMapperView = struct {
-        ptr: *const anyopaque,
-        vtable: *const VTable,
-
-        pub const VTable = struct {
-            getMovementVector: *const fn (ptr: *const anyopaque, input: *const Input) MovementVector,
-            isJumpActive: *const fn (ptr: *const anyopaque, input: *const Input) bool,
-            isCrouchActive: *const fn (ptr: *const anyopaque, input: *const Input) bool,
-        };
-
-        pub fn getMovementVector(self: InputMapperView, input: *const Input) MovementVector {
-            return self.vtable.getMovementVector(self.ptr, input);
-        }
-
-        pub fn isJumpActive(self: InputMapperView, input: *const Input) bool {
-            return self.vtable.isJumpActive(self.ptr, input);
-        }
-
-        pub fn isCrouchActive(self: InputMapperView, input: *const Input) bool {
-            return self.vtable.isCrouchActive(self.ptr, input);
-        }
-    };
 
     // 4-tap Halton(2,3) sequence centered to [-0.5, 0.5] pixel offsets.
     // We keep this to 4 samples to keep temporal convergence fast while matching
@@ -114,37 +89,11 @@ pub const Camera = struct {
         return JITTER_SEQUENCE[self.jitter_index];
     }
 
-    /// Update camera from input (call once per frame)
-    pub fn update(self: *Camera, input: *const Input, mapper: InputMapperView, delta_time: f32) void {
-        // Mouse look
-        const mouse_delta = input.getMouseDelta();
-        if (input.mouse_captured) {
-            self.yaw += @as(f32, @floatFromInt(mouse_delta.x)) * self.sensitivity;
-            self.pitch -= @as(f32, @floatFromInt(mouse_delta.y)) * self.sensitivity;
-
-            // Clamp pitch to prevent flipping
-            const max_pitch = std.math.degreesToRadians(89.0);
-            self.pitch = std.math.clamp(self.pitch, -max_pitch, max_pitch);
-
-            self.updateVectors();
-        }
-
-        // Keyboard movement
-        var move_dir = Vec3.zero;
-
-        const move_vec = mapper.getMovementVector(input);
-        if (move_vec.z > 0) move_dir = move_dir.add(self.forward);
-        if (move_vec.z < 0) move_dir = move_dir.sub(self.forward);
-        if (move_vec.x < 0) move_dir = move_dir.sub(self.right);
-        if (move_vec.x > 0) move_dir = move_dir.add(self.right);
-        if (mapper.isJumpActive(input)) move_dir = move_dir.add(Vec3.up);
-        if (mapper.isCrouchActive(input)) move_dir = move_dir.sub(Vec3.up);
-
-        // Normalize and apply speed
-        if (move_dir.lengthSquared() > 0) {
-            move_dir = move_dir.normalize();
-            self.position = self.position.add(move_dir.scale(self.move_speed * delta_time));
-        }
+    /// Set camera orientation directly and refresh cached axes.
+    pub fn setYawPitch(self: *Camera, yaw: f32, pitch: f32) void {
+        self.yaw = yaw;
+        self.pitch = pitch;
+        self.updateVectors();
     }
 
     fn updateVectors(self: *Camera) void {
@@ -160,13 +109,6 @@ pub const Camera = struct {
 
         // Up = right cross forward
         self.up = self.right.cross(self.forward).normalize();
-    }
-
-    /// Set camera orientation directly and refresh cached axes.
-    pub fn setYawPitch(self: *Camera, yaw: f32, pitch: f32) void {
-        self.yaw = yaw;
-        self.pitch = pitch;
-        self.updateVectors();
     }
 
     /// Get view matrix

--- a/modules/engine-graphics/src/camera.zig
+++ b/modules/engine-graphics/src/camera.zig
@@ -5,8 +5,6 @@ const Vec3 = @import("engine-math").Vec3;
 const Mat4 = @import("engine-math").Mat4;
 
 pub const Camera = struct {
-    pub const MovementVector = struct { x: f32, z: f32 };
-
     // 4-tap Halton(2,3) sequence centered to [-0.5, 0.5] pixel offsets.
     // We keep this to 4 samples to keep temporal convergence fast while matching
     // the current low-latency TAA target (minimal history lag and ghosting).

--- a/modules/engine-input/src/input.zig
+++ b/modules/engine-input/src/input.zig
@@ -125,8 +125,7 @@ pub const Input = struct {
                 }
             },
             c.SDL_EVENT_MOUSE_WHEEL => {
-                self.scroll_x = event.wheel.x;
-                self.scroll_y = event.wheel.y;
+                self.recordMouseWheel(event.wheel.x, event.wheel.y);
             },
             c.SDL_EVENT_WINDOW_RESIZED, c.SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED => {
                 // Use pixel size, not logical size, for proper HiDPI/Wayland support
@@ -163,6 +162,13 @@ pub const Input = struct {
     pub fn recordKeyUp(self: *Input, key: Key) void {
         self.keys_released.put(key, {}) catch return;
         _ = self.keys_down.remove(key);
+    }
+
+    /// Record a mouse wheel event. Multiple events within the same frame accumulate; `beginFrame` resets the totals.
+    /// Previously each event overwrote the previous delta, dropping rapid-scroll input. See issue #711.
+    pub fn recordMouseWheel(self: *Input, dx: f32, dy: f32) void {
+        self.scroll_x += dx;
+        self.scroll_y += dy;
     }
 
     // ========================================================================

--- a/modules/world-core/src/chunk.zig
+++ b/modules/world-core/src/chunk.zig
@@ -148,12 +148,16 @@ pub const Chunk = struct {
     }
 
     pub fn getLightSafe(self: *const Chunk, x: i32, y: i32, z: i32) PackedLight {
-        // Out-of-bounds in any direction returns zero light. Previously this returned MAX_LIGHT sky light for
-        // y >= CHUNK_SIZE_Y (a "light leak at chunk tops" — see issue #702). The meshing system samples across the Y=CHUNK_SIZE_Y
-        // boundary during subchunk meshing, and returning full daylight there caused bright visual artifacts at
-        // chunk tops. Returning 0 light is consistent with getBlockSafe and the X/Z bounds below.
+        // Out-of-bounds X/Z returns zero light. Out-of-bounds Y returns:
+        //   - MAX_LIGHT sky light for y >= CHUNK_SIZE_Y: the meshing system samples this
+        //     position to light the TOP FACE of the highest block in each column (e.g. a
+        //     mountain peak at y=255 queries y=256). The space above the world is open
+        //     sky, so the face should be full daylight. Returning 0 here makes mountain
+        //     tops render incorrectly dark.
+        //   - 0 light for y < 0: nothing emits light from below the world.
         if (x < 0 or x >= CHUNK_SIZE_X or z < 0 or z >= CHUNK_SIZE_Z) return PackedLight.init(0, 0);
-        if (y < 0 or y >= CHUNK_SIZE_Y) return PackedLight.init(0, 0);
+        if (y >= CHUNK_SIZE_Y) return PackedLight.init(MAX_LIGHT, 0);
+        if (y < 0) return PackedLight.init(0, 0);
         return self.getLight(@intCast(x), @intCast(y), @intCast(z));
     }
 

--- a/modules/world-core/src/chunk.zig
+++ b/modules/world-core/src/chunk.zig
@@ -148,9 +148,12 @@ pub const Chunk = struct {
     }
 
     pub fn getLightSafe(self: *const Chunk, x: i32, y: i32, z: i32) PackedLight {
+        // Out-of-bounds in any direction returns zero light. Previously this returned MAX_LIGHT sky light for
+        // y >= CHUNK_SIZE_Y (a "light leak at chunk tops" — see issue #702). The meshing system samples across the Y=CHUNK_SIZE_Y
+        // boundary during subchunk meshing, and returning full daylight there caused bright visual artifacts at
+        // chunk tops. Returning 0 light is consistent with getBlockSafe and the X/Z bounds below.
         if (x < 0 or x >= CHUNK_SIZE_X or z < 0 or z >= CHUNK_SIZE_Z) return PackedLight.init(0, 0);
-        if (y >= CHUNK_SIZE_Y) return PackedLight.init(MAX_LIGHT, 0);
-        if (y < 0) return PackedLight.init(0, 0);
+        if (y < 0 or y >= CHUNK_SIZE_Y) return PackedLight.init(0, 0);
         return self.getLight(@intCast(x), @intCast(y), @intCast(z));
     }
 

--- a/modules/world-core/src/chunk_tests.zig
+++ b/modules/world-core/src/chunk_tests.zig
@@ -134,10 +134,23 @@ test "Chunk.setBlock marks dirty and modified" {
     try testing.expect(chunk.modified);
 }
 
-test "Chunk.getLightSafe returns max light above world" {
+test "Chunk.getLightSafe returns zero for y above world (regression for #702)" {
+    // Previously this returned MAX_LIGHT for y >= CHUNK_SIZE_Y, leaking sky light through chunk tops during meshing.
+    // Out-of-bounds Y should be dark like the other OOB cases (matches getBlockSafe semantics).
     var chunk = Chunk.init(0, 0);
-    const light = chunk.getLightSafe(8, 300, 8);
-    try testing.expectEqual(@as(u4, MAX_LIGHT), light.sky_light);
+    const light_above = chunk.getLightSafe(8, 300, 8);
+    try testing.expectEqual(@as(u4, 0), light_above.sky_light);
+    try testing.expectEqual(@as(u4, 0), light_above.getBlockLight());
+
+    // The Y = CHUNK_SIZE_Y boundary itself (the most common sampling site at the topmost subchunk) must also be dark.
+    const light_at_boundary = chunk.getLightSafe(8, CHUNK_SIZE_Y, 8);
+    try testing.expectEqual(@as(u4, 0), light_at_boundary.sky_light);
+    try testing.expectEqual(@as(u4, 0), light_at_boundary.getBlockLight());
+
+    // In-bounds Y at the very top of the world still returns whatever was stored there.
+    chunk.setSkyLight(8, CHUNK_SIZE_Y - 1, 8, MAX_LIGHT);
+    const light_top_in_world = chunk.getLightSafe(8, CHUNK_SIZE_Y - 1, 8);
+    try testing.expectEqual(@as(u4, MAX_LIGHT), light_top_in_world.sky_light);
 }
 
 test "Chunk.getLightSafe returns zero for negative y" {

--- a/modules/world-core/src/chunk_tests.zig
+++ b/modules/world-core/src/chunk_tests.zig
@@ -134,23 +134,21 @@ test "Chunk.setBlock marks dirty and modified" {
     try testing.expect(chunk.modified);
 }
 
-test "Chunk.getLightSafe returns zero for y above world (regression for #702)" {
-    // Previously this returned MAX_LIGHT for y >= CHUNK_SIZE_Y, leaking sky light through chunk tops during meshing.
-    // Out-of-bounds Y should be dark like the other OOB cases (matches getBlockSafe semantics).
+test "Chunk.getLightSafe returns max sky light above world (top-face meshing contract)" {
+    // y >= CHUNK_SIZE_Y represents the open sky above the world. The greedy mesher
+    // samples this position to light the TOP FACE of the highest block in each column
+    // (e.g. a mountain peak at y=255 queries y=256 via lighting_sampler.sampleLightAtBoundary).
+    // Returning MAX_LIGHT here is what makes mountain tops correctly sky-lit. Returning 0
+    // would render them dark. See also: boundary.getLightCross (consistent with this).
     var chunk = Chunk.init(0, 0);
-    const light_above = chunk.getLightSafe(8, 300, 8);
-    try testing.expectEqual(@as(u4, 0), light_above.sky_light);
-    try testing.expectEqual(@as(u4, 0), light_above.getBlockLight());
+    const light = chunk.getLightSafe(8, 300, 8);
+    try testing.expectEqual(@as(u4, MAX_LIGHT), light.sky_light);
+    try testing.expectEqual(@as(u4, 0), light.getBlockLight());
 
-    // The Y = CHUNK_SIZE_Y boundary itself (the most common sampling site at the topmost subchunk) must also be dark.
+    // The Y = CHUNK_SIZE_Y boundary itself is the canonical sampling site for the
+    // topmost subchunk's top faces and must also return full sky light.
     const light_at_boundary = chunk.getLightSafe(8, CHUNK_SIZE_Y, 8);
-    try testing.expectEqual(@as(u4, 0), light_at_boundary.sky_light);
-    try testing.expectEqual(@as(u4, 0), light_at_boundary.getBlockLight());
-
-    // In-bounds Y at the very top of the world still returns whatever was stored there.
-    chunk.setSkyLight(8, CHUNK_SIZE_Y - 1, 8, MAX_LIGHT);
-    const light_top_in_world = chunk.getLightSafe(8, CHUNK_SIZE_Y - 1, 8);
-    try testing.expectEqual(@as(u4, MAX_LIGHT), light_top_in_world.sky_light);
+    try testing.expectEqual(@as(u4, MAX_LIGHT), light_at_boundary.sky_light);
 }
 
 test "Chunk.getLightSafe returns zero for negative y" {

--- a/modules/world-meshing/src/chunk_mesh.zig
+++ b/modules/world-meshing/src/chunk_mesh.zig
@@ -178,7 +178,7 @@ pub const ChunkMesh = struct {
         // Mesh horizontal slices (top/bottom faces). The loop iterates 17 boundaries
         // per subchunk (sy in [y0, y1] inclusive), mirroring the sx/sz loops below.
         // This is correct, NOT an off-by-one: greedy_mesher.meshSlice uses
-        // isEmittingSubchunk(.top, s - 1, ...) to assign each boundary face to the
+        // isEmittingSubchunk(.top, sy - 1, ...) to assign each boundary face to the
         // subchunk that owns the solid block, so no geometry is duplicated.
         //
         // The topmost iteration (sy = y1) is the boundary between the highest block

--- a/modules/world-meshing/src/chunk_mesh.zig
+++ b/modules/world-meshing/src/chunk_mesh.zig
@@ -175,9 +175,13 @@ pub const ChunkMesh = struct {
         const y0: i32 = @intCast(si * SUBCHUNK_SIZE);
         const y1: i32 = y0 + SUBCHUNK_SIZE;
 
-        // Mesh horizontal slices (top/bottom faces)
+        // Mesh horizontal slices (top/bottom faces). Iterate over the 16 Y layers of this subchunk
+        // (sy in [y0, y1)). The previous `sy <= y1` form iterated 17 times per subchunk and produced a
+        // duplicate slice at every subchunk boundary (e.g. sy=16 was visited by both subchunk 0 and 1).
+        // For the topmost subchunk it also queried getLightSafe at y=CHUNK_SIZE_Y, triggering the
+        // chunk-top light leak fixed alongside this in #702. See issue #705.
         var sy: i32 = y0;
-        while (sy <= y1) : (sy += 1) {
+        while (sy < y1) : (sy += 1) {
             try greedy_mesher.meshSlice(self.allocator, chunk, neighbors, .top, sy, si, solid_verts, cutout_verts, fluid_verts, atlas, mask);
         }
         // Mesh east/west face slices

--- a/modules/world-meshing/src/chunk_mesh.zig
+++ b/modules/world-meshing/src/chunk_mesh.zig
@@ -175,13 +175,21 @@ pub const ChunkMesh = struct {
         const y0: i32 = @intCast(si * SUBCHUNK_SIZE);
         const y1: i32 = y0 + SUBCHUNK_SIZE;
 
-        // Mesh horizontal slices (top/bottom faces). Iterate over the 16 Y layers of this subchunk
-        // (sy in [y0, y1)). The previous `sy <= y1` form iterated 17 times per subchunk and produced a
-        // duplicate slice at every subchunk boundary (e.g. sy=16 was visited by both subchunk 0 and 1).
-        // For the topmost subchunk it also queried getLightSafe at y=CHUNK_SIZE_Y, triggering the
-        // chunk-top light leak fixed alongside this in #702. See issue #705.
+        // Mesh horizontal slices (top/bottom faces). The loop iterates 17 boundaries
+        // per subchunk (sy in [y0, y1] inclusive), mirroring the sx/sz loops below.
+        // This is correct, NOT an off-by-one: greedy_mesher.meshSlice uses
+        // isEmittingSubchunk(.top, s - 1, ...) to assign each boundary face to the
+        // subchunk that owns the solid block, so no geometry is duplicated.
+        //
+        // The topmost iteration (sy = y1) is the boundary between the highest block
+        // of this subchunk (y = y1 - 1) and the block above. For interior subchunks
+        // that block belongs to the next subchunk; for the topmost subchunk
+        // (si = NUM_SUBCHUNKS - 1) it is the world-ceiling boundary at y = CHUNK_SIZE_Y.
+        // Dropping this iteration (e.g. `sy < y1`) loses the top face of the highest
+        // cube in every subchunk — see chunk_mesh_tests "emits top face for cube at
+        // subchunk boundary".
         var sy: i32 = y0;
-        while (sy < y1) : (sy += 1) {
+        while (sy <= y1) : (sy += 1) {
             try greedy_mesher.meshSlice(self.allocator, chunk, neighbors, .top, sy, si, solid_verts, cutout_verts, fluid_verts, atlas, mask);
         }
         // Mesh east/west face slices

--- a/modules/world-meshing/src/chunk_mesh_tests.zig
+++ b/modules/world-meshing/src/chunk_mesh_tests.zig
@@ -165,3 +165,51 @@ test "ChunkMesh tall_cross renders full height at subchunk top boundary" {
     try testing.expect(found_y15);
     try testing.expect(found_y17);
 }
+
+test "ChunkMesh emits top face for cube at subchunk boundary (regression for #705)" {
+    // Place a stone cube at y=15 — the LAST layer of subchunk 0. Its top face
+    // lives at the sy=16 boundary (between subchunk 0 and subchunk 1).
+    //
+    // The horizontal slice loop MUST iterate `sy <= y1` so subchunk 0 can emit
+    // this top face: greedy_mesher.meshSlice uses isEmittingSubchunk(.top, s - 1, ...)
+    // to assign the face to the subchunk that OWNS the solid block (y=15 → subchunk 0).
+    // Switching to `sy < y1` dropped the sy=16 iteration, so the top face was never
+    // emitted — and this happened at EVERY subchunk boundary (y=15, 31, ..., 255),
+    // not just the world ceiling.
+    //
+    // A standalone cube surrounded by air emits all 6 faces (6 verts each = 36).
+    // With the `sy < y1` regression only 5 faces (30 verts) were emitted.
+    var chunk = world_core.Chunk.init(0, 0);
+    chunk.setBlock(1, 15, 1, .stone);
+
+    var atlas: TextureAtlas = undefined;
+    atlas.tile_mappings = [_]TextureAtlas.BlockTiles{TextureAtlas.BlockTiles.uniform(7)} ** 256;
+
+    var mesh = ChunkMesh.init(testing.allocator);
+    defer mesh.deinitWithoutRHI();
+
+    try mesh.buildWithNeighbors(&chunk, NeighborChunks.empty, &atlas);
+
+    try testing.expect(mesh.pending_solid != null);
+    try testing.expectEqual(@as(usize, 36), mesh.pending_solid.?.len);
+}
+
+test "ChunkMesh emits top face for cube at world ceiling (regression for #705)" {
+    // Same regression at the world ceiling: a cube at y=CHUNK_SIZE_Y-1 needs its
+    // top face meshed at the sy=CHUNK_SIZE_Y boundary. This is the exact case
+    // the PR review flagged (mountain peaks at y=255 would show a hole).
+    const top_y = world_core.CHUNK_SIZE_Y - 1;
+    var chunk = world_core.Chunk.init(0, 0);
+    chunk.setBlock(1, top_y, 1, .stone);
+
+    var atlas: TextureAtlas = undefined;
+    atlas.tile_mappings = [_]TextureAtlas.BlockTiles{TextureAtlas.BlockTiles.uniform(7)} ** 256;
+
+    var mesh = ChunkMesh.init(testing.allocator);
+    defer mesh.deinitWithoutRHI();
+
+    try mesh.buildWithNeighbors(&chunk, NeighborChunks.empty, &atlas);
+
+    try testing.expect(mesh.pending_solid != null);
+    try testing.expectEqual(@as(usize, 36), mesh.pending_solid.?.len);
+}

--- a/modules/worldgen-overworld-v2/src/trees.zig
+++ b/modules/worldgen-overworld-v2/src/trees.zig
@@ -32,7 +32,9 @@ pub fn placeTrees(self: anytype, chunk: *Chunk, stop_flag: ?*const bool) void {
         var local_x: u32 = 0;
         while (local_x < CHUNK_SIZE_X) : (local_x += 1) {
             const surface_y = chunk.getSurfaceHeight(local_x, local_z);
-            if (surface_y <= self.params.sea_level or surface_y >= CHUNK_SIZE_Y - 8) continue;
+            // Explicit i32 cast: CHUNK_SIZE_Y is u32; mixed-sign comparison currently compiles via comptime peer resolution,
+            // but make it explicit so future type changes can't silently produce wrong results. See issue #707.
+            if (@as(i32, surface_y) <= self.params.sea_level or @as(i32, surface_y) >= @as(i32, CHUNK_SIZE_Y) - 8) continue;
 
             const surface = chunk.getBlock(local_x, @intCast(surface_y), local_z);
             if (surface != .grass and surface != .dirt and surface != .snow_block and surface != .sand) continue;

--- a/modules/worldgen-overworld-v2/src/vegetation.zig
+++ b/modules/worldgen-overworld-v2/src/vegetation.zig
@@ -28,7 +28,8 @@ pub fn placeVegetation(self: anytype, chunk: *Chunk, stop_flag: ?*const bool) vo
         var local_x: u32 = 0;
         while (local_x < CHUNK_SIZE_X) : (local_x += 1) {
             const surface_y = chunk.getSurfaceHeight(local_x, local_z);
-            if (surface_y <= 0 or surface_y >= CHUNK_SIZE_Y - 2) continue;
+            // Explicit i32 cast on both sides of the bounds check. See issue #707 / trees.zig for rationale.
+            if (@as(i32, surface_y) <= 0 or @as(i32, surface_y) >= @as(i32, CHUNK_SIZE_Y) - 2) continue;
 
             const biome = chunk.biomes[local_x + local_z * CHUNK_SIZE_X];
             const surface = chunk.getBlock(local_x, @intCast(surface_y), local_z);

--- a/src/input_tests.zig
+++ b/src/input_tests.zig
@@ -71,3 +71,23 @@ test "recordKeyUp clears down and marks released on success" {
     try testing.expect(!input.isKeyDown(.w));
     try testing.expect(input.isKeyReleased(.w));
 }
+
+test "recordMouseWheel accumulates per frame (regression for #711)" {
+    // Multiple SDL wheel events can fire between beginFrame() calls (high-resolution mice,
+    // trackpads, rapid gestures). Previously the second event overwrote the first via `=`,
+    // dropping deltas and causing inventory/UI scroll to skip slots and zoom to feel erratic.
+    var input = Input.init(testing.allocator);
+    defer input.deinit();
+
+    input.recordMouseWheel(1.0, 2.0);
+    input.recordMouseWheel(1.0, 3.0);
+    input.recordMouseWheel(-1.0, 1.0);
+
+    try testing.expectEqual(@as(f32, 1.0), input.scroll_x);
+    try testing.expectEqual(@as(f32, 6.0), input.scroll_y);
+
+    // beginFrame must still zero out the totals for the next frame.
+    input.beginFrame();
+    try testing.expectEqual(@as(f32, 0.0), input.scroll_x);
+    try testing.expectEqual(@as(f32, 0.0), input.scroll_y);
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -106,5 +106,6 @@ test {
     _ = @import("world-runtime").world_mutation;
     _ = @import("engine-audio").sdl_audio;
     _ = @import("input_tests.zig");
+    _ = @import("text_input_tests.zig");
     _ = @import("engine-ui").font;
 }

--- a/src/text_input_tests.zig
+++ b/src/text_input_tests.zig
@@ -1,0 +1,151 @@
+//! Regression tests for `text_input.handleTextTyping`.
+//!
+//! The audit (#708) claimed `std.ascii.toUpper('a')` returns `'a'` unchanged,
+//! implying Shift+letter produced lowercase output. That claim is incorrect — Zig's
+//! `std.ascii.toUpper('a')` returns `'A'`. These tests lock in the correct
+//! uppercase-on-shift behavior so any future regression (e.g. by switching to a
+//! different cast path) is caught immediately.
+
+const std = @import("std");
+const testing = std.testing;
+const Key = @import("engine-core").interfaces.Key;
+const IRawInputProvider = @import("engine-input").IRawInputProvider;
+const handleTextTyping = @import("game-core").text_input.handleTextTyping;
+
+/// In-memory mock of `IRawInputProvider` that reports a fixed set of "pressed" keys
+/// plus optional left/right shift state. Each VTable method just forwards to the
+/// struct's stored sets.
+const MockInput = struct {
+    pressed: std.AutoHashMap(Key, void),
+    shift_down: bool = false,
+
+    fn init(allocator: std.mem.Allocator, shift: bool) MockInput {
+        const pressed = std.AutoHashMap(Key, void).init(allocator);
+        return .{ .pressed = pressed, .shift_down = shift };
+    }
+
+    fn deinit(self: *MockInput) void {
+        self.pressed.deinit();
+    }
+
+    fn press(self: *MockInput, key: Key) !void {
+        try self.pressed.put(key, {});
+    }
+
+    fn interface(self: *MockInput) IRawInputProvider {
+        return .{ .ptr = self, .vtable = &VTABLE };
+    }
+
+    const VTABLE = IRawInputProvider.VTable{
+        .isKeyDown = isKeyDown,
+        .isKeyPressed = isKeyPressed,
+        .isKeyReleased = noopKeyBool,
+        .isMouseButtonDown = noopMouseButtonBool,
+        .isMouseButtonPressed = noopMouseButtonBool,
+        .isMouseButtonReleased = noopMouseButtonBool,
+        .getMouseDelta = noopMousePosition,
+        .getMousePosition = noopMousePosition,
+        .getScrollDelta = noopScroll,
+        .getWindowWidth = noopU32,
+        .getWindowHeight = noopU32,
+        .shouldQuit = noopBool,
+        .setShouldQuit = noopSetBool,
+        .isMouseCaptured = noopBool,
+        .setMouseCapture = noopSetCapture,
+    };
+
+    fn isKeyDown(ptr: *anyopaque, key: Key) bool {
+        const self: *MockInput = @ptrCast(@alignCast(ptr));
+        if ((key == .left_shift or key == .right_shift) and self.shift_down) return true;
+        return false;
+    }
+
+    fn isKeyPressed(ptr: *anyopaque, key: Key) bool {
+        const self: *MockInput = @ptrCast(@alignCast(ptr));
+        return self.pressed.contains(key);
+    }
+
+    fn noopKeyBool(ptr: *anyopaque, key: Key) bool {
+        _ = ptr;
+        _ = key;
+        return false;
+    }
+    fn noopMouseButtonBool(ptr: *anyopaque, btn: @import("engine-core").interfaces.MouseButton) bool {
+        _ = ptr;
+        _ = btn;
+        return false;
+    }
+    fn noopMousePosition(ptr: *anyopaque) @import("engine-input").MousePosition {
+        _ = ptr;
+        return .{ .x = 0, .y = 0 };
+    }
+    fn noopScroll(ptr: *anyopaque) @import("engine-input").ScrollDelta {
+        _ = ptr;
+        return .{ .x = 0, .y = 0 };
+    }
+    fn noopU32(ptr: *anyopaque) u32 {
+        _ = ptr;
+        return 0;
+    }
+    fn noopBool(ptr: *anyopaque) bool {
+        _ = ptr;
+        return false;
+    }
+    fn noopSetBool(ptr: *anyopaque, val: bool) void {
+        _ = ptr;
+        _ = val;
+    }
+    fn noopSetCapture(ptr: *anyopaque, window: ?*anyopaque, captured: bool) void {
+        _ = ptr;
+        _ = window;
+        _ = captured;
+    }
+};
+
+test "handleTextTyping produces lowercase letters without shift (regression for #708)" {
+    var mock = MockInput.init(testing.allocator, false);
+    defer mock.deinit();
+    try mock.press(.a);
+    try mock.press(.z);
+
+    var text = std.ArrayListUnmanaged(u8).empty;
+    defer text.deinit(testing.allocator);
+
+    try handleTextTyping(&text, testing.allocator, mock.interface(), 32);
+
+    try testing.expectEqualStrings("az", text.items);
+}
+
+test "handleTextTyping produces uppercase letters with shift (regression for #708)" {
+    // The audit's root-cause analysis claimed `std.ascii.toUpper('a') == 'a'` and that
+    // Shift produced lowercase. This test asserts the opposite: Shift+letter produces
+    // uppercase ASCII. If anyone reworks the cast path in text_input.zig, this test
+    // will catch a regression that reintroduces the bug the audit described.
+    var mock = MockInput.init(testing.allocator, true);
+    defer mock.deinit();
+    try mock.press(.a);
+    try mock.press(.z);
+
+    var text = std.ArrayListUnmanaged(u8).empty;
+    defer text.deinit(testing.allocator);
+
+    try handleTextTyping(&text, testing.allocator, mock.interface(), 32);
+
+    try testing.expectEqualStrings("AZ", text.items);
+}
+
+test "handleTextTyping respects max_len" {
+    var mock = MockInput.init(testing.allocator, false);
+    defer mock.deinit();
+    try mock.press(.a);
+    try mock.press(.b);
+    try mock.press(.c);
+
+    var text = std.ArrayListUnmanaged(u8).empty;
+    defer text.deinit(testing.allocator);
+
+    // max_len = 2 means the third press must be dropped.
+    try handleTextTyping(&text, testing.allocator, mock.interface(), 2);
+
+    try testing.expectEqualStrings("ab", text.items);
+}


### PR DESCRIPTION
## Summary

Sweep of the open `[Audit]` bug issues. Six issues get real code fixes or regression tests in this PR; five were already fixed by earlier PRs and are closed by linking here. The remaining two (#702 and #705) were investigated and found to be **misdiagnoses of correct behavior** — they are closed separately as not-planned with detailed rationale (see following section).

Closes #707. Closes #708. Closes #711. Closes #713. Closes #714. Closes #718. Closes #726. Closes #734. Closes #747.

---

## ⚠️ #702 and #705 — investigated, found to be misdiagnoses of correct behavior

These two issues are **not fixed by code changes** because the original code was already correct. They are closed separately as `not_planned` (with a pointer back to this PR) rather than via `Closes` here, so the closure reason is unambiguous and nobody later re-applies the audit's proposed (visually regressive) change.

The investigation was triggered by PR review feedback that my initial #705 fix (`sy <= y1` → `sy < y1`) dropped the top face of the world-ceiling block. Deeper analysis showed:

- **#705 (chunk_mesh buildSubchunk Y loop):** The 17-iteration loop (`sy <= y1`) is intentional and correct. It mirrors the `sx <= CHUNK_SIZE_X` / `sz <= CHUNK_SIZE_Z` loops. `greedy_mesher.meshSlice` uses `isEmittingSubchunk(.top, sy - 1, ...)` to assign each boundary face to the subchunk that owns the solid block, so no geometry is duplicated. The audit's comparison to `flat_quad_mesher.zig` (`y < y1`) was invalid — that mesher iterates over **blocks** within a subchunk, not **boundaries** between blocks. Switching to `sy < y1` was proven (via regression test) to drop the top face of the highest cube at **every** subchunk boundary (y=15, 31, …, 255), not just the world ceiling: a standalone cube at y=15 emits 30 vertices with `sy < y1` (5 faces) vs 36 with `sy <= y1` (all 6 faces).

- **#702 (getLightSafe MAX_LIGHT at y ≥ CHUNK_SIZE_Y):** `MAX_LIGHT` is the correct lighting contract. `lighting_sampler.sampleLightAtBoundary` (lighting_sampler.zig:37) samples `y = CHUNK_SIZE_Y` to light the **top face** of the highest block in each column (a mountain peak at y=255 queries y=256). The space above the world is open sky, so the face should be full daylight. Returning 0 (the audit's proposed fix) makes mountain tops incorrectly dark. `boundary.getLightCross` was flagged by review as inconsistent, but it was already returning `MAX_LIGHT` — the inconsistency only existed because of my initial (now-reverted) change to `getLightSafe`.

Although these are closed as not-planned, this PR adds value for both: documentation comments explaining the contracts, and regression tests that will catch any future attempt to re-introduce the audit's proposed changes.

---

## Real code fixes

| # | Severity | File | Change |
|---|---|---|---|
| #711 | High | `engine-input/input.zig` | `SDL_EVENT_MOUSE_WHEEL` assigned scroll deltas, so multiple wheel events within one frame (high-res mice, rapid trackpads) clobbered each other. Extracted a public `recordMouseWheel` helper that accumulates with `+=`, and wired the SDL handler through it. `beginFrame` still zeroes the totals per frame. |
| #713 | High | `engine-graphics/camera.zig` | `Camera.InputMapperView` was a vtable that nothing in the codebase ever constructed, and `Camera.update()` was never called (the game loop drives the camera via `player.update`). Removed the dead `InputMapperView` struct, dead `Camera.update`, and the now-orphaned `MovementVector` typedef to eliminate the null-vtable hazard. Unused `Input`/`Key` imports removed. |
| #707 | High | `worldgen-overworld-v2/{trees,vegetation}.zig` | `surface_y` (i16) was compared against `CHUNK_SIZE_Y - 8` (u32). The current code compiles via comptime peer resolution but is fragile. Made the bounds checks explicit `i32` comparisons so future type changes cannot silently produce wrong results. |
| #708 | Medium | `game-core/text_input.zig` | The audit's root-cause analysis claimed `std.ascii.toUpper('a')` returns `'a'` unchanged. That is incorrect — it returns `'A'` — so the existing code already produces uppercase letters on Shift. Added `src/text_input_tests.zig` with a `MockInput` to lock in lowercase-without-shift and uppercase-with-shift behavior, plus a `max_len` regression. |

## Already fixed by earlier PRs (closed by linking here)

| # | Severity | Reason |
|---|---|---|
| #747 | High | `gpu_mesher` `vkWaitForFences` now goes through the RHI compute facet added in #811, which returns a bool already checked in `finalizeCompletedMeshes`. Earlier hardening in #772. |
| #734 | Medium | `engine-physics/collision.zig` already sets `grounded` when `move.y < 0` and `hit_ceiling` when `move.y >= 0` (the correct polarity). |
| #726 | High | `engine-core/job_system.zig` already has the explicit `errdefer` block (lines 353-372) that documents LIFO ordering and joins spawned threads on partial failure. |
| #718 | High | The Mixer was rewritten in #831 to read the wrapped cursor at 0 directly in the same iteration, which is functionally equivalent to the audit's proposed `continue`. |
| #714 | Medium | #824 removed the stray `- 1` from the fallback path; current code returns `text.len * 6 * scale`. |

## Regression tests added

- `world-core/chunk_tests.zig`: documents the top-face meshing contract (`MAX_LIGHT` at `y=CHUNK_SIZE_Y`).
- `world-meshing/chunk_mesh_tests.zig`: cube at y=15 (subchunk boundary) and y=255 (world ceiling), both asserting 36 vertices — these would catch any re-introduction of the `sy < y1` regression.
- `src/input_tests.zig`: scroll accumulation across multiple events and `beginFrame` reset.
- `src/text_input_tests.zig`: new file — lowercase/uppercase via Shift, plus `max_len`.

## Out of scope

- #776 `[Audit][Umbrella]` SOLID architecture debt is intentionally NOT closed by this PR. It is a multi-phase tracking issue (24 sub-issues across P0–P3) whose own constraints require "small reviewable PRs targeting `dev`."

## Verification

```bash
nix develop --command zig fmt src/ modules/
nix develop --command zig build test                 # all tests + shader validation
nix develop --command zig build -Doptimize=ReleaseFast
```

All green.