### PR TITLE
fix(worldgen): prevent world map allocation overflow

### DIFF
--- a/modules/worldgen-overworld/src/world_map.zig
+++ b/modules/worldgen-overworld/src/world_map.zig
@@ -13,7 +13,8 @@ pub const WorldMap = struct {
         // Safety: ensure texture size is within typical hardware limits
         const safe_w = @min(width, 4096);
         const safe_h = @min(height, 4096);
-        const pixels = try allocator.alloc(u8, safe_w * safe_h * 4);
+        const pixel_bytes = @as(usize, safe_w) * @as(usize, safe_h) * 4;
+        const pixels = try allocator.alloc(u8, pixel_bytes);
         @memset(pixels, 0);
 
         return .{


### PR DESCRIPTION
## Summary
- promote world map allocation size math to usize before multiplying
- fixes Debug-mode integer overflow when loading a world map buffer

## Verification
- nix develop --command zig fmt modules/worldgen-overworld/src/world_map.zig
- nix develop --command env HOME=/tmp/opencode/zigcraft-home ZIGCRAFT_LOG_LEVEL=info zig build run -Dskip-present -Dauto-world=normal -Dstartup-diagnostic-seconds=5 -Dauto-preset=low
- nix develop --command zig build test