### PR TITLE
fix(audit): resolve P4 build docs and casing issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,8 @@ assets/shaders/     # GLSL shaders (vulkan/ contains SPIR-V)
 
 ### Naming Conventions
 - **Types/Structs/Enums**: `PascalCase` (`RenderSystem`, `BufferHandle`, `BlockType`)
-- **Functions/Variables**: `snake_case` (`init_renderer`, `mesh_queue`, `chunk_x`)
+- **Functions**: `camelCase` following Zig stdlib convention (`initRenderer`, `meshQueue`, `chunkX`)
+- **Variables**: `snake_case` (`mesh_queue`, `chunk_x`)
 - **Constants/Globals**: `SCREAMING_SNAKE_CASE` (`MAX_CHUNKS`, `CHUNK_SIZE_X`)
 - **Files**: `snake_case.zig`
 

--- a/build.zig
+++ b/build.zig
@@ -1,88 +1,82 @@
 const std = @import("std");
 
+const BuildOptions = struct {
+    options: *std.Build.Step.Options,
+    engine_ui_options: *std.Build.Step.Options,
+    world_lod_options: *std.Build.Step.Options,
+    world_runtime_options: *std.Build.Step.Options,
+    engine_graphics_options: *std.Build.Step.Options,
+    enable_debug_shadows: bool,
+    enable_imgui: bool,
+    chunk_debug_mode: bool,
+    chunk_debug_enable: []const u8,
+    startup_diagnostic_seconds: u32,
+    skip_present: bool,
+    monitor_index: i32,
+    monitor_name: []const u8,
+    window_video_driver: []const u8,
+    window_no_focus: bool,
+    shadow_test_variant: []const u8,
+    benchmark_preset: []const u8,
+    benchmark_duration: u32,
+    benchmark_output: []const u8,
+};
+
+const BuildModules = struct {
+    zig_math: *std.Build.Module,
+    zig_noise: *std.Build.Module,
+    fs_module: *std.Build.Module,
+    sync_module: *std.Build.Module,
+    c_module: *std.Build.Module,
+    engine_math: *std.Build.Module,
+    engine_audio: *std.Build.Module,
+    engine_core: *std.Build.Module,
+    engine_ecs: *std.Build.Module,
+    engine_input: *std.Build.Module,
+    engine_physics: *std.Build.Module,
+    engine_rhi: *std.Build.Module,
+    engine_graphics: *std.Build.Module,
+    engine_assets: *std.Build.Module,
+    engine_camera: *std.Build.Module,
+    engine_clouds: *std.Build.Module,
+    engine_atmosphere: *std.Build.Module,
+    engine_shadows: *std.Build.Module,
+    engine_lighting: *std.Build.Module,
+    engine_ui: *std.Build.Module,
+    world_core: *std.Build.Module,
+    world_worldgen: *std.Build.Module,
+    world_meshing: *std.Build.Module,
+    world_lod: *std.Build.Module,
+    world_runtime: *std.Build.Module,
+    world_persistence: *std.Build.Module,
+    game_core: *std.Build.Module,
+    game_ui: *std.Build.Module,
+};
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const options = b.addOptions();
-    const enable_debug_shadows = b.option(bool, "debug_shadows", "Enable debug shadow visualization resources") orelse false;
-    options.addOption(bool, "debug_shadows", enable_debug_shadows);
+    const opts = defineBuildOptions(b);
+    const modules = defineModules(b, target, optimize, opts);
+    defineBuildSteps(b, target, optimize, opts, modules);
+}
 
-    const enable_imgui = b.option(bool, "imgui", "Enable Dear ImGui debug UI integration") orelse true;
-    options.addOption(bool, "imgui", enable_imgui);
-    const engine_ui_options = b.addOptions();
-    engine_ui_options.addOption(bool, "imgui", enable_imgui);
-
-    const smoke_test = b.option(bool, "smoke-test", "Enable automated smoke test mode (auto-loads world and exits)") orelse false;
-    options.addOption(bool, "smoke_test", smoke_test);
-
-    const chunk_debug_mode = b.option(bool, "chunk-debug-mode", "Disable LOD, water, caves, and decorations for chunk-only debugging") orelse false;
-    options.addOption(bool, "chunk_debug_mode", chunk_debug_mode);
-
-    const chunk_debug_enable = b.option([]const u8, "chunk-debug-enable", "Re-enable one subsystem in chunk-debug-mode (lod, water, caves, decorations)") orelse "";
-    options.addOption([]const u8, "chunk_debug_enable", chunk_debug_enable);
-    const auto_world = b.option([]const u8, "auto-world", "Auto-open a world generator directly by id or alias (normal, overworld, overworld-v2, flat, test)") orelse "";
-    options.addOption([]const u8, "auto_world", auto_world);
-
-    const auto_preset = b.option([]const u8, "auto-preset", "Graphics preset to apply for auto-world launches (low, medium, high, ultra, extreme)") orelse "";
-    options.addOption([]const u8, "auto_preset", auto_preset);
-
-    const startup_diagnostic_seconds = b.option(u32, "startup-diagnostic-seconds", "Wait N seconds after auto-world startup, log chunk counts, and exit") orelse 0;
-    options.addOption(u32, "startup_diagnostic_seconds", startup_diagnostic_seconds);
-    const world_lod_options = b.addOptions();
-    world_lod_options.addOption(u32, "startup_diagnostic_seconds", startup_diagnostic_seconds);
-    const world_runtime_options = b.addOptions();
-    world_runtime_options.addOption(u32, "startup_diagnostic_seconds", startup_diagnostic_seconds);
-    world_runtime_options.addOption(bool, "world_runtime_module", true);
-
-    const skip_present = b.option(bool, "skip-present", "Skip presentation (headless mode) to avoid driver crashes") orelse false;
-    options.addOption(bool, "skip_present", skip_present);
-
-    const monitor_index = b.option(i32, "monitor-index", "Open the game window on a specific SDL display index (0-based, -1 = default)") orelse -1;
-    options.addOption(i32, "monitor_index", monitor_index);
-
-    const monitor_name = b.option([]const u8, "monitor-name", "Move the game window to a named Hyprland monitor (e.g. DP-2)") orelse "";
-    options.addOption([]const u8, "monitor_name", monitor_name);
-
-    const window_video_driver = b.option([]const u8, "window-video-driver", "SDL video driver override for the game window (x11, wayland, or empty)") orelse "";
-    options.addOption([]const u8, "window_video_driver", window_video_driver);
-
-    const window_no_focus = b.option(bool, "window-no-focus", "Create the game window without taking keyboard focus") orelse false;
-    options.addOption(bool, "window_no_focus", window_no_focus);
-
-    const engine_graphics_options = b.addOptions();
-    engine_graphics_options.addOption(bool, "debug_shadows", enable_debug_shadows);
-    engine_graphics_options.addOption(bool, "chunk_debug_mode", chunk_debug_mode);
-    engine_graphics_options.addOption([]const u8, "chunk_debug_enable", chunk_debug_enable);
-    engine_graphics_options.addOption(bool, "skip_present", skip_present);
-    engine_graphics_options.addOption(bool, "imgui", enable_imgui);
-
-    const screenshot_path = b.option([]const u8, "screenshot-path", "Capture a PNG screenshot after N frames and exit") orelse "";
-    options.addOption([]const u8, "screenshot_path", screenshot_path);
-
-    const screenshot_frame = b.option(u32, "screenshot-frame", "Frame number to capture when screenshot-path is set") orelse 120;
-    options.addOption(u32, "screenshot_frame", screenshot_frame);
-
-    const screenshot_delay_seconds = b.option(u32, "screenshot-delay-seconds", "Seconds to wait after screenshot target is ready before capture") orelse 0;
-    options.addOption(u32, "screenshot_delay_seconds", screenshot_delay_seconds);
-
-    const shadow_test_scene = b.option(bool, "shadow-test-scene", "Launch the deterministic shadow/cave lighting test scene") orelse false;
-    options.addOption(bool, "shadow_test_scene", shadow_test_scene);
-
-    const shadow_test_variant = b.option([]const u8, "shadow-test-variant", "Shadow test scene variant (dug-cave, bend)") orelse "dug-cave";
-    options.addOption([]const u8, "shadow_test_variant", shadow_test_variant);
-
-    const benchmark = b.option(bool, "benchmark", "Enable benchmark mode") orelse false;
-    options.addOption(bool, "benchmark", benchmark);
-
-    const benchmark_preset = b.option([]const u8, "benchmark-preset", "Graphics preset to benchmark (low, medium, high, ultra, extreme)") orelse "medium";
-    options.addOption([]const u8, "benchmark_preset", benchmark_preset);
-
-    const benchmark_duration = b.option(u32, "benchmark-duration", "Benchmark duration in seconds") orelse 60;
-    options.addOption(u32, "benchmark_duration", benchmark_duration);
-
-    const benchmark_output = b.option([]const u8, "benchmark-output", "Benchmark JSON output path") orelse "benchmark_results.json";
-    options.addOption([]const u8, "benchmark_output", benchmark_output);
+fn defineModules(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    opts: BuildOptions,
+) BuildModules {
+    const options = opts.options;
+    const enable_imgui = opts.enable_imgui;
+    const engine_ui_options = opts.engine_ui_options;
+    const world_lod_options = opts.world_lod_options;
+    const world_runtime_options = opts.world_runtime_options;
+    const engine_graphics_options = opts.engine_graphics_options;
+    const chunk_debug_mode = opts.chunk_debug_mode;
+    const chunk_debug_enable = opts.chunk_debug_enable;
+    const shadow_test_variant = opts.shadow_test_variant;
 
     const zig_math = b.createModule(.{
         .root_source_file = b.path("libs/zig-math/math.zig"),
@@ -152,6 +146,37 @@ pub fn build(b: *std.Build) void {
     const world_persistence = b.createModule(.{ .root_source_file = b.path("modules/world-persistence/src/root.zig"), .target = target, .optimize = optimize });
     const game_core = b.createModule(.{ .root_source_file = b.path("modules/game-core/src/root.zig"), .target = target, .optimize = optimize });
     const game_ui = b.createModule(.{ .root_source_file = b.path("modules/game-ui/src/root.zig"), .target = target, .optimize = optimize });
+
+    const modules = BuildModules{
+        .zig_math = zig_math,
+        .zig_noise = zig_noise,
+        .fs_module = fs_module,
+        .sync_module = sync_module,
+        .c_module = c_module,
+        .engine_math = engine_math,
+        .engine_audio = engine_audio,
+        .engine_core = engine_core,
+        .engine_ecs = engine_ecs,
+        .engine_input = engine_input,
+        .engine_physics = engine_physics,
+        .engine_rhi = engine_rhi,
+        .engine_graphics = engine_graphics,
+        .engine_assets = engine_assets,
+        .engine_camera = engine_camera,
+        .engine_clouds = engine_clouds,
+        .engine_atmosphere = engine_atmosphere,
+        .engine_shadows = engine_shadows,
+        .engine_lighting = engine_lighting,
+        .engine_ui = engine_ui,
+        .world_core = world_core,
+        .world_worldgen = world_worldgen,
+        .world_meshing = world_meshing,
+        .world_lod = world_lod,
+        .world_runtime = world_runtime,
+        .world_persistence = world_persistence,
+        .game_core = game_core,
+        .game_ui = game_ui,
+    };
 
     addSharedImports(engine_math, zig_math, zig_noise, fs_module, sync_module, c_module, options);
     addSharedImports(engine_audio, zig_math, zig_noise, fs_module, sync_module, c_module, options);
@@ -310,11 +335,43 @@ pub fn build(b: *std.Build) void {
     world_runtime.addOptions("world_runtime_options", world_runtime_options);
 
     addSharedImportsNoOptions(game_core, zig_math, zig_noise, fs_module, sync_module, c_module);
-    addProjectModuleImports(game_core, engine_math, engine_audio, engine_core, engine_ecs, engine_input, engine_physics, engine_rhi, engine_graphics, engine_assets, engine_camera, engine_clouds, engine_atmosphere, engine_shadows, engine_lighting, engine_ui, world_core, world_worldgen, world_meshing, world_lod, world_runtime, world_persistence);
+    addProjectModuleImports(game_core, modules);
 
     addSharedImportsNoOptions(game_ui, zig_math, zig_noise, fs_module, sync_module, c_module);
-    addProjectModuleImports(game_ui, engine_math, engine_audio, engine_core, engine_ecs, engine_input, engine_physics, engine_rhi, engine_graphics, engine_assets, engine_camera, engine_clouds, engine_atmosphere, engine_shadows, engine_lighting, engine_ui, world_core, world_worldgen, world_meshing, world_lod, world_runtime, world_persistence);
+    addProjectModuleImports(game_ui, modules);
     game_ui.addImport("game-core", game_core);
+
+    return modules;
+}
+
+fn defineBuildSteps(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    opts: BuildOptions,
+    modules: BuildModules,
+) void {
+    const options = opts.options;
+    const enable_debug_shadows = opts.enable_debug_shadows;
+    const enable_imgui = opts.enable_imgui;
+    const monitor_index = opts.monitor_index;
+    const monitor_name = opts.monitor_name;
+    const window_video_driver = opts.window_video_driver;
+    const window_no_focus = opts.window_no_focus;
+    const benchmark_preset = opts.benchmark_preset;
+    const benchmark_duration = opts.benchmark_duration;
+    const benchmark_output = opts.benchmark_output;
+    const zig_math = modules.zig_math;
+    const zig_noise = modules.zig_noise;
+    const fs_module = modules.fs_module;
+    const sync_module = modules.sync_module;
+    const c_module = modules.c_module;
+    const engine_core = modules.engine_core;
+    const engine_graphics = modules.engine_graphics;
+    const world_core = modules.world_core;
+    const world_worldgen = modules.world_worldgen;
+    const game_core = modules.game_core;
+    const game_ui = modules.game_ui;
 
     const root_module = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
@@ -326,7 +383,7 @@ pub fn build(b: *std.Build) void {
     root_module.addImport("fs", fs_module);
     root_module.addImport("sync", sync_module);
     root_module.addImport("c", c_module);
-    addProjectModuleImports(root_module, engine_math, engine_audio, engine_core, engine_ecs, engine_input, engine_physics, engine_rhi, engine_graphics, engine_assets, engine_camera, engine_clouds, engine_atmosphere, engine_shadows, engine_lighting, engine_ui, world_core, world_worldgen, world_meshing, world_lod, world_runtime, world_persistence);
+    addProjectModuleImports(root_module, modules);
     root_module.addImport("game-core", game_core);
     root_module.addImport("game-ui", game_ui);
     root_module.addOptions("build_options", options);
@@ -401,7 +458,7 @@ pub fn build(b: *std.Build) void {
     benchmark_root_module.addImport("fs", fs_module);
     benchmark_root_module.addImport("sync", sync_module);
     benchmark_root_module.addImport("c", c_module);
-    addProjectModuleImports(benchmark_root_module, engine_math, engine_audio, engine_core, engine_ecs, engine_input, engine_physics, engine_rhi, engine_graphics, engine_assets, engine_camera, engine_clouds, engine_atmosphere, engine_shadows, engine_lighting, engine_ui, world_core, world_worldgen, world_meshing, world_lod, world_runtime, world_persistence);
+    addProjectModuleImports(benchmark_root_module, modules);
     benchmark_root_module.addImport("game-core", game_core);
     benchmark_root_module.addImport("game-ui", game_ui);
     benchmark_root_module.addOptions("build_options", benchmark_options);
@@ -502,7 +559,7 @@ pub fn build(b: *std.Build) void {
     test_root_module.addImport("fs", fs_module);
     test_root_module.addImport("sync", sync_module);
     test_root_module.addImport("c", c_module);
-    addProjectModuleImports(test_root_module, engine_math, engine_audio, engine_core, engine_ecs, engine_input, engine_physics, engine_rhi, engine_graphics, engine_assets, engine_camera, engine_clouds, engine_atmosphere, engine_shadows, engine_lighting, engine_ui, world_core, world_worldgen, world_meshing, world_lod, world_runtime, world_persistence);
+    addProjectModuleImports(test_root_module, modules);
     test_root_module.addImport("game-core", game_core);
     test_root_module.addImport("game-ui", game_ui);
     test_root_module.addOptions("build_options", options);
@@ -543,7 +600,7 @@ pub fn build(b: *std.Build) void {
     integration_root_module.addImport("fs", fs_module);
     integration_root_module.addImport("sync", sync_module);
     integration_root_module.addImport("c", c_module);
-    addProjectModuleImports(integration_root_module, engine_math, engine_audio, engine_core, engine_ecs, engine_input, engine_physics, engine_rhi, engine_graphics, engine_assets, engine_camera, engine_clouds, engine_atmosphere, engine_shadows, engine_lighting, engine_ui, world_core, world_worldgen, world_meshing, world_lod, world_runtime, world_persistence);
+    addProjectModuleImports(integration_root_module, modules);
     integration_root_module.addImport("game-core", game_core);
     integration_root_module.addImport("game-ui", game_ui);
     integration_root_module.addOptions("build_options", options);
@@ -623,57 +680,146 @@ pub fn build(b: *std.Build) void {
     const run_robust_step = b.step("run-robust", "Run the GPU robustness demo");
     run_robust_step.dependOn(&run_robust_cmd.step);
 
-    const validate_vulkan_terrain_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/terrain.vert" });
-    const validate_vulkan_terrain_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/terrain.frag" });
-    const validate_vulkan_shadow_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/shadow.vert" });
-    const validate_vulkan_shadow_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/shadow.frag" });
-    const validate_vulkan_sky_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/sky.vert" });
-    const validate_vulkan_sky_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/sky.frag" });
-    const validate_vulkan_ui_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/ui.vert" });
-    const validate_vulkan_ui_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/ui.frag" });
-    const validate_vulkan_ui_tex_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/ui_tex.vert" });
-    const validate_vulkan_ui_tex_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/ui_tex.frag" });
-    const validate_vulkan_debug_shadow_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/debug_shadow.vert" });
-    const validate_vulkan_debug_shadow_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/debug_shadow.frag" });
-    const validate_vulkan_ssao_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/ssao.vert" });
-    const validate_vulkan_ssao_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/ssao.frag" });
-    const validate_vulkan_ssao_blur_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/ssao_blur.frag" });
-    const validate_vulkan_g_pass_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/g_pass.frag" });
-    const validate_vulkan_taa_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/taa.vert" });
-    const validate_vulkan_taa_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/taa.frag" });
-    const validate_vulkan_lpv_inject_comp = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/lpv_inject.comp" });
-    const validate_vulkan_lpv_propagate_comp = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/lpv_propagate.comp" });
-    const validate_vulkan_culling_comp = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/culling.comp" });
-    const validate_vulkan_depth_pyramid_comp = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/depth_pyramid.comp" });
-    const validate_vulkan_water_vert = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/water.vert" });
-    const validate_vulkan_water_frag = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/water.frag" });
-    const validate_vulkan_mesh_comp = b.addSystemCommand(&.{ "glslangValidator", "-V", "assets/shaders/vulkan/mesh.comp" });
+    defineShaderValidation(b, test_step);
+}
 
-    test_step.dependOn(&validate_vulkan_terrain_vert.step);
-    test_step.dependOn(&validate_vulkan_terrain_frag.step);
-    test_step.dependOn(&validate_vulkan_shadow_vert.step);
-    test_step.dependOn(&validate_vulkan_shadow_frag.step);
-    test_step.dependOn(&validate_vulkan_sky_vert.step);
-    test_step.dependOn(&validate_vulkan_sky_frag.step);
-    test_step.dependOn(&validate_vulkan_ui_vert.step);
-    test_step.dependOn(&validate_vulkan_ui_frag.step);
-    test_step.dependOn(&validate_vulkan_ui_tex_vert.step);
-    test_step.dependOn(&validate_vulkan_ui_tex_frag.step);
-    test_step.dependOn(&validate_vulkan_debug_shadow_vert.step);
-    test_step.dependOn(&validate_vulkan_debug_shadow_frag.step);
-    test_step.dependOn(&validate_vulkan_ssao_vert.step);
-    test_step.dependOn(&validate_vulkan_ssao_frag.step);
-    test_step.dependOn(&validate_vulkan_ssao_blur_frag.step);
-    test_step.dependOn(&validate_vulkan_g_pass_frag.step);
-    test_step.dependOn(&validate_vulkan_taa_vert.step);
-    test_step.dependOn(&validate_vulkan_taa_frag.step);
-    test_step.dependOn(&validate_vulkan_lpv_inject_comp.step);
-    test_step.dependOn(&validate_vulkan_lpv_propagate_comp.step);
-    test_step.dependOn(&validate_vulkan_culling_comp.step);
-    test_step.dependOn(&validate_vulkan_depth_pyramid_comp.step);
-    test_step.dependOn(&validate_vulkan_water_vert.step);
-    test_step.dependOn(&validate_vulkan_water_frag.step);
-    test_step.dependOn(&validate_vulkan_mesh_comp.step);
+fn defineBuildOptions(b: *std.Build) BuildOptions {
+    const options = b.addOptions();
+    const enable_debug_shadows = b.option(bool, "debug_shadows", "Enable debug shadow visualization resources") orelse false;
+    options.addOption(bool, "debug_shadows", enable_debug_shadows);
+
+    const enable_imgui = b.option(bool, "imgui", "Enable Dear ImGui debug UI integration") orelse true;
+    options.addOption(bool, "imgui", enable_imgui);
+    const engine_ui_options = b.addOptions();
+    engine_ui_options.addOption(bool, "imgui", enable_imgui);
+
+    const smoke_test = b.option(bool, "smoke-test", "Enable automated smoke test mode (auto-loads world and exits)") orelse false;
+    options.addOption(bool, "smoke_test", smoke_test);
+
+    const chunk_debug_mode = b.option(bool, "chunk-debug-mode", "Disable LOD, water, caves, and decorations for chunk-only debugging") orelse false;
+    options.addOption(bool, "chunk_debug_mode", chunk_debug_mode);
+
+    const chunk_debug_enable = b.option([]const u8, "chunk-debug-enable", "Re-enable one subsystem in chunk-debug-mode (lod, water, caves, decorations)") orelse "";
+    options.addOption([]const u8, "chunk_debug_enable", chunk_debug_enable);
+    const auto_world = b.option([]const u8, "auto-world", "Auto-open a world generator directly by id or alias (normal, overworld, overworld-v2, flat, test)") orelse "";
+    options.addOption([]const u8, "auto_world", auto_world);
+
+    const auto_preset = b.option([]const u8, "auto-preset", "Graphics preset to apply for auto-world launches (low, medium, high, ultra, extreme)") orelse "";
+    options.addOption([]const u8, "auto_preset", auto_preset);
+
+    const startup_diagnostic_seconds = b.option(u32, "startup-diagnostic-seconds", "Wait N seconds after auto-world startup, log chunk counts, and exit") orelse 0;
+    options.addOption(u32, "startup_diagnostic_seconds", startup_diagnostic_seconds);
+    const world_lod_options = b.addOptions();
+    world_lod_options.addOption(u32, "startup_diagnostic_seconds", startup_diagnostic_seconds);
+    const world_runtime_options = b.addOptions();
+    world_runtime_options.addOption(u32, "startup_diagnostic_seconds", startup_diagnostic_seconds);
+    world_runtime_options.addOption(bool, "world_runtime_module", true);
+
+    const skip_present = b.option(bool, "skip-present", "Skip presentation (headless mode) to avoid driver crashes") orelse false;
+    options.addOption(bool, "skip_present", skip_present);
+
+    const monitor_index = b.option(i32, "monitor-index", "Open the game window on a specific SDL display index (0-based, -1 = default)") orelse -1;
+    options.addOption(i32, "monitor_index", monitor_index);
+
+    const monitor_name = b.option([]const u8, "monitor-name", "Move the game window to a named Hyprland monitor (e.g. DP-2)") orelse "";
+    options.addOption([]const u8, "monitor_name", monitor_name);
+
+    const window_video_driver = b.option([]const u8, "window-video-driver", "SDL video driver override for the game window (x11, wayland, or empty)") orelse "";
+    options.addOption([]const u8, "window_video_driver", window_video_driver);
+
+    const window_no_focus = b.option(bool, "window-no-focus", "Create the game window without taking keyboard focus") orelse false;
+    options.addOption(bool, "window_no_focus", window_no_focus);
+
+    const engine_graphics_options = b.addOptions();
+    engine_graphics_options.addOption(bool, "debug_shadows", enable_debug_shadows);
+    engine_graphics_options.addOption(bool, "chunk_debug_mode", chunk_debug_mode);
+    engine_graphics_options.addOption([]const u8, "chunk_debug_enable", chunk_debug_enable);
+    engine_graphics_options.addOption(bool, "skip_present", skip_present);
+    engine_graphics_options.addOption(bool, "imgui", enable_imgui);
+
+    const screenshot_path = b.option([]const u8, "screenshot-path", "Capture a PNG screenshot after N frames and exit") orelse "";
+    options.addOption([]const u8, "screenshot_path", screenshot_path);
+
+    const screenshot_frame = b.option(u32, "screenshot-frame", "Frame number to capture when screenshot-path is set") orelse 120;
+    options.addOption(u32, "screenshot_frame", screenshot_frame);
+
+    const screenshot_delay_seconds = b.option(u32, "screenshot-delay-seconds", "Seconds to wait after screenshot target is ready before capture") orelse 0;
+    options.addOption(u32, "screenshot_delay_seconds", screenshot_delay_seconds);
+
+    const shadow_test_scene = b.option(bool, "shadow-test-scene", "Launch the deterministic shadow/cave lighting test scene") orelse false;
+    options.addOption(bool, "shadow_test_scene", shadow_test_scene);
+
+    const shadow_test_variant = b.option([]const u8, "shadow-test-variant", "Shadow test scene variant (dug-cave, bend)") orelse "dug-cave";
+    options.addOption([]const u8, "shadow_test_variant", shadow_test_variant);
+
+    const benchmark = b.option(bool, "benchmark", "Enable benchmark mode") orelse false;
+    options.addOption(bool, "benchmark", benchmark);
+
+    const benchmark_preset = b.option([]const u8, "benchmark-preset", "Graphics preset to benchmark (low, medium, high, ultra, extreme)") orelse "medium";
+    options.addOption([]const u8, "benchmark_preset", benchmark_preset);
+
+    const benchmark_duration = b.option(u32, "benchmark-duration", "Benchmark duration in seconds") orelse 60;
+    options.addOption(u32, "benchmark_duration", benchmark_duration);
+
+    const benchmark_output = b.option([]const u8, "benchmark-output", "Benchmark JSON output path") orelse "benchmark_results.json";
+    options.addOption([]const u8, "benchmark_output", benchmark_output);
+
+    return .{
+        .options = options,
+        .engine_ui_options = engine_ui_options,
+        .world_lod_options = world_lod_options,
+        .world_runtime_options = world_runtime_options,
+        .engine_graphics_options = engine_graphics_options,
+        .enable_debug_shadows = enable_debug_shadows,
+        .enable_imgui = enable_imgui,
+        .chunk_debug_mode = chunk_debug_mode,
+        .chunk_debug_enable = chunk_debug_enable,
+        .startup_diagnostic_seconds = startup_diagnostic_seconds,
+        .skip_present = skip_present,
+        .monitor_index = monitor_index,
+        .monitor_name = monitor_name,
+        .window_video_driver = window_video_driver,
+        .window_no_focus = window_no_focus,
+        .shadow_test_variant = shadow_test_variant,
+        .benchmark_preset = benchmark_preset,
+        .benchmark_duration = benchmark_duration,
+        .benchmark_output = benchmark_output,
+    };
+}
+
+fn defineShaderValidation(b: *std.Build, test_step: *std.Build.Step) void {
+    const shader_paths = [_][]const u8{
+        "assets/shaders/vulkan/terrain.vert",
+        "assets/shaders/vulkan/terrain.frag",
+        "assets/shaders/vulkan/shadow.vert",
+        "assets/shaders/vulkan/shadow.frag",
+        "assets/shaders/vulkan/sky.vert",
+        "assets/shaders/vulkan/sky.frag",
+        "assets/shaders/vulkan/ui.vert",
+        "assets/shaders/vulkan/ui.frag",
+        "assets/shaders/vulkan/ui_tex.vert",
+        "assets/shaders/vulkan/ui_tex.frag",
+        "assets/shaders/vulkan/debug_shadow.vert",
+        "assets/shaders/vulkan/debug_shadow.frag",
+        "assets/shaders/vulkan/ssao.vert",
+        "assets/shaders/vulkan/ssao.frag",
+        "assets/shaders/vulkan/ssao_blur.frag",
+        "assets/shaders/vulkan/g_pass.frag",
+        "assets/shaders/vulkan/taa.vert",
+        "assets/shaders/vulkan/taa.frag",
+        "assets/shaders/vulkan/lpv_inject.comp",
+        "assets/shaders/vulkan/lpv_propagate.comp",
+        "assets/shaders/vulkan/culling.comp",
+        "assets/shaders/vulkan/depth_pyramid.comp",
+        "assets/shaders/vulkan/water.vert",
+        "assets/shaders/vulkan/water.frag",
+        "assets/shaders/vulkan/mesh.comp",
+    };
+
+    for (shader_paths) |path| {
+        const validate = b.addSystemCommand(&.{ "glslangValidator", "-V", path });
+        test_step.dependOn(&validate.step);
+    }
 }
 
 fn addCimgui(_: *std.Build, compile: *std.Build.Step.Compile) void {
@@ -696,47 +842,27 @@ fn addSharedImportsNoOptions(module: *std.Build.Module, zig_math: *std.Build.Mod
 
 fn addProjectModuleImports(
     module: *std.Build.Module,
-    engine_math: *std.Build.Module,
-    engine_audio: *std.Build.Module,
-    engine_core: *std.Build.Module,
-    engine_ecs: *std.Build.Module,
-    engine_input: *std.Build.Module,
-    engine_physics: *std.Build.Module,
-    engine_rhi: *std.Build.Module,
-    engine_graphics: *std.Build.Module,
-    engine_assets: *std.Build.Module,
-    engine_camera: *std.Build.Module,
-    engine_clouds: *std.Build.Module,
-    engine_atmosphere: *std.Build.Module,
-    engine_shadows: *std.Build.Module,
-    engine_lighting: *std.Build.Module,
-    engine_ui: *std.Build.Module,
-    world_core: *std.Build.Module,
-    world_worldgen: *std.Build.Module,
-    world_meshing: *std.Build.Module,
-    world_lod: *std.Build.Module,
-    world_runtime: *std.Build.Module,
-    world_persistence: *std.Build.Module,
+    modules: BuildModules,
 ) void {
-    module.addImport("engine-math", engine_math);
-    module.addImport("engine-audio", engine_audio);
-    module.addImport("engine-core", engine_core);
-    module.addImport("engine-ecs", engine_ecs);
-    module.addImport("engine-input", engine_input);
-    module.addImport("engine-physics", engine_physics);
-    module.addImport("engine-rhi", engine_rhi);
-    module.addImport("engine-graphics", engine_graphics);
-    module.addImport("engine-assets", engine_assets);
-    module.addImport("engine-camera", engine_camera);
-    module.addImport("engine-clouds", engine_clouds);
-    module.addImport("engine-atmosphere", engine_atmosphere);
-    module.addImport("engine-shadows", engine_shadows);
-    module.addImport("engine-lighting", engine_lighting);
-    module.addImport("engine-ui", engine_ui);
-    module.addImport("world-core", world_core);
-    module.addImport("world-worldgen", world_worldgen);
-    module.addImport("world-meshing", world_meshing);
-    module.addImport("world-lod", world_lod);
-    module.addImport("world-runtime", world_runtime);
-    module.addImport("world-persistence", world_persistence);
+    module.addImport("engine-math", modules.engine_math);
+    module.addImport("engine-audio", modules.engine_audio);
+    module.addImport("engine-core", modules.engine_core);
+    module.addImport("engine-ecs", modules.engine_ecs);
+    module.addImport("engine-input", modules.engine_input);
+    module.addImport("engine-physics", modules.engine_physics);
+    module.addImport("engine-rhi", modules.engine_rhi);
+    module.addImport("engine-graphics", modules.engine_graphics);
+    module.addImport("engine-assets", modules.engine_assets);
+    module.addImport("engine-camera", modules.engine_camera);
+    module.addImport("engine-clouds", modules.engine_clouds);
+    module.addImport("engine-atmosphere", modules.engine_atmosphere);
+    module.addImport("engine-shadows", modules.engine_shadows);
+    module.addImport("engine-lighting", modules.engine_lighting);
+    module.addImport("engine-ui", modules.engine_ui);
+    module.addImport("world-core", modules.world_core);
+    module.addImport("world-worldgen", modules.world_worldgen);
+    module.addImport("world-meshing", modules.world_meshing);
+    module.addImport("world-lod", modules.world_lod);
+    module.addImport("world-runtime", modules.world_runtime);
+    module.addImport("world-persistence", modules.world_persistence);
 }

--- a/modules/engine-core/src/interfaces.zig
+++ b/modules/engine-core/src/interfaces.zig
@@ -62,42 +62,62 @@ pub const IRenderSettings = struct {
         self.vtable.setBloom(self.ptr, enabled);
     }
 
+    /// Sets bloom strength used by the post-process composite.
+    /// Values are backend-defined floats, normally authored by graphics settings UI.
     pub fn setBloomIntensity(self: IRenderSettings, intensity: f32) void {
         self.vtable.setBloomIntensity(self.ptr, intensity);
     }
 
+    /// Sets the temporal anti-aliasing blend factor.
+    /// Lower values favor the current frame; higher values retain more history and may increase ghosting.
     pub fn setTAABlendFactor(self: IRenderSettings, value: f32) void {
         self.vtable.setTAABlendFactor(self.ptr, value);
     }
 
+    /// Sets how aggressively TAA rejects history using velocity differences.
+    /// Higher values preserve more history; lower values reduce ghosting near fast motion.
     pub fn setTAAVelocityRejection(self: IRenderSettings, value: f32) void {
         self.vtable.setTAAVelocityRejection(self.ptr, value);
     }
 
+    /// Enables or disables vignette post-processing.
+    /// The setting affects only post-process composition, not scene lighting.
     pub fn setVignetteEnabled(self: IRenderSettings, enabled: bool) void {
         self.vtable.setVignetteEnabled(self.ptr, enabled);
     }
 
+    /// Sets the vignette darkening strength used during post-processing.
+    /// Implementations should clamp out-of-range values to their supported range.
     pub fn setVignetteIntensity(self: IRenderSettings, intensity: f32) void {
         self.vtable.setVignetteIntensity(self.ptr, intensity);
     }
 
+    /// Enables or disables film-grain post-processing.
+    /// This does not affect render targets, only final color presentation.
     pub fn setFilmGrainEnabled(self: IRenderSettings, enabled: bool) void {
         self.vtable.setFilmGrainEnabled(self.ptr, enabled);
     }
 
+    /// Sets the film-grain strength used by the post-process pass.
+    /// Backends may quantize or clamp this setting to their shader-supported range.
     pub fn setFilmGrainIntensity(self: IRenderSettings, intensity: f32) void {
         self.vtable.setFilmGrainIntensity(self.ptr, intensity);
     }
 
+    /// Sets volumetric effect density for fog/cloud/atmosphere style rendering.
+    /// The value is consumed by later frames and may be clamped by the backend.
     pub fn setVolumetricDensity(self: IRenderSettings, density: f32) void {
         self.vtable.setVolumetricDensity(self.ptr, density);
     }
 
+    /// Enables or disables the debug shadow-map visualization path.
+    /// Intended for diagnostics; normal gameplay rendering should leave this disabled.
     pub fn setDebugShadowView(self: IRenderSettings, enabled: bool) void {
         self.vtable.setDebugShadowView(self.ptr, enabled);
     }
 
+    /// Sets the requested MSAA sample count.
+    /// The backend may recreate render targets or clamp unsupported sample counts.
     pub fn setMSAA(self: IRenderSettings, samples: u8) void {
         self.vtable.setMSAA(self.ptr, samples);
     }

--- a/modules/engine-core/src/interfaces.zig
+++ b/modules/engine-core/src/interfaces.zig
@@ -26,26 +26,38 @@ pub const IRenderSettings = struct {
         setMSAA: *const fn (ptr: *anyopaque, samples: u8) void,
     };
 
+    /// Enables or disables wireframe rendering in the active render settings backend.
+    /// The setting affects subsequent frames and is typically driven by debug UI or hotkeys.
     pub fn setWireframe(self: IRenderSettings, enabled: bool) void {
         self.vtable.setWireframe(self.ptr, enabled);
     }
 
+    /// Enables or disables vertical synchronization for presentation.
+    /// Backends may apply this on the next swapchain or presentation configuration update.
     pub fn setVSync(self: IRenderSettings, enabled: bool) void {
         self.vtable.setVSync(self.ptr, enabled);
     }
 
+    /// Enables or disables material texture sampling in terrain and world rendering.
+    /// Disabling textures leaves geometry active while forcing fallback material colors.
     pub fn setTexturesEnabled(self: IRenderSettings, enabled: bool) void {
         self.vtable.setTexturesEnabled(self.ptr, enabled);
     }
 
+    /// Sets the anisotropic filtering level requested for sampled textures.
+    /// The backend clamps unsupported levels to device capabilities.
     pub fn setAnisotropicFiltering(self: IRenderSettings, level: u8) void {
         self.vtable.setAnisotropicFiltering(self.ptr, level);
     }
 
+    /// Enables or disables FXAA post-processing.
+    /// The setting affects post-process pass selection for subsequent frames.
     pub fn setFXAA(self: IRenderSettings, enabled: bool) void {
         self.vtable.setFXAA(self.ptr, enabled);
     }
 
+    /// Enables or disables bloom post-processing.
+    /// When disabled, bloom extraction and composite work may be skipped by the renderer.
     pub fn setBloom(self: IRenderSettings, enabled: bool) void {
         self.vtable.setBloom(self.ptr, enabled);
     }
@@ -109,18 +121,26 @@ pub const IScreenManager = struct {
         drawParentScreen: *const fn (ptr: *anyopaque, current_ptr: *anyopaque, ui: *anyopaque) anyerror!void,
     };
 
+    /// Pushes a screen onto the navigation stack.
+    /// Ownership and lifetime of `screen` are defined by the concrete screen manager implementation.
     pub fn pushScreen(self: IScreenManager, screen: ScreenHandle) void {
         self.vtable.pushScreen(self.ptr, screen);
     }
 
+    /// Pops the current screen from the navigation stack.
+    /// Implementations decide how to handle an empty or root-only stack.
     pub fn popScreen(self: IScreenManager) void {
         self.vtable.popScreen(self.ptr);
     }
 
+    /// Replaces the active screen with `screen`.
+    /// This is used for hard navigation transitions such as leaving a modal flow.
     pub fn setScreen(self: IScreenManager, screen: ScreenHandle) void {
         self.vtable.setScreen(self.ptr, screen);
     }
 
+    /// Draws the parent screen behind the current screen when overlays need backdrop rendering.
+    /// Propagates drawing errors from the concrete UI implementation.
     pub fn drawParentScreen(self: IScreenManager, current_ptr: *anyopaque, ui: *anyopaque) !void {
         try self.vtable.drawParentScreen(self.ptr, current_ptr, ui);
     }

--- a/modules/engine-graphics/src/vulkan/culling_system.zig
+++ b/modules/engine-graphics/src/vulkan/culling_system.zig
@@ -121,7 +121,7 @@ pub const CullingSystem = struct {
         };
     }
 
-    pub fn update_aabb_data(self: *CullingSystem, frame_index: usize, chunks: []const ChunkCullData) void {
+    pub fn updateAABBData(self: *CullingSystem, frame_index: usize, chunks: []const ChunkCullData) void {
         const buf = &self.aabb_buffers[frame_index];
         if (buf.mapped_ptr == null) return;
         const copy_len = @min(chunks.len, self.max_chunks) * @sizeOf(ChunkCullData);
@@ -220,14 +220,14 @@ pub const CullingSystem = struct {
         self.copyCounterToReadback(cmd, fi);
     }
 
-    pub fn read_visible_count(self: *CullingSystem, frame_index: usize) u32 {
+    pub fn readVisibleCount(self: *CullingSystem, frame_index: usize) u32 {
         const buf = &self.counter_readback_buffers[frame_index];
         if (buf.mapped_ptr == null) return 0;
         const ptr: *align(1) u32 = @ptrCast(@alignCast(buf.mapped_ptr.?));
         return ptr.*;
     }
 
-    pub fn read_visible_indices(self: *CullingSystem, frame_index: usize, count: u32, out: []u32) void {
+    pub fn readVisibleIndices(self: *CullingSystem, frame_index: usize, count: u32, out: []u32) void {
         if (count == 0) return;
         const buf = &self.visible_index_buffers[frame_index];
         if (buf.mapped_ptr == null) return;
@@ -462,9 +462,9 @@ pub const CullingSystem = struct {
 
 const interface_vtable = culling.ICullingSystem.VTable{
     .deinit = interfaceDeinit,
-    .update_aabb_data = interfaceUpdateAabbData,
-    .read_visible_count = interfaceReadVisibleCount,
-    .read_visible_indices = interfaceReadVisibleIndices,
+    .updateAABBData = interfaceUpdateAabbData,
+    .readVisibleCount = interfaceReadVisibleCount,
+    .readVisibleIndices = interfaceReadVisibleIndices,
     .dispatch = interfaceDispatch,
 };
 
@@ -475,17 +475,17 @@ fn interfaceDeinit(ptr: *anyopaque) void {
 
 fn interfaceUpdateAabbData(ptr: *anyopaque, frame_index: usize, chunks: []const ChunkCullData) void {
     const self: *CullingSystem = @ptrCast(@alignCast(ptr));
-    self.update_aabb_data(frame_index, chunks);
+    self.updateAABBData(frame_index, chunks);
 }
 
 fn interfaceReadVisibleCount(ptr: *anyopaque, frame_index: usize) u32 {
     const self: *CullingSystem = @ptrCast(@alignCast(ptr));
-    return self.read_visible_count(frame_index);
+    return self.readVisibleCount(frame_index);
 }
 
 fn interfaceReadVisibleIndices(ptr: *anyopaque, frame_index: usize, count: u32, out: []u32) void {
     const self: *CullingSystem = @ptrCast(@alignCast(ptr));
-    self.read_visible_indices(frame_index, count, out);
+    self.readVisibleIndices(frame_index, count, out);
 }
 
 fn interfaceDispatch(ptr: *anyopaque, config: culling.DispatchConfig) void {

--- a/modules/engine-rhi/src/culling.zig
+++ b/modules/engine-rhi/src/culling.zig
@@ -19,9 +19,9 @@ pub const ICullingSystem = struct {
 
     pub const VTable = struct {
         deinit: *const fn (ptr: *anyopaque) void,
-        update_aabb_data: *const fn (ptr: *anyopaque, frame_index: usize, chunks: []const ChunkCullData) void,
-        read_visible_count: *const fn (ptr: *anyopaque, frame_index: usize) u32,
-        read_visible_indices: *const fn (ptr: *anyopaque, frame_index: usize, count: u32, out: []u32) void,
+        updateAABBData: *const fn (ptr: *anyopaque, frame_index: usize, chunks: []const ChunkCullData) void,
+        readVisibleCount: *const fn (ptr: *anyopaque, frame_index: usize) u32,
+        readVisibleIndices: *const fn (ptr: *anyopaque, frame_index: usize, count: u32, out: []u32) void,
         dispatch: *const fn (ptr: *anyopaque, config: DispatchConfig) void,
     };
 
@@ -29,16 +29,16 @@ pub const ICullingSystem = struct {
         self.vtable.deinit(self.ptr);
     }
 
-    pub fn update_aabb_data(self: ICullingSystem, frame_index: usize, chunks: []const ChunkCullData) void {
-        self.vtable.update_aabb_data(self.ptr, frame_index, chunks);
+    pub fn updateAABBData(self: ICullingSystem, frame_index: usize, chunks: []const ChunkCullData) void {
+        self.vtable.updateAABBData(self.ptr, frame_index, chunks);
     }
 
-    pub fn read_visible_count(self: ICullingSystem, frame_index: usize) u32 {
-        return self.vtable.read_visible_count(self.ptr, frame_index);
+    pub fn readVisibleCount(self: ICullingSystem, frame_index: usize) u32 {
+        return self.vtable.readVisibleCount(self.ptr, frame_index);
     }
 
-    pub fn read_visible_indices(self: ICullingSystem, frame_index: usize, count: u32, out: []u32) void {
-        self.vtable.read_visible_indices(self.ptr, frame_index, count, out);
+    pub fn readVisibleIndices(self: ICullingSystem, frame_index: usize, count: u32, out: []u32) void {
+        self.vtable.readVisibleIndices(self.ptr, frame_index, count, out);
     }
 
     pub fn dispatch(self: ICullingSystem, config: DispatchConfig) void {

--- a/modules/engine-rhi/src/culling.zig
+++ b/modules/engine-rhi/src/culling.zig
@@ -25,22 +25,32 @@ pub const ICullingSystem = struct {
         dispatch: *const fn (ptr: *anyopaque, config: DispatchConfig) void,
     };
 
+    /// Releases backend culling buffers, pipelines, and readback resources.
+    /// No dispatch or readback methods may be used after this returns.
     pub fn deinit(self: ICullingSystem) void {
         self.vtable.deinit(self.ptr);
     }
 
+    /// Uploads chunk AABB data for the selected frame-in-flight slot.
+    /// `chunks` is copied or staged by the backend and must match the dispatch chunk count used for that frame.
     pub fn updateAABBData(self: ICullingSystem, frame_index: usize, chunks: []const ChunkCullData) void {
         self.vtable.updateAABBData(self.ptr, frame_index, chunks);
     }
 
+    /// Reads the visible chunk count produced by a previous culling dispatch.
+    /// The returned value is valid only after the backend has completed the corresponding frame's compute work.
     pub fn readVisibleCount(self: ICullingSystem, frame_index: usize) u32 {
         return self.vtable.readVisibleCount(self.ptr, frame_index);
     }
 
+    /// Copies visible chunk indices from backend readback storage into `out`.
+    /// `count` should come from `readVisibleCount`; the implementation clamps writes to `out.len`.
     pub fn readVisibleIndices(self: ICullingSystem, frame_index: usize, count: u32, out: []u32) void {
         self.vtable.readVisibleIndices(self.ptr, frame_index, count, out);
     }
 
+    /// Dispatches GPU frustum/occlusion culling for the configured chunk set.
+    /// Must run on the render thread with current-frame AABB data already uploaded.
     pub fn dispatch(self: ICullingSystem, config: DispatchConfig) void {
         self.vtable.dispatch(self.ptr, config);
     }

--- a/modules/engine-rhi/src/rhi.zig
+++ b/modules/engine-rhi/src/rhi.zig
@@ -124,51 +124,63 @@ pub const IResourceFactory = struct {
         unmapBuffer: *const fn (ptr: *anyopaque, handle: BufferHandle) void,
     };
 
-    /// Forwards `createBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Allocates a backend buffer with the requested byte size and usage flags.
+    /// The returned handle is owned by the caller and must later be passed to `destroyBuffer`. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn createBuffer(self: IResourceFactory, size: usize, usage: BufferUsage) RhiError!BufferHandle {
         return self.vtable.createBuffer(self.ptr, size, usage);
     }
-    /// Forwards `uploadBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Uploads a complete byte slice into an existing buffer handle.
+    /// The handle must be live and large enough for `data`; ownership of `data` remains with the caller. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn uploadBuffer(self: IResourceFactory, handle: BufferHandle, data: []const u8) RhiError!void {
         return self.vtable.uploadBuffer(self.ptr, handle, data);
     }
-    /// Forwards `updateBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Writes `data` into an existing buffer starting at `offset` bytes.
+    /// `offset + data.len` must fit the allocation; the backend defines when the write becomes visible to GPU work. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn updateBuffer(self: IResourceFactory, handle: BufferHandle, offset: usize, data: []const u8) RhiError!void {
         return self.vtable.updateBuffer(self.ptr, handle, offset, data);
     }
-    /// Forwards `destroyBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Releases a buffer handle previously returned by `createBuffer`.
+    /// Callers must not use the handle again after destruction; invalid or already-destroyed handles are backend errors. Must be called from the render thread that owns the backend context.
     pub fn destroyBuffer(self: IResourceFactory, handle: BufferHandle) void {
         self.vtable.destroyBuffer(self.ptr, handle);
     }
-    /// Forwards `createTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Creates a 2D texture resource and optionally initializes it from CPU pixels.
+    /// `data`, when provided, must match the texture dimensions, format, and configuration expected by the backend. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn createTexture(self: IResourceFactory, width: u32, height: u32, format: TextureFormat, config: TextureConfig, data: ?[]const u8) RhiError!TextureHandle {
         return self.vtable.createTexture(self.ptr, width, height, format, config, data);
     }
-    /// Forwards `createTexture3D` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Creates a 3D texture resource and optionally initializes it from CPU voxel data.
+    /// `data`, when provided, must match width, height, depth, and format layout. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn createTexture3D(self: IResourceFactory, width: u32, height: u32, depth: u32, format: TextureFormat, config: TextureConfig, data: ?[]const u8) RhiError!TextureHandle {
         return self.vtable.createTexture3D(self.ptr, width, height, depth, format, config, data);
     }
-    /// Forwards `destroyTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Releases a texture handle previously returned by a texture creation call.
+    /// The texture must no longer be referenced by queued draw or compute work. Must be called from the render thread that owns the backend context.
     pub fn destroyTexture(self: IResourceFactory, handle: TextureHandle) void {
         self.vtable.destroyTexture(self.ptr, handle);
     }
-    /// Forwards `updateTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Replaces texture contents from a CPU byte slice.
+    /// The texture handle must be live and the byte layout must match the texture format. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn updateTexture(self: IResourceFactory, handle: TextureHandle, data: []const u8) RhiError!void {
         return self.vtable.updateTexture(self.ptr, handle, data);
     }
-    /// Forwards `createShader` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Builds a shader program from null-terminated vertex and fragment sources.
+    /// Returned shader handles are backend-owned objects and must be destroyed explicitly. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn createShader(self: IResourceFactory, vertex_src: [*c]const u8, fragment_src: [*c]const u8) RhiError!ShaderHandle {
         return self.vtable.createShader(self.ptr, vertex_src, fragment_src);
     }
-    /// Forwards `destroyShader` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Destroys a shader program handle.
+    /// The shader must not be bound by subsequent draw calls after this returns. Must be called from the render thread that owns the backend context.
     pub fn destroyShader(self: IResourceFactory, handle: ShaderHandle) void {
         self.vtable.destroyShader(self.ptr, handle);
     }
-    /// Forwards `mapBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Maps a buffer for CPU access when the backend supports host-visible memory for it.
+    /// Returns `null` for buffers that cannot be mapped; non-null pointers are valid until `unmapBuffer`. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn mapBuffer(self: IResourceFactory, handle: BufferHandle) RhiError!?*anyopaque {
         return self.vtable.mapBuffer(self.ptr, handle);
     }
-    /// Forwards `unmapBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends CPU access to a mapped buffer.
+    /// The handle must refer to a buffer previously mapped through this interface. Must be called from the render thread that owns the backend context.
     pub fn unmapBuffer(self: IResourceFactory, handle: BufferHandle) void {
         self.vtable.unmapBuffer(self.ptr, handle);
     }
@@ -188,51 +200,63 @@ pub const IResourceFactory = struct {
 pub const ResourceManager = struct {
     factory: IResourceFactory,
 
-    /// Forwards `createBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Allocates a backend buffer with the requested byte size and usage flags.
+    /// The returned handle is owned by the caller and must later be passed to `destroyBuffer`. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn createBuffer(self: ResourceManager, size: usize, usage: BufferUsage) RhiError!BufferHandle {
         return self.factory.createBuffer(size, usage);
     }
-    /// Forwards `uploadBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Uploads a complete byte slice into an existing buffer handle.
+    /// The handle must be live and large enough for `data`; ownership of `data` remains with the caller. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn uploadBuffer(self: ResourceManager, handle: BufferHandle, data: []const u8) RhiError!void {
         return self.factory.uploadBuffer(handle, data);
     }
-    /// Forwards `updateBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Writes `data` into an existing buffer starting at `offset` bytes.
+    /// `offset + data.len` must fit the allocation; the backend defines when the write becomes visible to GPU work. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn updateBuffer(self: ResourceManager, handle: BufferHandle, offset: usize, data: []const u8) RhiError!void {
         return self.factory.updateBuffer(handle, offset, data);
     }
-    /// Forwards `destroyBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Releases a buffer handle previously returned by `createBuffer`.
+    /// Callers must not use the handle again after destruction; invalid or already-destroyed handles are backend errors. Must be called from the render thread that owns the backend context.
     pub fn destroyBuffer(self: ResourceManager, handle: BufferHandle) void {
         self.factory.destroyBuffer(handle);
     }
-    /// Forwards `createTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Creates a 2D texture resource and optionally initializes it from CPU pixels.
+    /// `data`, when provided, must match the texture dimensions, format, and configuration expected by the backend. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn createTexture(self: ResourceManager, width: u32, height: u32, format: TextureFormat, config: TextureConfig, data: ?[]const u8) RhiError!TextureHandle {
         return self.factory.createTexture(width, height, format, config, data);
     }
-    /// Forwards `createTexture3D` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Creates a 3D texture resource and optionally initializes it from CPU voxel data.
+    /// `data`, when provided, must match width, height, depth, and format layout. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn createTexture3D(self: ResourceManager, width: u32, height: u32, depth: u32, format: TextureFormat, config: TextureConfig, data: ?[]const u8) RhiError!TextureHandle {
         return self.factory.createTexture3D(width, height, depth, format, config, data);
     }
-    /// Forwards `destroyTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Releases a texture handle previously returned by a texture creation call.
+    /// The texture must no longer be referenced by queued draw or compute work. Must be called from the render thread that owns the backend context.
     pub fn destroyTexture(self: ResourceManager, handle: TextureHandle) void {
         self.factory.destroyTexture(handle);
     }
-    /// Forwards `updateTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Replaces texture contents from a CPU byte slice.
+    /// The texture handle must be live and the byte layout must match the texture format. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn updateTexture(self: ResourceManager, handle: TextureHandle, data: []const u8) RhiError!void {
         return self.factory.updateTexture(handle, data);
     }
-    /// Forwards `createShader` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Builds a shader program from null-terminated vertex and fragment sources.
+    /// Returned shader handles are backend-owned objects and must be destroyed explicitly. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn createShader(self: ResourceManager, vertex_src: [*c]const u8, fragment_src: [*c]const u8) RhiError!ShaderHandle {
         return self.factory.createShader(vertex_src, fragment_src);
     }
-    /// Forwards `destroyShader` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Destroys a shader program handle.
+    /// The shader must not be bound by subsequent draw calls after this returns. Must be called from the render thread that owns the backend context.
     pub fn destroyShader(self: ResourceManager, handle: ShaderHandle) void {
         self.factory.destroyShader(handle);
     }
-    /// Forwards `mapBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Maps a buffer for CPU access when the backend supports host-visible memory for it.
+    /// Returns `null` for buffers that cannot be mapped; non-null pointers are valid until `unmapBuffer`. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn mapBuffer(self: ResourceManager, handle: BufferHandle) RhiError!?*anyopaque {
         return self.factory.mapBuffer(handle);
     }
-    /// Forwards `unmapBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends CPU access to a mapped buffer.
+    /// The handle must refer to a buffer previously mapped through this interface. Must be called from the render thread that owns the backend context.
     pub fn unmapBuffer(self: ResourceManager, handle: BufferHandle) void {
         self.factory.unmapBuffer(handle);
     }
@@ -265,157 +289,194 @@ pub const RenderContext = struct {
 
     // --- IRenderContext delegates ---
 
-    /// Forwards `beginFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins frame for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginFrame(self: RenderContext) void {
         self.render.beginFrame();
     }
-    /// Forwards `endFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends frame for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endFrame(self: RenderContext) void {
         self.render.endFrame();
     }
-    /// Forwards `abortFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Cancels the current frame after a recoverable startup or rendering failure.
+    /// Use only before `endFrame`; the backend may discard recorded commands for the active frame. Must be called from the render thread that owns the backend context.
     pub fn abortFrame(self: RenderContext) void {
         self.render.abortFrame();
     }
-    /// Forwards `beginMainPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins main pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginMainPass(self: RenderContext) void {
         self.passes.beginMainPass();
     }
-    /// Forwards `endMainPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends main pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endMainPass(self: RenderContext) void {
         self.passes.endMainPass();
     }
-    /// Forwards `beginPostProcessPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins post process pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginPostProcessPass(self: RenderContext) void {
         self.passes.beginPostProcessPass();
     }
-    /// Forwards `endPostProcessPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends post process pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endPostProcessPass(self: RenderContext) void {
         self.passes.endPostProcessPass();
     }
-    /// Forwards `beginGPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins g pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginGPass(self: RenderContext) void {
         self.passes.beginGPass();
     }
-    /// Forwards `endGPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends g pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endGPass(self: RenderContext) void {
         self.passes.endGPass();
     }
-    /// Forwards `beginFXAAPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins f x a a pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginFXAAPass(self: RenderContext) void {
         self.passes.beginFXAAPass();
     }
-    /// Forwards `endFXAAPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends f x a a pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endFXAAPass(self: RenderContext) void {
         self.passes.endFXAAPass();
     }
-    /// Forwards `computeBloom` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Provides RHI access for compute bloom.
+    /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules.
     pub fn computeBloom(self: RenderContext) void {
         self.post_process.computeBloom();
     }
-    /// Forwards `computeTAA` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Provides RHI access for compute t a a.
+    /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules.
     pub fn computeTAA(self: RenderContext) void {
         self.post_process.computeTAA();
     }
-    /// Forwards `computeDepthPyramid` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Provides RHI access for compute depth pyramid.
+    /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules.
     pub fn computeDepthPyramid(self: RenderContext) void {
         self.post_process.computeDepthPyramid();
     }
-    /// Forwards `drawSky` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Provides RHI access for draw sky.
+    /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation.
     pub fn drawSky(self: RenderContext, params: SkyParams) RhiError!void {
         return self.effects.drawSky(params);
     }
-    /// Forwards `beginWaterDraw` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins water draw for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginWaterDraw(self: RenderContext, reflection: TextureHandle, scene_depth: TextureHandle) bool {
         return self.effects.beginWaterDraw(reflection, scene_depth);
     }
-    /// Forwards `endWaterDraw` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends water draw for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endWaterDraw(self: RenderContext) void {
         self.effects.endWaterDraw();
     }
-    /// Forwards `requestSwapchainRecreate` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Marks the swapchain-dependent render targets for recreation.
+    /// Use after window resize or presentation errors; actual recreation is backend-controlled. Must be called from the render thread that owns the backend context.
     pub fn requestSwapchainRecreate(self: RenderContext) void {
         self.render.requestSwapchainRecreate();
     }
-    /// Forwards `setClearColor` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets clear color on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setClearColor(self: RenderContext, color: Vec3) void {
         self.render.vtable.setClearColor(self.render.ptr, color);
     }
-    /// Forwards `getNativeSwapchainExtent` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns native swapchain extent from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getNativeSwapchainExtent(self: RenderContext) [2]u32 {
         return self.vulkan.getSwapchainExtent();
     }
-    /// Forwards `getNativeDevice` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns native device from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getNativeDevice(self: RenderContext) u64 {
         return self.vulkan.getDevice();
     }
 
     // --- IGraphicsCommandEncoder delegates ---
 
-    /// Forwards `bindTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Binds a texture handle to the requested shader slot.
+    /// The handle must be live and compatible with the active pipeline layout. Must be called from the render thread that owns the backend context.
     pub fn bindTexture(self: RenderContext, handle: TextureHandle, slot: u32) void {
         self.encoder.bindTexture(handle, slot);
     }
-    /// Forwards `bindBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Binds a buffer handle for subsequent draw or dispatch commands.
+    /// The handle must be live and match the binding expected by the current pipeline. Must be called from the render thread that owns the backend context.
     pub fn bindBuffer(self: RenderContext, handle: BufferHandle, usage: BufferUsage) void {
         self.encoder.bindBuffer(handle, usage);
     }
-    /// Forwards `pushConstants` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Uploads a small byte payload as push constants for the active pipeline.
+    /// The payload size and layout must match the shader stage declaration. Must be called from the render thread that owns the backend context.
     pub fn pushConstants(self: RenderContext, stages: ShaderStageFlags, offset: u32, size: u32, data: *const anyopaque) void {
         self.encoder.pushConstants(stages, offset, size, data);
     }
-    /// Forwards `draw` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Issues a non-indexed draw using the currently bound graphics state.
+    /// A compatible pipeline and vertex buffer must already be bound. Must be called from the render thread that owns the backend context.
     pub fn draw(self: RenderContext, handle: BufferHandle, count: u32, mode: DrawMode) void {
         self.encoder.draw(handle, count, mode);
     }
-    /// Forwards `drawOffset` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Issues a non-indexed draw starting at a byte or vertex offset in the bound buffer.
+    /// The offset and vertex count must stay within the bound buffer allocation. Must be called from the render thread that owns the backend context.
     pub fn drawOffset(self: RenderContext, handle: BufferHandle, count: u32, mode: DrawMode, offset: usize) void {
         self.encoder.drawOffset(handle, count, mode, offset);
     }
-    /// Forwards `drawIndexed` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Issues an indexed draw using currently bound vertex and index buffers.
+    /// Index data and pipeline state must be valid for the requested primitive topology. Must be called from the render thread that owns the backend context.
     pub fn drawIndexed(self: RenderContext, vbo: BufferHandle, ebo: BufferHandle, count: u32) void {
         self.encoder.drawIndexed(vbo, ebo, count);
     }
-    /// Forwards `drawIndirect` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Issues indirect draw commands from a GPU buffer.
+    /// The indirect buffer must contain backend-compatible command records and remain valid through submission. Must be called from the render thread that owns the backend context.
     pub fn drawIndirect(self: RenderContext, handle: BufferHandle, command_buffer: BufferHandle, offset: usize, draw_count: u32, stride: u32) void {
         self.encoder.drawIndirect(handle, command_buffer, offset, draw_count, stride);
     }
-    /// Forwards `drawInstance` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Issues an instanced draw using currently bound per-instance state.
+    /// Instance buffers and model data must be populated for the active frame. Must be called from the render thread that owns the backend context.
     pub fn drawInstance(self: RenderContext, handle: BufferHandle, count: u32, instance_index: u32) void {
         self.encoder.drawInstance(handle, count, instance_index);
     }
-    /// Forwards `setViewport` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets viewport on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setViewport(self: RenderContext, width: u32, height: u32) void {
         self.encoder.setViewport(width, height);
     }
 
     // --- IRenderStateContext delegates ---
 
-    /// Forwards `setModelMatrix` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets model matrix on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setModelMatrix(self: RenderContext, model: Mat4, color: Vec3, mask_radius: f32) void {
         self.state.setModelMatrix(model, color, mask_radius);
     }
-    /// Forwards `setInstanceBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets instance buffer on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setInstanceBuffer(self: RenderContext, handle: BufferHandle) void {
         self.state.setInstanceBuffer(handle);
     }
-    /// Forwards `setLODInstanceBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets l o d instance buffer on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setLODInstanceBuffer(self: RenderContext, handle: BufferHandle) void {
         self.state.setLODInstanceBuffer(handle);
     }
-    /// Forwards `setTerrainPipelineBound` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets terrain pipeline bound on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setTerrainPipelineBound(self: RenderContext, bound: bool) void {
         self.state.setTerrainPipelineBound(bound);
     }
-    /// Forwards `setSelectionMode` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets selection mode on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setSelectionMode(self: RenderContext, enabled: bool) void {
         self.state.setSelectionMode(enabled);
     }
-    /// Forwards `updateGlobalUniforms` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Updates camera, lighting, and frame-global shader uniforms.
+    /// Uniform payloads are copied into backend-managed per-frame storage. Must be called from the render thread that owns the backend context.
     pub fn updateGlobalUniforms(self: RenderContext, uniforms: GlobalUniforms, frame_params: FrameRenderParams) !void {
         try self.state.updateGlobalUniforms(uniforms, frame_params);
     }
-    /// Forwards `setTextureUniforms` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets texture uniforms on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setTextureUniforms(self: RenderContext, texture_enabled: bool, shadow_map_handles: [SHADOW_CASCADE_COUNT]TextureHandle) void {
         self.state.setTextureUniforms(texture_enabled, shadow_map_handles);
     }
@@ -432,19 +493,23 @@ pub const IShadowContext = struct {
         getShadowMapHandle: *const fn (ptr: *anyopaque, cascade_index: u32) TextureHandle,
     };
 
-    /// Forwards `beginPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginPass(self: IShadowContext, cascade_index: u32, light_space_matrix: Mat4) void {
         self.vtable.beginPass(self.ptr, cascade_index, light_space_matrix);
     }
-    /// Forwards `endPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endPass(self: IShadowContext) void {
         self.vtable.endPass(self.ptr);
     }
-    /// Forwards `updateUniforms` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Updates subsystem uniform data for later draws in the current frame.
+    /// Inputs must remain valid for the duration of the call; backend storage owns any copied data. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation.
     pub fn updateUniforms(self: IShadowContext, params: ShadowParams) !void {
         try self.vtable.updateUniforms(self.ptr, params);
     }
-    /// Forwards `getShadowMapHandle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns shadow map handle from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getShadowMapHandle(self: IShadowContext, cascade_index: u32) TextureHandle {
         return self.vtable.getShadowMapHandle(self.ptr, cascade_index);
     }
@@ -466,19 +531,23 @@ pub const IShadowContext = struct {
 pub const ShadowSystemWrapper = struct {
     ctx: IShadowContext,
 
-    /// Forwards `beginPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginPass(self: ShadowSystemWrapper, cascade_index: u32, light_space_matrix: Mat4) void {
         self.ctx.beginPass(cascade_index, light_space_matrix);
     }
-    /// Forwards `endPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endPass(self: ShadowSystemWrapper) void {
         self.ctx.endPass();
     }
-    /// Forwards `updateUniforms` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Updates subsystem uniform data for later draws in the current frame.
+    /// Inputs must remain valid for the duration of the call; backend storage owns any copied data. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation.
     pub fn updateUniforms(self: ShadowSystemWrapper, params: ShadowParams) !void {
         try self.ctx.updateUniforms(params);
     }
-    /// Forwards `getShadowMapHandle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns shadow map handle from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getShadowMapHandle(self: ShadowSystemWrapper, cascade_index: u32) TextureHandle {
         return self.ctx.getShadowMapHandle(cascade_index);
     }
@@ -496,23 +565,28 @@ pub const IWaterContext = struct {
         computeReflectedViewProj: *const fn (ptr: *anyopaque, view: Mat4, proj: Mat4, camera_pos: Vec3) Mat4,
     };
 
-    /// Forwards `beginReflectionPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins reflection pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginReflectionPass(self: IWaterContext) void {
         self.vtable.beginReflectionPass(self.ptr);
     }
-    /// Forwards `endReflectionPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends reflection pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endReflectionPass(self: IWaterContext) void {
         self.vtable.endReflectionPass(self.ptr);
     }
-    /// Forwards `getReflectionTextureHandle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns reflection texture handle from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getReflectionTextureHandle(self: IWaterContext) TextureHandle {
         return self.vtable.getReflectionTextureHandle(self.ptr);
     }
-    /// Forwards `getSceneDepthTextureHandle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns scene depth texture handle from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getSceneDepthTextureHandle(self: IWaterContext) TextureHandle {
         return self.vtable.getSceneDepthTextureHandle(self.ptr);
     }
-    /// Forwards `computeReflectedViewProj` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Computes the reflected view-projection matrix used for water reflections.
+    /// The input view-projection matrix is not modified.
     pub fn computeReflectedViewProj(self: IWaterContext, view: Mat4, proj: Mat4, camera_pos: Vec3) Mat4 {
         return self.vtable.computeReflectedViewProj(self.ptr, view, proj, camera_pos);
     }
@@ -521,23 +595,28 @@ pub const IWaterContext = struct {
 pub const WaterSystemWrapper = struct {
     ctx: IWaterContext,
 
-    /// Forwards `beginReflectionPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins reflection pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginReflectionPass(self: WaterSystemWrapper) void {
         self.ctx.beginReflectionPass();
     }
-    /// Forwards `endReflectionPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends reflection pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endReflectionPass(self: WaterSystemWrapper) void {
         self.ctx.endReflectionPass();
     }
-    /// Forwards `getReflectionTextureHandle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns reflection texture handle from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getReflectionTextureHandle(self: WaterSystemWrapper) TextureHandle {
         return self.ctx.getReflectionTextureHandle();
     }
-    /// Forwards `getSceneDepthTextureHandle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns scene depth texture handle from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getSceneDepthTextureHandle(self: WaterSystemWrapper) TextureHandle {
         return self.ctx.getSceneDepthTextureHandle();
     }
-    /// Forwards `computeReflectedViewProj` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Computes the reflected view-projection matrix used for water reflections.
+    /// The input view-projection matrix is not modified.
     pub fn computeReflectedViewProj(self: WaterSystemWrapper, view: Mat4, proj: Mat4, camera_pos: Vec3) Mat4 {
         return self.ctx.computeReflectedViewProj(view, proj, camera_pos);
     }
@@ -557,31 +636,38 @@ pub const IUIContext = struct {
         bindPipeline: *const fn (ptr: *anyopaque, textured: bool) void,
     };
 
-    /// Forwards `beginPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginPass(self: IUIContext, width: f32, height: f32) void {
         self.vtable.beginPass(self.ptr, width, height);
     }
-    /// Forwards `endPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endPass(self: IUIContext) void {
         self.vtable.endPass(self.ptr);
     }
-    /// Forwards `drawRect` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Queues an immediate-mode rectangle draw for the active UI pass.
+    /// Coordinates and colors are interpreted by the UI backend for the current frame. Must be called from the render thread that owns the backend context.
     pub fn drawRect(self: IUIContext, rect: Rect, color: Color) void {
         self.vtable.drawRect(self.ptr, rect, color);
     }
-    /// Forwards `drawTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Queues an immediate-mode textured rectangle draw for the active UI pass.
+    /// The texture handle must be valid and accessible to the UI pipeline. Must be called from the render thread that owns the backend context.
     pub fn drawTexture(self: IUIContext, texture: TextureHandle, rect: Rect) void {
         self.vtable.drawTexture(self.ptr, texture, rect);
     }
-    /// Forwards `drawTextureRegion` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Queues a textured UI rectangle using a subregion of the source texture.
+    /// Source and destination rectangles are consumed immediately by the active UI pass. Must be called from the render thread that owns the backend context.
     pub fn drawTextureRegion(self: IUIContext, texture: TextureHandle, rect: Rect, uv: UVRect, color: Color) void {
         self.vtable.drawTextureRegion(self.ptr, texture, rect, uv, color);
     }
-    /// Forwards `drawDepthTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Queues a debug draw of a depth texture through the UI pipeline.
+    /// The depth texture must remain valid for the current frame. Must be called from the render thread that owns the backend context.
     pub fn drawDepthTexture(self: IUIContext, texture: TextureHandle, rect: Rect) void {
         self.vtable.drawDepthTexture(self.ptr, texture, rect);
     }
-    /// Forwards `bindPipeline` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Binds the UI pipeline variant needed by subsequent UI draw commands.
+    /// Call inside an active UI pass before issuing dependent draw calls. Must be called from the render thread that owns the backend context.
     pub fn bindPipeline(self: IUIContext, textured: bool) void {
         self.vtable.bindPipeline(self.ptr, textured);
     }
@@ -598,19 +684,23 @@ pub const IImGuiContext = struct {
         renderDrawData: *const fn (ptr: *anyopaque, draw_data: *anyopaque) void,
     };
 
-    /// Forwards `initBackend` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Initializes the ImGui backend bridge against the active renderer.
+    /// Must run after the graphics backend exists and before rendering ImGui draw data. Must be called from the render thread that owns the backend context.
     pub fn initBackend(self: IImGuiContext, window: *anyopaque) bool {
         return self.vtable.initBackend(self.ptr, window);
     }
-    /// Forwards `shutdownBackend` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Shuts down ImGui backend resources.
+    /// No further ImGui draw-data rendering is valid until `initBackend` succeeds again. Must be called from the render thread that owns the backend context.
     pub fn shutdownBackend(self: IImGuiContext) void {
         self.vtable.shutdownBackend(self.ptr);
     }
-    /// Forwards `newFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Starts a new ImGui frame for the backend bridge.
+    /// Call once per frame before building ImGui widgets. Must be called from the render thread that owns the backend context.
     pub fn newFrame(self: IImGuiContext) void {
         self.vtable.newFrame(self.ptr);
     }
-    /// Forwards `renderDrawData` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Submits ImGui draw data to the backend for the current frame.
+    /// The draw data must be produced by the active ImGui frame and used on the render thread. Must be called from the render thread that owns the backend context.
     pub fn renderDrawData(self: IImGuiContext, draw_data: *anyopaque) void {
         self.vtable.renderDrawData(self.ptr, draw_data);
     }
@@ -631,31 +721,38 @@ pub const IImGuiContext = struct {
 pub const UIRenderer = struct {
     ctx: IUIContext,
 
-    /// Forwards `beginPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginPass(self: UIRenderer, width: f32, height: f32) void {
         self.ctx.beginPass(width, height);
     }
-    /// Forwards `endPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endPass(self: UIRenderer) void {
         self.ctx.endPass();
     }
-    /// Forwards `drawRect` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Queues an immediate-mode rectangle draw for the active UI pass.
+    /// Coordinates and colors are interpreted by the UI backend for the current frame. Must be called from the render thread that owns the backend context.
     pub fn drawRect(self: UIRenderer, rect: Rect, color: Color) void {
         self.ctx.drawRect(rect, color);
     }
-    /// Forwards `drawTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Queues an immediate-mode textured rectangle draw for the active UI pass.
+    /// The texture handle must be valid and accessible to the UI pipeline. Must be called from the render thread that owns the backend context.
     pub fn drawTexture(self: UIRenderer, texture: TextureHandle, rect: Rect) void {
         self.ctx.drawTexture(texture, rect);
     }
-    /// Forwards `drawTextureRegion` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Queues a textured UI rectangle using a subregion of the source texture.
+    /// Source and destination rectangles are consumed immediately by the active UI pass. Must be called from the render thread that owns the backend context.
     pub fn drawTextureRegion(self: UIRenderer, texture: TextureHandle, rect: Rect, uv: UVRect, color: Color) void {
         self.ctx.drawTextureRegion(texture, rect, uv, color);
     }
-    /// Forwards `drawDepthTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Queues a debug draw of a depth texture through the UI pipeline.
+    /// The depth texture must remain valid for the current frame. Must be called from the render thread that owns the backend context.
     pub fn drawDepthTexture(self: UIRenderer, texture: TextureHandle, rect: Rect) void {
         self.ctx.drawDepthTexture(texture, rect);
     }
-    /// Forwards `bindPipeline` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Binds the UI pipeline variant needed by subsequent UI draw commands.
+    /// Call inside an active UI pass before issuing dependent draw calls. Must be called from the render thread that owns the backend context.
     pub fn bindPipeline(self: UIRenderer, textured: bool) void {
         self.ctx.bindPipeline(textured);
     }
@@ -677,39 +774,48 @@ pub const IGraphicsCommandEncoder = struct {
         setViewport: *const fn (ptr: *anyopaque, width: u32, height: u32) void,
     };
 
-    /// Forwards `bindTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Binds a texture handle to the requested shader slot.
+    /// The handle must be live and compatible with the active pipeline layout. Must be called from the render thread that owns the backend context.
     pub fn bindTexture(self: IGraphicsCommandEncoder, handle: TextureHandle, slot: u32) void {
         self.vtable.bindTexture(self.ptr, handle, slot);
     }
-    /// Forwards `bindBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Binds a buffer handle for subsequent draw or dispatch commands.
+    /// The handle must be live and match the binding expected by the current pipeline. Must be called from the render thread that owns the backend context.
     pub fn bindBuffer(self: IGraphicsCommandEncoder, handle: BufferHandle, usage: BufferUsage) void {
         self.vtable.bindBuffer(self.ptr, handle, usage);
     }
-    /// Forwards `pushConstants` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Uploads a small byte payload as push constants for the active pipeline.
+    /// The payload size and layout must match the shader stage declaration. Must be called from the render thread that owns the backend context.
     pub fn pushConstants(self: IGraphicsCommandEncoder, stages: ShaderStageFlags, offset: u32, size: u32, data: *const anyopaque) void {
         self.vtable.pushConstants(self.ptr, stages, offset, size, data);
     }
-    /// Forwards `draw` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Issues a non-indexed draw using the currently bound graphics state.
+    /// A compatible pipeline and vertex buffer must already be bound. Must be called from the render thread that owns the backend context.
     pub fn draw(self: IGraphicsCommandEncoder, handle: BufferHandle, count: u32, mode: DrawMode) void {
         self.vtable.draw(self.ptr, handle, count, mode);
     }
-    /// Forwards `drawOffset` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Issues a non-indexed draw starting at a byte or vertex offset in the bound buffer.
+    /// The offset and vertex count must stay within the bound buffer allocation. Must be called from the render thread that owns the backend context.
     pub fn drawOffset(self: IGraphicsCommandEncoder, handle: BufferHandle, count: u32, mode: DrawMode, offset: usize) void {
         self.vtable.drawOffset(self.ptr, handle, count, mode, offset);
     }
-    /// Forwards `drawIndexed` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Issues an indexed draw using currently bound vertex and index buffers.
+    /// Index data and pipeline state must be valid for the requested primitive topology. Must be called from the render thread that owns the backend context.
     pub fn drawIndexed(self: IGraphicsCommandEncoder, vbo: BufferHandle, ebo: BufferHandle, count: u32) void {
         self.vtable.drawIndexed(self.ptr, vbo, ebo, count);
     }
-    /// Forwards `drawIndirect` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Issues indirect draw commands from a GPU buffer.
+    /// The indirect buffer must contain backend-compatible command records and remain valid through submission. Must be called from the render thread that owns the backend context.
     pub fn drawIndirect(self: IGraphicsCommandEncoder, handle: BufferHandle, command_buffer: BufferHandle, offset: usize, draw_count: u32, stride: u32) void {
         self.vtable.drawIndirect(self.ptr, handle, command_buffer, offset, draw_count, stride);
     }
-    /// Forwards `drawInstance` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Issues an instanced draw using currently bound per-instance state.
+    /// Instance buffers and model data must be populated for the active frame. Must be called from the render thread that owns the backend context.
     pub fn drawInstance(self: IGraphicsCommandEncoder, handle: BufferHandle, count: u32, instance_index: u32) void {
         self.vtable.drawInstance(self.ptr, handle, count, instance_index);
     }
-    /// Forwards `setViewport` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets viewport on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setViewport(self: IGraphicsCommandEncoder, width: u32, height: u32) void {
         self.vtable.setViewport(self.ptr, width, height);
     }
@@ -729,31 +835,38 @@ pub const IRenderStateContext = struct {
         setTextureUniforms: *const fn (ptr: *anyopaque, texture_enabled: bool, shadow_map_handles: [SHADOW_CASCADE_COUNT]TextureHandle) void,
     };
 
-    /// Forwards `setModelMatrix` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets model matrix on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setModelMatrix(self: IRenderStateContext, model: Mat4, color: Vec3, mask_radius: f32) void {
         self.vtable.setModelMatrix(self.ptr, model, color, mask_radius);
     }
-    /// Forwards `setInstanceBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets instance buffer on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setInstanceBuffer(self: IRenderStateContext, handle: BufferHandle) void {
         self.vtable.setInstanceBuffer(self.ptr, handle);
     }
-    /// Forwards `setLODInstanceBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets l o d instance buffer on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setLODInstanceBuffer(self: IRenderStateContext, handle: BufferHandle) void {
         self.vtable.setLODInstanceBuffer(self.ptr, handle);
     }
-    /// Forwards `setTerrainPipelineBound` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets terrain pipeline bound on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setTerrainPipelineBound(self: IRenderStateContext, bound: bool) void {
         self.vtable.setTerrainPipelineBound(self.ptr, bound);
     }
-    /// Forwards `setSelectionMode` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets selection mode on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setSelectionMode(self: IRenderStateContext, enabled: bool) void {
         self.vtable.setSelectionMode(self.ptr, enabled);
     }
-    /// Forwards `updateGlobalUniforms` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Updates camera, lighting, and frame-global shader uniforms.
+    /// Uniform payloads are copied into backend-managed per-frame storage. Must be called from the render thread that owns the backend context.
     pub fn updateGlobalUniforms(self: IRenderStateContext, uniforms: GlobalUniforms, frame_params: FrameRenderParams) !void {
         try self.vtable.updateGlobalUniforms(self.ptr, uniforms, frame_params);
     }
-    /// Forwards `setTextureUniforms` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets texture uniforms on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setTextureUniforms(self: IRenderStateContext, texture_enabled: bool, shadow_map_handles: [SHADOW_CASCADE_COUNT]TextureHandle) void {
         self.vtable.setTextureUniforms(self.ptr, texture_enabled, shadow_map_handles);
     }
@@ -768,7 +881,8 @@ pub const ISSAOContext = struct {
         compute: *const fn (ptr: *anyopaque, proj: Mat4, inv_proj: Mat4) void,
     };
 
-    /// Forwards `compute` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the compute command interface.
+    /// Use for backend compute buffers, pipelines, dispatches, and barriers.
     pub fn compute(self: ISSAOContext, proj: Mat4, inv_proj: Mat4) void {
         self.vtable.compute(self.ptr, proj, inv_proj);
     }
@@ -783,7 +897,8 @@ pub const IDebugOverlayContext = struct {
         drawDebugShadowMap: *const fn (ptr: *anyopaque, cascade_index: usize, depth_map_handle: TextureHandle) void,
     };
 
-    /// Forwards `drawDebugShadowMap` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Draws a debug visualization of the shadow map.
+    /// Call from a debug overlay pass with a valid shadow-map target. Must be called from the render thread that owns the backend context.
     pub fn drawDebugShadowMap(self: IDebugOverlayContext, cascade_index: usize, depth_map_handle: TextureHandle) void {
         self.vtable.drawDebugShadowMap(self.ptr, cascade_index, depth_map_handle);
     }
@@ -835,63 +950,78 @@ pub const IComputeContext = struct {
         hasCommandBuffer: *const fn (ptr: *anyopaque) bool,
     };
 
-    /// Forwards `bindComputePipeline` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Binds a compute pipeline for following compute commands.
+    /// The pipeline handle must be live and compatible with later descriptor bindings. Must be called from the render thread that owns the backend context.
     pub fn bindComputePipeline(self: IComputeContext, pipeline: ComputePipeline) void {
         self.vtable.bindComputePipeline(self.ptr, pipeline);
     }
-    /// Forwards `bindDescriptorSet` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Binds a descriptor set for the active compute pipeline.
+    /// The set layout must match the currently bound pipeline. Must be called from the render thread that owns the backend context.
     pub fn bindDescriptorSet(self: IComputeContext, pipeline: ComputePipeline, frame_index: usize) void {
         self.vtable.bindDescriptorSet(self.ptr, pipeline, frame_index);
     }
-    /// Forwards `createComputeBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Allocates a buffer intended for compute workloads.
+    /// Usage and size must match the dispatch path that will read or write the buffer. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn createComputeBuffer(self: IComputeContext, size: usize, host_visible: bool) RhiError!ComputeBuffer {
         return self.vtable.createComputeBuffer(self.ptr, size, host_visible);
     }
-    /// Forwards `destroyComputeBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Destroys a compute buffer handle.
+    /// No queued compute work may reference the buffer after destruction. Must be called from the render thread that owns the backend context.
     pub fn destroyComputeBuffer(self: IComputeContext, buffer: *ComputeBuffer) void {
         self.vtable.destroyComputeBuffer(self.ptr, buffer);
     }
-    /// Forwards `createComputePipeline` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Creates a compute pipeline from shader bytecode or backend shader metadata.
+    /// The returned handle is owned by the caller and must be destroyed explicitly. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn createComputePipeline(self: IComputeContext, allocator: Allocator, shader_path: []const u8, storage_binding_count: u32, push_constant_size: u32) anyerror!ComputePipeline {
         return self.vtable.createComputePipeline(self.ptr, allocator, shader_path, storage_binding_count, push_constant_size);
     }
-    /// Forwards `updateComputeDescriptors` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Refreshes descriptor bindings for a compute pipeline.
+    /// All referenced buffers and textures must be live and layout-compatible. Must be called from the render thread that owns the backend context.
     pub fn updateComputeDescriptors(self: IComputeContext, pipeline: ComputePipeline, frame_index: usize, storage_buffers: []const ComputeBufferBinding) void {
         self.vtable.updateComputeDescriptors(self.ptr, pipeline, frame_index, storage_buffers);
     }
-    /// Forwards `destroyComputePipeline` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Destroys a compute pipeline handle.
+    /// The pipeline must not be bound by any later dispatch. Must be called from the render thread that owns the backend context.
     pub fn destroyComputePipeline(self: IComputeContext, pipeline: *ComputePipeline) void {
         self.vtable.destroyComputePipeline(self.ptr, pipeline);
     }
-    /// Forwards `dispatch` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Dispatches compute workgroups for the active compute pipeline.
+    /// Group counts must match shader expectations and bound resource sizes. Must be called from the render thread that owns the backend context.
     pub fn dispatch(self: IComputeContext, group_count_x: u32, group_count_y: u32, group_count_z: u32) void {
         self.vtable.dispatch(self.ptr, group_count_x, group_count_y, group_count_z);
     }
-    /// Forwards `pushConstants` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Uploads a small byte payload as push constants for the active pipeline.
+    /// The payload size and layout must match the shader stage declaration. Must be called from the render thread that owns the backend context.
     pub fn pushConstants(self: IComputeContext, pipeline: ComputePipeline, offset: u32, size: u32, data: *const anyopaque) void {
         self.vtable.pushConstants(self.ptr, pipeline, offset, size, data);
     }
-    /// Forwards `fillBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Records a command to fill a buffer range with a repeated value.
+    /// The target range must be valid for the buffer allocation. Must be called from the render thread that owns the backend context.
     pub fn fillBuffer(self: IComputeContext, buffer: ComputeBuffer, offset: u64, size: u64, data: u32) void {
         self.vtable.fillBuffer(self.ptr, buffer, offset, size, data);
     }
-    /// Forwards `copyBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Records a GPU buffer-to-buffer copy.
+    /// Source and destination ranges must be valid and non-overlapping unless the backend documents otherwise. Must be called from the render thread that owns the backend context.
     pub fn copyBuffer(self: IComputeContext, src_buffer: ComputeBufferBinding, dst_buffer: ComputeBufferBinding, src_offset: u64, dst_offset: u64, size: u64) void {
         self.vtable.copyBuffer(self.ptr, src_buffer, dst_buffer, src_offset, dst_offset, size);
     }
-    /// Forwards `pipelineBarrier` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Inserts a backend synchronization barrier between pipeline stages.
+    /// Use to make prior writes visible to later reads or writes. Must be called from the render thread that owns the backend context.
     pub fn pipelineBarrier(self: IComputeContext, src_stage: PipelineStageFlags, dst_stage: PipelineStageFlags, src_access: AccessFlags, dst_access: AccessFlags) void {
         self.vtable.pipelineBarrier(self.ptr, src_stage, dst_stage, src_access, dst_access);
     }
-    /// Forwards `bufferBarrier` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Inserts synchronization for a specific buffer resource.
+    /// The buffer handle must be live and the access masks must describe the surrounding commands. Must be called from the render thread that owns the backend context.
     pub fn bufferBarrier(self: IComputeContext, buffer: ComputeBufferBinding, src_stage: PipelineStageFlags, dst_stage: PipelineStageFlags, src_access: AccessFlags, dst_access: AccessFlags, offset: u64, size: u64) void {
         self.vtable.bufferBarrier(self.ptr, buffer, src_stage, dst_stage, src_access, dst_access, offset, size);
     }
-    /// Forwards `waitForFrameFence` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Waits for the frame fence associated with a frame index.
+    /// Use only for explicit synchronization points; waiting on the render thread may stall the frame.
     pub fn waitForFrameFence(self: IComputeContext, frame_index: usize) bool {
         return self.vtable.waitForFrameFence(self.ptr, frame_index);
     }
-    /// Forwards `hasCommandBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Reports whether the backend has a command buffer for a frame index.
+    /// Useful for optional compute paths that must skip frames without command recording.
     pub fn hasCommandBuffer(self: IComputeContext) bool {
         return self.vtable.hasCommandBuffer(self.ptr);
     }
@@ -916,27 +1046,33 @@ pub const IRenderContext = struct {
         setClearColor: *const fn (ptr: *anyopaque, color: Vec3) void,
     };
 
-    /// Forwards `beginFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins frame for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginFrame(self: IRenderContext) void {
         self.vtable.beginFrame(self.ptr);
     }
-    /// Forwards `endFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends frame for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endFrame(self: IRenderContext) void {
         self.vtable.endFrame(self.ptr);
     }
-    /// Forwards `abortFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Cancels the current frame after a recoverable startup or rendering failure.
+    /// Use only before `endFrame`; the backend may discard recorded commands for the active frame. Must be called from the render thread that owns the backend context.
     pub fn abortFrame(self: IRenderContext) void {
         self.vtable.abortFrame(self.ptr);
     }
-    /// Forwards `requestSwapchainRecreate` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Marks the swapchain-dependent render targets for recreation.
+    /// Use after window resize or presentation errors; actual recreation is backend-controlled. Must be called from the render thread that owns the backend context.
     pub fn requestSwapchainRecreate(self: IRenderContext) void {
         self.vtable.requestSwapchainRecreate(self.ptr);
     }
-    /// Forwards `getEncoder` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns encoder from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getEncoder(self: IRenderContext) IGraphicsCommandEncoder {
         return self.vtable.getEncoder(self.ptr);
     }
-    /// Forwards `getState` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns state from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getState(self: IRenderContext) IRenderStateContext {
         return self.vtable.getStateContext(self.ptr);
     }
@@ -957,35 +1093,43 @@ pub const IPassOrchestrationContext = struct {
         endFXAAPass: *const fn (ptr: *anyopaque) void,
     };
 
-    /// Forwards `beginMainPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins main pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginMainPass(self: IPassOrchestrationContext) void {
         self.vtable.beginMainPass(self.ptr);
     }
-    /// Forwards `endMainPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends main pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endMainPass(self: IPassOrchestrationContext) void {
         self.vtable.endMainPass(self.ptr);
     }
-    /// Forwards `beginPostProcessPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins post process pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginPostProcessPass(self: IPassOrchestrationContext) void {
         self.vtable.beginPostProcessPass(self.ptr);
     }
-    /// Forwards `endPostProcessPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends post process pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endPostProcessPass(self: IPassOrchestrationContext) void {
         self.vtable.endPostProcessPass(self.ptr);
     }
-    /// Forwards `beginGPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins g pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginGPass(self: IPassOrchestrationContext) void {
         self.vtable.beginGPass(self.ptr);
     }
-    /// Forwards `endGPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends g pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endGPass(self: IPassOrchestrationContext) void {
         self.vtable.endGPass(self.ptr);
     }
-    /// Forwards `beginFXAAPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins f x a a pass for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginFXAAPass(self: IPassOrchestrationContext) void {
         self.vtable.beginFXAAPass(self.ptr);
     }
-    /// Forwards `endFXAAPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends f x a a pass for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endFXAAPass(self: IPassOrchestrationContext) void {
         self.vtable.endFXAAPass(self.ptr);
     }
@@ -1001,15 +1145,18 @@ pub const IPostProcessContext = struct {
         computeDepthPyramid: *const fn (ptr: *anyopaque) void,
     };
 
-    /// Forwards `computeBloom` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Provides RHI access for compute bloom.
+    /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules.
     pub fn computeBloom(self: IPostProcessContext) void {
         self.vtable.computeBloom(self.ptr);
     }
-    /// Forwards `computeTAA` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Provides RHI access for compute t a a.
+    /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules.
     pub fn computeTAA(self: IPostProcessContext) void {
         self.vtable.computeTAA(self.ptr);
     }
-    /// Forwards `computeDepthPyramid` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Provides RHI access for compute depth pyramid.
+    /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules.
     pub fn computeDepthPyramid(self: IPostProcessContext) void {
         self.vtable.computeDepthPyramid(self.ptr);
     }
@@ -1025,15 +1172,18 @@ pub const IRenderEffectsContext = struct {
         endWaterDraw: *const fn (ptr: *anyopaque) void,
     };
 
-    /// Forwards `drawSky` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Provides RHI access for draw sky.
+    /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation.
     pub fn drawSky(self: IRenderEffectsContext, params: SkyParams) RhiError!void {
         return self.vtable.drawSky(self.ptr, params);
     }
-    /// Forwards `beginWaterDraw` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins water draw for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginWaterDraw(self: IRenderEffectsContext, reflection: TextureHandle, scene_depth: TextureHandle) bool {
         return self.vtable.beginWaterDraw(self.ptr, reflection, scene_depth);
     }
-    /// Forwards `endWaterDraw` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends water draw for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endWaterDraw(self: IRenderEffectsContext) void {
         self.vtable.endWaterDraw(self.ptr);
     }
@@ -1059,43 +1209,53 @@ pub const VulkanNativeHandles = struct {
         getSwapchainImageCount: *const fn (ptr: *anyopaque) u32,
     };
 
-    /// Forwards `getCommandBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns command buffer from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getCommandBuffer(self: VulkanNativeHandles) u64 {
         return self.vtable.getCommandBuffer(self.ptr);
     }
-    /// Forwards `getSwapchainExtent` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns swapchain extent from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getSwapchainExtent(self: VulkanNativeHandles) [2]u32 {
         return self.vtable.getSwapchainExtent(self.ptr);
     }
-    /// Forwards `getDevice` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns device from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getDevice(self: VulkanNativeHandles) u64 {
         return self.vtable.getDevice(self.ptr);
     }
-    /// Forwards `getInstance` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns instance from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getInstance(self: VulkanNativeHandles) u64 {
         return self.vtable.getInstance(self.ptr);
     }
-    /// Forwards `getPhysicalDevice` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns physical device from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getPhysicalDevice(self: VulkanNativeHandles) u64 {
         return self.vtable.getPhysicalDevice(self.ptr);
     }
-    /// Forwards `getQueue` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns queue from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getQueue(self: VulkanNativeHandles) u64 {
         return self.vtable.getQueue(self.ptr);
     }
-    /// Forwards `getQueueFamily` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns queue family from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getQueueFamily(self: VulkanNativeHandles) u32 {
         return self.vtable.getQueueFamily(self.ptr);
     }
-    /// Forwards `getDescriptorPool` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns descriptor pool from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getDescriptorPool(self: VulkanNativeHandles) u64 {
         return self.vtable.getDescriptorPool(self.ptr);
     }
-    /// Forwards `getUiRenderPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns ui render pass from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getUiRenderPass(self: VulkanNativeHandles) u64 {
         return self.vtable.getUiRenderPass(self.ptr);
     }
-    /// Forwards `getSwapchainImageCount` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns swapchain image count from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getSwapchainImageCount(self: VulkanNativeHandles) u32 {
         return self.vtable.getSwapchainImageCount(self.ptr);
     }
@@ -1118,38 +1278,46 @@ pub const IDeviceQuery = struct {
         waitIdle: *const fn (ptr: *anyopaque) void,
     };
 
-    /// Forwards `getFrameIndex` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns frame index from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getFrameIndex(self: IDeviceQuery) usize {
         return self.vtable.getFrameIndex(self.ptr);
     }
-    /// Forwards `supportsIndirectFirstInstance` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Reports whether indirect draw commands may use non-zero `firstInstance`.
+    /// Callers must fall back to direct or rebased draws when this returns false.
     pub fn supportsIndirectFirstInstance(self: IDeviceQuery) bool {
         return self.vtable.supportsIndirectFirstInstance(self.ptr);
     }
-    /// Forwards `getFaultCount` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns fault count from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getFaultCount(self: IDeviceQuery) u32 {
         return self.vtable.getFaultCount(self.ptr);
     }
-    /// Forwards `getValidationErrorCount` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns validation error count from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getValidationErrorCount(self: IDeviceQuery) u32 {
         return self.vtable.getValidationErrorCount(self.ptr);
     }
 
-    /// Forwards `getDrawCallCount` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns draw call count from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getDrawCallCount(self: IDeviceQuery) u32 {
         return self.vtable.getDrawCallCount(self.ptr);
     }
 
-    /// Forwards `getDeviceLocalVramBytes` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns device local vram bytes from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getDeviceLocalVramBytes(self: IDeviceQuery) u64 {
         return self.vtable.getDeviceLocalVramBytes(self.ptr);
     }
 
-    /// Forwards `getRenderResolution` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns render resolution from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getRenderResolution(self: IDeviceQuery) RenderResolution {
         return self.vtable.getRenderResolution(self.ptr);
     }
-    /// Forwards `waitIdle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Blocks until the backend device has completed queued work.
+    /// Use during shutdown, resource teardown, or tests; avoid in normal frame paths.
     pub fn waitIdle(self: IDeviceQuery) void {
         self.vtable.waitIdle(self.ptr);
     }
@@ -1167,23 +1335,28 @@ pub const IDeviceTiming = struct {
         setTimingEnabled: *const fn (ptr: *anyopaque, enabled: bool) void,
     };
 
-    /// Forwards `beginPassTiming` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Begins pass timing for the current frame.
+    /// Must be paired with the matching end call and used from the render thread.
     pub fn beginPassTiming(self: IDeviceTiming, pass_name: []const u8) void {
         self.vtable.beginPassTiming(self.ptr, pass_name);
     }
-    /// Forwards `endPassTiming` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Ends pass timing for the current frame.
+    /// All commands for that scope must be recorded before this call.
     pub fn endPassTiming(self: IDeviceTiming, pass_name: []const u8) void {
         self.vtable.endPassTiming(self.ptr, pass_name);
     }
-    /// Forwards `getTimingResults` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns timing results from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getTimingResults(self: IDeviceTiming) GpuTimingResults {
         return self.vtable.getTimingResults(self.ptr);
     }
-    /// Forwards `isTimingEnabled` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Reports whether GPU timing capture is enabled.
+    /// Callers can use this to avoid timing-only work when profiling is disabled.
     pub fn isTimingEnabled(self: IDeviceTiming) bool {
         return self.vtable.isTimingEnabled(self.ptr);
     }
-    /// Forwards `setTimingEnabled` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets timing enabled on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setTimingEnabled(self: IDeviceTiming, enabled: bool) void {
         self.vtable.setTimingEnabled(self.ptr, enabled);
     }
@@ -1217,87 +1390,108 @@ pub const IRenderQualityOptions = struct {
         getResolutionScale: *const fn (ctx: *anyopaque) f32,
     };
 
-    /// Forwards `setWireframe` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets wireframe on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setWireframe(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setWireframe(self.ptr, enabled);
     }
-    /// Forwards `setTexturesEnabled` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets textures enabled on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setTexturesEnabled(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setTexturesEnabled(self.ptr, enabled);
     }
-    /// Forwards `setDebugShadowView` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets debug shadow view on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setDebugShadowView(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setDebugShadowView(self.ptr, enabled);
     }
-    /// Forwards `setShadowDebugChannel` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets shadow debug channel on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setShadowDebugChannel(self: IRenderQualityOptions, channel: u32) void {
         self.vtable.setShadowDebugChannel(self.ptr, channel);
     }
-    /// Forwards `setVSync` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets v sync on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setVSync(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setVSync(self.ptr, enabled);
     }
-    /// Forwards `setAnisotropicFiltering` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets anisotropic filtering on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setAnisotropicFiltering(self: IRenderQualityOptions, level: u8) void {
         self.vtable.setAnisotropicFiltering(self.ptr, level);
     }
-    /// Forwards `setVolumetricDensity` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets volumetric density on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setVolumetricDensity(self: IRenderQualityOptions, density: f32) void {
         self.vtable.setVolumetricDensity(self.ptr, density);
     }
-    /// Forwards `setMSAA` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets m s a a on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setMSAA(self: IRenderQualityOptions, samples: u8) void {
         self.vtable.setMSAA(self.ptr, samples);
     }
-    /// Forwards `setFXAA` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets f x a a on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setFXAA(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setFXAA(self.ptr, enabled);
     }
-    /// Forwards `setBloom` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets bloom on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setBloom(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setBloom(self.ptr, enabled);
     }
-    /// Forwards `setBloomIntensity` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets bloom intensity on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setBloomIntensity(self: IRenderQualityOptions, intensity: f32) void {
         self.vtable.setBloomIntensity(self.ptr, intensity);
     }
-    /// Forwards `setVignetteEnabled` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets vignette enabled on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setVignetteEnabled(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setVignetteEnabled(self.ptr, enabled);
     }
-    /// Forwards `setVignetteIntensity` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets vignette intensity on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setVignetteIntensity(self: IRenderQualityOptions, intensity: f32) void {
         self.vtable.setVignetteIntensity(self.ptr, intensity);
     }
-    /// Forwards `setFilmGrainEnabled` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets film grain enabled on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setFilmGrainEnabled(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setFilmGrainEnabled(self.ptr, enabled);
     }
-    /// Forwards `setFilmGrainIntensity` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets film grain intensity on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setFilmGrainIntensity(self: IRenderQualityOptions, intensity: f32) void {
         self.vtable.setFilmGrainIntensity(self.ptr, intensity);
     }
-    /// Forwards `setColorGradingEnabled` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets color grading enabled on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setColorGradingEnabled(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setColorGradingEnabled(self.ptr, enabled);
     }
-    /// Forwards `setColorGradingIntensity` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets color grading intensity on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setColorGradingIntensity(self: IRenderQualityOptions, intensity: f32) void {
         self.vtable.setColorGradingIntensity(self.ptr, intensity);
     }
-    /// Forwards `setTAABlendFactor` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets t a a blend factor on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setTAABlendFactor(self: IRenderQualityOptions, value: f32) void {
         self.vtable.setTAABlendFactor(self.ptr, value);
     }
-    /// Forwards `setTAAVelocityRejection` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets t a a velocity rejection on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setTAAVelocityRejection(self: IRenderQualityOptions, value: f32) void {
         self.vtable.setTAAVelocityRejection(self.ptr, value);
     }
-    /// Forwards `setDynamicResolution` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Sets dynamic resolution on the active graphics backend.
+    /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setDynamicResolution(self: IRenderQualityOptions, enabled: bool, min_scale: f32, max_scale: f32, target_fps: u32) void {
         self.vtable.setDynamicResolution(self.ptr, enabled, min_scale, max_scale, target_fps);
     }
-    /// Forwards `getResolutionScale` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns resolution scale from the active graphics backend.
+    /// The returned value is backend-owned or diagnostic unless the specific type documents otherwise.
     pub fn getResolutionScale(self: IRenderQualityOptions) f32 {
         return self.vtable.getResolutionScale(self.ptr);
     }
@@ -1311,7 +1505,8 @@ pub const IDeviceRecovery = struct {
         recover: *const fn (ctx: *anyopaque) anyerror!void,
     };
 
-    /// Forwards `recover` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Attempts to recover the graphics backend after a recoverable failure.
+    /// Returns an error if backend resources cannot be recreated safely. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn recover(self: IDeviceRecovery) !void {
         return self.vtable.recover(self.ptr);
     }
@@ -1325,7 +1520,8 @@ pub const ICullingSystemFactory = struct {
         createCullingSystem: *const fn (ctx: *anyopaque, allocator: Allocator, max_chunks: usize) anyerror!?ICullingSystem,
     };
 
-    /// Forwards `createCullingSystem` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Creates a GPU culling system bound to the active backend resources.
+    /// The caller owns the returned interface and must deinitialize it through its contract. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn createCullingSystem(self: ICullingSystemFactory, allocator: Allocator, max_chunks: usize) anyerror!?ICullingSystem {
         return self.vtable.createCullingSystem(self.ptr, allocator, max_chunks);
     }
@@ -1339,7 +1535,8 @@ pub const IScreenshotContext = struct {
         captureFrame: *const fn (ctx: *anyopaque, path: []const u8) bool,
     };
 
-    /// Forwards `captureFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Captures the current framebuffer to the requested output path.
+    /// The path must be writable and capture resources must be available for the active backend. Must be called from the render thread that owns the backend context.
     pub fn captureFrame(self: IScreenshotContext, path: []const u8) bool {
         return self.vtable.captureFrame(self.ptr, path);
     }
@@ -1413,7 +1610,8 @@ pub const RHI = struct {
         screenshot: ?*const IScreenshotContext.VTable = null,
     };
 
-    /// Forwards `composeVTable` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Builds the composite RHI vtable from subsystem interfaces.
+    /// Used during RHI construction; all subsystem pointers must outlive the composed `RHI`.
     pub fn composeVTable(lifecycle: Lifecycle, interfaces: Interfaces) VTable {
         return .{
             .init = lifecycle.init,
@@ -1440,19 +1638,23 @@ pub const RHI = struct {
         };
     }
 
-    /// Forwards `factory` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the resource factory interface for direct buffer, texture, and shader lifecycle operations.
+    /// The returned interface borrows the RHI backend and must not outlive it.
     pub fn factory(self: RHI) IResourceFactory {
         return .{ .ptr = self.ptr, .vtable = self.vtable.resources orelse unreachable };
     }
-    /// Forwards `resourceManager` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the convenience resource manager wrapper.
+    /// Use when a subsystem needs resource lifecycle operations without the full RHI surface.
     pub fn resourceManager(self: RHI) ResourceManager {
         return .{ .factory = self.factory() };
     }
-    /// Forwards `context` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the legacy render-context wrapper for frame and draw operations.
+    /// Prefer narrower interfaces for new subsystem code when possible.
     pub fn context(self: RHI) IRenderContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.render orelse unreachable };
     }
-    /// Forwards `renderContext` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the frame-local render context wrapper.
+    /// Construct per frame because encoder and pass state are tied to current backend state.
     pub fn renderContext(self: RHI) RenderContext {
         const rc = self.context();
         return .{
@@ -1465,15 +1667,18 @@ pub const RHI = struct {
             .state = rc.getState(),
         };
     }
-    /// Forwards `passOrchestration` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the pass orchestration interface.
+    /// Use to begin and end high-level render passes in backend-defined order.
     pub fn passOrchestration(self: RHI) IPassOrchestrationContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.passes orelse unreachable };
     }
-    /// Forwards `postProcess` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the post-processing interface.
+    /// Use for bloom, TAA, and depth-pyramid compute passes.
     pub fn postProcess(self: RHI) IPostProcessContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.post_process orelse unreachable };
     }
-    /// Forwards `renderEffects` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the render-effects interface.
+    /// Use for sky, water, and other effect-specific draw orchestration.
     pub fn renderEffects(self: RHI) IRenderEffectsContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.effects orelse unreachable };
     }
@@ -1483,97 +1688,120 @@ pub const RHI = struct {
     pub fn vulkanHandles(self: RHI) VulkanNativeHandles {
         return .{ .ptr = self.ptr, .vtable = self.vtable.vulkan orelse unreachable };
     }
-    /// Forwards `encoder` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the graphics command encoder interface.
+    /// The encoder is frame-scoped and follows render-thread ownership.
     pub fn encoder(self: RHI) IGraphicsCommandEncoder {
         return self.context().getEncoder();
     }
-    /// Forwards `state` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the render state interface.
+    /// Use to update uniforms, bind instance buffers, and configure draw state.
     pub fn state(self: RHI) IRenderStateContext {
         return self.context().getState();
     }
-    /// Forwards `ssao` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the SSAO subsystem interface.
+    /// The subsystem remains owned by the RHI backend.
     pub fn ssao(self: RHI) ISSAOContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.ssao orelse unreachable };
     }
-    /// Forwards `debugOverlay` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the debug-overlay rendering interface.
+    /// Use only for diagnostic visualizations.
     pub fn debugOverlay(self: RHI) IDebugOverlayContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.debug_overlay orelse unreachable };
     }
-    /// Forwards `shadow` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the shadow-scene pass interface.
+    /// Use for shadow-map pass control and uniforms.
     pub fn shadow(self: RHI) IShadowContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.shadow orelse unreachable };
     }
-    /// Forwards `shadowSystem` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the shadow system interface.
+    /// Use for shadow resources and debug inspection.
     pub fn shadowSystem(self: RHI) ShadowSystemWrapper {
         return .{ .ctx = self.shadow() };
     }
-    /// Forwards `waterSystem` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the water reflection system interface.
+    /// Use for reflection pass control and water render targets.
     pub fn waterSystem(self: RHI) WaterSystemWrapper {
         return .{ .ctx = self.water() };
     }
-    /// Forwards `water` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the water convenience wrapper.
+    /// This borrows the RHI backend and must not outlive it.
     pub fn water(self: RHI) IWaterContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.water orelse unreachable };
     }
-    /// Forwards `compute` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the compute command interface.
+    /// Use for backend compute buffers, pipelines, dispatches, and barriers.
     pub fn compute(self: RHI) IComputeContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.compute orelse unreachable };
     }
-    /// Forwards `ui` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the immediate-mode UI rendering interface.
+    /// Use inside UI pass setup for rectangles and textures.
     pub fn ui(self: RHI) IUIContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.ui orelse unreachable };
     }
-    /// Forwards `imgui` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the Dear ImGui backend interface.
+    /// Use when the optional ImGui integration is enabled.
     pub fn imgui(self: RHI) IImGuiContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.imgui orelse unreachable };
     }
-    /// Forwards `uiRenderer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the convenience UI renderer wrapper.
+    /// This narrows callers to UI drawing operations.
     pub fn uiRenderer(self: RHI) UIRenderer {
         return .{ .ctx = self.ui() };
     }
-    /// Forwards `query` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns backend query and diagnostic counters.
+    /// Use for frame index, indirect support, validation, and memory telemetry.
     pub fn query(self: RHI) IDeviceQuery {
         return .{ .ptr = self.ptr, .vtable = self.vtable.query orelse unreachable };
     }
-    /// Forwards `timing` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the GPU timing interface.
+    /// Use for optional pass timing capture and result retrieval.
     pub fn timing(self: RHI) IDeviceTiming {
         return .{ .ptr = self.ptr, .vtable = self.vtable.timing orelse unreachable };
     }
-    /// Forwards `options` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the render-quality option interface.
+    /// Use to mutate graphics settings exposed by the backend.
     pub fn options(self: RHI) IRenderQualityOptions {
         return self.renderQualityOptions();
     }
-    /// Forwards `renderQualityOptions` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the convenience render-quality wrapper.
+    /// This narrows callers to quality option mutation and queries.
     pub fn renderQualityOptions(self: RHI) IRenderQualityOptions {
         return .{ .ptr = self.ptr, .vtable = self.vtable.quality orelse unreachable };
     }
-    /// Forwards `recovery` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the backend recovery interface.
+    /// Use only around recoverable device or swapchain failures.
     pub fn recovery(self: RHI) IDeviceRecovery {
         return .{ .ptr = self.ptr, .vtable = self.vtable.recovery orelse unreachable };
     }
-    /// Forwards `cullingFactory` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the GPU culling factory interface.
+    /// Use to construct culling systems backed by the active RHI.
     pub fn cullingFactory(self: RHI) ICullingSystemFactory {
         return .{ .ptr = self.ptr, .vtable = self.vtable.culling_factory orelse unreachable };
     }
-    /// Forwards `screenshot` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Returns the screenshot capture interface.
+    /// Use for test and diagnostic frame capture.
     pub fn screenshot(self: RHI) IScreenshotContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.screenshot orelse unreachable };
     }
-    /// Forwards `createCullingSystem` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Creates a GPU culling system bound to the active backend resources.
+    /// The caller owns the returned interface and must deinitialize it through its contract. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation. Must be called from the render thread that owns the backend context.
     pub fn createCullingSystem(self: RHI, allocator: Allocator, max_chunks: usize) anyerror!?ICullingSystem {
         return self.cullingFactory().createCullingSystem(allocator, max_chunks);
     }
 
     // Lifecycle
-    /// Forwards `init` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Constructs an `RHI` composite from a backend pointer and vtable.
+    /// The backend pointer and vtable must remain valid until `deinit`.
     pub fn init(self: RHI, allocator: Allocator, device: ?*RenderDevice) !void {
         return self.vtable.init(self.ptr, allocator, device);
     }
-    /// Forwards `deinit` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Destroys the RHI backend and releases owned graphics resources.
+    /// No borrowed subsystem interfaces may be used after this returns. Must be called from the render thread that owns the backend context.
     pub fn deinit(self: RHI) void {
         self.vtable.deinit(self.ptr);
     }
-    /// Forwards `waitIdle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
+    /// Blocks until the backend device has completed queued work.
+    /// Use during shutdown, resource teardown, or tests; avoid in normal frame paths.
     pub fn waitIdle(self: RHI) void {
         (self.vtable.query orelse unreachable).waitIdle(self.ptr);
     }

--- a/modules/engine-rhi/src/rhi.zig
+++ b/modules/engine-rhi/src/rhi.zig
@@ -124,39 +124,51 @@ pub const IResourceFactory = struct {
         unmapBuffer: *const fn (ptr: *anyopaque, handle: BufferHandle) void,
     };
 
+    /// Forwards `createBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn createBuffer(self: IResourceFactory, size: usize, usage: BufferUsage) RhiError!BufferHandle {
         return self.vtable.createBuffer(self.ptr, size, usage);
     }
+    /// Forwards `uploadBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn uploadBuffer(self: IResourceFactory, handle: BufferHandle, data: []const u8) RhiError!void {
         return self.vtable.uploadBuffer(self.ptr, handle, data);
     }
+    /// Forwards `updateBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn updateBuffer(self: IResourceFactory, handle: BufferHandle, offset: usize, data: []const u8) RhiError!void {
         return self.vtable.updateBuffer(self.ptr, handle, offset, data);
     }
+    /// Forwards `destroyBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn destroyBuffer(self: IResourceFactory, handle: BufferHandle) void {
         self.vtable.destroyBuffer(self.ptr, handle);
     }
+    /// Forwards `createTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn createTexture(self: IResourceFactory, width: u32, height: u32, format: TextureFormat, config: TextureConfig, data: ?[]const u8) RhiError!TextureHandle {
         return self.vtable.createTexture(self.ptr, width, height, format, config, data);
     }
+    /// Forwards `createTexture3D` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn createTexture3D(self: IResourceFactory, width: u32, height: u32, depth: u32, format: TextureFormat, config: TextureConfig, data: ?[]const u8) RhiError!TextureHandle {
         return self.vtable.createTexture3D(self.ptr, width, height, depth, format, config, data);
     }
+    /// Forwards `destroyTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn destroyTexture(self: IResourceFactory, handle: TextureHandle) void {
         self.vtable.destroyTexture(self.ptr, handle);
     }
+    /// Forwards `updateTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn updateTexture(self: IResourceFactory, handle: TextureHandle, data: []const u8) RhiError!void {
         return self.vtable.updateTexture(self.ptr, handle, data);
     }
+    /// Forwards `createShader` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn createShader(self: IResourceFactory, vertex_src: [*c]const u8, fragment_src: [*c]const u8) RhiError!ShaderHandle {
         return self.vtable.createShader(self.ptr, vertex_src, fragment_src);
     }
+    /// Forwards `destroyShader` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn destroyShader(self: IResourceFactory, handle: ShaderHandle) void {
         self.vtable.destroyShader(self.ptr, handle);
     }
+    /// Forwards `mapBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn mapBuffer(self: IResourceFactory, handle: BufferHandle) RhiError!?*anyopaque {
         return self.vtable.mapBuffer(self.ptr, handle);
     }
+    /// Forwards `unmapBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn unmapBuffer(self: IResourceFactory, handle: BufferHandle) void {
         self.vtable.unmapBuffer(self.ptr, handle);
     }
@@ -176,39 +188,51 @@ pub const IResourceFactory = struct {
 pub const ResourceManager = struct {
     factory: IResourceFactory,
 
+    /// Forwards `createBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn createBuffer(self: ResourceManager, size: usize, usage: BufferUsage) RhiError!BufferHandle {
         return self.factory.createBuffer(size, usage);
     }
+    /// Forwards `uploadBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn uploadBuffer(self: ResourceManager, handle: BufferHandle, data: []const u8) RhiError!void {
         return self.factory.uploadBuffer(handle, data);
     }
+    /// Forwards `updateBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn updateBuffer(self: ResourceManager, handle: BufferHandle, offset: usize, data: []const u8) RhiError!void {
         return self.factory.updateBuffer(handle, offset, data);
     }
+    /// Forwards `destroyBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn destroyBuffer(self: ResourceManager, handle: BufferHandle) void {
         self.factory.destroyBuffer(handle);
     }
+    /// Forwards `createTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn createTexture(self: ResourceManager, width: u32, height: u32, format: TextureFormat, config: TextureConfig, data: ?[]const u8) RhiError!TextureHandle {
         return self.factory.createTexture(width, height, format, config, data);
     }
+    /// Forwards `createTexture3D` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn createTexture3D(self: ResourceManager, width: u32, height: u32, depth: u32, format: TextureFormat, config: TextureConfig, data: ?[]const u8) RhiError!TextureHandle {
         return self.factory.createTexture3D(width, height, depth, format, config, data);
     }
+    /// Forwards `destroyTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn destroyTexture(self: ResourceManager, handle: TextureHandle) void {
         self.factory.destroyTexture(handle);
     }
+    /// Forwards `updateTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn updateTexture(self: ResourceManager, handle: TextureHandle, data: []const u8) RhiError!void {
         return self.factory.updateTexture(handle, data);
     }
+    /// Forwards `createShader` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn createShader(self: ResourceManager, vertex_src: [*c]const u8, fragment_src: [*c]const u8) RhiError!ShaderHandle {
         return self.factory.createShader(vertex_src, fragment_src);
     }
+    /// Forwards `destroyShader` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn destroyShader(self: ResourceManager, handle: ShaderHandle) void {
         self.factory.destroyShader(handle);
     }
+    /// Forwards `mapBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn mapBuffer(self: ResourceManager, handle: BufferHandle) RhiError!?*anyopaque {
         return self.factory.mapBuffer(handle);
     }
+    /// Forwards `unmapBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn unmapBuffer(self: ResourceManager, handle: BufferHandle) void {
         self.factory.unmapBuffer(handle);
     }
@@ -241,120 +265,157 @@ pub const RenderContext = struct {
 
     // --- IRenderContext delegates ---
 
+    /// Forwards `beginFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginFrame(self: RenderContext) void {
         self.render.beginFrame();
     }
+    /// Forwards `endFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endFrame(self: RenderContext) void {
         self.render.endFrame();
     }
+    /// Forwards `abortFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn abortFrame(self: RenderContext) void {
         self.render.abortFrame();
     }
+    /// Forwards `beginMainPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginMainPass(self: RenderContext) void {
         self.passes.beginMainPass();
     }
+    /// Forwards `endMainPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endMainPass(self: RenderContext) void {
         self.passes.endMainPass();
     }
+    /// Forwards `beginPostProcessPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginPostProcessPass(self: RenderContext) void {
         self.passes.beginPostProcessPass();
     }
+    /// Forwards `endPostProcessPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endPostProcessPass(self: RenderContext) void {
         self.passes.endPostProcessPass();
     }
+    /// Forwards `beginGPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginGPass(self: RenderContext) void {
         self.passes.beginGPass();
     }
+    /// Forwards `endGPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endGPass(self: RenderContext) void {
         self.passes.endGPass();
     }
+    /// Forwards `beginFXAAPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginFXAAPass(self: RenderContext) void {
         self.passes.beginFXAAPass();
     }
+    /// Forwards `endFXAAPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endFXAAPass(self: RenderContext) void {
         self.passes.endFXAAPass();
     }
+    /// Forwards `computeBloom` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn computeBloom(self: RenderContext) void {
         self.post_process.computeBloom();
     }
+    /// Forwards `computeTAA` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn computeTAA(self: RenderContext) void {
         self.post_process.computeTAA();
     }
+    /// Forwards `computeDepthPyramid` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn computeDepthPyramid(self: RenderContext) void {
         self.post_process.computeDepthPyramid();
     }
+    /// Forwards `drawSky` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawSky(self: RenderContext, params: SkyParams) RhiError!void {
         return self.effects.drawSky(params);
     }
+    /// Forwards `beginWaterDraw` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginWaterDraw(self: RenderContext, reflection: TextureHandle, scene_depth: TextureHandle) bool {
         return self.effects.beginWaterDraw(reflection, scene_depth);
     }
+    /// Forwards `endWaterDraw` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endWaterDraw(self: RenderContext) void {
         self.effects.endWaterDraw();
     }
+    /// Forwards `requestSwapchainRecreate` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn requestSwapchainRecreate(self: RenderContext) void {
         self.render.requestSwapchainRecreate();
     }
+    /// Forwards `setClearColor` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setClearColor(self: RenderContext, color: Vec3) void {
         self.render.vtable.setClearColor(self.render.ptr, color);
     }
+    /// Forwards `getNativeSwapchainExtent` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getNativeSwapchainExtent(self: RenderContext) [2]u32 {
         return self.vulkan.getSwapchainExtent();
     }
+    /// Forwards `getNativeDevice` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getNativeDevice(self: RenderContext) u64 {
         return self.vulkan.getDevice();
     }
 
     // --- IGraphicsCommandEncoder delegates ---
 
+    /// Forwards `bindTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn bindTexture(self: RenderContext, handle: TextureHandle, slot: u32) void {
         self.encoder.bindTexture(handle, slot);
     }
+    /// Forwards `bindBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn bindBuffer(self: RenderContext, handle: BufferHandle, usage: BufferUsage) void {
         self.encoder.bindBuffer(handle, usage);
     }
+    /// Forwards `pushConstants` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn pushConstants(self: RenderContext, stages: ShaderStageFlags, offset: u32, size: u32, data: *const anyopaque) void {
         self.encoder.pushConstants(stages, offset, size, data);
     }
+    /// Forwards `draw` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn draw(self: RenderContext, handle: BufferHandle, count: u32, mode: DrawMode) void {
         self.encoder.draw(handle, count, mode);
     }
+    /// Forwards `drawOffset` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawOffset(self: RenderContext, handle: BufferHandle, count: u32, mode: DrawMode, offset: usize) void {
         self.encoder.drawOffset(handle, count, mode, offset);
     }
+    /// Forwards `drawIndexed` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawIndexed(self: RenderContext, vbo: BufferHandle, ebo: BufferHandle, count: u32) void {
         self.encoder.drawIndexed(vbo, ebo, count);
     }
+    /// Forwards `drawIndirect` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawIndirect(self: RenderContext, handle: BufferHandle, command_buffer: BufferHandle, offset: usize, draw_count: u32, stride: u32) void {
         self.encoder.drawIndirect(handle, command_buffer, offset, draw_count, stride);
     }
+    /// Forwards `drawInstance` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawInstance(self: RenderContext, handle: BufferHandle, count: u32, instance_index: u32) void {
         self.encoder.drawInstance(handle, count, instance_index);
     }
+    /// Forwards `setViewport` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setViewport(self: RenderContext, width: u32, height: u32) void {
         self.encoder.setViewport(width, height);
     }
 
     // --- IRenderStateContext delegates ---
 
+    /// Forwards `setModelMatrix` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setModelMatrix(self: RenderContext, model: Mat4, color: Vec3, mask_radius: f32) void {
         self.state.setModelMatrix(model, color, mask_radius);
     }
+    /// Forwards `setInstanceBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setInstanceBuffer(self: RenderContext, handle: BufferHandle) void {
         self.state.setInstanceBuffer(handle);
     }
+    /// Forwards `setLODInstanceBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setLODInstanceBuffer(self: RenderContext, handle: BufferHandle) void {
         self.state.setLODInstanceBuffer(handle);
     }
+    /// Forwards `setTerrainPipelineBound` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setTerrainPipelineBound(self: RenderContext, bound: bool) void {
         self.state.setTerrainPipelineBound(bound);
     }
+    /// Forwards `setSelectionMode` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setSelectionMode(self: RenderContext, enabled: bool) void {
         self.state.setSelectionMode(enabled);
     }
+    /// Forwards `updateGlobalUniforms` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn updateGlobalUniforms(self: RenderContext, uniforms: GlobalUniforms, frame_params: FrameRenderParams) !void {
         try self.state.updateGlobalUniforms(uniforms, frame_params);
     }
+    /// Forwards `setTextureUniforms` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setTextureUniforms(self: RenderContext, texture_enabled: bool, shadow_map_handles: [SHADOW_CASCADE_COUNT]TextureHandle) void {
         self.state.setTextureUniforms(texture_enabled, shadow_map_handles);
     }
@@ -371,15 +432,19 @@ pub const IShadowContext = struct {
         getShadowMapHandle: *const fn (ptr: *anyopaque, cascade_index: u32) TextureHandle,
     };
 
+    /// Forwards `beginPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginPass(self: IShadowContext, cascade_index: u32, light_space_matrix: Mat4) void {
         self.vtable.beginPass(self.ptr, cascade_index, light_space_matrix);
     }
+    /// Forwards `endPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endPass(self: IShadowContext) void {
         self.vtable.endPass(self.ptr);
     }
+    /// Forwards `updateUniforms` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn updateUniforms(self: IShadowContext, params: ShadowParams) !void {
         try self.vtable.updateUniforms(self.ptr, params);
     }
+    /// Forwards `getShadowMapHandle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getShadowMapHandle(self: IShadowContext, cascade_index: u32) TextureHandle {
         return self.vtable.getShadowMapHandle(self.ptr, cascade_index);
     }
@@ -401,15 +466,19 @@ pub const IShadowContext = struct {
 pub const ShadowSystemWrapper = struct {
     ctx: IShadowContext,
 
+    /// Forwards `beginPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginPass(self: ShadowSystemWrapper, cascade_index: u32, light_space_matrix: Mat4) void {
         self.ctx.beginPass(cascade_index, light_space_matrix);
     }
+    /// Forwards `endPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endPass(self: ShadowSystemWrapper) void {
         self.ctx.endPass();
     }
+    /// Forwards `updateUniforms` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn updateUniforms(self: ShadowSystemWrapper, params: ShadowParams) !void {
         try self.ctx.updateUniforms(params);
     }
+    /// Forwards `getShadowMapHandle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getShadowMapHandle(self: ShadowSystemWrapper, cascade_index: u32) TextureHandle {
         return self.ctx.getShadowMapHandle(cascade_index);
     }
@@ -427,18 +496,23 @@ pub const IWaterContext = struct {
         computeReflectedViewProj: *const fn (ptr: *anyopaque, view: Mat4, proj: Mat4, camera_pos: Vec3) Mat4,
     };
 
+    /// Forwards `beginReflectionPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginReflectionPass(self: IWaterContext) void {
         self.vtable.beginReflectionPass(self.ptr);
     }
+    /// Forwards `endReflectionPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endReflectionPass(self: IWaterContext) void {
         self.vtable.endReflectionPass(self.ptr);
     }
+    /// Forwards `getReflectionTextureHandle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getReflectionTextureHandle(self: IWaterContext) TextureHandle {
         return self.vtable.getReflectionTextureHandle(self.ptr);
     }
+    /// Forwards `getSceneDepthTextureHandle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getSceneDepthTextureHandle(self: IWaterContext) TextureHandle {
         return self.vtable.getSceneDepthTextureHandle(self.ptr);
     }
+    /// Forwards `computeReflectedViewProj` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn computeReflectedViewProj(self: IWaterContext, view: Mat4, proj: Mat4, camera_pos: Vec3) Mat4 {
         return self.vtable.computeReflectedViewProj(self.ptr, view, proj, camera_pos);
     }
@@ -447,18 +521,23 @@ pub const IWaterContext = struct {
 pub const WaterSystemWrapper = struct {
     ctx: IWaterContext,
 
+    /// Forwards `beginReflectionPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginReflectionPass(self: WaterSystemWrapper) void {
         self.ctx.beginReflectionPass();
     }
+    /// Forwards `endReflectionPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endReflectionPass(self: WaterSystemWrapper) void {
         self.ctx.endReflectionPass();
     }
+    /// Forwards `getReflectionTextureHandle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getReflectionTextureHandle(self: WaterSystemWrapper) TextureHandle {
         return self.ctx.getReflectionTextureHandle();
     }
+    /// Forwards `getSceneDepthTextureHandle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getSceneDepthTextureHandle(self: WaterSystemWrapper) TextureHandle {
         return self.ctx.getSceneDepthTextureHandle();
     }
+    /// Forwards `computeReflectedViewProj` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn computeReflectedViewProj(self: WaterSystemWrapper, view: Mat4, proj: Mat4, camera_pos: Vec3) Mat4 {
         return self.ctx.computeReflectedViewProj(view, proj, camera_pos);
     }
@@ -478,24 +557,31 @@ pub const IUIContext = struct {
         bindPipeline: *const fn (ptr: *anyopaque, textured: bool) void,
     };
 
+    /// Forwards `beginPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginPass(self: IUIContext, width: f32, height: f32) void {
         self.vtable.beginPass(self.ptr, width, height);
     }
+    /// Forwards `endPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endPass(self: IUIContext) void {
         self.vtable.endPass(self.ptr);
     }
+    /// Forwards `drawRect` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawRect(self: IUIContext, rect: Rect, color: Color) void {
         self.vtable.drawRect(self.ptr, rect, color);
     }
+    /// Forwards `drawTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawTexture(self: IUIContext, texture: TextureHandle, rect: Rect) void {
         self.vtable.drawTexture(self.ptr, texture, rect);
     }
+    /// Forwards `drawTextureRegion` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawTextureRegion(self: IUIContext, texture: TextureHandle, rect: Rect, uv: UVRect, color: Color) void {
         self.vtable.drawTextureRegion(self.ptr, texture, rect, uv, color);
     }
+    /// Forwards `drawDepthTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawDepthTexture(self: IUIContext, texture: TextureHandle, rect: Rect) void {
         self.vtable.drawDepthTexture(self.ptr, texture, rect);
     }
+    /// Forwards `bindPipeline` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn bindPipeline(self: IUIContext, textured: bool) void {
         self.vtable.bindPipeline(self.ptr, textured);
     }
@@ -512,15 +598,19 @@ pub const IImGuiContext = struct {
         renderDrawData: *const fn (ptr: *anyopaque, draw_data: *anyopaque) void,
     };
 
+    /// Forwards `initBackend` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn initBackend(self: IImGuiContext, window: *anyopaque) bool {
         return self.vtable.initBackend(self.ptr, window);
     }
+    /// Forwards `shutdownBackend` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn shutdownBackend(self: IImGuiContext) void {
         self.vtable.shutdownBackend(self.ptr);
     }
+    /// Forwards `newFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn newFrame(self: IImGuiContext) void {
         self.vtable.newFrame(self.ptr);
     }
+    /// Forwards `renderDrawData` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn renderDrawData(self: IImGuiContext, draw_data: *anyopaque) void {
         self.vtable.renderDrawData(self.ptr, draw_data);
     }
@@ -541,24 +631,31 @@ pub const IImGuiContext = struct {
 pub const UIRenderer = struct {
     ctx: IUIContext,
 
+    /// Forwards `beginPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginPass(self: UIRenderer, width: f32, height: f32) void {
         self.ctx.beginPass(width, height);
     }
+    /// Forwards `endPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endPass(self: UIRenderer) void {
         self.ctx.endPass();
     }
+    /// Forwards `drawRect` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawRect(self: UIRenderer, rect: Rect, color: Color) void {
         self.ctx.drawRect(rect, color);
     }
+    /// Forwards `drawTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawTexture(self: UIRenderer, texture: TextureHandle, rect: Rect) void {
         self.ctx.drawTexture(texture, rect);
     }
+    /// Forwards `drawTextureRegion` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawTextureRegion(self: UIRenderer, texture: TextureHandle, rect: Rect, uv: UVRect, color: Color) void {
         self.ctx.drawTextureRegion(texture, rect, uv, color);
     }
+    /// Forwards `drawDepthTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawDepthTexture(self: UIRenderer, texture: TextureHandle, rect: Rect) void {
         self.ctx.drawDepthTexture(texture, rect);
     }
+    /// Forwards `bindPipeline` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn bindPipeline(self: UIRenderer, textured: bool) void {
         self.ctx.bindPipeline(textured);
     }
@@ -580,30 +677,39 @@ pub const IGraphicsCommandEncoder = struct {
         setViewport: *const fn (ptr: *anyopaque, width: u32, height: u32) void,
     };
 
+    /// Forwards `bindTexture` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn bindTexture(self: IGraphicsCommandEncoder, handle: TextureHandle, slot: u32) void {
         self.vtable.bindTexture(self.ptr, handle, slot);
     }
+    /// Forwards `bindBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn bindBuffer(self: IGraphicsCommandEncoder, handle: BufferHandle, usage: BufferUsage) void {
         self.vtable.bindBuffer(self.ptr, handle, usage);
     }
+    /// Forwards `pushConstants` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn pushConstants(self: IGraphicsCommandEncoder, stages: ShaderStageFlags, offset: u32, size: u32, data: *const anyopaque) void {
         self.vtable.pushConstants(self.ptr, stages, offset, size, data);
     }
+    /// Forwards `draw` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn draw(self: IGraphicsCommandEncoder, handle: BufferHandle, count: u32, mode: DrawMode) void {
         self.vtable.draw(self.ptr, handle, count, mode);
     }
+    /// Forwards `drawOffset` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawOffset(self: IGraphicsCommandEncoder, handle: BufferHandle, count: u32, mode: DrawMode, offset: usize) void {
         self.vtable.drawOffset(self.ptr, handle, count, mode, offset);
     }
+    /// Forwards `drawIndexed` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawIndexed(self: IGraphicsCommandEncoder, vbo: BufferHandle, ebo: BufferHandle, count: u32) void {
         self.vtable.drawIndexed(self.ptr, vbo, ebo, count);
     }
+    /// Forwards `drawIndirect` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawIndirect(self: IGraphicsCommandEncoder, handle: BufferHandle, command_buffer: BufferHandle, offset: usize, draw_count: u32, stride: u32) void {
         self.vtable.drawIndirect(self.ptr, handle, command_buffer, offset, draw_count, stride);
     }
+    /// Forwards `drawInstance` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawInstance(self: IGraphicsCommandEncoder, handle: BufferHandle, count: u32, instance_index: u32) void {
         self.vtable.drawInstance(self.ptr, handle, count, instance_index);
     }
+    /// Forwards `setViewport` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setViewport(self: IGraphicsCommandEncoder, width: u32, height: u32) void {
         self.vtable.setViewport(self.ptr, width, height);
     }
@@ -623,24 +729,31 @@ pub const IRenderStateContext = struct {
         setTextureUniforms: *const fn (ptr: *anyopaque, texture_enabled: bool, shadow_map_handles: [SHADOW_CASCADE_COUNT]TextureHandle) void,
     };
 
+    /// Forwards `setModelMatrix` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setModelMatrix(self: IRenderStateContext, model: Mat4, color: Vec3, mask_radius: f32) void {
         self.vtable.setModelMatrix(self.ptr, model, color, mask_radius);
     }
+    /// Forwards `setInstanceBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setInstanceBuffer(self: IRenderStateContext, handle: BufferHandle) void {
         self.vtable.setInstanceBuffer(self.ptr, handle);
     }
+    /// Forwards `setLODInstanceBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setLODInstanceBuffer(self: IRenderStateContext, handle: BufferHandle) void {
         self.vtable.setLODInstanceBuffer(self.ptr, handle);
     }
+    /// Forwards `setTerrainPipelineBound` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setTerrainPipelineBound(self: IRenderStateContext, bound: bool) void {
         self.vtable.setTerrainPipelineBound(self.ptr, bound);
     }
+    /// Forwards `setSelectionMode` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setSelectionMode(self: IRenderStateContext, enabled: bool) void {
         self.vtable.setSelectionMode(self.ptr, enabled);
     }
+    /// Forwards `updateGlobalUniforms` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn updateGlobalUniforms(self: IRenderStateContext, uniforms: GlobalUniforms, frame_params: FrameRenderParams) !void {
         try self.vtable.updateGlobalUniforms(self.ptr, uniforms, frame_params);
     }
+    /// Forwards `setTextureUniforms` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setTextureUniforms(self: IRenderStateContext, texture_enabled: bool, shadow_map_handles: [SHADOW_CASCADE_COUNT]TextureHandle) void {
         self.vtable.setTextureUniforms(self.ptr, texture_enabled, shadow_map_handles);
     }
@@ -655,6 +768,7 @@ pub const ISSAOContext = struct {
         compute: *const fn (ptr: *anyopaque, proj: Mat4, inv_proj: Mat4) void,
     };
 
+    /// Forwards `compute` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn compute(self: ISSAOContext, proj: Mat4, inv_proj: Mat4) void {
         self.vtable.compute(self.ptr, proj, inv_proj);
     }
@@ -669,6 +783,7 @@ pub const IDebugOverlayContext = struct {
         drawDebugShadowMap: *const fn (ptr: *anyopaque, cascade_index: usize, depth_map_handle: TextureHandle) void,
     };
 
+    /// Forwards `drawDebugShadowMap` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawDebugShadowMap(self: IDebugOverlayContext, cascade_index: usize, depth_map_handle: TextureHandle) void {
         self.vtable.drawDebugShadowMap(self.ptr, cascade_index, depth_map_handle);
     }
@@ -720,48 +835,63 @@ pub const IComputeContext = struct {
         hasCommandBuffer: *const fn (ptr: *anyopaque) bool,
     };
 
+    /// Forwards `bindComputePipeline` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn bindComputePipeline(self: IComputeContext, pipeline: ComputePipeline) void {
         self.vtable.bindComputePipeline(self.ptr, pipeline);
     }
+    /// Forwards `bindDescriptorSet` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn bindDescriptorSet(self: IComputeContext, pipeline: ComputePipeline, frame_index: usize) void {
         self.vtable.bindDescriptorSet(self.ptr, pipeline, frame_index);
     }
+    /// Forwards `createComputeBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn createComputeBuffer(self: IComputeContext, size: usize, host_visible: bool) RhiError!ComputeBuffer {
         return self.vtable.createComputeBuffer(self.ptr, size, host_visible);
     }
+    /// Forwards `destroyComputeBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn destroyComputeBuffer(self: IComputeContext, buffer: *ComputeBuffer) void {
         self.vtable.destroyComputeBuffer(self.ptr, buffer);
     }
+    /// Forwards `createComputePipeline` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn createComputePipeline(self: IComputeContext, allocator: Allocator, shader_path: []const u8, storage_binding_count: u32, push_constant_size: u32) anyerror!ComputePipeline {
         return self.vtable.createComputePipeline(self.ptr, allocator, shader_path, storage_binding_count, push_constant_size);
     }
+    /// Forwards `updateComputeDescriptors` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn updateComputeDescriptors(self: IComputeContext, pipeline: ComputePipeline, frame_index: usize, storage_buffers: []const ComputeBufferBinding) void {
         self.vtable.updateComputeDescriptors(self.ptr, pipeline, frame_index, storage_buffers);
     }
+    /// Forwards `destroyComputePipeline` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn destroyComputePipeline(self: IComputeContext, pipeline: *ComputePipeline) void {
         self.vtable.destroyComputePipeline(self.ptr, pipeline);
     }
+    /// Forwards `dispatch` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn dispatch(self: IComputeContext, group_count_x: u32, group_count_y: u32, group_count_z: u32) void {
         self.vtable.dispatch(self.ptr, group_count_x, group_count_y, group_count_z);
     }
+    /// Forwards `pushConstants` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn pushConstants(self: IComputeContext, pipeline: ComputePipeline, offset: u32, size: u32, data: *const anyopaque) void {
         self.vtable.pushConstants(self.ptr, pipeline, offset, size, data);
     }
+    /// Forwards `fillBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn fillBuffer(self: IComputeContext, buffer: ComputeBuffer, offset: u64, size: u64, data: u32) void {
         self.vtable.fillBuffer(self.ptr, buffer, offset, size, data);
     }
+    /// Forwards `copyBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn copyBuffer(self: IComputeContext, src_buffer: ComputeBufferBinding, dst_buffer: ComputeBufferBinding, src_offset: u64, dst_offset: u64, size: u64) void {
         self.vtable.copyBuffer(self.ptr, src_buffer, dst_buffer, src_offset, dst_offset, size);
     }
+    /// Forwards `pipelineBarrier` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn pipelineBarrier(self: IComputeContext, src_stage: PipelineStageFlags, dst_stage: PipelineStageFlags, src_access: AccessFlags, dst_access: AccessFlags) void {
         self.vtable.pipelineBarrier(self.ptr, src_stage, dst_stage, src_access, dst_access);
     }
+    /// Forwards `bufferBarrier` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn bufferBarrier(self: IComputeContext, buffer: ComputeBufferBinding, src_stage: PipelineStageFlags, dst_stage: PipelineStageFlags, src_access: AccessFlags, dst_access: AccessFlags, offset: u64, size: u64) void {
         self.vtable.bufferBarrier(self.ptr, buffer, src_stage, dst_stage, src_access, dst_access, offset, size);
     }
+    /// Forwards `waitForFrameFence` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn waitForFrameFence(self: IComputeContext, frame_index: usize) bool {
         return self.vtable.waitForFrameFence(self.ptr, frame_index);
     }
+    /// Forwards `hasCommandBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn hasCommandBuffer(self: IComputeContext) bool {
         return self.vtable.hasCommandBuffer(self.ptr);
     }
@@ -786,21 +916,27 @@ pub const IRenderContext = struct {
         setClearColor: *const fn (ptr: *anyopaque, color: Vec3) void,
     };
 
+    /// Forwards `beginFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginFrame(self: IRenderContext) void {
         self.vtable.beginFrame(self.ptr);
     }
+    /// Forwards `endFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endFrame(self: IRenderContext) void {
         self.vtable.endFrame(self.ptr);
     }
+    /// Forwards `abortFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn abortFrame(self: IRenderContext) void {
         self.vtable.abortFrame(self.ptr);
     }
+    /// Forwards `requestSwapchainRecreate` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn requestSwapchainRecreate(self: IRenderContext) void {
         self.vtable.requestSwapchainRecreate(self.ptr);
     }
+    /// Forwards `getEncoder` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getEncoder(self: IRenderContext) IGraphicsCommandEncoder {
         return self.vtable.getEncoder(self.ptr);
     }
+    /// Forwards `getState` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getState(self: IRenderContext) IRenderStateContext {
         return self.vtable.getStateContext(self.ptr);
     }
@@ -821,27 +957,35 @@ pub const IPassOrchestrationContext = struct {
         endFXAAPass: *const fn (ptr: *anyopaque) void,
     };
 
+    /// Forwards `beginMainPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginMainPass(self: IPassOrchestrationContext) void {
         self.vtable.beginMainPass(self.ptr);
     }
+    /// Forwards `endMainPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endMainPass(self: IPassOrchestrationContext) void {
         self.vtable.endMainPass(self.ptr);
     }
+    /// Forwards `beginPostProcessPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginPostProcessPass(self: IPassOrchestrationContext) void {
         self.vtable.beginPostProcessPass(self.ptr);
     }
+    /// Forwards `endPostProcessPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endPostProcessPass(self: IPassOrchestrationContext) void {
         self.vtable.endPostProcessPass(self.ptr);
     }
+    /// Forwards `beginGPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginGPass(self: IPassOrchestrationContext) void {
         self.vtable.beginGPass(self.ptr);
     }
+    /// Forwards `endGPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endGPass(self: IPassOrchestrationContext) void {
         self.vtable.endGPass(self.ptr);
     }
+    /// Forwards `beginFXAAPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginFXAAPass(self: IPassOrchestrationContext) void {
         self.vtable.beginFXAAPass(self.ptr);
     }
+    /// Forwards `endFXAAPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endFXAAPass(self: IPassOrchestrationContext) void {
         self.vtable.endFXAAPass(self.ptr);
     }
@@ -857,12 +1001,15 @@ pub const IPostProcessContext = struct {
         computeDepthPyramid: *const fn (ptr: *anyopaque) void,
     };
 
+    /// Forwards `computeBloom` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn computeBloom(self: IPostProcessContext) void {
         self.vtable.computeBloom(self.ptr);
     }
+    /// Forwards `computeTAA` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn computeTAA(self: IPostProcessContext) void {
         self.vtable.computeTAA(self.ptr);
     }
+    /// Forwards `computeDepthPyramid` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn computeDepthPyramid(self: IPostProcessContext) void {
         self.vtable.computeDepthPyramid(self.ptr);
     }
@@ -878,12 +1025,15 @@ pub const IRenderEffectsContext = struct {
         endWaterDraw: *const fn (ptr: *anyopaque) void,
     };
 
+    /// Forwards `drawSky` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn drawSky(self: IRenderEffectsContext, params: SkyParams) RhiError!void {
         return self.vtable.drawSky(self.ptr, params);
     }
+    /// Forwards `beginWaterDraw` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginWaterDraw(self: IRenderEffectsContext, reflection: TextureHandle, scene_depth: TextureHandle) bool {
         return self.vtable.beginWaterDraw(self.ptr, reflection, scene_depth);
     }
+    /// Forwards `endWaterDraw` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endWaterDraw(self: IRenderEffectsContext) void {
         self.vtable.endWaterDraw(self.ptr);
     }
@@ -909,33 +1059,43 @@ pub const VulkanNativeHandles = struct {
         getSwapchainImageCount: *const fn (ptr: *anyopaque) u32,
     };
 
+    /// Forwards `getCommandBuffer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getCommandBuffer(self: VulkanNativeHandles) u64 {
         return self.vtable.getCommandBuffer(self.ptr);
     }
+    /// Forwards `getSwapchainExtent` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getSwapchainExtent(self: VulkanNativeHandles) [2]u32 {
         return self.vtable.getSwapchainExtent(self.ptr);
     }
+    /// Forwards `getDevice` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getDevice(self: VulkanNativeHandles) u64 {
         return self.vtable.getDevice(self.ptr);
     }
+    /// Forwards `getInstance` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getInstance(self: VulkanNativeHandles) u64 {
         return self.vtable.getInstance(self.ptr);
     }
+    /// Forwards `getPhysicalDevice` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getPhysicalDevice(self: VulkanNativeHandles) u64 {
         return self.vtable.getPhysicalDevice(self.ptr);
     }
+    /// Forwards `getQueue` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getQueue(self: VulkanNativeHandles) u64 {
         return self.vtable.getQueue(self.ptr);
     }
+    /// Forwards `getQueueFamily` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getQueueFamily(self: VulkanNativeHandles) u32 {
         return self.vtable.getQueueFamily(self.ptr);
     }
+    /// Forwards `getDescriptorPool` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getDescriptorPool(self: VulkanNativeHandles) u64 {
         return self.vtable.getDescriptorPool(self.ptr);
     }
+    /// Forwards `getUiRenderPass` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getUiRenderPass(self: VulkanNativeHandles) u64 {
         return self.vtable.getUiRenderPass(self.ptr);
     }
+    /// Forwards `getSwapchainImageCount` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getSwapchainImageCount(self: VulkanNativeHandles) u32 {
         return self.vtable.getSwapchainImageCount(self.ptr);
     }
@@ -958,30 +1118,38 @@ pub const IDeviceQuery = struct {
         waitIdle: *const fn (ptr: *anyopaque) void,
     };
 
+    /// Forwards `getFrameIndex` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getFrameIndex(self: IDeviceQuery) usize {
         return self.vtable.getFrameIndex(self.ptr);
     }
+    /// Forwards `supportsIndirectFirstInstance` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn supportsIndirectFirstInstance(self: IDeviceQuery) bool {
         return self.vtable.supportsIndirectFirstInstance(self.ptr);
     }
+    /// Forwards `getFaultCount` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getFaultCount(self: IDeviceQuery) u32 {
         return self.vtable.getFaultCount(self.ptr);
     }
+    /// Forwards `getValidationErrorCount` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getValidationErrorCount(self: IDeviceQuery) u32 {
         return self.vtable.getValidationErrorCount(self.ptr);
     }
 
+    /// Forwards `getDrawCallCount` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getDrawCallCount(self: IDeviceQuery) u32 {
         return self.vtable.getDrawCallCount(self.ptr);
     }
 
+    /// Forwards `getDeviceLocalVramBytes` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getDeviceLocalVramBytes(self: IDeviceQuery) u64 {
         return self.vtable.getDeviceLocalVramBytes(self.ptr);
     }
 
+    /// Forwards `getRenderResolution` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getRenderResolution(self: IDeviceQuery) RenderResolution {
         return self.vtable.getRenderResolution(self.ptr);
     }
+    /// Forwards `waitIdle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn waitIdle(self: IDeviceQuery) void {
         self.vtable.waitIdle(self.ptr);
     }
@@ -999,18 +1167,23 @@ pub const IDeviceTiming = struct {
         setTimingEnabled: *const fn (ptr: *anyopaque, enabled: bool) void,
     };
 
+    /// Forwards `beginPassTiming` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn beginPassTiming(self: IDeviceTiming, pass_name: []const u8) void {
         self.vtable.beginPassTiming(self.ptr, pass_name);
     }
+    /// Forwards `endPassTiming` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn endPassTiming(self: IDeviceTiming, pass_name: []const u8) void {
         self.vtable.endPassTiming(self.ptr, pass_name);
     }
+    /// Forwards `getTimingResults` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getTimingResults(self: IDeviceTiming) GpuTimingResults {
         return self.vtable.getTimingResults(self.ptr);
     }
+    /// Forwards `isTimingEnabled` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn isTimingEnabled(self: IDeviceTiming) bool {
         return self.vtable.isTimingEnabled(self.ptr);
     }
+    /// Forwards `setTimingEnabled` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setTimingEnabled(self: IDeviceTiming, enabled: bool) void {
         self.vtable.setTimingEnabled(self.ptr, enabled);
     }
@@ -1044,66 +1217,87 @@ pub const IRenderQualityOptions = struct {
         getResolutionScale: *const fn (ctx: *anyopaque) f32,
     };
 
+    /// Forwards `setWireframe` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setWireframe(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setWireframe(self.ptr, enabled);
     }
+    /// Forwards `setTexturesEnabled` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setTexturesEnabled(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setTexturesEnabled(self.ptr, enabled);
     }
+    /// Forwards `setDebugShadowView` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setDebugShadowView(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setDebugShadowView(self.ptr, enabled);
     }
+    /// Forwards `setShadowDebugChannel` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setShadowDebugChannel(self: IRenderQualityOptions, channel: u32) void {
         self.vtable.setShadowDebugChannel(self.ptr, channel);
     }
+    /// Forwards `setVSync` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setVSync(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setVSync(self.ptr, enabled);
     }
+    /// Forwards `setAnisotropicFiltering` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setAnisotropicFiltering(self: IRenderQualityOptions, level: u8) void {
         self.vtable.setAnisotropicFiltering(self.ptr, level);
     }
+    /// Forwards `setVolumetricDensity` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setVolumetricDensity(self: IRenderQualityOptions, density: f32) void {
         self.vtable.setVolumetricDensity(self.ptr, density);
     }
+    /// Forwards `setMSAA` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setMSAA(self: IRenderQualityOptions, samples: u8) void {
         self.vtable.setMSAA(self.ptr, samples);
     }
+    /// Forwards `setFXAA` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setFXAA(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setFXAA(self.ptr, enabled);
     }
+    /// Forwards `setBloom` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setBloom(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setBloom(self.ptr, enabled);
     }
+    /// Forwards `setBloomIntensity` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setBloomIntensity(self: IRenderQualityOptions, intensity: f32) void {
         self.vtable.setBloomIntensity(self.ptr, intensity);
     }
+    /// Forwards `setVignetteEnabled` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setVignetteEnabled(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setVignetteEnabled(self.ptr, enabled);
     }
+    /// Forwards `setVignetteIntensity` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setVignetteIntensity(self: IRenderQualityOptions, intensity: f32) void {
         self.vtable.setVignetteIntensity(self.ptr, intensity);
     }
+    /// Forwards `setFilmGrainEnabled` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setFilmGrainEnabled(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setFilmGrainEnabled(self.ptr, enabled);
     }
+    /// Forwards `setFilmGrainIntensity` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setFilmGrainIntensity(self: IRenderQualityOptions, intensity: f32) void {
         self.vtable.setFilmGrainIntensity(self.ptr, intensity);
     }
+    /// Forwards `setColorGradingEnabled` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setColorGradingEnabled(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setColorGradingEnabled(self.ptr, enabled);
     }
+    /// Forwards `setColorGradingIntensity` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setColorGradingIntensity(self: IRenderQualityOptions, intensity: f32) void {
         self.vtable.setColorGradingIntensity(self.ptr, intensity);
     }
+    /// Forwards `setTAABlendFactor` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setTAABlendFactor(self: IRenderQualityOptions, value: f32) void {
         self.vtable.setTAABlendFactor(self.ptr, value);
     }
+    /// Forwards `setTAAVelocityRejection` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setTAAVelocityRejection(self: IRenderQualityOptions, value: f32) void {
         self.vtable.setTAAVelocityRejection(self.ptr, value);
     }
+    /// Forwards `setDynamicResolution` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn setDynamicResolution(self: IRenderQualityOptions, enabled: bool, min_scale: f32, max_scale: f32, target_fps: u32) void {
         self.vtable.setDynamicResolution(self.ptr, enabled, min_scale, max_scale, target_fps);
     }
+    /// Forwards `getResolutionScale` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn getResolutionScale(self: IRenderQualityOptions) f32 {
         return self.vtable.getResolutionScale(self.ptr);
     }
@@ -1117,6 +1311,7 @@ pub const IDeviceRecovery = struct {
         recover: *const fn (ctx: *anyopaque) anyerror!void,
     };
 
+    /// Forwards `recover` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn recover(self: IDeviceRecovery) !void {
         return self.vtable.recover(self.ptr);
     }
@@ -1130,6 +1325,7 @@ pub const ICullingSystemFactory = struct {
         createCullingSystem: *const fn (ctx: *anyopaque, allocator: Allocator, max_chunks: usize) anyerror!?ICullingSystem,
     };
 
+    /// Forwards `createCullingSystem` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn createCullingSystem(self: ICullingSystemFactory, allocator: Allocator, max_chunks: usize) anyerror!?ICullingSystem {
         return self.vtable.createCullingSystem(self.ptr, allocator, max_chunks);
     }
@@ -1143,6 +1339,7 @@ pub const IScreenshotContext = struct {
         captureFrame: *const fn (ctx: *anyopaque, path: []const u8) bool,
     };
 
+    /// Forwards `captureFrame` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn captureFrame(self: IScreenshotContext, path: []const u8) bool {
         return self.vtable.captureFrame(self.ptr, path);
     }
@@ -1216,6 +1413,7 @@ pub const RHI = struct {
         screenshot: ?*const IScreenshotContext.VTable = null,
     };
 
+    /// Forwards `composeVTable` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn composeVTable(lifecycle: Lifecycle, interfaces: Interfaces) VTable {
         return .{
             .init = lifecycle.init,
@@ -1242,15 +1440,19 @@ pub const RHI = struct {
         };
     }
 
+    /// Forwards `factory` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn factory(self: RHI) IResourceFactory {
         return .{ .ptr = self.ptr, .vtable = self.vtable.resources orelse unreachable };
     }
+    /// Forwards `resourceManager` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn resourceManager(self: RHI) ResourceManager {
         return .{ .factory = self.factory() };
     }
+    /// Forwards `context` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn context(self: RHI) IRenderContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.render orelse unreachable };
     }
+    /// Forwards `renderContext` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn renderContext(self: RHI) RenderContext {
         const rc = self.context();
         return .{
@@ -1263,12 +1465,15 @@ pub const RHI = struct {
             .state = rc.getState(),
         };
     }
+    /// Forwards `passOrchestration` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn passOrchestration(self: RHI) IPassOrchestrationContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.passes orelse unreachable };
     }
+    /// Forwards `postProcess` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn postProcess(self: RHI) IPostProcessContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.post_process orelse unreachable };
     }
+    /// Forwards `renderEffects` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn renderEffects(self: RHI) IRenderEffectsContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.effects orelse unreachable };
     }
@@ -1278,74 +1483,97 @@ pub const RHI = struct {
     pub fn vulkanHandles(self: RHI) VulkanNativeHandles {
         return .{ .ptr = self.ptr, .vtable = self.vtable.vulkan orelse unreachable };
     }
+    /// Forwards `encoder` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn encoder(self: RHI) IGraphicsCommandEncoder {
         return self.context().getEncoder();
     }
+    /// Forwards `state` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn state(self: RHI) IRenderStateContext {
         return self.context().getState();
     }
+    /// Forwards `ssao` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn ssao(self: RHI) ISSAOContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.ssao orelse unreachable };
     }
+    /// Forwards `debugOverlay` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn debugOverlay(self: RHI) IDebugOverlayContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.debug_overlay orelse unreachable };
     }
+    /// Forwards `shadow` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn shadow(self: RHI) IShadowContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.shadow orelse unreachable };
     }
+    /// Forwards `shadowSystem` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn shadowSystem(self: RHI) ShadowSystemWrapper {
         return .{ .ctx = self.shadow() };
     }
+    /// Forwards `waterSystem` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn waterSystem(self: RHI) WaterSystemWrapper {
         return .{ .ctx = self.water() };
     }
+    /// Forwards `water` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn water(self: RHI) IWaterContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.water orelse unreachable };
     }
+    /// Forwards `compute` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn compute(self: RHI) IComputeContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.compute orelse unreachable };
     }
+    /// Forwards `ui` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn ui(self: RHI) IUIContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.ui orelse unreachable };
     }
+    /// Forwards `imgui` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn imgui(self: RHI) IImGuiContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.imgui orelse unreachable };
     }
+    /// Forwards `uiRenderer` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn uiRenderer(self: RHI) UIRenderer {
         return .{ .ctx = self.ui() };
     }
+    /// Forwards `query` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn query(self: RHI) IDeviceQuery {
         return .{ .ptr = self.ptr, .vtable = self.vtable.query orelse unreachable };
     }
+    /// Forwards `timing` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn timing(self: RHI) IDeviceTiming {
         return .{ .ptr = self.ptr, .vtable = self.vtable.timing orelse unreachable };
     }
+    /// Forwards `options` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn options(self: RHI) IRenderQualityOptions {
         return self.renderQualityOptions();
     }
+    /// Forwards `renderQualityOptions` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn renderQualityOptions(self: RHI) IRenderQualityOptions {
         return .{ .ptr = self.ptr, .vtable = self.vtable.quality orelse unreachable };
     }
+    /// Forwards `recovery` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn recovery(self: RHI) IDeviceRecovery {
         return .{ .ptr = self.ptr, .vtable = self.vtable.recovery orelse unreachable };
     }
+    /// Forwards `cullingFactory` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn cullingFactory(self: RHI) ICullingSystemFactory {
         return .{ .ptr = self.ptr, .vtable = self.vtable.culling_factory orelse unreachable };
     }
+    /// Forwards `screenshot` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn screenshot(self: RHI) IScreenshotContext {
         return .{ .ptr = self.ptr, .vtable = self.vtable.screenshot orelse unreachable };
     }
+    /// Forwards `createCullingSystem` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn createCullingSystem(self: RHI, allocator: Allocator, max_chunks: usize) anyerror!?ICullingSystem {
         return self.cullingFactory().createCullingSystem(allocator, max_chunks);
     }
 
     // Lifecycle
+    /// Forwards `init` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn init(self: RHI, allocator: Allocator, device: ?*RenderDevice) !void {
         return self.vtable.init(self.ptr, allocator, device);
     }
+    /// Forwards `deinit` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn deinit(self: RHI) void {
         self.vtable.deinit(self.ptr);
     }
+    /// Forwards `waitIdle` to the active RHI backend. Callers must provide valid handles and preserve backend render-thread sequencing.
     pub fn waitIdle(self: RHI) void {
         (self.vtable.query orelse unreachable).waitIdle(self.ptr);
     }

--- a/modules/engine-rhi/src/rhi.zig
+++ b/modules/engine-rhi/src/rhi.zig
@@ -289,12 +289,12 @@ pub const RenderContext = struct {
 
     // --- IRenderContext delegates ---
 
-    /// Begins frame for the current frame.
+    /// Begins the per-frame command recording scope.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginFrame(self: RenderContext) void {
         self.render.beginFrame();
     }
-    /// Ends frame for the current frame.
+    /// Ends the per-frame command recording scope and submits queued frame work.
     /// All commands for that scope must be recorded before this call.
     pub fn endFrame(self: RenderContext) void {
         self.render.endFrame();
@@ -304,72 +304,72 @@ pub const RenderContext = struct {
     pub fn abortFrame(self: RenderContext) void {
         self.render.abortFrame();
     }
-    /// Begins main pass for the current frame.
+    /// Begins the main scene render pass for opaque and sky/world drawing.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginMainPass(self: RenderContext) void {
         self.passes.beginMainPass();
     }
-    /// Ends main pass for the current frame.
+    /// Ends the main scene render pass and finalizes its attachments for later passes.
     /// All commands for that scope must be recorded before this call.
     pub fn endMainPass(self: RenderContext) void {
         self.passes.endMainPass();
     }
-    /// Begins post process pass for the current frame.
+    /// Begins the post-process pass that consumes scene color/depth outputs.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginPostProcessPass(self: RenderContext) void {
         self.passes.beginPostProcessPass();
     }
-    /// Ends post process pass for the current frame.
+    /// Ends the post-process pass and makes its output available for presentation or later passes.
     /// All commands for that scope must be recorded before this call.
     pub fn endPostProcessPass(self: RenderContext) void {
         self.passes.endPostProcessPass();
     }
-    /// Begins g pass for the current frame.
+    /// Begins the G-pass that writes geometry buffers for screen-space effects.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginGPass(self: RenderContext) void {
         self.passes.beginGPass();
     }
-    /// Ends g pass for the current frame.
+    /// Ends the G-pass and makes geometry buffers available to SSAO or lighting passes.
     /// All commands for that scope must be recorded before this call.
     pub fn endGPass(self: RenderContext) void {
         self.passes.endGPass();
     }
-    /// Begins f x a a pass for the current frame.
+    /// Begins the FXAA post-process pass for the current frame.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginFXAAPass(self: RenderContext) void {
         self.passes.beginFXAAPass();
     }
-    /// Ends f x a a pass for the current frame.
+    /// Ends the FXAA post-process pass for the current frame.
     /// All commands for that scope must be recorded before this call.
     pub fn endFXAAPass(self: RenderContext) void {
         self.passes.endFXAAPass();
     }
-    /// Provides RHI access for compute bloom.
+    /// Runs the bloom extraction and blur compute passes for the current frame.
     /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules.
     pub fn computeBloom(self: RenderContext) void {
         self.post_process.computeBloom();
     }
-    /// Provides RHI access for compute t a a.
+    /// Runs the TAA resolve pass using the current color, history, and velocity inputs.
     /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules.
     pub fn computeTAA(self: RenderContext) void {
         self.post_process.computeTAA();
     }
-    /// Provides RHI access for compute depth pyramid.
+    /// Builds the hierarchical depth pyramid used by culling and screen-space effects.
     /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules.
     pub fn computeDepthPyramid(self: RenderContext) void {
         self.post_process.computeDepthPyramid();
     }
-    /// Provides RHI access for draw sky.
+    /// Draws the sky and atmosphere contribution for the current camera parameters.
     /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation.
     pub fn drawSky(self: RenderContext, params: SkyParams) RhiError!void {
         return self.effects.drawSky(params);
     }
-    /// Begins water draw for the current frame.
+    /// Begins water rendering using reflection and scene-depth textures as inputs.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginWaterDraw(self: RenderContext, reflection: TextureHandle, scene_depth: TextureHandle) bool {
         return self.effects.beginWaterDraw(reflection, scene_depth);
     }
-    /// Ends water draw for the current frame.
+    /// Ends water rendering and restores normal scene rendering state.
     /// All commands for that scope must be recorded before this call.
     pub fn endWaterDraw(self: RenderContext) void {
         self.effects.endWaterDraw();
@@ -455,7 +455,7 @@ pub const RenderContext = struct {
     pub fn setInstanceBuffer(self: RenderContext, handle: BufferHandle) void {
         self.state.setInstanceBuffer(handle);
     }
-    /// Sets l o d instance buffer on the active graphics backend.
+    /// Binds the LOD instance buffer used by distant-terrain draw calls.
     /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setLODInstanceBuffer(self: RenderContext, handle: BufferHandle) void {
         self.state.setLODInstanceBuffer(handle);
@@ -493,12 +493,12 @@ pub const IShadowContext = struct {
         getShadowMapHandle: *const fn (ptr: *anyopaque, cascade_index: u32) TextureHandle,
     };
 
-    /// Begins pass for the current frame.
-    /// Must be paired with the matching end call and used from the render thread.
+    /// Begins rendering one shadow cascade using the supplied light-space transform.
+    /// Must be paired with `endPass` after all shadow casters for the cascade are drawn.
     pub fn beginPass(self: IShadowContext, cascade_index: u32, light_space_matrix: Mat4) void {
         self.vtable.beginPass(self.ptr, cascade_index, light_space_matrix);
     }
-    /// Ends pass for the current frame.
+    /// Ends this subsystem render pass and finalizes its pass-local state.
     /// All commands for that scope must be recorded before this call.
     pub fn endPass(self: IShadowContext) void {
         self.vtable.endPass(self.ptr);
@@ -531,12 +531,12 @@ pub const IShadowContext = struct {
 pub const ShadowSystemWrapper = struct {
     ctx: IShadowContext,
 
-    /// Begins pass for the current frame.
-    /// Must be paired with the matching end call and used from the render thread.
+    /// Begins rendering one shadow cascade through the focused shadow-system wrapper.
+    /// Must be paired with `endPass`; draw shadow casters between the two calls.
     pub fn beginPass(self: ShadowSystemWrapper, cascade_index: u32, light_space_matrix: Mat4) void {
         self.ctx.beginPass(cascade_index, light_space_matrix);
     }
-    /// Ends pass for the current frame.
+    /// Ends this subsystem render pass and finalizes its pass-local state.
     /// All commands for that scope must be recorded before this call.
     pub fn endPass(self: ShadowSystemWrapper) void {
         self.ctx.endPass();
@@ -565,12 +565,12 @@ pub const IWaterContext = struct {
         computeReflectedViewProj: *const fn (ptr: *anyopaque, view: Mat4, proj: Mat4, camera_pos: Vec3) Mat4,
     };
 
-    /// Begins reflection pass for the current frame.
+    /// Begins rendering the reflected scene into the water reflection target.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginReflectionPass(self: IWaterContext) void {
         self.vtable.beginReflectionPass(self.ptr);
     }
-    /// Ends reflection pass for the current frame.
+    /// Ends reflection rendering and makes the reflection texture available to water shading.
     /// All commands for that scope must be recorded before this call.
     pub fn endReflectionPass(self: IWaterContext) void {
         self.vtable.endReflectionPass(self.ptr);
@@ -595,12 +595,12 @@ pub const IWaterContext = struct {
 pub const WaterSystemWrapper = struct {
     ctx: IWaterContext,
 
-    /// Begins reflection pass for the current frame.
+    /// Begins rendering the reflected scene into the water reflection target.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginReflectionPass(self: WaterSystemWrapper) void {
         self.ctx.beginReflectionPass();
     }
-    /// Ends reflection pass for the current frame.
+    /// Ends reflection rendering and makes the reflection texture available to water shading.
     /// All commands for that scope must be recorded before this call.
     pub fn endReflectionPass(self: WaterSystemWrapper) void {
         self.ctx.endReflectionPass();
@@ -636,12 +636,12 @@ pub const IUIContext = struct {
         bindPipeline: *const fn (ptr: *anyopaque, textured: bool) void,
     };
 
-    /// Begins pass for the current frame.
-    /// Must be paired with the matching end call and used from the render thread.
+    /// Begins the immediate-mode UI pass for a framebuffer of `width` by `height` pixels.
+    /// UI draw calls must be issued between this call and `endPass` on the render thread.
     pub fn beginPass(self: IUIContext, width: f32, height: f32) void {
         self.vtable.beginPass(self.ptr, width, height);
     }
-    /// Ends pass for the current frame.
+    /// Ends this subsystem render pass and finalizes its pass-local state.
     /// All commands for that scope must be recorded before this call.
     pub fn endPass(self: IUIContext) void {
         self.vtable.endPass(self.ptr);
@@ -721,12 +721,12 @@ pub const IImGuiContext = struct {
 pub const UIRenderer = struct {
     ctx: IUIContext,
 
-    /// Begins pass for the current frame.
-    /// Must be paired with the matching end call and used from the render thread.
+    /// Begins the immediate-mode UI pass through the focused UI renderer wrapper.
+    /// UI rectangles and textures queued after this call target the supplied framebuffer size.
     pub fn beginPass(self: UIRenderer, width: f32, height: f32) void {
         self.ctx.beginPass(width, height);
     }
-    /// Ends pass for the current frame.
+    /// Ends this subsystem render pass and finalizes its pass-local state.
     /// All commands for that scope must be recorded before this call.
     pub fn endPass(self: UIRenderer) void {
         self.ctx.endPass();
@@ -845,7 +845,7 @@ pub const IRenderStateContext = struct {
     pub fn setInstanceBuffer(self: IRenderStateContext, handle: BufferHandle) void {
         self.vtable.setInstanceBuffer(self.ptr, handle);
     }
-    /// Sets l o d instance buffer on the active graphics backend.
+    /// Binds the LOD instance buffer used by distant-terrain draw calls.
     /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setLODInstanceBuffer(self: IRenderStateContext, handle: BufferHandle) void {
         self.vtable.setLODInstanceBuffer(self.ptr, handle);
@@ -1046,12 +1046,12 @@ pub const IRenderContext = struct {
         setClearColor: *const fn (ptr: *anyopaque, color: Vec3) void,
     };
 
-    /// Begins frame for the current frame.
+    /// Begins the per-frame command recording scope.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginFrame(self: IRenderContext) void {
         self.vtable.beginFrame(self.ptr);
     }
-    /// Ends frame for the current frame.
+    /// Ends the per-frame command recording scope and submits queued frame work.
     /// All commands for that scope must be recorded before this call.
     pub fn endFrame(self: IRenderContext) void {
         self.vtable.endFrame(self.ptr);
@@ -1093,42 +1093,42 @@ pub const IPassOrchestrationContext = struct {
         endFXAAPass: *const fn (ptr: *anyopaque) void,
     };
 
-    /// Begins main pass for the current frame.
+    /// Begins the main scene render pass for opaque and sky/world drawing.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginMainPass(self: IPassOrchestrationContext) void {
         self.vtable.beginMainPass(self.ptr);
     }
-    /// Ends main pass for the current frame.
+    /// Ends the main scene render pass and finalizes its attachments for later passes.
     /// All commands for that scope must be recorded before this call.
     pub fn endMainPass(self: IPassOrchestrationContext) void {
         self.vtable.endMainPass(self.ptr);
     }
-    /// Begins post process pass for the current frame.
+    /// Begins the post-process pass that consumes scene color/depth outputs.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginPostProcessPass(self: IPassOrchestrationContext) void {
         self.vtable.beginPostProcessPass(self.ptr);
     }
-    /// Ends post process pass for the current frame.
+    /// Ends the post-process pass and makes its output available for presentation or later passes.
     /// All commands for that scope must be recorded before this call.
     pub fn endPostProcessPass(self: IPassOrchestrationContext) void {
         self.vtable.endPostProcessPass(self.ptr);
     }
-    /// Begins g pass for the current frame.
+    /// Begins the G-pass that writes geometry buffers for screen-space effects.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginGPass(self: IPassOrchestrationContext) void {
         self.vtable.beginGPass(self.ptr);
     }
-    /// Ends g pass for the current frame.
+    /// Ends the G-pass and makes geometry buffers available to SSAO or lighting passes.
     /// All commands for that scope must be recorded before this call.
     pub fn endGPass(self: IPassOrchestrationContext) void {
         self.vtable.endGPass(self.ptr);
     }
-    /// Begins f x a a pass for the current frame.
+    /// Begins the FXAA post-process pass for the current frame.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginFXAAPass(self: IPassOrchestrationContext) void {
         self.vtable.beginFXAAPass(self.ptr);
     }
-    /// Ends f x a a pass for the current frame.
+    /// Ends the FXAA post-process pass for the current frame.
     /// All commands for that scope must be recorded before this call.
     pub fn endFXAAPass(self: IPassOrchestrationContext) void {
         self.vtable.endFXAAPass(self.ptr);
@@ -1145,17 +1145,17 @@ pub const IPostProcessContext = struct {
         computeDepthPyramid: *const fn (ptr: *anyopaque) void,
     };
 
-    /// Provides RHI access for compute bloom.
+    /// Runs the bloom extraction and blur compute passes for the current frame.
     /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules.
     pub fn computeBloom(self: IPostProcessContext) void {
         self.vtable.computeBloom(self.ptr);
     }
-    /// Provides RHI access for compute t a a.
+    /// Runs the TAA resolve pass using the current color, history, and velocity inputs.
     /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules.
     pub fn computeTAA(self: IPostProcessContext) void {
         self.vtable.computeTAA(self.ptr);
     }
-    /// Provides RHI access for compute depth pyramid.
+    /// Builds the hierarchical depth pyramid used by culling and screen-space effects.
     /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules.
     pub fn computeDepthPyramid(self: IPostProcessContext) void {
         self.vtable.computeDepthPyramid(self.ptr);
@@ -1172,17 +1172,17 @@ pub const IRenderEffectsContext = struct {
         endWaterDraw: *const fn (ptr: *anyopaque) void,
     };
 
-    /// Provides RHI access for draw sky.
+    /// Draws the sky and atmosphere contribution for the current camera parameters.
     /// The call delegates to backend-owned state and must obey the active backend lifetime and render-thread rules. Propagates `RhiError` when the backend cannot allocate, stage, or encode the requested operation.
     pub fn drawSky(self: IRenderEffectsContext, params: SkyParams) RhiError!void {
         return self.vtable.drawSky(self.ptr, params);
     }
-    /// Begins water draw for the current frame.
+    /// Begins water rendering using reflection and scene-depth textures as inputs.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginWaterDraw(self: IRenderEffectsContext, reflection: TextureHandle, scene_depth: TextureHandle) bool {
         return self.vtable.beginWaterDraw(self.ptr, reflection, scene_depth);
     }
-    /// Ends water draw for the current frame.
+    /// Ends water rendering and restores normal scene rendering state.
     /// All commands for that scope must be recorded before this call.
     pub fn endWaterDraw(self: IRenderEffectsContext) void {
         self.vtable.endWaterDraw(self.ptr);
@@ -1335,12 +1335,12 @@ pub const IDeviceTiming = struct {
         setTimingEnabled: *const fn (ptr: *anyopaque, enabled: bool) void,
     };
 
-    /// Begins pass timing for the current frame.
+    /// Starts GPU timestamp collection for a named render pass.
     /// Must be paired with the matching end call and used from the render thread.
     pub fn beginPassTiming(self: IDeviceTiming, pass_name: []const u8) void {
         self.vtable.beginPassTiming(self.ptr, pass_name);
     }
-    /// Ends pass timing for the current frame.
+    /// Stops GPU timestamp collection for a named render pass.
     /// All commands for that scope must be recorded before this call.
     pub fn endPassTiming(self: IDeviceTiming, pass_name: []const u8) void {
         self.vtable.endPassTiming(self.ptr, pass_name);
@@ -1425,12 +1425,12 @@ pub const IRenderQualityOptions = struct {
     pub fn setVolumetricDensity(self: IRenderQualityOptions, density: f32) void {
         self.vtable.setVolumetricDensity(self.ptr, density);
     }
-    /// Sets m s a a on the active graphics backend.
+    /// Sets the requested MSAA sample count on the active graphics backend.
     /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setMSAA(self: IRenderQualityOptions, samples: u8) void {
         self.vtable.setMSAA(self.ptr, samples);
     }
-    /// Sets f x a a on the active graphics backend.
+    /// Enables or disables FXAA on the active graphics backend.
     /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setFXAA(self: IRenderQualityOptions, enabled: bool) void {
         self.vtable.setFXAA(self.ptr, enabled);
@@ -1475,12 +1475,12 @@ pub const IRenderQualityOptions = struct {
     pub fn setColorGradingIntensity(self: IRenderQualityOptions, intensity: f32) void {
         self.vtable.setColorGradingIntensity(self.ptr, intensity);
     }
-    /// Sets t a a blend factor on the active graphics backend.
+    /// Sets the TAA history blend factor on the active graphics backend.
     /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setTAABlendFactor(self: IRenderQualityOptions, value: f32) void {
         self.vtable.setTAABlendFactor(self.ptr, value);
     }
-    /// Sets t a a velocity rejection on the active graphics backend.
+    /// Sets the TAA velocity rejection threshold on the active graphics backend.
     /// The setting affects later frames or later commands according to backend state lifetime. Must be called from the render thread that owns the backend context.
     pub fn setTAAVelocityRejection(self: IRenderQualityOptions, value: f32) void {
         self.vtable.setTAAVelocityRejection(self.ptr, value);

--- a/modules/world-core/src/chunk.zig
+++ b/modules/world-core/src/chunk.zig
@@ -49,6 +49,7 @@ pub const Chunk = struct {
     modified: bool = false,
     pin_count: std.atomic.Value(u32),
 
+    /// Chunk storage API `init` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn init(chunk_x: i32, chunk_z: i32) Chunk {
         return .{
             .chunk_x = chunk_x,
@@ -64,6 +65,7 @@ pub const Chunk = struct {
         };
     }
 
+    /// Chunk storage API `getIndex` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getIndex(x: u32, y: u32, z: u32) usize {
         std.debug.assert(x < CHUNK_SIZE_X);
         std.debug.assert(y < CHUNK_SIZE_Y);
@@ -71,82 +73,101 @@ pub const Chunk = struct {
         return @as(usize, x) + @as(usize, z) * CHUNK_SIZE_X + @as(usize, y) * CHUNK_SIZE_X * CHUNK_SIZE_Z;
     }
 
+    /// Chunk storage API `getBlock` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getBlock(self: *const Chunk, x: u32, y: u32, z: u32) BlockType {
         return self.blocks[getIndex(x, y, z)];
     }
 
+    /// Chunk storage API `setBlock` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn setBlock(self: *Chunk, x: u32, y: u32, z: u32, block: BlockType) void {
         self.blocks[getIndex(x, y, z)] = block;
         self.dirty = true;
         self.modified = true;
     }
 
+    /// Chunk storage API `getBlockSafe` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getBlockSafe(self: *const Chunk, x: i32, y: i32, z: i32) BlockType {
         if (x < 0 or x >= CHUNK_SIZE_X or y < 0 or y >= CHUNK_SIZE_Y or z < 0 or z >= CHUNK_SIZE_Z) return .air;
         return self.getBlock(@intCast(x), @intCast(y), @intCast(z));
     }
 
+    /// Chunk storage API `getBiome` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getBiome(self: *const Chunk, x: u32, z: u32) BiomeId {
         return self.biomes[x + z * CHUNK_SIZE_X];
     }
 
+    /// Chunk storage API `setBiome` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn setBiome(self: *Chunk, x: u32, z: u32, biome: BiomeId) void {
         self.biomes[x + z * CHUNK_SIZE_X] = biome;
         self.dirty = true;
     }
 
+    /// Chunk storage API `getLight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getLight(self: *const Chunk, x: u32, y: u32, z: u32) PackedLight {
         return self.light[getIndex(x, y, z)];
     }
 
+    /// Chunk storage API `setLight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn setLight(self: *Chunk, x: u32, y: u32, z: u32, light_val: PackedLight) void {
         self.light[getIndex(x, y, z)] = light_val;
     }
 
+    /// Chunk storage API `getSkyLight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getSkyLight(self: *const Chunk, x: u32, y: u32, z: u32) u4 {
         return self.light[getIndex(x, y, z)].getSkyLight();
     }
 
+    /// Chunk storage API `setSkyLight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn setSkyLight(self: *Chunk, x: u32, y: u32, z: u32, val: u4) void {
         self.light[getIndex(x, y, z)].setSkyLight(val);
     }
 
+    /// Chunk storage API `getEntranceBounce` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getEntranceBounce(self: *const Chunk, x: u32, y: u32, z: u32) u4 {
         return self.entrance_bounce[getIndex(x, y, z)];
     }
 
+    /// Chunk storage API `setEntranceBounce` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn setEntranceBounce(self: *Chunk, x: u32, y: u32, z: u32, val: u4) void {
         self.entrance_bounce[getIndex(x, y, z)] = val;
     }
 
+    /// Chunk storage API `getEntranceDir` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getEntranceDir(self: *const Chunk, x: u32, y: u32, z: u32) u8 {
         return self.entrance_dir[getIndex(x, y, z)];
     }
 
+    /// Chunk storage API `setEntranceDir` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn setEntranceDir(self: *Chunk, x: u32, y: u32, z: u32, val: u8) void {
         self.entrance_dir[getIndex(x, y, z)] = val;
     }
 
+    /// Chunk storage API `getBlockLight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getBlockLight(self: *const Chunk, x: u32, y: u32, z: u32) u4 {
         return self.light[getIndex(x, y, z)].getBlockLight();
     }
 
+    /// Chunk storage API `getSurfaceHeight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getSurfaceHeight(self: *const Chunk, x: u32, z: u32) i16 {
         return self.heightmap[x + z * CHUNK_SIZE_X];
     }
 
+    /// Chunk storage API `setSurfaceHeight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn setSurfaceHeight(self: *Chunk, x: u32, z: u32, height: i16) void {
         self.heightmap[x + z * CHUNK_SIZE_X] = height;
     }
 
+    /// Chunk storage API `setBlockLight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn setBlockLight(self: *Chunk, x: u32, y: u32, z: u32, val: u4) void {
         self.light[getIndex(x, y, z)].setBlockLight(val);
     }
 
+    /// Chunk storage API `setBlockLightRGB` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn setBlockLightRGB(self: *Chunk, x: u32, y: u32, z: u32, r: u4, g: u4, b: u4) void {
         self.light[getIndex(x, y, z)].setBlockLightRGB(r, g, b);
     }
 
+    /// Chunk storage API `getLightSafe` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getLightSafe(self: *const Chunk, x: i32, y: i32, z: i32) PackedLight {
         // Out-of-bounds X/Z returns zero light. Out-of-bounds Y returns:
         //   - MAX_LIGHT sky light for y >= CHUNK_SIZE_Y: the meshing system samples this
@@ -161,24 +182,29 @@ pub const Chunk = struct {
         return self.getLight(@intCast(x), @intCast(y), @intCast(z));
     }
 
+    /// Chunk storage API `getEntranceBounceSafe` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getEntranceBounceSafe(self: *const Chunk, x: i32, y: i32, z: i32) u4 {
         if (x < 0 or x >= CHUNK_SIZE_X or z < 0 or z >= CHUNK_SIZE_Z or y < 0 or y >= CHUNK_SIZE_Y) return 0;
         return self.getEntranceBounce(@intCast(x), @intCast(y), @intCast(z));
     }
 
+    /// Chunk storage API `getEntranceDirSafe` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getEntranceDirSafe(self: *const Chunk, x: i32, y: i32, z: i32) u8 {
         if (x < 0 or x >= CHUNK_SIZE_X or z < 0 or z >= CHUNK_SIZE_Z or y < 0 or y >= CHUNK_SIZE_Y) return packEntranceDir(0, 0);
         return self.getEntranceDir(@intCast(x), @intCast(y), @intCast(z));
     }
 
+    /// Chunk storage API `getWorldX` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getWorldX(self: *const Chunk) i32 {
         return self.chunk_x * CHUNK_SIZE_X;
     }
 
+    /// Chunk storage API `getWorldZ` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getWorldZ(self: *const Chunk) i32 {
         return self.chunk_z * CHUNK_SIZE_Z;
     }
 
+    /// Chunk storage API `getHighestSolidY` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn getHighestSolidY(self: *const Chunk, x: u32, z: u32) u32 {
         var y: i32 = CHUNK_SIZE_Y - 1;
         while (y >= 0) : (y -= 1) {
@@ -188,23 +214,28 @@ pub const Chunk = struct {
         return 0;
     }
 
+    /// Chunk storage API `pin` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn pin(self: *Chunk) void {
         _ = self.pin_count.fetchAdd(1, .monotonic);
     }
 
+    /// Chunk storage API `unpin` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn unpin(self: *Chunk) void {
         _ = self.pin_count.fetchSub(1, .monotonic);
     }
 
+    /// Chunk storage API `isPinned` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn isPinned(self: *const Chunk) bool {
         return self.pin_count.load(.monotonic) > 0;
     }
 
+    /// Chunk storage API `fill` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn fill(self: *Chunk, block: BlockType) void {
         @memset(&self.blocks, block);
         self.dirty = true;
     }
 
+    /// Chunk storage API `fillLayer` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn fillLayer(self: *Chunk, y: u32, block: BlockType) void {
         var x: u32 = 0;
         while (x < CHUNK_SIZE_X) : (x += 1) {
@@ -215,6 +246,7 @@ pub const Chunk = struct {
         }
     }
 
+    /// Chunk storage API `generateFlat` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn generateFlat(self: *Chunk, ground_level: u32) void {
         var y: u32 = 0;
         while (y < CHUNK_SIZE_Y) : (y += 1) {
@@ -235,6 +267,7 @@ pub const Chunk = struct {
         self.dirty = true;
     }
 
+    /// Chunk storage API `updateSkylightColumn` reads or mutates chunk-local block and light data using world-core coordinate conventions.
     pub fn updateSkylightColumn(self: *Chunk, x: u32, z: u32) void {
         var sky_light: u4 = MAX_LIGHT;
         var y: i32 = CHUNK_SIZE_Y - 1;
@@ -251,11 +284,13 @@ pub const Chunk = struct {
     }
 };
 
+/// Chunk storage API `worldToChunkFromFloat` reads or mutates chunk-local block and light data using world-core coordinate conventions.
 pub fn worldToChunkFromFloat(world_x: f32, world_z: f32) struct { chunk_x: i32, chunk_z: i32 } {
     const chunk = worldToChunk(@as(i32, @intFromFloat(@floor(world_x))), @as(i32, @intFromFloat(@floor(world_z))));
     return .{ .chunk_x = chunk.chunk_x, .chunk_z = chunk.chunk_z };
 }
 
+/// Chunk storage API `worldToChunk` reads or mutates chunk-local block and light data using world-core coordinate conventions.
 pub fn worldToChunk(world_x: i32, world_z: i32) struct { chunk_x: i32, chunk_z: i32 } {
     return .{
         .chunk_x = @divFloor(world_x, CHUNK_SIZE_X),
@@ -263,6 +298,7 @@ pub fn worldToChunk(world_x: i32, world_z: i32) struct { chunk_x: i32, chunk_z: 
     };
 }
 
+/// Chunk storage API `worldToLocal` reads or mutates chunk-local block and light data using world-core coordinate conventions.
 pub fn worldToLocal(world_x: i32, world_z: i32) struct { x: u32, z: u32 } {
     return .{
         .x = @intCast(@mod(world_x, CHUNK_SIZE_X)),

--- a/modules/world-core/src/chunk.zig
+++ b/modules/world-core/src/chunk.zig
@@ -49,7 +49,8 @@ pub const Chunk = struct {
     modified: bool = false,
     pin_count: std.atomic.Value(u32),
 
-    /// Chunk storage API `init` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Allocates and initializes chunk block, biome, light, and height storage.
+    /// The caller owns the returned chunk and must later call `deinit` if provided by owning storage.
     pub fn init(chunk_x: i32, chunk_z: i32) Chunk {
         return .{
             .chunk_x = chunk_x,
@@ -65,7 +66,8 @@ pub const Chunk = struct {
         };
     }
 
-    /// Chunk storage API `getIndex` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns index from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getIndex(x: u32, y: u32, z: u32) usize {
         std.debug.assert(x < CHUNK_SIZE_X);
         std.debug.assert(y < CHUNK_SIZE_Y);
@@ -73,101 +75,120 @@ pub const Chunk = struct {
         return @as(usize, x) + @as(usize, z) * CHUNK_SIZE_X + @as(usize, y) * CHUNK_SIZE_X * CHUNK_SIZE_Z;
     }
 
-    /// Chunk storage API `getBlock` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns block from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getBlock(self: *const Chunk, x: u32, y: u32, z: u32) BlockType {
         return self.blocks[getIndex(x, y, z)];
     }
 
-    /// Chunk storage API `setBlock` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Writes block into chunk-local storage.
+    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
     pub fn setBlock(self: *Chunk, x: u32, y: u32, z: u32, block: BlockType) void {
         self.blocks[getIndex(x, y, z)] = block;
         self.dirty = true;
         self.modified = true;
     }
 
-    /// Chunk storage API `getBlockSafe` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns block safe from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getBlockSafe(self: *const Chunk, x: i32, y: i32, z: i32) BlockType {
         if (x < 0 or x >= CHUNK_SIZE_X or y < 0 or y >= CHUNK_SIZE_Y or z < 0 or z >= CHUNK_SIZE_Z) return .air;
         return self.getBlock(@intCast(x), @intCast(y), @intCast(z));
     }
 
-    /// Chunk storage API `getBiome` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns biome from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getBiome(self: *const Chunk, x: u32, z: u32) BiomeId {
         return self.biomes[x + z * CHUNK_SIZE_X];
     }
 
-    /// Chunk storage API `setBiome` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Writes biome into chunk-local storage.
+    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
     pub fn setBiome(self: *Chunk, x: u32, z: u32, biome: BiomeId) void {
         self.biomes[x + z * CHUNK_SIZE_X] = biome;
         self.dirty = true;
     }
 
-    /// Chunk storage API `getLight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns light from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getLight(self: *const Chunk, x: u32, y: u32, z: u32) PackedLight {
         return self.light[getIndex(x, y, z)];
     }
 
-    /// Chunk storage API `setLight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Writes light into chunk-local storage.
+    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
     pub fn setLight(self: *Chunk, x: u32, y: u32, z: u32, light_val: PackedLight) void {
         self.light[getIndex(x, y, z)] = light_val;
     }
 
-    /// Chunk storage API `getSkyLight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns sky light from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getSkyLight(self: *const Chunk, x: u32, y: u32, z: u32) u4 {
         return self.light[getIndex(x, y, z)].getSkyLight();
     }
 
-    /// Chunk storage API `setSkyLight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Writes sky light into chunk-local storage.
+    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
     pub fn setSkyLight(self: *Chunk, x: u32, y: u32, z: u32, val: u4) void {
         self.light[getIndex(x, y, z)].setSkyLight(val);
     }
 
-    /// Chunk storage API `getEntranceBounce` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns entrance bounce from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getEntranceBounce(self: *const Chunk, x: u32, y: u32, z: u32) u4 {
         return self.entrance_bounce[getIndex(x, y, z)];
     }
 
-    /// Chunk storage API `setEntranceBounce` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Writes entrance bounce into chunk-local storage.
+    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
     pub fn setEntranceBounce(self: *Chunk, x: u32, y: u32, z: u32, val: u4) void {
         self.entrance_bounce[getIndex(x, y, z)] = val;
     }
 
-    /// Chunk storage API `getEntranceDir` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns entrance dir from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getEntranceDir(self: *const Chunk, x: u32, y: u32, z: u32) u8 {
         return self.entrance_dir[getIndex(x, y, z)];
     }
 
-    /// Chunk storage API `setEntranceDir` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Writes entrance dir into chunk-local storage.
+    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
     pub fn setEntranceDir(self: *Chunk, x: u32, y: u32, z: u32, val: u8) void {
         self.entrance_dir[getIndex(x, y, z)] = val;
     }
 
-    /// Chunk storage API `getBlockLight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns block light from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getBlockLight(self: *const Chunk, x: u32, y: u32, z: u32) u4 {
         return self.light[getIndex(x, y, z)].getBlockLight();
     }
 
-    /// Chunk storage API `getSurfaceHeight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns surface height from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getSurfaceHeight(self: *const Chunk, x: u32, z: u32) i16 {
         return self.heightmap[x + z * CHUNK_SIZE_X];
     }
 
-    /// Chunk storage API `setSurfaceHeight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Writes surface height into chunk-local storage.
+    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
     pub fn setSurfaceHeight(self: *Chunk, x: u32, z: u32, height: i16) void {
         self.heightmap[x + z * CHUNK_SIZE_X] = height;
     }
 
-    /// Chunk storage API `setBlockLight` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Writes block light into chunk-local storage.
+    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
     pub fn setBlockLight(self: *Chunk, x: u32, y: u32, z: u32, val: u4) void {
         self.light[getIndex(x, y, z)].setBlockLight(val);
     }
 
-    /// Chunk storage API `setBlockLightRGB` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Writes block light r g b into chunk-local storage.
+    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
     pub fn setBlockLightRGB(self: *Chunk, x: u32, y: u32, z: u32, r: u4, g: u4, b: u4) void {
         self.light[getIndex(x, y, z)].setBlockLightRGB(r, g, b);
     }
 
-    /// Chunk storage API `getLightSafe` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns light safe from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getLightSafe(self: *const Chunk, x: i32, y: i32, z: i32) PackedLight {
         // Out-of-bounds X/Z returns zero light. Out-of-bounds Y returns:
         //   - MAX_LIGHT sky light for y >= CHUNK_SIZE_Y: the meshing system samples this
@@ -182,29 +203,34 @@ pub const Chunk = struct {
         return self.getLight(@intCast(x), @intCast(y), @intCast(z));
     }
 
-    /// Chunk storage API `getEntranceBounceSafe` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns entrance bounce safe from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getEntranceBounceSafe(self: *const Chunk, x: i32, y: i32, z: i32) u4 {
         if (x < 0 or x >= CHUNK_SIZE_X or z < 0 or z >= CHUNK_SIZE_Z or y < 0 or y >= CHUNK_SIZE_Y) return 0;
         return self.getEntranceBounce(@intCast(x), @intCast(y), @intCast(z));
     }
 
-    /// Chunk storage API `getEntranceDirSafe` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns entrance dir safe from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getEntranceDirSafe(self: *const Chunk, x: i32, y: i32, z: i32) u8 {
         if (x < 0 or x >= CHUNK_SIZE_X or z < 0 or z >= CHUNK_SIZE_Z or y < 0 or y >= CHUNK_SIZE_Y) return packEntranceDir(0, 0);
         return self.getEntranceDir(@intCast(x), @intCast(y), @intCast(z));
     }
 
-    /// Chunk storage API `getWorldX` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns world x from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getWorldX(self: *const Chunk) i32 {
         return self.chunk_x * CHUNK_SIZE_X;
     }
 
-    /// Chunk storage API `getWorldZ` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns world z from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getWorldZ(self: *const Chunk) i32 {
         return self.chunk_z * CHUNK_SIZE_Z;
     }
 
-    /// Chunk storage API `getHighestSolidY` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Returns highest solid y from chunk-local storage.
+    /// Coordinates must be chunk-local unless the function name explicitly says world.
     pub fn getHighestSolidY(self: *const Chunk, x: u32, z: u32) u32 {
         var y: i32 = CHUNK_SIZE_Y - 1;
         while (y >= 0) : (y -= 1) {
@@ -214,28 +240,33 @@ pub const Chunk = struct {
         return 0;
     }
 
-    /// Chunk storage API `pin` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Manages chunk pin state through `pin`.
+    /// Pinned chunks should not be unloaded while worker jobs may reference them.
     pub fn pin(self: *Chunk) void {
         _ = self.pin_count.fetchAdd(1, .monotonic);
     }
 
-    /// Chunk storage API `unpin` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Manages chunk pin state through `unpin`.
+    /// Pinned chunks should not be unloaded while worker jobs may reference them.
     pub fn unpin(self: *Chunk) void {
         _ = self.pin_count.fetchSub(1, .monotonic);
     }
 
-    /// Chunk storage API `isPinned` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Manages chunk pin state through `isPinned`.
+    /// Pinned chunks should not be unloaded while worker jobs may reference them.
     pub fn isPinned(self: *const Chunk) bool {
         return self.pin_count.load(.monotonic) > 0;
     }
 
-    /// Chunk storage API `fill` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Bulk-updates chunk contents through `fill`.
+    /// The operation mutates block, light, or height data for generation and lighting paths.
     pub fn fill(self: *Chunk, block: BlockType) void {
         @memset(&self.blocks, block);
         self.dirty = true;
     }
 
-    /// Chunk storage API `fillLayer` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Bulk-updates chunk contents through `fillLayer`.
+    /// The operation mutates block, light, or height data for generation and lighting paths.
     pub fn fillLayer(self: *Chunk, y: u32, block: BlockType) void {
         var x: u32 = 0;
         while (x < CHUNK_SIZE_X) : (x += 1) {
@@ -246,7 +277,8 @@ pub const Chunk = struct {
         }
     }
 
-    /// Chunk storage API `generateFlat` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Bulk-updates chunk contents through `generateFlat`.
+    /// The operation mutates block, light, or height data for generation and lighting paths.
     pub fn generateFlat(self: *Chunk, ground_level: u32) void {
         var y: u32 = 0;
         while (y < CHUNK_SIZE_Y) : (y += 1) {
@@ -267,7 +299,8 @@ pub const Chunk = struct {
         self.dirty = true;
     }
 
-    /// Chunk storage API `updateSkylightColumn` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+    /// Bulk-updates chunk contents through `updateSkylightColumn`.
+    /// The operation mutates block, light, or height data for generation and lighting paths.
     pub fn updateSkylightColumn(self: *Chunk, x: u32, z: u32) void {
         var sky_light: u4 = MAX_LIGHT;
         var y: i32 = CHUNK_SIZE_Y - 1;
@@ -284,13 +317,15 @@ pub const Chunk = struct {
     }
 };
 
-/// Chunk storage API `worldToChunkFromFloat` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+/// Converts world coordinates with `worldToChunkFromFloat`.
+/// Uses ZigCraft chunk sizing and floor-division conventions for negative coordinates.
 pub fn worldToChunkFromFloat(world_x: f32, world_z: f32) struct { chunk_x: i32, chunk_z: i32 } {
     const chunk = worldToChunk(@as(i32, @intFromFloat(@floor(world_x))), @as(i32, @intFromFloat(@floor(world_z))));
     return .{ .chunk_x = chunk.chunk_x, .chunk_z = chunk.chunk_z };
 }
 
-/// Chunk storage API `worldToChunk` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+/// Converts world coordinates with `worldToChunk`.
+/// Uses ZigCraft chunk sizing and floor-division conventions for negative coordinates.
 pub fn worldToChunk(world_x: i32, world_z: i32) struct { chunk_x: i32, chunk_z: i32 } {
     return .{
         .chunk_x = @divFloor(world_x, CHUNK_SIZE_X),
@@ -298,7 +333,8 @@ pub fn worldToChunk(world_x: i32, world_z: i32) struct { chunk_x: i32, chunk_z: 
     };
 }
 
-/// Chunk storage API `worldToLocal` reads or mutates chunk-local block and light data using world-core coordinate conventions.
+/// Converts world coordinates with `worldToLocal`.
+/// Uses ZigCraft chunk sizing and floor-division conventions for negative coordinates.
 pub fn worldToLocal(world_x: i32, world_z: i32) struct { x: u32, z: u32 } {
     return .{
         .x = @intCast(@mod(world_x, CHUNK_SIZE_X)),

--- a/modules/world-core/src/chunk.zig
+++ b/modules/world-core/src/chunk.zig
@@ -49,8 +49,8 @@ pub const Chunk = struct {
     modified: bool = false,
     pin_count: std.atomic.Value(u32),
 
-    /// Allocates and initializes chunk block, biome, light, and height storage.
-    /// The caller owns the returned chunk and must later call `deinit` if provided by owning storage.
+    /// Creates a new chunk at chunk coordinates `(chunk_x, chunk_z)` with default air, plains biome, and zero light.
+    /// The returned value owns no heap memory; chunk storage containers own its lifetime and synchronization.
     pub fn init(chunk_x: i32, chunk_z: i32) Chunk {
         return .{
             .chunk_x = chunk_x,
@@ -66,8 +66,8 @@ pub const Chunk = struct {
         };
     }
 
-    /// Returns index from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Converts chunk-local `(x, y, z)` coordinates into the flat storage index.
+    /// Coordinates must be in bounds; debug builds assert on invalid local positions.
     pub fn getIndex(x: u32, y: u32, z: u32) usize {
         std.debug.assert(x < CHUNK_SIZE_X);
         std.debug.assert(y < CHUNK_SIZE_Y);
@@ -75,120 +75,120 @@ pub const Chunk = struct {
         return @as(usize, x) + @as(usize, z) * CHUNK_SIZE_X + @as(usize, y) * CHUNK_SIZE_X * CHUNK_SIZE_Z;
     }
 
-    /// Returns block from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Reads the block at chunk-local coordinates.
+    /// Coordinates must be in bounds; use `getBlockSafe` for unchecked neighbor sampling.
     pub fn getBlock(self: *const Chunk, x: u32, y: u32, z: u32) BlockType {
         return self.blocks[getIndex(x, y, z)];
     }
 
-    /// Writes block into chunk-local storage.
-    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
+    /// Writes a block at chunk-local coordinates and marks the chunk dirty and modified.
+    /// Coordinates must be in bounds; callers are responsible for scheduling mesh/light updates.
     pub fn setBlock(self: *Chunk, x: u32, y: u32, z: u32, block: BlockType) void {
         self.blocks[getIndex(x, y, z)] = block;
         self.dirty = true;
         self.modified = true;
     }
 
-    /// Returns block safe from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Safely reads a block for possibly out-of-bounds local coordinates.
+    /// Out-of-range samples return `.air`, matching neighbor-missing meshing behavior.
     pub fn getBlockSafe(self: *const Chunk, x: i32, y: i32, z: i32) BlockType {
         if (x < 0 or x >= CHUNK_SIZE_X or y < 0 or y >= CHUNK_SIZE_Y or z < 0 or z >= CHUNK_SIZE_Z) return .air;
         return self.getBlock(@intCast(x), @intCast(y), @intCast(z));
     }
 
-    /// Returns biome from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Reads the biome id for a horizontal chunk-local column.
+    /// `x` and `z` must be in range `[0, CHUNK_SIZE_X/Z)`.
     pub fn getBiome(self: *const Chunk, x: u32, z: u32) BiomeId {
         return self.biomes[x + z * CHUNK_SIZE_X];
     }
 
-    /// Writes biome into chunk-local storage.
-    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
+    /// Writes the biome id for a horizontal chunk-local column and marks the chunk dirty.
+    /// This affects tinting and terrain metadata but does not mark the chunk player-modified.
     pub fn setBiome(self: *Chunk, x: u32, z: u32, biome: BiomeId) void {
         self.biomes[x + z * CHUNK_SIZE_X] = biome;
         self.dirty = true;
     }
 
-    /// Returns light from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Reads packed sky/block light at chunk-local coordinates.
+    /// Coordinates must be in bounds and are not checked outside debug assertions in `getIndex`.
     pub fn getLight(self: *const Chunk, x: u32, y: u32, z: u32) PackedLight {
         return self.light[getIndex(x, y, z)];
     }
 
-    /// Writes light into chunk-local storage.
-    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
+    /// Writes packed sky/block light at chunk-local coordinates.
+    /// Lighting callers are responsible for marking dependent meshes dirty when needed.
     pub fn setLight(self: *Chunk, x: u32, y: u32, z: u32, light_val: PackedLight) void {
         self.light[getIndex(x, y, z)] = light_val;
     }
 
-    /// Returns sky light from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Reads only the sky-light channel at chunk-local coordinates.
+    /// Coordinates must be in bounds.
     pub fn getSkyLight(self: *const Chunk, x: u32, y: u32, z: u32) u4 {
         return self.light[getIndex(x, y, z)].getSkyLight();
     }
 
-    /// Writes sky light into chunk-local storage.
-    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
+    /// Writes only the sky-light channel at chunk-local coordinates.
+    /// Coordinates must be in bounds and `val` is a packed 4-bit light value.
     pub fn setSkyLight(self: *Chunk, x: u32, y: u32, z: u32, val: u4) void {
         self.light[getIndex(x, y, z)].setSkyLight(val);
     }
 
-    /// Returns entrance bounce from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Reads the entrance-bounce light value used by cave/entrance lighting propagation.
+    /// Coordinates must be in bounds.
     pub fn getEntranceBounce(self: *const Chunk, x: u32, y: u32, z: u32) u4 {
         return self.entrance_bounce[getIndex(x, y, z)];
     }
 
-    /// Writes entrance bounce into chunk-local storage.
-    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
+    /// Writes the entrance-bounce light value used by cave/entrance lighting propagation.
+    /// Coordinates must be in bounds and `val` is stored as a 4-bit value.
     pub fn setEntranceBounce(self: *Chunk, x: u32, y: u32, z: u32, val: u4) void {
         self.entrance_bounce[getIndex(x, y, z)] = val;
     }
 
-    /// Returns entrance dir from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Reads the packed horizontal direction associated with entrance lighting.
+    /// Coordinates must be in bounds.
     pub fn getEntranceDir(self: *const Chunk, x: u32, y: u32, z: u32) u8 {
         return self.entrance_dir[getIndex(x, y, z)];
     }
 
-    /// Writes entrance dir into chunk-local storage.
-    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
+    /// Writes the packed horizontal direction associated with entrance lighting.
+    /// Use `packEntranceDir` to encode direction components.
     pub fn setEntranceDir(self: *Chunk, x: u32, y: u32, z: u32, val: u8) void {
         self.entrance_dir[getIndex(x, y, z)] = val;
     }
 
-    /// Returns block light from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Reads only the block-light channel at chunk-local coordinates.
+    /// Coordinates must be in bounds.
     pub fn getBlockLight(self: *const Chunk, x: u32, y: u32, z: u32) u4 {
         return self.light[getIndex(x, y, z)].getBlockLight();
     }
 
-    /// Returns surface height from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Reads the cached surface height for a horizontal chunk-local column.
+    /// The value is maintained by generation/lighting paths and used by worldgen and meshing.
     pub fn getSurfaceHeight(self: *const Chunk, x: u32, z: u32) i16 {
         return self.heightmap[x + z * CHUNK_SIZE_X];
     }
 
-    /// Writes surface height into chunk-local storage.
-    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
+    /// Writes the cached surface height for a horizontal chunk-local column.
+    /// Does not recompute lighting or mesh data by itself.
     pub fn setSurfaceHeight(self: *Chunk, x: u32, z: u32, height: i16) void {
         self.heightmap[x + z * CHUNK_SIZE_X] = height;
     }
 
-    /// Writes block light into chunk-local storage.
-    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
+    /// Writes the scalar block-light channel at chunk-local coordinates.
+    /// Coordinates must be in bounds and `val` is a packed 4-bit light value.
     pub fn setBlockLight(self: *Chunk, x: u32, y: u32, z: u32, val: u4) void {
         self.light[getIndex(x, y, z)].setBlockLight(val);
     }
 
-    /// Writes block light r g b into chunk-local storage.
-    /// Callers must keep coordinates in bounds; safe variants should be used for unchecked world input.
+    /// Writes RGB block-light channels at chunk-local coordinates.
+    /// Coordinates must be in bounds and each channel is a packed 4-bit value.
     pub fn setBlockLightRGB(self: *Chunk, x: u32, y: u32, z: u32, r: u4, g: u4, b: u4) void {
         self.light[getIndex(x, y, z)].setBlockLightRGB(r, g, b);
     }
 
-    /// Returns light safe from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Safely reads packed light for possibly out-of-bounds local coordinates.
+    /// Horizontal out-of-range samples return dark; samples above the world return full sky light for top-face meshing.
     pub fn getLightSafe(self: *const Chunk, x: i32, y: i32, z: i32) PackedLight {
         // Out-of-bounds X/Z returns zero light. Out-of-bounds Y returns:
         //   - MAX_LIGHT sky light for y >= CHUNK_SIZE_Y: the meshing system samples this
@@ -203,34 +203,34 @@ pub const Chunk = struct {
         return self.getLight(@intCast(x), @intCast(y), @intCast(z));
     }
 
-    /// Returns entrance bounce safe from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Safely reads entrance-bounce light for possibly out-of-bounds local coordinates.
+    /// Out-of-range samples return zero bounce light.
     pub fn getEntranceBounceSafe(self: *const Chunk, x: i32, y: i32, z: i32) u4 {
         if (x < 0 or x >= CHUNK_SIZE_X or z < 0 or z >= CHUNK_SIZE_Z or y < 0 or y >= CHUNK_SIZE_Y) return 0;
         return self.getEntranceBounce(@intCast(x), @intCast(y), @intCast(z));
     }
 
-    /// Returns entrance dir safe from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Safely reads packed entrance direction for possibly out-of-bounds local coordinates.
+    /// Out-of-range samples return the neutral zero direction.
     pub fn getEntranceDirSafe(self: *const Chunk, x: i32, y: i32, z: i32) u8 {
         if (x < 0 or x >= CHUNK_SIZE_X or z < 0 or z >= CHUNK_SIZE_Z or y < 0 or y >= CHUNK_SIZE_Y) return packEntranceDir(0, 0);
         return self.getEntranceDir(@intCast(x), @intCast(y), @intCast(z));
     }
 
-    /// Returns world x from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Returns the world-space block X coordinate of this chunk's minimum X edge.
+    /// This is `chunk_x * CHUNK_SIZE_X` and works for negative chunk coordinates.
     pub fn getWorldX(self: *const Chunk) i32 {
         return self.chunk_x * CHUNK_SIZE_X;
     }
 
-    /// Returns world z from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Returns the world-space block Z coordinate of this chunk's minimum Z edge.
+    /// This is `chunk_z * CHUNK_SIZE_Z` and works for negative chunk coordinates.
     pub fn getWorldZ(self: *const Chunk) i32 {
         return self.chunk_z * CHUNK_SIZE_Z;
     }
 
-    /// Returns highest solid y from chunk-local storage.
-    /// Coordinates must be chunk-local unless the function name explicitly says world.
+    /// Scans a local column from top to bottom and returns the highest non-air, non-water block Y.
+    /// Returns zero when the column has no solid block; `x` and `z` must be in bounds.
     pub fn getHighestSolidY(self: *const Chunk, x: u32, z: u32) u32 {
         var y: i32 = CHUNK_SIZE_Y - 1;
         while (y >= 0) : (y -= 1) {
@@ -240,33 +240,33 @@ pub const Chunk = struct {
         return 0;
     }
 
-    /// Manages chunk pin state through `pin`.
-    /// Pinned chunks should not be unloaded while worker jobs may reference them.
+    /// Increments the async-work pin count for this chunk.
+    /// Streamers must not unload pinned chunks while worker jobs may still read them.
     pub fn pin(self: *Chunk) void {
         _ = self.pin_count.fetchAdd(1, .monotonic);
     }
 
-    /// Manages chunk pin state through `unpin`.
-    /// Pinned chunks should not be unloaded while worker jobs may reference them.
+    /// Decrements the async-work pin count for this chunk.
+    /// Must be paired with a previous `pin`; callers are responsible for avoiding underflow.
     pub fn unpin(self: *Chunk) void {
         _ = self.pin_count.fetchSub(1, .monotonic);
     }
 
-    /// Manages chunk pin state through `isPinned`.
-    /// Pinned chunks should not be unloaded while worker jobs may reference them.
+    /// Reports whether any async job currently pins this chunk.
+    /// This is an atomic read suitable for streamer unload checks.
     pub fn isPinned(self: *const Chunk) bool {
         return self.pin_count.load(.monotonic) > 0;
     }
 
-    /// Bulk-updates chunk contents through `fill`.
-    /// The operation mutates block, light, or height data for generation and lighting paths.
+    /// Fills every block in the chunk with one block type and marks block data dirty.
+    /// Does not update biome, light, or heightmap arrays.
     pub fn fill(self: *Chunk, block: BlockType) void {
         @memset(&self.blocks, block);
         self.dirty = true;
     }
 
-    /// Bulk-updates chunk contents through `fillLayer`.
-    /// The operation mutates block, light, or height data for generation and lighting paths.
+    /// Fills one horizontal Y layer with a block type using normal `setBlock` mutation semantics.
+    /// `y` must be in bounds; the chunk becomes dirty and modified.
     pub fn fillLayer(self: *Chunk, y: u32, block: BlockType) void {
         var x: u32 = 0;
         while (x < CHUNK_SIZE_X) : (x += 1) {
@@ -277,8 +277,8 @@ pub const Chunk = struct {
         }
     }
 
-    /// Bulk-updates chunk contents through `generateFlat`.
-    /// The operation mutates block, light, or height data for generation and lighting paths.
+    /// Generates a simple flat terrain stack of bedrock, stone, dirt, grass, and air.
+    /// Marks the chunk generated and dirty; intended for tests and flat-world generation.
     pub fn generateFlat(self: *Chunk, ground_level: u32) void {
         var y: u32 = 0;
         while (y < CHUNK_SIZE_Y) : (y += 1) {
@@ -299,8 +299,8 @@ pub const Chunk = struct {
         self.dirty = true;
     }
 
-    /// Bulk-updates chunk contents through `updateSkylightColumn`.
-    /// The operation mutates block, light, or height data for generation and lighting paths.
+    /// Recomputes top-down sky light for one local `(x, z)` column.
+    /// Opaque blocks stop sky light and water attenuates it by one level per block.
     pub fn updateSkylightColumn(self: *Chunk, x: u32, z: u32) void {
         var sky_light: u4 = MAX_LIGHT;
         var y: i32 = CHUNK_SIZE_Y - 1;
@@ -317,15 +317,15 @@ pub const Chunk = struct {
     }
 };
 
-/// Converts world coordinates with `worldToChunkFromFloat`.
-/// Uses ZigCraft chunk sizing and floor-division conventions for negative coordinates.
+/// Converts floating world X/Z coordinates to chunk coordinates.
+/// Coordinates are floored to block coordinates first, then converted with negative-safe floor division.
 pub fn worldToChunkFromFloat(world_x: f32, world_z: f32) struct { chunk_x: i32, chunk_z: i32 } {
     const chunk = worldToChunk(@as(i32, @intFromFloat(@floor(world_x))), @as(i32, @intFromFloat(@floor(world_z))));
     return .{ .chunk_x = chunk.chunk_x, .chunk_z = chunk.chunk_z };
 }
 
-/// Converts world coordinates with `worldToChunk`.
-/// Uses ZigCraft chunk sizing and floor-division conventions for negative coordinates.
+/// Converts integer world X/Z block coordinates to chunk coordinates.
+/// Uses floor division so negative world coordinates map to the containing negative chunk.
 pub fn worldToChunk(world_x: i32, world_z: i32) struct { chunk_x: i32, chunk_z: i32 } {
     return .{
         .chunk_x = @divFloor(world_x, CHUNK_SIZE_X),
@@ -333,8 +333,8 @@ pub fn worldToChunk(world_x: i32, world_z: i32) struct { chunk_x: i32, chunk_z: 
     };
 }
 
-/// Converts world coordinates with `worldToLocal`.
-/// Uses ZigCraft chunk sizing and floor-division conventions for negative coordinates.
+/// Converts integer world X/Z block coordinates to local coordinates inside their containing chunk.
+/// Uses modulo semantics that produce values in `[0, CHUNK_SIZE_X/Z)` even for negative world coordinates.
 pub fn worldToLocal(world_x: i32, world_z: i32) struct { x: u32, z: u32 } {
     return .{
         .x = @intCast(@mod(world_x, CHUNK_SIZE_X)),

--- a/modules/world-lod/src/lod_chunk.zig
+++ b/modules/world-lod/src/lod_chunk.zig
@@ -32,7 +32,8 @@ pub const LODRegionKey = struct {
     /// LOD level
     lod: LODLevel,
 
-    /// LOD chunk API `fromChunkCoords` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Creates LOD chunk identity/state using `fromChunkCoords`.
+    /// The returned value starts with deterministic coordinates, LOD level, and lifecycle state.
     pub fn fromChunkCoords(chunk_x: i32, chunk_z: i32, lod: LODLevel) LODRegionKey {
         const scale: i32 = @intCast(lod.chunksPerSide());
         return .{
@@ -42,7 +43,8 @@ pub const LODRegionKey = struct {
         };
     }
 
-    /// LOD chunk API `hash` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `hash`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn hash(self: LODRegionKey) u64 {
         const ux: u64 = @bitCast(@as(i64, self.rx));
         const uz: u64 = @bitCast(@as(i64, self.rz));
@@ -50,12 +52,14 @@ pub const LODRegionKey = struct {
         return ux ^ (uz *% 0x9e3779b97f4a7c15) ^ (ul *% 0x517cc1b727220a95);
     }
 
-    /// LOD chunk API `eql` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `eql`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn eql(a: LODRegionKey, b: LODRegionKey) bool {
         return a.rx == b.rx and a.rz == b.rz and a.lod == b.lod;
     }
 
-    /// LOD chunk API `parentKey` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Provides LOD chunk helper `parentKey`.
+    /// Used by LOD scheduling, meshing, or rendering code to keep chunk state consistent.
     pub fn parentKey(self: LODRegionKey) ?LODRegionKey {
         const lod_idx = @intFromEnum(self.lod);
         if (lod_idx + 1 >= LODLevel.count) return null;
@@ -66,7 +70,8 @@ pub const LODRegionKey = struct {
         };
     }
 
-    /// LOD chunk API `childKeys` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Provides LOD chunk helper `childKeys`.
+    /// Used by LOD scheduling, meshing, or rendering code to keep chunk state consistent.
     pub fn childKeys(self: LODRegionKey) ?[4]LODRegionKey {
         const lod_idx = @intFromEnum(self.lod);
         if (lod_idx == 0) return null;
@@ -99,14 +104,16 @@ pub const ChunkBounds = struct {
     max_x: i32,
     max_z: i32,
 
-    /// LOD chunk API `distanceSquaredToPoint` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Provides LOD chunk helper `distanceSquaredToPoint`.
+    /// Used by LOD scheduling, meshing, or rendering code to keep chunk state consistent.
     pub fn distanceSquaredToPoint(self: ChunkBounds, point_x: i32, point_z: i32) i64 {
         const dx = axisDistance(point_x, self.min_x, self.max_x);
         const dz = axisDistance(point_z, self.min_z, self.max_z);
         return dx * dx + dz * dz;
     }
 
-    /// LOD chunk API `intersectsRadius` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Computes LOD distance/radius policy through `intersectsRadius`.
+    /// Inputs are chunk or world distances; results are used by scheduler and renderer culling.
     pub fn intersectsRadius(self: ChunkBounds, center_x: i32, center_z: i32, radius_chunks: i32) bool {
         const radius_sq: i64 = @as(i64, radius_chunks) * @as(i64, radius_chunks);
         return self.distanceSquaredToPoint(center_x, center_z) <= radius_sq;
@@ -121,13 +128,15 @@ pub const ChunkBounds = struct {
 
 /// Context for LODRegionKey HashMap
 pub const LODRegionKeyContext = struct {
-    /// LOD chunk API `hash` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `hash`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn hash(self: @This(), key: LODRegionKey) u64 {
         _ = self;
         return key.hash();
     }
 
-    /// LOD chunk API `eql` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `eql`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn eql(self: @This(), a: LODRegionKey, b: LODRegionKey) bool {
         _ = self;
         return a.eql(b);
@@ -183,7 +192,8 @@ pub const LODChunk = struct {
     /// or edit). The manager writes the region container to disk lazily.
     store_dirty: bool,
 
-    /// LOD chunk API `init` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Creates LOD chunk identity/state using `init`.
+    /// The returned value starts with deterministic coordinates, LOD level, and lifecycle state.
     pub fn init(rx: i32, rz: i32, lod: LODLevel) LODChunk {
         return .{
             .region_x = rx,
@@ -203,7 +213,8 @@ pub const LODChunk = struct {
         };
     }
 
-    /// LOD chunk API `deinit` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Releases heap-owned simplified data and mesh references held by the LOD chunk.
+    /// Pinned chunks must not be deinitialized while worker jobs still reference them.
     pub fn deinit(self: *LODChunk, allocator: std.mem.Allocator) void {
         _ = allocator;
         switch (self.data) {
@@ -214,57 +225,68 @@ pub const LODChunk = struct {
         self.* = undefined;
     }
 
-    /// LOD chunk API `pin` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Manages worker-safety pin state through `pin`.
+    /// Pinned chunks are protected from unload while background work may still access them.
     pub fn pin(self: *LODChunk) void {
         _ = self.pin_count.fetchAdd(1, .monotonic);
     }
 
-    /// LOD chunk API `unpin` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Manages worker-safety pin state through `unpin`.
+    /// Pinned chunks are protected from unload while background work may still access them.
     pub fn unpin(self: *LODChunk) void {
         _ = self.pin_count.fetchSub(1, .monotonic);
     }
 
-    /// LOD chunk API `isPinned` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Manages worker-safety pin state through `isPinned`.
+    /// Pinned chunks are protected from unload while background work may still access them.
     pub fn isPinned(self: *const LODChunk) bool {
         return self.pin_count.load(.monotonic) > 0;
     }
 
-    /// LOD chunk API `key` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `key`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn key(self: *const LODChunk) LODRegionKey {
         return .{ .rx = self.region_x, .rz = self.region_z, .lod = self.lod_level };
     }
 
-    /// LOD chunk API `getState` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getState`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getState(self: *const LODChunk) LODState {
         return self.state;
     }
 
-    /// LOD chunk API `setState` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Updates LOD chunk lifecycle state via `setState`.
+    /// State changes are used by streaming, transition, and renderability decisions.
     pub fn setState(self: *LODChunk, state: LODState) void {
         self.state = state;
     }
 
-    /// LOD chunk API `isInFlight` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `isInFlight`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn isInFlight(self: *const LODChunk) bool {
         return self.state == .generating or self.state == .meshing or self.state == .uploading;
     }
 
-    /// LOD chunk API `isRenderable` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `isRenderable`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn isRenderable(self: *const LODChunk) bool {
         return self.state == .renderable;
     }
 
-    /// LOD chunk API `lodLevel` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `lodLevel`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn lodLevel(self: *const LODChunk) LODLevel {
         return self.lod_level;
     }
 
-    /// LOD chunk API `readyChildren` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `readyChildren`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn readyChildren(self: *const LODChunk) u8 {
         return self.ready_children;
     }
 
-    /// LOD chunk API `transitionFadeProgress` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `transitionFadeProgress`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn transitionFadeProgress(self: *const LODChunk) f32 {
         if (self.transition_frames_remaining == 0) return 1.0;
         const remaining = @as(f32, @floatFromInt(self.transition_frames_remaining));
@@ -274,7 +296,8 @@ pub const LODChunk = struct {
         return 1.0 - t;
     }
 
-    /// LOD chunk API `adjustReadyChildren` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Updates LOD chunk lifecycle state via `adjustReadyChildren`.
+    /// State changes are used by streaming, transition, and renderability decisions.
     pub fn adjustReadyChildren(self: *LODChunk, delta: i8) void {
         const before = self.ready_children;
         if (delta > 0) {
@@ -290,19 +313,22 @@ pub const LODChunk = struct {
         }
     }
 
-    /// LOD chunk API `markRenderable` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Updates LOD chunk lifecycle state via `markRenderable`.
+    /// State changes are used by streaming, transition, and renderability decisions.
     pub fn markRenderable(self: *LODChunk, ready_children: u8) void {
         self.ready_children = @min(ready_children, 4);
         self.transition_frames_remaining = TRANSITION_FADE_FRAMES;
         self.state = .renderable;
     }
 
-    /// LOD chunk API `tickTransition` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Updates LOD chunk lifecycle state via `tickTransition`.
+    /// State changes are used by streaming, transition, and renderability decisions.
     pub fn tickTransition(self: *LODChunk) void {
         if (self.transition_frames_remaining > 0) self.transition_frames_remaining -= 1;
     }
 
-    /// LOD chunk API `isCoveredByFinerLOD` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `isCoveredByFinerLOD`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn isCoveredByFinerLOD(self: *const LODChunk, fallback_missing_child_threshold: f32) bool {
         if (self.lod_level == .lod0) return false;
         const missing_children = 4 - @min(self.ready_children, 4);
@@ -310,13 +336,15 @@ pub const LODChunk = struct {
         return missing_fraction <= fallback_missing_child_threshold and self.transition_frames_remaining == 0;
     }
 
-    /// LOD chunk API `markSourceDirty` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Updates LOD chunk lifecycle state via `markSourceDirty`.
+    /// State changes are used by streaming, transition, and renderability decisions.
     pub fn markSourceDirty(self: *LODChunk) void {
         self.dirty = true;
         self.store_dirty = true;
     }
 
-    /// LOD chunk API `setReadyChildren` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Updates LOD chunk lifecycle state via `setReadyChildren`.
+    /// State changes are used by streaming, transition, and renderability decisions.
     pub fn setReadyChildren(self: *LODChunk, ready_children: u8) void {
         self.ready_children = @min(ready_children, 4);
     }
@@ -345,7 +373,8 @@ pub const LODChunk = struct {
         };
     }
 
-    /// LOD chunk API `updateHeightBoundsFromData` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Provides LOD chunk helper `updateHeightBoundsFromData`.
+    /// Used by LOD scheduling, meshing, or rendering code to keep chunk state consistent.
     pub fn updateHeightBoundsFromData(self: *LODChunk) void {
         switch (self.data) {
             .simplified => |*data| {
@@ -376,7 +405,8 @@ pub const LODChunk = struct {
         }
     }
 
-    /// LOD chunk API `chunkBounds` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `chunkBounds`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn chunkBounds(self: *const LODChunk) ChunkBounds {
         return .{
             .min_x = self.region_x * @as(i32, @intCast(self.lod_level.chunksPerSide())),
@@ -415,43 +445,53 @@ pub const ILODConfig = struct {
         getLODStoreSizeCapMB: *const fn (ptr: *anyopaque) u32,
     };
 
-    /// LOD chunk API `getRadii` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getRadii`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getRadii(self: ILODConfig) [LODLevel.count]i32 {
         return self.vtable.getRadii(self.ptr);
     }
-    /// LOD chunk API `getChunkRenderRadius` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getChunkRenderRadius`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getChunkRenderRadius(self: ILODConfig) i32 {
         return self.vtable.getChunkRenderRadius(self.ptr);
     }
-    /// LOD chunk API `getActiveLODCount` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getActiveLODCount`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getActiveLODCount(self: ILODConfig) u32 {
         return self.vtable.getActiveLODCount(self.ptr);
     }
-    /// LOD chunk API `setActiveLODCount` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Updates LOD chunk lifecycle state via `setActiveLODCount`.
+    /// State changes are used by streaming, transition, and renderability decisions.
     pub fn setActiveLODCount(self: ILODConfig, count: u32) void {
         self.vtable.setActiveLODCount(self.ptr, count);
     }
-    /// LOD chunk API `setChunkRenderRadius` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Updates LOD chunk lifecycle state via `setChunkRenderRadius`.
+    /// State changes are used by streaming, transition, and renderability decisions.
     pub fn setChunkRenderRadius(self: ILODConfig, radius: i32) void {
         self.vtable.setChunkRenderRadius(self.ptr, radius);
     }
-    /// LOD chunk API `setLOD0Radius` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Updates LOD chunk lifecycle state via `setLOD0Radius`.
+    /// State changes are used by streaming, transition, and renderability decisions.
     pub fn setLOD0Radius(self: ILODConfig, radius: i32) void {
         self.vtable.setLOD0Radius(self.ptr, radius);
     }
-    /// LOD chunk API `setRadii` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Updates LOD chunk lifecycle state via `setRadii`.
+    /// State changes are used by streaming, transition, and renderability decisions.
     pub fn setRadii(self: ILODConfig, radii: [LODLevel.count]i32) void {
         self.vtable.setRadii(self.ptr, radii);
     }
-    /// LOD chunk API `getLODForDistance` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getLODForDistance`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getLODForDistance(self: ILODConfig, dist_chunks: i32) LODLevel {
         return self.vtable.getLODForDistance(self.ptr, dist_chunks);
     }
-    /// LOD chunk API `isInRange` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `isInRange`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn isInRange(self: ILODConfig, dist_chunks: i32) bool {
         return self.vtable.isInRange(self.ptr, dist_chunks);
     }
-    /// LOD chunk API `getMaxUploadsPerFrame` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getMaxUploadsPerFrame`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getMaxUploadsPerFrame(self: ILODConfig) u32 {
         return self.vtable.getMaxUploadsPerFrame(self.ptr);
     }
@@ -462,53 +502,63 @@ pub const ILODConfig = struct {
         return self.vtable.calculateMaskRadius(self.ptr);
     }
 
-    /// LOD chunk API `getQEMTarget` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getQEMTarget`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getQEMTarget(self: ILODConfig, lod: LODLevel) u32 {
         return self.vtable.getQEMTarget(self.ptr, lod);
     }
 
-    /// LOD chunk API `getQEMMinInputTriangles` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getQEMMinInputTriangles`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getQEMMinInputTriangles(self: ILODConfig) u32 {
         return self.vtable.getQEMMinInputTriangles(self.ptr);
     }
 
-    /// LOD chunk API `getHorizontalDetail` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getHorizontalDetail`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getHorizontalDetail(self: ILODConfig, lod: LODLevel) u32 {
         return self.vtable.getHorizontalDetail(self.ptr, lod);
     }
 
-    /// LOD chunk API `getVerticalSpanBudget` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getVerticalSpanBudget`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getVerticalSpanBudget(self: ILODConfig) u8 {
         return self.vtable.getVerticalSpanBudget(self.ptr);
     }
 
-    /// LOD chunk API `getMeshPath` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getMeshPath`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getMeshPath(self: ILODConfig) LODMeshPath {
         return self.vtable.getMeshPath(self.ptr);
     }
 
-    /// LOD chunk API `getFogStartPercent` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getFogStartPercent`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getFogStartPercent(self: ILODConfig, lod: LODLevel) f32 {
         return self.vtable.getFogStartPercent(self.ptr, lod);
     }
 
-    /// LOD chunk API `getFallbackMissingChildThreshold` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getFallbackMissingChildThreshold`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getFallbackMissingChildThreshold(self: ILODConfig) f32 {
         return self.vtable.getFallbackMissingChildThreshold(self.ptr);
     }
 
-    /// LOD chunk API `getMemoryBudgetMB` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getMemoryBudgetMB`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getMemoryBudgetMB(self: ILODConfig) u32 {
         return self.vtable.getMemoryBudgetMB(self.ptr);
     }
 
-    /// LOD chunk API `getLODStoreSizeCapMB` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getLODStoreSizeCapMB`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getLODStoreSizeCapMB(self: ILODConfig) u32 {
         return self.vtable.getLODStoreSizeCapMB(self.ptr);
     }
 };
 
-/// LOD chunk API `activeLODCount` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+/// Provides LOD chunk helper `activeLODCount`.
+/// Used by LOD scheduling, meshing, or rendering code to keep chunk state consistent.
 pub fn activeLODCount(config: ILODConfig) usize {
     return @intCast(std.math.clamp(config.getActiveLODCount(), 1, LODLevel.count));
 }
@@ -559,17 +609,20 @@ pub const LODConfig = struct {
     /// a coarser parent must remain visible as fallback terrain.
     fallback_missing_child_threshold: f32 = 0.2,
 
-    /// LOD chunk API `getQEMTarget` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getQEMTarget`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getQEMTarget(self: *const LODConfig, lod: LODLevel) u32 {
         return self.qem_triangle_targets[@intFromEnum(lod)];
     }
 
-    /// LOD chunk API `radiiForRenderDistance` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Computes LOD distance/radius policy through `radiiForRenderDistance`.
+    /// Inputs are chunk or world distances; results are used by scheduler and renderer culling.
     pub fn radiiForRenderDistance(distance: i32) [LODLevel.count]i32 {
         return radiiForDistances(distance, default_horizon_radius);
     }
 
-    /// LOD chunk API `radiiForDistances` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Computes LOD distance/radius policy through `radiiForDistances`.
+    /// Inputs are chunk or world distances; results are used by scheduler and renderer culling.
     pub fn radiiForDistances(distance: i32, horizon_distance: i32) [LODLevel.count]i32 {
         const requested = @max(distance, 1);
         const lod0_target = @max(@as(i64, requested) * 3, @as(i64, requested + 16));
@@ -585,18 +638,21 @@ pub const LODConfig = struct {
         return .{ lod0, lod1, lod2, lod3, horizon };
     }
 
-    /// LOD chunk API `activeCountForRenderDistance` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Computes LOD distance/radius policy through `activeCountForRenderDistance`.
+    /// Inputs are chunk or world distances; results are used by scheduler and renderer culling.
     pub fn activeCountForRenderDistance(distance: i32) u32 {
         _ = distance;
         return LODLevel.count;
     }
 
-    /// LOD chunk API `coarsestLOD` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Provides LOD chunk helper `coarsestLOD`.
+    /// Used by LOD scheduling, meshing, or rendering code to keep chunk state consistent.
     pub fn coarsestLOD() LODLevel {
         return @enumFromInt(@as(u3, @intCast(LODLevel.count - 1)));
     }
 
-    /// LOD chunk API `getLODForDistance` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `getLODForDistance`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn getLODForDistance(self: *const LODConfig, dist_chunks: i32) LODLevel {
         const active_lod_count = activeLODCount(self.interfaceConst());
         for (0..active_lod_count) |i| {
@@ -605,7 +661,8 @@ pub const LODConfig = struct {
         return @enumFromInt(@as(u3, @intCast(active_lod_count - 1)));
     }
 
-    /// LOD chunk API `isInRange` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
+    /// Returns LOD chunk/configuration data via `isInRange`.
+    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
     pub fn isInRange(self: *const LODConfig, dist_chunks: i32) bool {
         return dist_chunks <= self.radii[activeLODCount(self.interfaceConst()) - 1];
     }

--- a/modules/world-lod/src/lod_chunk.zig
+++ b/modules/world-lod/src/lod_chunk.zig
@@ -32,6 +32,7 @@ pub const LODRegionKey = struct {
     /// LOD level
     lod: LODLevel,
 
+    /// LOD chunk API `fromChunkCoords` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn fromChunkCoords(chunk_x: i32, chunk_z: i32, lod: LODLevel) LODRegionKey {
         const scale: i32 = @intCast(lod.chunksPerSide());
         return .{
@@ -41,6 +42,7 @@ pub const LODRegionKey = struct {
         };
     }
 
+    /// LOD chunk API `hash` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn hash(self: LODRegionKey) u64 {
         const ux: u64 = @bitCast(@as(i64, self.rx));
         const uz: u64 = @bitCast(@as(i64, self.rz));
@@ -48,10 +50,12 @@ pub const LODRegionKey = struct {
         return ux ^ (uz *% 0x9e3779b97f4a7c15) ^ (ul *% 0x517cc1b727220a95);
     }
 
+    /// LOD chunk API `eql` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn eql(a: LODRegionKey, b: LODRegionKey) bool {
         return a.rx == b.rx and a.rz == b.rz and a.lod == b.lod;
     }
 
+    /// LOD chunk API `parentKey` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn parentKey(self: LODRegionKey) ?LODRegionKey {
         const lod_idx = @intFromEnum(self.lod);
         if (lod_idx + 1 >= LODLevel.count) return null;
@@ -62,6 +66,7 @@ pub const LODRegionKey = struct {
         };
     }
 
+    /// LOD chunk API `childKeys` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn childKeys(self: LODRegionKey) ?[4]LODRegionKey {
         const lod_idx = @intFromEnum(self.lod);
         if (lod_idx == 0) return null;
@@ -94,12 +99,14 @@ pub const ChunkBounds = struct {
     max_x: i32,
     max_z: i32,
 
+    /// LOD chunk API `distanceSquaredToPoint` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn distanceSquaredToPoint(self: ChunkBounds, point_x: i32, point_z: i32) i64 {
         const dx = axisDistance(point_x, self.min_x, self.max_x);
         const dz = axisDistance(point_z, self.min_z, self.max_z);
         return dx * dx + dz * dz;
     }
 
+    /// LOD chunk API `intersectsRadius` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn intersectsRadius(self: ChunkBounds, center_x: i32, center_z: i32, radius_chunks: i32) bool {
         const radius_sq: i64 = @as(i64, radius_chunks) * @as(i64, radius_chunks);
         return self.distanceSquaredToPoint(center_x, center_z) <= radius_sq;
@@ -114,11 +121,13 @@ pub const ChunkBounds = struct {
 
 /// Context for LODRegionKey HashMap
 pub const LODRegionKeyContext = struct {
+    /// LOD chunk API `hash` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn hash(self: @This(), key: LODRegionKey) u64 {
         _ = self;
         return key.hash();
     }
 
+    /// LOD chunk API `eql` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn eql(self: @This(), a: LODRegionKey, b: LODRegionKey) bool {
         _ = self;
         return a.eql(b);
@@ -174,6 +183,7 @@ pub const LODChunk = struct {
     /// or edit). The manager writes the region container to disk lazily.
     store_dirty: bool,
 
+    /// LOD chunk API `init` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn init(rx: i32, rz: i32, lod: LODLevel) LODChunk {
         return .{
             .region_x = rx,
@@ -193,6 +203,7 @@ pub const LODChunk = struct {
         };
     }
 
+    /// LOD chunk API `deinit` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn deinit(self: *LODChunk, allocator: std.mem.Allocator) void {
         _ = allocator;
         switch (self.data) {
@@ -203,46 +214,57 @@ pub const LODChunk = struct {
         self.* = undefined;
     }
 
+    /// LOD chunk API `pin` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn pin(self: *LODChunk) void {
         _ = self.pin_count.fetchAdd(1, .monotonic);
     }
 
+    /// LOD chunk API `unpin` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn unpin(self: *LODChunk) void {
         _ = self.pin_count.fetchSub(1, .monotonic);
     }
 
+    /// LOD chunk API `isPinned` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn isPinned(self: *const LODChunk) bool {
         return self.pin_count.load(.monotonic) > 0;
     }
 
+    /// LOD chunk API `key` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn key(self: *const LODChunk) LODRegionKey {
         return .{ .rx = self.region_x, .rz = self.region_z, .lod = self.lod_level };
     }
 
+    /// LOD chunk API `getState` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getState(self: *const LODChunk) LODState {
         return self.state;
     }
 
+    /// LOD chunk API `setState` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn setState(self: *LODChunk, state: LODState) void {
         self.state = state;
     }
 
+    /// LOD chunk API `isInFlight` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn isInFlight(self: *const LODChunk) bool {
         return self.state == .generating or self.state == .meshing or self.state == .uploading;
     }
 
+    /// LOD chunk API `isRenderable` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn isRenderable(self: *const LODChunk) bool {
         return self.state == .renderable;
     }
 
+    /// LOD chunk API `lodLevel` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn lodLevel(self: *const LODChunk) LODLevel {
         return self.lod_level;
     }
 
+    /// LOD chunk API `readyChildren` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn readyChildren(self: *const LODChunk) u8 {
         return self.ready_children;
     }
 
+    /// LOD chunk API `transitionFadeProgress` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn transitionFadeProgress(self: *const LODChunk) f32 {
         if (self.transition_frames_remaining == 0) return 1.0;
         const remaining = @as(f32, @floatFromInt(self.transition_frames_remaining));
@@ -252,6 +274,7 @@ pub const LODChunk = struct {
         return 1.0 - t;
     }
 
+    /// LOD chunk API `adjustReadyChildren` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn adjustReadyChildren(self: *LODChunk, delta: i8) void {
         const before = self.ready_children;
         if (delta > 0) {
@@ -267,16 +290,19 @@ pub const LODChunk = struct {
         }
     }
 
+    /// LOD chunk API `markRenderable` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn markRenderable(self: *LODChunk, ready_children: u8) void {
         self.ready_children = @min(ready_children, 4);
         self.transition_frames_remaining = TRANSITION_FADE_FRAMES;
         self.state = .renderable;
     }
 
+    /// LOD chunk API `tickTransition` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn tickTransition(self: *LODChunk) void {
         if (self.transition_frames_remaining > 0) self.transition_frames_remaining -= 1;
     }
 
+    /// LOD chunk API `isCoveredByFinerLOD` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn isCoveredByFinerLOD(self: *const LODChunk, fallback_missing_child_threshold: f32) bool {
         if (self.lod_level == .lod0) return false;
         const missing_children = 4 - @min(self.ready_children, 4);
@@ -284,11 +310,13 @@ pub const LODChunk = struct {
         return missing_fraction <= fallback_missing_child_threshold and self.transition_frames_remaining == 0;
     }
 
+    /// LOD chunk API `markSourceDirty` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn markSourceDirty(self: *LODChunk) void {
         self.dirty = true;
         self.store_dirty = true;
     }
 
+    /// LOD chunk API `setReadyChildren` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn setReadyChildren(self: *LODChunk, ready_children: u8) void {
         self.ready_children = @min(ready_children, 4);
     }
@@ -317,6 +345,7 @@ pub const LODChunk = struct {
         };
     }
 
+    /// LOD chunk API `updateHeightBoundsFromData` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn updateHeightBoundsFromData(self: *LODChunk) void {
         switch (self.data) {
             .simplified => |*data| {
@@ -347,6 +376,7 @@ pub const LODChunk = struct {
         }
     }
 
+    /// LOD chunk API `chunkBounds` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn chunkBounds(self: *const LODChunk) ChunkBounds {
         return .{
             .min_x = self.region_x * @as(i32, @intCast(self.lod_level.chunksPerSide())),
@@ -385,33 +415,43 @@ pub const ILODConfig = struct {
         getLODStoreSizeCapMB: *const fn (ptr: *anyopaque) u32,
     };
 
+    /// LOD chunk API `getRadii` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getRadii(self: ILODConfig) [LODLevel.count]i32 {
         return self.vtable.getRadii(self.ptr);
     }
+    /// LOD chunk API `getChunkRenderRadius` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getChunkRenderRadius(self: ILODConfig) i32 {
         return self.vtable.getChunkRenderRadius(self.ptr);
     }
+    /// LOD chunk API `getActiveLODCount` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getActiveLODCount(self: ILODConfig) u32 {
         return self.vtable.getActiveLODCount(self.ptr);
     }
+    /// LOD chunk API `setActiveLODCount` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn setActiveLODCount(self: ILODConfig, count: u32) void {
         self.vtable.setActiveLODCount(self.ptr, count);
     }
+    /// LOD chunk API `setChunkRenderRadius` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn setChunkRenderRadius(self: ILODConfig, radius: i32) void {
         self.vtable.setChunkRenderRadius(self.ptr, radius);
     }
+    /// LOD chunk API `setLOD0Radius` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn setLOD0Radius(self: ILODConfig, radius: i32) void {
         self.vtable.setLOD0Radius(self.ptr, radius);
     }
+    /// LOD chunk API `setRadii` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn setRadii(self: ILODConfig, radii: [LODLevel.count]i32) void {
         self.vtable.setRadii(self.ptr, radii);
     }
+    /// LOD chunk API `getLODForDistance` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getLODForDistance(self: ILODConfig, dist_chunks: i32) LODLevel {
         return self.vtable.getLODForDistance(self.ptr, dist_chunks);
     }
+    /// LOD chunk API `isInRange` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn isInRange(self: ILODConfig, dist_chunks: i32) bool {
         return self.vtable.isInRange(self.ptr, dist_chunks);
     }
+    /// LOD chunk API `getMaxUploadsPerFrame` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getMaxUploadsPerFrame(self: ILODConfig) u32 {
         return self.vtable.getMaxUploadsPerFrame(self.ptr);
     }
@@ -422,43 +462,53 @@ pub const ILODConfig = struct {
         return self.vtable.calculateMaskRadius(self.ptr);
     }
 
+    /// LOD chunk API `getQEMTarget` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getQEMTarget(self: ILODConfig, lod: LODLevel) u32 {
         return self.vtable.getQEMTarget(self.ptr, lod);
     }
 
+    /// LOD chunk API `getQEMMinInputTriangles` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getQEMMinInputTriangles(self: ILODConfig) u32 {
         return self.vtable.getQEMMinInputTriangles(self.ptr);
     }
 
+    /// LOD chunk API `getHorizontalDetail` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getHorizontalDetail(self: ILODConfig, lod: LODLevel) u32 {
         return self.vtable.getHorizontalDetail(self.ptr, lod);
     }
 
+    /// LOD chunk API `getVerticalSpanBudget` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getVerticalSpanBudget(self: ILODConfig) u8 {
         return self.vtable.getVerticalSpanBudget(self.ptr);
     }
 
+    /// LOD chunk API `getMeshPath` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getMeshPath(self: ILODConfig) LODMeshPath {
         return self.vtable.getMeshPath(self.ptr);
     }
 
+    /// LOD chunk API `getFogStartPercent` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getFogStartPercent(self: ILODConfig, lod: LODLevel) f32 {
         return self.vtable.getFogStartPercent(self.ptr, lod);
     }
 
+    /// LOD chunk API `getFallbackMissingChildThreshold` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getFallbackMissingChildThreshold(self: ILODConfig) f32 {
         return self.vtable.getFallbackMissingChildThreshold(self.ptr);
     }
 
+    /// LOD chunk API `getMemoryBudgetMB` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getMemoryBudgetMB(self: ILODConfig) u32 {
         return self.vtable.getMemoryBudgetMB(self.ptr);
     }
 
+    /// LOD chunk API `getLODStoreSizeCapMB` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getLODStoreSizeCapMB(self: ILODConfig) u32 {
         return self.vtable.getLODStoreSizeCapMB(self.ptr);
     }
 };
 
+/// LOD chunk API `activeLODCount` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
 pub fn activeLODCount(config: ILODConfig) usize {
     return @intCast(std.math.clamp(config.getActiveLODCount(), 1, LODLevel.count));
 }
@@ -509,14 +559,17 @@ pub const LODConfig = struct {
     /// a coarser parent must remain visible as fallback terrain.
     fallback_missing_child_threshold: f32 = 0.2,
 
+    /// LOD chunk API `getQEMTarget` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getQEMTarget(self: *const LODConfig, lod: LODLevel) u32 {
         return self.qem_triangle_targets[@intFromEnum(lod)];
     }
 
+    /// LOD chunk API `radiiForRenderDistance` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn radiiForRenderDistance(distance: i32) [LODLevel.count]i32 {
         return radiiForDistances(distance, default_horizon_radius);
     }
 
+    /// LOD chunk API `radiiForDistances` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn radiiForDistances(distance: i32, horizon_distance: i32) [LODLevel.count]i32 {
         const requested = @max(distance, 1);
         const lod0_target = @max(@as(i64, requested) * 3, @as(i64, requested + 16));
@@ -532,15 +585,18 @@ pub const LODConfig = struct {
         return .{ lod0, lod1, lod2, lod3, horizon };
     }
 
+    /// LOD chunk API `activeCountForRenderDistance` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn activeCountForRenderDistance(distance: i32) u32 {
         _ = distance;
         return LODLevel.count;
     }
 
+    /// LOD chunk API `coarsestLOD` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn coarsestLOD() LODLevel {
         return @enumFromInt(@as(u3, @intCast(LODLevel.count - 1)));
     }
 
+    /// LOD chunk API `getLODForDistance` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn getLODForDistance(self: *const LODConfig, dist_chunks: i32) LODLevel {
         const active_lod_count = activeLODCount(self.interfaceConst());
         for (0..active_lod_count) |i| {
@@ -549,6 +605,7 @@ pub const LODConfig = struct {
         return @enumFromInt(@as(u3, @intCast(active_lod_count - 1)));
     }
 
+    /// LOD chunk API `isInRange` reads or updates one distant-terrain chunk while preserving its generation and mesh lifecycle invariants.
     pub fn isInRange(self: *const LODConfig, dist_chunks: i32) bool {
         return dist_chunks <= self.radii[activeLODCount(self.interfaceConst()) - 1];
     }

--- a/modules/world-lod/src/lod_chunk.zig
+++ b/modules/world-lod/src/lod_chunk.zig
@@ -32,8 +32,8 @@ pub const LODRegionKey = struct {
     /// LOD level
     lod: LODLevel,
 
-    /// Creates LOD chunk identity/state using `fromChunkCoords`.
-    /// The returned value starts with deterministic coordinates, LOD level, and lifecycle state.
+    /// Converts full-detail chunk coordinates to the containing LOD region key.
+    /// Uses floor division so negative world coordinates map to the correct parent region.
     pub fn fromChunkCoords(chunk_x: i32, chunk_z: i32, lod: LODLevel) LODRegionKey {
         const scale: i32 = @intCast(lod.chunksPerSide());
         return .{
@@ -43,8 +43,8 @@ pub const LODRegionKey = struct {
         };
     }
 
-    /// Returns LOD chunk/configuration data via `hash`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Hashes the region coordinates and LOD level for use in region maps.
+    /// The hash is deterministic and does not inspect mutable chunk state.
     pub fn hash(self: LODRegionKey) u64 {
         const ux: u64 = @bitCast(@as(i64, self.rx));
         const uz: u64 = @bitCast(@as(i64, self.rz));
@@ -52,14 +52,14 @@ pub const LODRegionKey = struct {
         return ux ^ (uz *% 0x9e3779b97f4a7c15) ^ (ul *% 0x517cc1b727220a95);
     }
 
-    /// Returns LOD chunk/configuration data via `eql`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Compares two region keys by coordinates and LOD level.
+    /// Intended for hash-map key equality and has no side effects.
     pub fn eql(a: LODRegionKey, b: LODRegionKey) bool {
         return a.rx == b.rx and a.rz == b.rz and a.lod == b.lod;
     }
 
-    /// Provides LOD chunk helper `parentKey`.
-    /// Used by LOD scheduling, meshing, or rendering code to keep chunk state consistent.
+    /// Returns the coarser parent region that spatially contains this region.
+    /// Returns `null` for the coarsest LOD because no parent level exists.
     pub fn parentKey(self: LODRegionKey) ?LODRegionKey {
         const lod_idx = @intFromEnum(self.lod);
         if (lod_idx + 1 >= LODLevel.count) return null;
@@ -70,8 +70,8 @@ pub const LODRegionKey = struct {
         };
     }
 
-    /// Provides LOD chunk helper `childKeys`.
-    /// Used by LOD scheduling, meshing, or rendering code to keep chunk state consistent.
+    /// Returns the four direct finer child regions covered by this region.
+    /// Returns `null` for LOD0 because it has no finer LOD children.
     pub fn childKeys(self: LODRegionKey) ?[4]LODRegionKey {
         const lod_idx = @intFromEnum(self.lod);
         if (lod_idx == 0) return null;
@@ -104,16 +104,16 @@ pub const ChunkBounds = struct {
     max_x: i32,
     max_z: i32,
 
-    /// Provides LOD chunk helper `distanceSquaredToPoint`.
-    /// Used by LOD scheduling, meshing, or rendering code to keep chunk state consistent.
+    /// Computes squared distance from a chunk-coordinate point to this bounds rectangle.
+    /// Points inside the rectangle return zero; used to avoid square roots in range tests.
     pub fn distanceSquaredToPoint(self: ChunkBounds, point_x: i32, point_z: i32) i64 {
         const dx = axisDistance(point_x, self.min_x, self.max_x);
         const dz = axisDistance(point_z, self.min_z, self.max_z);
         return dx * dx + dz * dz;
     }
 
-    /// Computes LOD distance/radius policy through `intersectsRadius`.
-    /// Inputs are chunk or world distances; results are used by scheduler and renderer culling.
+    /// Tests whether this chunk bounds intersects a radius around a chunk-coordinate center.
+    /// The radius is expressed in chunks and is evaluated radially, not as an axis-aligned square.
     pub fn intersectsRadius(self: ChunkBounds, center_x: i32, center_z: i32, radius_chunks: i32) bool {
         const radius_sq: i64 = @as(i64, radius_chunks) * @as(i64, radius_chunks);
         return self.distanceSquaredToPoint(center_x, center_z) <= radius_sq;
@@ -128,15 +128,15 @@ pub const ChunkBounds = struct {
 
 /// Context for LODRegionKey HashMap
 pub const LODRegionKeyContext = struct {
-    /// Returns LOD chunk/configuration data via `hash`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Hashes a region key for `std.HashMap` storage.
+    /// The context has no state; hashing delegates to the key's deterministic hash.
     pub fn hash(self: @This(), key: LODRegionKey) u64 {
         _ = self;
         return key.hash();
     }
 
-    /// Returns LOD chunk/configuration data via `eql`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Compares two region keys for `std.HashMap` lookup.
+    /// The context has no state and the comparison is side-effect-free.
     pub fn eql(self: @This(), a: LODRegionKey, b: LODRegionKey) bool {
         _ = self;
         return a.eql(b);
@@ -192,8 +192,8 @@ pub const LODChunk = struct {
     /// or edit). The manager writes the region container to disk lazily.
     store_dirty: bool,
 
-    /// Creates LOD chunk identity/state using `init`.
-    /// The returned value starts with deterministic coordinates, LOD level, and lifecycle state.
+    /// Creates an empty LOD region record in the missing state.
+    /// Source data, mesh handles, readiness counts, and transition state are initialized to safe defaults.
     pub fn init(rx: i32, rz: i32, lod: LODLevel) LODChunk {
         return .{
             .region_x = rx,
@@ -225,68 +225,68 @@ pub const LODChunk = struct {
         self.* = undefined;
     }
 
-    /// Manages worker-safety pin state through `pin`.
-    /// Pinned chunks are protected from unload while background work may still access them.
+    /// Increments the async-work pin count for this LOD chunk.
+    /// Managers must not unload or deinitialize pinned chunks while worker jobs may still reference them.
     pub fn pin(self: *LODChunk) void {
         _ = self.pin_count.fetchAdd(1, .monotonic);
     }
 
-    /// Manages worker-safety pin state through `unpin`.
-    /// Pinned chunks are protected from unload while background work may still access them.
+    /// Decrements the async-work pin count for this LOD chunk.
+    /// Must be paired with a previous `pin`; callers are responsible for avoiding underflow.
     pub fn unpin(self: *LODChunk) void {
         _ = self.pin_count.fetchSub(1, .monotonic);
     }
 
-    /// Manages worker-safety pin state through `isPinned`.
-    /// Pinned chunks are protected from unload while background work may still access them.
+    /// Reports whether any async job currently pins this LOD chunk.
+    /// This is an atomic read suitable for eviction checks.
     pub fn isPinned(self: *const LODChunk) bool {
         return self.pin_count.load(.monotonic) > 0;
     }
 
-    /// Returns LOD chunk/configuration data via `key`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the immutable map key corresponding to this chunk's region coordinates and LOD level.
+    /// The key can be used to look up the same chunk in manager maps.
     pub fn key(self: *const LODChunk) LODRegionKey {
         return .{ .rx = self.region_x, .rz = self.region_z, .lod = self.lod_level };
     }
 
-    /// Returns LOD chunk/configuration data via `getState`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the current lifecycle state of this LOD chunk.
+    /// The value drives scheduler decisions such as generation, meshing, upload, and rendering.
     pub fn getState(self: *const LODChunk) LODState {
         return self.state;
     }
 
-    /// Updates LOD chunk lifecycle state via `setState`.
-    /// State changes are used by streaming, transition, and renderability decisions.
+    /// Sets the lifecycle state used by LOD scheduling and rendering.
+    /// Call from the manager/update thread that owns the chunk maps.
     pub fn setState(self: *LODChunk, state: LODState) void {
         self.state = state;
     }
 
-    /// Returns LOD chunk/configuration data via `isInFlight`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Reports whether generation, meshing, or upload work is currently in flight for this chunk.
+    /// Eviction code should keep in-flight chunks until work completes or is cancelled.
     pub fn isInFlight(self: *const LODChunk) bool {
         return self.state == .generating or self.state == .meshing or self.state == .uploading;
     }
 
-    /// Returns LOD chunk/configuration data via `isRenderable`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Reports whether this chunk has uploaded mesh data ready for rendering.
+    /// This is a state query only; it does not validate the mesh handle.
     pub fn isRenderable(self: *const LODChunk) bool {
         return self.state == .renderable;
     }
 
-    /// Returns LOD chunk/configuration data via `lodLevel`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the LOD level represented by this region.
+    /// Higher levels cover larger areas with more simplified geometry.
     pub fn lodLevel(self: *const LODChunk) LODLevel {
         return self.lod_level;
     }
 
-    /// Returns LOD chunk/configuration data via `readyChildren`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns how many direct finer children are currently renderable.
+    /// Parent fallback rendering uses this count to decide coverage and fade behavior.
     pub fn readyChildren(self: *const LODChunk) u8 {
         return self.ready_children;
     }
 
-    /// Returns LOD chunk/configuration data via `transitionFadeProgress`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the normalized fade progress for parent/child LOD hierarchy transitions.
+    /// Child regions fade in while fully covered parents fade out according to remaining transition frames.
     pub fn transitionFadeProgress(self: *const LODChunk) f32 {
         if (self.transition_frames_remaining == 0) return 1.0;
         const remaining = @as(f32, @floatFromInt(self.transition_frames_remaining));
@@ -296,8 +296,8 @@ pub const LODChunk = struct {
         return 1.0 - t;
     }
 
-    /// Updates LOD chunk lifecycle state via `adjustReadyChildren`.
-    /// State changes are used by streaming, transition, and renderability decisions.
+    /// Adjusts the count of renderable direct child regions, clamped to `[0, 4]`.
+    /// Crossing into full child coverage starts a transition fade; losing coverage cancels it.
     pub fn adjustReadyChildren(self: *LODChunk, delta: i8) void {
         const before = self.ready_children;
         if (delta > 0) {
@@ -313,22 +313,22 @@ pub const LODChunk = struct {
         }
     }
 
-    /// Updates LOD chunk lifecycle state via `markRenderable`.
-    /// State changes are used by streaming, transition, and renderability decisions.
+    /// Marks this chunk renderable after mesh upload completes.
+    /// Sets child readiness, starts a transition fade, and moves lifecycle state to `.renderable`.
     pub fn markRenderable(self: *LODChunk, ready_children: u8) void {
         self.ready_children = @min(ready_children, 4);
         self.transition_frames_remaining = TRANSITION_FADE_FRAMES;
         self.state = .renderable;
     }
 
-    /// Updates LOD chunk lifecycle state via `tickTransition`.
-    /// State changes are used by streaming, transition, and renderability decisions.
+    /// Advances transition fading by one render/update tick.
+    /// Does nothing once the transition counter has reached zero.
     pub fn tickTransition(self: *LODChunk) void {
         if (self.transition_frames_remaining > 0) self.transition_frames_remaining -= 1;
     }
 
-    /// Returns LOD chunk/configuration data via `isCoveredByFinerLOD`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Reports whether finer renderable children cover this region sufficiently to hide the parent.
+    /// `fallback_missing_child_threshold` controls how much missing child coverage is tolerated.
     pub fn isCoveredByFinerLOD(self: *const LODChunk, fallback_missing_child_threshold: f32) bool {
         if (self.lod_level == .lod0) return false;
         const missing_children = 4 - @min(self.ready_children, 4);
@@ -336,15 +336,15 @@ pub const LODChunk = struct {
         return missing_fraction <= fallback_missing_child_threshold and self.transition_frames_remaining == 0;
     }
 
-    /// Updates LOD chunk lifecycle state via `markSourceDirty`.
-    /// State changes are used by streaming, transition, and renderability decisions.
+    /// Marks source data dirty after chunk-derived ingestion or edits.
+    /// Also marks persistent cache storage dirty so the manager can flush updated source data.
     pub fn markSourceDirty(self: *LODChunk) void {
         self.dirty = true;
         self.store_dirty = true;
     }
 
-    /// Updates LOD chunk lifecycle state via `setReadyChildren`.
-    /// State changes are used by streaming, transition, and renderability decisions.
+    /// Sets the ready-child count directly, clamped to four direct children.
+    /// Used when reconstructing or synchronizing hierarchy state from manager bookkeeping.
     pub fn setReadyChildren(self: *LODChunk, ready_children: u8) void {
         self.ready_children = @min(ready_children, 4);
     }
@@ -373,8 +373,8 @@ pub const LODChunk = struct {
         };
     }
 
-    /// Provides LOD chunk helper `updateHeightBoundsFromData`.
-    /// Used by LOD scheduling, meshing, or rendering code to keep chunk state consistent.
+    /// Recomputes world-space min/max height bounds from simplified source data.
+    /// Full or empty chunks leave existing bounds unchanged; call after replacing simplified data.
     pub fn updateHeightBoundsFromData(self: *LODChunk) void {
         switch (self.data) {
             .simplified => |*data| {
@@ -405,8 +405,8 @@ pub const LODChunk = struct {
         }
     }
 
-    /// Returns LOD chunk/configuration data via `chunkBounds`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the full-detail chunk-coordinate bounds covered by this LOD region.
+    /// Bounds are inclusive and derived from region coordinates plus chunks-per-side for the LOD level.
     pub fn chunkBounds(self: *const LODChunk) ChunkBounds {
         return .{
             .min_x = self.region_x * @as(i32, @intCast(self.lod_level.chunksPerSide())),
@@ -445,53 +445,53 @@ pub const ILODConfig = struct {
         getLODStoreSizeCapMB: *const fn (ptr: *anyopaque) u32,
     };
 
-    /// Returns LOD chunk/configuration data via `getRadii`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns configured outer radii for every LOD level in chunks.
+    /// Callers should use `getActiveLODCount` to know how many entries are currently active.
     pub fn getRadii(self: ILODConfig) [LODLevel.count]i32 {
         return self.vtable.getRadii(self.ptr);
     }
-    /// Returns LOD chunk/configuration data via `getChunkRenderRadius`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the high-detail chunk render radius that LOD terrain must avoid overlapping.
+    /// Shader masking and eviction use this to preserve the full-detail chunk ring.
     pub fn getChunkRenderRadius(self: ILODConfig) i32 {
         return self.vtable.getChunkRenderRadius(self.ptr);
     }
-    /// Returns LOD chunk/configuration data via `getActiveLODCount`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the number of LOD levels currently enabled by configuration.
+    /// Implementations clamp the value to at least one and at most `LODLevel.count`.
     pub fn getActiveLODCount(self: ILODConfig) u32 {
         return self.vtable.getActiveLODCount(self.ptr);
     }
-    /// Updates LOD chunk lifecycle state via `setActiveLODCount`.
-    /// State changes are used by streaming, transition, and renderability decisions.
+    /// Sets how many LOD levels should participate in scheduling and rendering.
+    /// Implementations should clamp out-of-range values to the supported LOD count.
     pub fn setActiveLODCount(self: ILODConfig, count: u32) void {
         self.vtable.setActiveLODCount(self.ptr, count);
     }
-    /// Updates LOD chunk lifecycle state via `setChunkRenderRadius`.
-    /// State changes are used by streaming, transition, and renderability decisions.
+    /// Sets the full-detail chunk render radius used by LOD masking and radius expansion.
+    /// Implementations should clamp invalid radii to a positive value.
     pub fn setChunkRenderRadius(self: ILODConfig, radius: i32) void {
         self.vtable.setChunkRenderRadius(self.ptr, radius);
     }
-    /// Updates LOD chunk lifecycle state via `setLOD0Radius`.
-    /// State changes are used by streaming, transition, and renderability decisions.
+    /// Sets the outer radius for the LOD0 ring.
+    /// This affects near-distance LOD scheduling without changing the full-detail chunk radius.
     pub fn setLOD0Radius(self: ILODConfig, radius: i32) void {
         self.vtable.setLOD0Radius(self.ptr, radius);
     }
-    /// Updates LOD chunk lifecycle state via `setRadii`.
-    /// State changes are used by streaming, transition, and renderability decisions.
+    /// Replaces all configured LOD outer radii at once.
+    /// Callers must provide radii in increasing order if they want monotonic distance selection.
     pub fn setRadii(self: ILODConfig, radii: [LODLevel.count]i32) void {
         self.vtable.setRadii(self.ptr, radii);
     }
-    /// Returns LOD chunk/configuration data via `getLODForDistance`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Selects the LOD level for a distance from the player measured in chunks.
+    /// Distances beyond active radii resolve to the coarsest active LOD.
     pub fn getLODForDistance(self: ILODConfig, dist_chunks: i32) LODLevel {
         return self.vtable.getLODForDistance(self.ptr, dist_chunks);
     }
-    /// Returns LOD chunk/configuration data via `isInRange`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Reports whether a chunk-distance lies inside the active LOD horizon.
+    /// Used before scheduling or retaining distant LOD regions.
     pub fn isInRange(self: ILODConfig, dist_chunks: i32) bool {
         return self.vtable.isInRange(self.ptr, dist_chunks);
     }
-    /// Returns LOD chunk/configuration data via `getMaxUploadsPerFrame`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the maximum number of LOD uploads the manager should attempt per frame.
+    /// This is a scheduler throttle, separate from byte-budget throttling.
     pub fn getMaxUploadsPerFrame(self: ILODConfig) u32 {
         return self.vtable.getMaxUploadsPerFrame(self.ptr);
     }
@@ -502,63 +502,63 @@ pub const ILODConfig = struct {
         return self.vtable.calculateMaskRadius(self.ptr);
     }
 
-    /// Returns LOD chunk/configuration data via `getQEMTarget`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the target triangle budget for QEM simplification at one LOD level.
+    /// A value of zero means that level should not use QEM reduction.
     pub fn getQEMTarget(self: ILODConfig, lod: LODLevel) u32 {
         return self.vtable.getQEMTarget(self.ptr, lod);
     }
 
-    /// Returns LOD chunk/configuration data via `getQEMMinInputTriangles`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the minimum input triangle count required before QEM simplification is attempted.
+    /// Smaller meshes use the cheaper non-QEM path to avoid unnecessary work.
     pub fn getQEMMinInputTriangles(self: ILODConfig) u32 {
         return self.vtable.getQEMMinInputTriangles(self.ptr);
     }
 
-    /// Returns LOD chunk/configuration data via `getHorizontalDetail`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the horizontal sample resolution used to generate a mesh for one LOD level.
+    /// Higher values preserve more terrain detail at higher CPU/GPU cost.
     pub fn getHorizontalDetail(self: ILODConfig, lod: LODLevel) u32 {
         return self.vtable.getHorizontalDetail(self.ptr, lod);
     }
 
-    /// Returns LOD chunk/configuration data via `getVerticalSpanBudget`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the maximum number of vertical spans retained per LOD column.
+    /// Implementations clamp this to the storage capacity of `LODSimplifiedData`.
     pub fn getVerticalSpanBudget(self: ILODConfig) u8 {
         return self.vtable.getVerticalSpanBudget(self.ptr);
     }
 
-    /// Returns LOD chunk/configuration data via `getMeshPath`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns which mesh-generation algorithm the LOD manager should use.
+    /// The value selects between column-span, QEM, or other backend-supported paths.
     pub fn getMeshPath(self: ILODConfig) LODMeshPath {
         return self.vtable.getMeshPath(self.ptr);
     }
 
-    /// Returns LOD chunk/configuration data via `getFogStartPercent`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns where fog should begin within an LOD level's radius, as a fraction in `[0, 1]`.
+    /// Renderers use this to hide distant LOD transitions and horizon cutoffs.
     pub fn getFogStartPercent(self: ILODConfig, lod: LODLevel) f32 {
         return self.vtable.getFogStartPercent(self.ptr, lod);
     }
 
-    /// Returns LOD chunk/configuration data via `getFallbackMissingChildThreshold`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the fraction of missing finer children allowed before a parent fallback remains visible.
+    /// Values are clamped by concrete implementations to `[0, 1]`.
     pub fn getFallbackMissingChildThreshold(self: ILODConfig) f32 {
         return self.vtable.getFallbackMissingChildThreshold(self.ptr);
     }
 
-    /// Returns LOD chunk/configuration data via `getMemoryBudgetMB`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the approximate memory budget for LOD meshes and source data in MiB.
+    /// The manager uses this to decide when to shrink radii or evict regions.
     pub fn getMemoryBudgetMB(self: ILODConfig) u32 {
         return self.vtable.getMemoryBudgetMB(self.ptr);
     }
 
-    /// Returns LOD chunk/configuration data via `getLODStoreSizeCapMB`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the persistent LOD cache store size cap in MiB.
+    /// Cache maintenance uses this to bound disk usage for source-data containers.
     pub fn getLODStoreSizeCapMB(self: ILODConfig) u32 {
         return self.vtable.getLODStoreSizeCapMB(self.ptr);
     }
 };
 
-/// Provides LOD chunk helper `activeLODCount`.
-/// Used by LOD scheduling, meshing, or rendering code to keep chunk state consistent.
+/// Returns the active LOD count as a `usize`, clamped to the supported range.
+/// Use this when indexing fixed arrays whose length is `LODLevel.count`.
 pub fn activeLODCount(config: ILODConfig) usize {
     return @intCast(std.math.clamp(config.getActiveLODCount(), 1, LODLevel.count));
 }
@@ -609,20 +609,20 @@ pub const LODConfig = struct {
     /// a coarser parent must remain visible as fallback terrain.
     fallback_missing_child_threshold: f32 = 0.2,
 
-    /// Returns LOD chunk/configuration data via `getQEMTarget`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Returns the configured QEM triangle target for one LOD level.
+    /// Used by mesh builders to choose simplification aggressiveness.
     pub fn getQEMTarget(self: *const LODConfig, lod: LODLevel) u32 {
         return self.qem_triangle_targets[@intFromEnum(lod)];
     }
 
-    /// Computes LOD distance/radius policy through `radiiForRenderDistance`.
-    /// Inputs are chunk or world distances; results are used by scheduler and renderer culling.
+    /// Expands a full-detail render distance into the default LOD radius ladder.
+    /// The farthest radius uses the default horizon distance.
     pub fn radiiForRenderDistance(distance: i32) [LODLevel.count]i32 {
         return radiiForDistances(distance, default_horizon_radius);
     }
 
-    /// Computes LOD distance/radius policy through `radiiForDistances`.
-    /// Inputs are chunk or world distances; results are used by scheduler and renderer culling.
+    /// Expands full-detail and horizon distances into monotonically increasing LOD radii.
+    /// Radii are expressed in chunks and are clamped so they do not exceed the horizon.
     pub fn radiiForDistances(distance: i32, horizon_distance: i32) [LODLevel.count]i32 {
         const requested = @max(distance, 1);
         const lod0_target = @max(@as(i64, requested) * 3, @as(i64, requested + 16));
@@ -638,21 +638,21 @@ pub const LODConfig = struct {
         return .{ lod0, lod1, lod2, lod3, horizon };
     }
 
-    /// Computes LOD distance/radius policy through `activeCountForRenderDistance`.
-    /// Inputs are chunk or world distances; results are used by scheduler and renderer culling.
+    /// Returns how many LOD levels should be active for a render-distance setting.
+    /// The current policy keeps all levels active regardless of near render distance.
     pub fn activeCountForRenderDistance(distance: i32) u32 {
         _ = distance;
         return LODLevel.count;
     }
 
-    /// Provides LOD chunk helper `coarsestLOD`.
-    /// Used by LOD scheduling, meshing, or rendering code to keep chunk state consistent.
+    /// Returns the coarsest supported LOD level.
+    /// Use as a fallback when a distance exceeds all configured active radii.
     pub fn coarsestLOD() LODLevel {
         return @enumFromInt(@as(u3, @intCast(LODLevel.count - 1)));
     }
 
-    /// Returns LOD chunk/configuration data via `getLODForDistance`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Selects the concrete LOD level for a chunk distance using this config's active radii.
+    /// Distances beyond active radii resolve to the coarsest active LOD.
     pub fn getLODForDistance(self: *const LODConfig, dist_chunks: i32) LODLevel {
         const active_lod_count = activeLODCount(self.interfaceConst());
         for (0..active_lod_count) |i| {
@@ -661,8 +661,8 @@ pub const LODConfig = struct {
         return @enumFromInt(@as(u3, @intCast(active_lod_count - 1)));
     }
 
-    /// Returns LOD chunk/configuration data via `isInRange`.
-    /// The query is side-effect-free unless the implementation explicitly updates cached bounds.
+    /// Reports whether a chunk distance lies inside this config's active LOD horizon.
+    /// The horizon is the outer radius of the coarsest active LOD.
     pub fn isInRange(self: *const LODConfig, dist_chunks: i32) bool {
         return dist_chunks <= self.radii[activeLODCount(self.interfaceConst()) - 1];
     }

--- a/modules/world-lod/src/lod_geometry.zig
+++ b/modules/world-lod/src/lod_geometry.zig
@@ -20,10 +20,8 @@ pub const FullDetailMesh = struct {
     indices: []u32,
 };
 
-/// Build a full-detail indexed triangle mesh from LOD heightmap data.
-/// Produces fine-grained quads with per-vertex heights suitable for QEM simplification.
-/// The mesh uses 1-block resolution: each cell in the heightmap grid becomes a quad
-/// subdivided into 2 triangles with separate indices for QEM edge collapse.
+/// Appends a four-vertex quad and six triangle indices to the caller-owned mesh buffers.
+/// The quad vertices are copied in order and indexed as two triangles `(0,1,2)` and `(0,2,3)`.
 pub fn appendIndexedQuad(
     vertices: *std.ArrayListUnmanaged(Vertex),
     indices: *std.ArrayListUnmanaged(u32),
@@ -50,8 +48,8 @@ pub const SkirtParams = struct {
 
 pub const SkirtDir = enum { north, south, east, west };
 
-/// Computes make skirt quad for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Builds the vertical boundary skirt quad used to hide cracks at the edge of an LOD heightfield.
+/// `params.x/z/size` choose the edge segment, `avg_h` is the top edge, and the bottom edge drops below it to cover neighbor gaps.
 pub fn makeSkirtQuad(params: SkirtParams, tile_id: u16, world_x: i32, world_z: i32) [4]Vertex {
     const p = params;
     const cr = unpackR(p.avg_c) * p.brightness;
@@ -94,8 +92,8 @@ pub fn makeSkirtQuad(params: SkirtParams, tile_id: u16, world_x: i32, world_z: i
     };
 }
 
-/// Computes build full detail heightmap mesh from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Builds an indexed full-detail heightfield mesh from simplified LOD samples.
+/// Each heightmap cell emits a textured top quad, and boundary cells also emit skirts to cover holes before QEM simplification.
 pub fn buildFullDetailHeightmapMesh(
     allocator: std.mem.Allocator,
     lod_level: LODLevel,
@@ -208,8 +206,8 @@ pub const SEA_LEVEL_WATER_EPSILON: f32 = 2.0;
 pub const SYNTHETIC_SEAFLOOR_SKIRT: f32 = 8.0;
 pub const LOD_TREE_COVERAGE_THRESHOLD: f32 = 0.08;
 
-/// Reports whether is l o d water cell for a sampled LOD cell or span.
-/// The query is deterministic and does not mutate the supplied simplified data.
+/// Classifies a coarse LOD cell as water using averaged coverage, wet-sample count, and representative depth.
+/// Used for coarse material selection where a single fine water sample should not flood the whole cell.
 pub fn isLODWaterCell(data: *const LODSimplifiedData, gx: u32, gz: u32) bool {
     const stats = waterCoverageStats(data, gx, gz);
     const water_coverage = stats.average_coverage;
@@ -217,20 +215,20 @@ pub fn isLODWaterCell(data: *const LODSimplifiedData, gx: u32, gz: u32) bool {
     return stats.wet_samples >= 2 and water_coverage >= 0.25 and stats.representative_depth >= 1.5;
 }
 
-/// Reports whether is fine sample l o d for a sampled LOD cell or span.
-/// The query is deterministic and does not mutate the supplied simplified data.
+/// Reports whether an LOD level should sample one grid cell directly instead of blending a 2x2 neighborhood.
+/// LOD0 and LOD1 preserve per-cell detail; coarser levels average neighboring samples for stability.
 pub fn isFineSampleLOD(lod_level: LODLevel) bool {
     return @intFromEnum(lod_level) <= @intFromEnum(LODLevel.lod1);
 }
 
-/// Reads cell index from the clamped LOD sample grid.
-/// Coordinates are clamped to the simplified data width.
+/// Returns the clamped flat index for a sample-grid coordinate.
+/// `gx` and `gz` may point at a neighbor cell; values are clamped to the valid `data.width` range.
 pub fn cellIndex(data: *const LODSimplifiedData, gx: u32, gz: u32) u32 {
     return @min(gx, data.width - 1) + @min(gz, data.width - 1) * data.width;
 }
 
-/// Computes cell color for l o d for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Returns the representative packed RGB color for an LOD cell.
+/// Fine LODs use the direct sample; coarse LODs average the surrounding 2x2 colors to avoid abrupt material changes.
 pub fn cellColorForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) u32 {
     if (isFineSampleLOD(lod_level)) return data.colors[cellIndex(data, gx, gz)];
     const c00 = data.colors[cellIndex(data, gx, gz)];
@@ -240,15 +238,15 @@ pub fn cellColorForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_lev
     return averageColor(c00, c10, c01, c11);
 }
 
-/// Reads ambient occlusion for l o d from the clamped LOD sample grid.
-/// Coordinates are clamped to the simplified data width.
+/// Returns representative ambient occlusion for an LOD cell.
+/// Fine LODs use the direct lighting sample; coarse LODs average neighboring lighting to smooth distant terrain.
 pub fn ambientOcclusionForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
     if (isFineSampleLOD(lod_level)) return data.lighting[cellIndex(data, gx, gz)].ambient_occlusion;
     return averageAmbientOcclusion(data, gx, gz);
 }
 
-/// Reports whether is l o d water cell for l o d for a sampled LOD cell or span.
-/// The query is deterministic and does not mutate the supplied simplified data.
+/// Classifies water for a cell using LOD-specific sampling rules.
+/// Fine levels require the direct sample to be a shallow-or-deeper water surface; coarse levels use coverage statistics.
 pub fn isLODWaterCellForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) bool {
     if (isFineSampleLOD(lod_level)) {
         const water = data.water[cellIndex(data, gx, gz)];
@@ -257,14 +255,14 @@ pub fn isLODWaterCellForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lo
     return isLODWaterCell(data, gx, gz);
 }
 
-/// Computes quantized height from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Rounds a height to the nearest block unit for mesh seam stability.
+/// Quantization keeps adjacent LOD cells from producing tiny floating-point cracks.
 pub fn quantizedHeight(height: f32) f32 {
     return @round(height);
 }
 
-/// Computes terrain height for point from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns the solid terrain height used below water surfaces.
+/// For water cells, this clamps the visible terrain floor below the water surface instead of returning the water plane.
 pub fn terrainHeightForPoint(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const clamped_x = @min(gx, data.width - 1);
     const clamped_z = @min(gz, data.width - 1);
@@ -280,55 +278,55 @@ pub fn terrainHeightForPoint(data: *const LODSimplifiedData, gx: u32, gz: u32) f
     return @min(height, floor_height);
 }
 
-/// Computes terrain surface height for point from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns the stitched terrain surface height at a sample-grid point.
+/// Coordinates are clamped and then passed through seam stitching so region boundaries agree.
 pub fn terrainSurfaceHeightForPoint(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const clamped_x = @min(gx, data.width - 1);
     const clamped_z = @min(gz, data.width - 1);
     return stitchedHeight(data, clamped_x, clamped_z);
 }
 
-/// Computes quantized terrain height for point from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns the quantized solid terrain height for a sample-grid point.
+/// This is the terrain-floor height, not necessarily the visible water surface.
 pub fn quantizedTerrainHeightForPoint(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return quantizedHeight(terrainHeightForPoint(data, gx, gz));
 }
 
-/// Computes quantized cell terrain height from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns a quantized solid terrain height for an LOD cell.
+/// Used by material and span generation when terrain should remain below water.
 pub fn quantizedCellTerrainHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return quantizedHeight(terrainHeightForPoint(data, gx, gz));
 }
 
-/// Computes quantized cell surface height from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns a quantized stitched surface height for an LOD cell.
+/// Unlike terrain-floor height, this keeps dry columns at the visible terrain surface.
 pub fn quantizedCellSurfaceHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return quantizedHeight(terrainSurfaceHeightForPoint(data, gx, gz));
 }
 
-/// Computes quantized cell terrain height for l o d from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns terrain height using fine or coarse sampling appropriate to the LOD level.
+/// Fine levels sample the exact point; coarser levels use the representative cell terrain height.
 pub fn quantizedCellTerrainHeightForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
     if (isFineSampleLOD(lod_level)) return quantizedTerrainHeightForPoint(data, gx, gz);
     return quantizedCellTerrainHeight(data, gx, gz);
 }
 
-/// Computes quantized cell visual terrain height for l o d from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns the height that should be visible for a terrain column at the requested LOD.
+/// Water cells use terrain-floor height, while dry fine cells use the stitched surface height.
 pub fn quantizedCellVisualTerrainHeightForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, is_water_cell: bool) f32 {
     if (is_water_cell) return quantizedCellTerrainHeightForLOD(data, gx, gz, lod_level);
     if (isFineSampleLOD(lod_level)) return quantizedHeight(terrainSurfaceHeightForPoint(data, gx, gz));
     return quantizedCellSurfaceHeight(data, gx, gz);
 }
 
-/// Computes max water surface height for cell from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns the representative water surface height for a cell when water exists.
+/// Currently delegates to the representative surface picker so water quads share the same height policy.
 pub fn maxWaterSurfaceHeightForCell(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) ?f32 {
     return representativeWaterSurfaceHeightForCell(data, gx, gz, lod_level);
 }
 
-/// Computes representative water surface height for cell from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Finds the water surface height to use for a fine or coarse LOD cell.
+/// Fine cells inspect one sample; coarse cells scan the 2x2 neighborhood and return the first valid water surface.
 pub fn representativeWaterSurfaceHeightForCell(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) ?f32 {
     if (isFineSampleLOD(lod_level)) {
         const idx = cellIndex(data, gx, gz);
@@ -357,8 +355,8 @@ pub fn representativeWaterSurfaceHeightForCell(data: *const LODSimplifiedData, g
     return null;
 }
 
-/// Computes normalized water surface height from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Normalizes ocean water surfaces near sea level to the canonical sea-level height.
+/// This removes tiny generator deviations that would otherwise create visible ocean seams.
 pub fn normalizedWaterSurfaceHeight(data: *const LODSimplifiedData, idx: u32, water: world_core.LODWaterState) f32 {
     if (isOceanBiome(data.biomes[idx]) and @abs(water.surface_height - WORLDGEN_SEA_LEVEL) <= SEA_LEVEL_WATER_EPSILON) {
         return WORLDGEN_SEA_LEVEL;
@@ -366,8 +364,8 @@ pub fn normalizedWaterSurfaceHeight(data: *const LODSimplifiedData, idx: u32, wa
     return water.surface_height;
 }
 
-/// Reports whether is ocean biome for a sampled LOD cell or span.
-/// The query is deterministic and does not mutate the supplied simplified data.
+/// Reports whether a biome should use ocean water normalization and ocean-floor material fallback.
+/// Only ocean-family biomes return true.
 pub fn isOceanBiome(biome: BiomeId) bool {
     return switch (biome) {
         .deep_ocean, .ocean, .warm_ocean, .frozen_ocean, .cold_ocean => true,
@@ -375,15 +373,15 @@ pub fn isOceanBiome(biome: BiomeId) bool {
     };
 }
 
-/// Computes quantized water surface height for cell from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns the quantized water plane for a cell, falling back to terrain height when no water is present.
+/// Used when constructing water spans and side faces that need a stable top height.
 pub fn quantizedWaterSurfaceHeightForCell(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
     if (maxWaterSurfaceHeightForCell(data, gx, gz, lod_level)) |height| return quantizedHeight(height);
     return quantizedCellTerrainHeightForLOD(data, gx, gz, lod_level);
 }
 
-/// Computes quantized water surface height for span from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns a quantized water height for a vertical span.
+/// When the cell has no representative water surface, `fallback_height` supplies the span top.
 pub fn quantizedWaterSurfaceHeightForSpan(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, fallback_height: f32) f32 {
     if (maxWaterSurfaceHeightForCell(data, gx, gz, lod_level)) |height| return quantizedHeight(height);
     return quantizedHeight(fallback_height);
@@ -395,21 +393,21 @@ pub const FoldedCanopyColumn = struct {
     color: u32,
 };
 
-/// Reports whether should fold canopy into terrain for a sampled LOD cell or span.
-/// The query is deterministic and does not mutate the supplied simplified data.
+/// Reports whether vegetation canopy should be merged into terrain height for this LOD level.
+/// The current policy leaves canopy as separate geometry for every level.
 pub fn shouldFoldCanopyIntoTerrain(lod_level: LODLevel) bool {
     _ = lod_level;
     return false;
 }
 
-/// Reports whether should render l o d tree trunk for a sampled LOD cell or span.
-/// The query is deterministic and does not mutate the supplied simplified data.
+/// Reports whether LOD tree trunks are still detailed enough to render at this level.
+/// Very coarse levels skip trunks to avoid noisy distant vertical slivers.
 pub fn shouldRenderLODTreeTrunk(lod_level: LODLevel) bool {
     return @intFromEnum(lod_level) <= @intFromEnum(LODLevel.lod3);
 }
 
-/// Computes folded canopy column for l o d for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Builds a synthetic canopy column when tree coverage should raise the visible LOD terrain.
+/// Returns null for water, non-tree terrain, low coverage, or LOD policies that keep canopy separate.
 pub fn foldedCanopyColumnForLOD(
     data: *const LODSimplifiedData,
     gx: u32,
@@ -434,8 +432,8 @@ pub fn foldedCanopyColumnForLOD(
     };
 }
 
-/// Computes quantized visual column height for l o d from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns the final visible column height after water and optional canopy folding are considered.
+/// This is the height used by column-span mesh generation for the top of visible terrain.
 pub fn quantizedVisualColumnHeightForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
     const is_water_cell = isLODWaterCellForLOD(data, gx, gz, lod_level);
     const terrain_block = terrainBlockForLODQuadForLOD(data, gx, gz, is_water_cell, lod_level);
@@ -446,8 +444,8 @@ pub fn quantizedVisualColumnHeightForLOD(data: *const LODSimplifiedData, gx: u32
     return base_height;
 }
 
-/// Selects terrain block for l o d quad for a representative LOD terrain cell.
-/// The selection folds fine terrain samples into stable coarse LOD material output.
+/// Chooses the side/top terrain block for a possibly-water coarse LOD quad.
+/// Water cells prefer a solid side/subsurface material, then representative surface material, then ocean-floor fallback.
 pub fn terrainBlockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32, is_water_cell: bool) BlockType {
     if (!is_water_cell) return blockForLODQuad(data, gx, gz);
 
@@ -461,8 +459,8 @@ pub fn terrainBlockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32, 
     return data.biomes[idx].getOceanFloorBlock(representativeWaterDepth(data, gx, gz));
 }
 
-/// Selects terrain block for l o d quad for l o d for a representative LOD terrain cell.
-/// The selection folds fine terrain samples into stable coarse LOD material output.
+/// Chooses the representative terrain material for a quad using LOD-specific sampling rules.
+/// Fine water cells use direct material layers; coarser cells use the coarse representative material logic.
 pub fn terrainBlockForLODQuadForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, is_water_cell: bool, lod_level: LODLevel) BlockType {
     if (!isFineSampleLOD(lod_level)) return terrainBlockForLODQuad(data, gx, gz, is_water_cell);
     if (!is_water_cell) return blockForLODCell(data, gx, gz);
@@ -475,8 +473,8 @@ pub fn terrainBlockForLODQuadForLOD(data: *const LODSimplifiedData, gx: u32, gz:
     return data.biomes[idx].getOceanFloorBlock(data.water[idx].depth);
 }
 
-/// Computes get lod side tile for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Returns the atlas tile id used for LOD side faces of a block.
+/// Air falls back to the stone side tile so missing side material does not sample an invalid atlas entry.
 pub fn getLodSideTile(block: BlockType, atlas: *const TextureAtlas) u16 {
     if (block == .air) return Vertex.LOD_TILE_ID;
     if (isLeafBlock(block)) return Vertex.LOD_TILE_ID;
@@ -485,14 +483,14 @@ pub fn getLodSideTile(block: BlockType, atlas: *const TextureAtlas) u16 {
     return tiles.side;
 }
 
-/// Computes boundary skirt depth for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Computes how far boundary skirts should drop below a column top.
+/// Water-adjacent skirts drop to a synthetic seafloor so ocean edges do not expose holes.
 pub fn boundarySkirtDepth(size: f32) f32 {
     return std.math.clamp(size, 16.0, 32.0);
 }
 
-/// Computes heightfield side brightness from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns directional brightness for vertical heightfield side faces.
+/// North/south/east/west sides use different factors to preserve block-like directional shading.
 pub fn heightfieldSideBrightness(dir: FaceDir) f32 {
     return switch (dir) {
         .west, .east => 0.8,
@@ -500,8 +498,8 @@ pub fn heightfieldSideBrightness(dir: FaceDir) f32 {
     };
 }
 
-/// Appends add stepped heightfield sides geometry to the provided mesh buffers.
-/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
+/// Adds vertical side geometry around a heightfield cell wherever neighboring cells are lower.
+/// The function compares center height against four neighbors and emits side faces down to terrain or seafloor depth.
 pub fn addSteppedHeightfieldSides(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -524,8 +522,8 @@ pub fn addSteppedHeightfieldSides(
     try addHeightfieldSide(allocator, vertices, wx, wz, size, column_height, if (gz + 1 >= data.width - 1) null else quantizedVisualColumnHeightForLOD(data, gx, gz + 1, lod_level), color, side_tile, .south, world_x, world_z);
 }
 
-/// Appends add heightfield side geometry to the provided mesh buffers.
-/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
+/// Adds one vertical side face for a heightfield column edge.
+/// The face uses the provided direction, material tile, color, and world offsets for stable UVs.
 pub fn addHeightfieldSide(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -559,8 +557,8 @@ pub const HeightInterval = struct {
     max_height: f32,
 };
 
-/// Computes collect column spans for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Collects the vertical material spans that should be meshed for one LOD column.
+/// It combines terrain, water, canopy folding, and material-layer data into a bounded span list.
 pub fn collectColumnSpans(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, out: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]LODColumnSpan) usize {
     var count: usize = 0;
     var has_water_span = false;
@@ -638,8 +636,8 @@ pub fn collectColumnSpans(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_
     return count;
 }
 
-/// Computes synthetic seafloor min height from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Computes a fallback seafloor height below water for skirt and side geometry.
+/// The result is clamped below the water surface so ocean boundaries hide missing neighboring terrain.
 pub fn syntheticSeafloorMinHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const x_min = if (gx == 0) gx else gx - 1;
     const z_min = if (gz == 0) gz else gz - 1;
@@ -658,8 +656,8 @@ pub fn syntheticSeafloorMinHeight(data: *const LODSimplifiedData, gx: u32, gz: u
     return @max(0.0, min_height - SYNTHETIC_SEAFLOOR_SKIRT);
 }
 
-/// Computes fold canopy into spans for l o d for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Optionally merges vegetation canopy information into column spans for distant rendering.
+/// When enabled, it raises or inserts a leaf span based on tree coverage and average height.
 pub fn foldCanopyIntoSpansForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, spans: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]LODColumnSpan, count: *usize) void {
     if (!shouldFoldCanopyIntoTerrain(lod_level) or count.* == 0) return;
 
@@ -702,22 +700,22 @@ pub fn foldCanopyIntoSpansForLOD(data: *const LODSimplifiedData, gx: u32, gz: u3
     });
 }
 
-/// Reports whether is detached canopy span for a sampled LOD cell or span.
-/// The query is deterministic and does not mutate the supplied simplified data.
+/// Reports whether a span represents canopy detached above the terrain surface.
+/// Detached canopy is treated differently from solid ground spans when selecting visible surfaces.
 pub fn isDetachedCanopySpan(span: LODColumnSpan, base_height: f32) bool {
     return isLeafBlock(span.block) and span.min_height > base_height + 0.5;
 }
 
-/// Selects representative span block for a representative LOD terrain cell.
-/// The selection folds fine terrain samples into stable coarse LOD material output.
+/// Returns the block type that best represents a vertical material span.
+/// Air-like spans use fallback material so emitted faces sample a visible tile.
 pub fn representativeSpanBlock(layers: world_core.LODMaterialLayers) BlockType {
     if (layers.surface != .air) return layers.surface;
     if (layers.subsurface != .air) return layers.subsurface;
     return layers.foundation;
 }
 
-/// Appends insert column span geometry to the provided mesh buffers.
-/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
+/// Inserts a bounded vertical span into the per-column span list.
+/// The list is kept ordered and capped so mesh generation respects `MAX_LOD_VERTICAL_SPANS`.
 pub fn insertColumnSpan(out: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]LODColumnSpan, count: *usize, span: LODColumnSpan) void {
     if (count.* >= out.len) return;
     var dst = count.*;
@@ -728,8 +726,8 @@ pub fn insertColumnSpan(out: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]LODColumnSp
     out[dst] = span;
 }
 
-/// Computes highest solid span index for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Finds the highest span that should behave as solid terrain.
+/// Returns null when a column contains only air, water, or detached canopy spans.
 pub fn highestSolidSpanIndex(spans: []const LODColumnSpan) ?usize {
     var i = spans.len;
     while (i > 0) {
@@ -739,8 +737,8 @@ pub fn highestSolidSpanIndex(spans: []const LODColumnSpan) ?usize {
     return null;
 }
 
-/// Appends add exposed span faces geometry to the provided mesh buffers.
-/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
+/// Emits faces for portions of a vertical span that are visible from a neighbor direction.
+/// Neighbor intervals are subtracted so covered span ranges do not produce hidden geometry.
 pub fn addExposedSpanFaces(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -763,8 +761,8 @@ pub fn addExposedSpanFaces(
     try addExposedSpanFace(allocator, vertices, data, gx, gz, gx, if (gz + 1 >= data.width - 1) null else gz + 1, lod_level, span, wx, wz, size, color, tile_id, .south, world_x, world_z);
 }
 
-/// Appends add exposed span face geometry to the provided mesh buffers.
-/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
+/// Emits one vertical quad for an exposed interval of a span side.
+/// The interval bounds become the face bottom/top heights and share the span material color.
 pub fn addExposedSpanFace(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -817,8 +815,8 @@ pub fn addExposedSpanFace(
     }
 }
 
-/// Computes subtract covered interval for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Subtracts an occluding height interval from a set of visible height intervals.
+/// Used to split side faces around neighboring spans that cover part of the same vertical range.
 pub fn subtractCoveredInterval(intervals: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]HeightInterval, count: *usize, cover_min: f32, cover_max: f32) void {
     var i: usize = 0;
     while (i < count.*) {
@@ -860,14 +858,14 @@ pub fn subtractCoveredInterval(intervals: *[world_core.MAX_LOD_VERTICAL_SPANS + 
 pub const LOD_UV_BLOCK_SCALE: f32 = 1.0;
 pub const LOD_UV_WRAP_BLOCKS: i32 = 256;
 
-/// Computes lod u v offset for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Computes a repeatable atlas UV offset from world block coordinates.
+/// The offset keeps tiled LOD texture sampling stable as neighboring regions stream in.
 pub fn lodUVOffset(coord: i32) f32 {
     return @floatFromInt(@mod(coord, LOD_UV_WRAP_BLOCKS));
 }
 
-/// Computes top face u v for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Computes atlas UVs for a top face using world-space X/Z position.
+/// World offsets make top textures line up across LOD region boundaries.
 pub fn topFaceUV(pos: [3]f32, world_x: i32, world_z: i32) [2]f32 {
     return .{
         (lodUVOffset(world_x) + pos[0]) * LOD_UV_BLOCK_SCALE,
@@ -875,8 +873,8 @@ pub fn topFaceUV(pos: [3]f32, world_x: i32, world_z: i32) [2]f32 {
     };
 }
 
-/// Computes side face u v for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Computes atlas UVs for a vertical side face using face direction and world position.
+/// Horizontal coordinate follows the face axis while vertical coordinate follows height.
 pub fn sideFaceUV(pos: [3]f32, dir: FaceDir, world_x: i32, world_z: i32) [2]f32 {
     const horizontal = switch (dir) {
         .north, .south => lodUVOffset(world_x) + pos[0],
@@ -885,8 +883,8 @@ pub fn sideFaceUV(pos: [3]f32, dir: FaceDir, world_x: i32, world_z: i32) [2]f32 
     return .{ horizontal * LOD_UV_BLOCK_SCALE, pos[1] * LOD_UV_BLOCK_SCALE };
 }
 
-/// Computes skirt dir to face dir for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Maps a skirt edge direction to the corresponding material face direction.
+/// The result selects the correct side-face UV and texture slot for boundary skirts.
 pub fn skirtDirToFaceDir(dir: SkirtDir) FaceDir {
     return switch (dir) {
         .north => .north,
@@ -896,8 +894,8 @@ pub fn skirtDirToFaceDir(dir: SkirtDir) FaceDir {
     };
 }
 
-/// Selects block for l o d cell for a representative LOD terrain cell.
-/// The selection folds fine terrain samples into stable coarse LOD material output.
+/// Returns the direct top block for a fine LOD cell.
+/// Coordinates are clamped through `cellIndex`, so edge callers can safely request neighbor samples.
 pub fn blockForLODCell(data: *const LODSimplifiedData, gx: u32, gz: u32) BlockType {
     const clamped_x = @min(gx, data.width - 1);
     const clamped_z = @min(gz, data.width - 1);
@@ -908,15 +906,15 @@ pub fn blockForLODCell(data: *const LODSimplifiedData, gx: u32, gz: u32) BlockTy
     return data.biomes[idx].getSurfaceBlock();
 }
 
-/// Selects block for l o d quad for a representative LOD terrain cell.
-/// The selection folds fine terrain samples into stable coarse LOD material output.
+/// Chooses a representative top block for a coarse LOD quad.
+/// The function samples the 2x2 neighborhood and prefers stable surface material over isolated outliers.
 pub fn blockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32) BlockType {
     if (isLODWaterCell(data, gx, gz)) return .water;
     return representativeSurfaceBlock(data, gx, gz);
 }
 
-/// Selects representative surface block for a representative LOD terrain cell.
-/// The selection folds fine terrain samples into stable coarse LOD material output.
+/// Returns the best visible surface block from a coarse 2x2 cell neighborhood.
+/// Air and water are ignored when a solid representative material is available.
 pub fn representativeSurfaceBlock(data: *const LODSimplifiedData, gx: u32, gz: u32) BlockType {
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -950,8 +948,8 @@ pub fn representativeSurfaceBlock(data: *const LODSimplifiedData, gx: u32, gz: u
     return blockForLODCell(data, gx, gz);
 }
 
-/// Computes representative water depth from water coverage samples.
-/// The function treats missing or dry samples as non-water and does not mutate source data.
+/// Computes a representative water depth for a coarse cell.
+/// Depth is weighted by water coverage so thin or partial water samples have less influence.
 pub fn representativeWaterDepth(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -976,8 +974,8 @@ pub fn representativeWaterDepth(data: *const LODSimplifiedData, gx: u32, gz: u32
     return weighted_depth / coverage;
 }
 
-/// Selects select cell material for a representative LOD terrain cell.
-/// The selection folds fine terrain samples into stable coarse LOD material output.
+/// Chooses top and side atlas materials for an LOD mesh cell.
+/// Water cells get water top material and terrain side fallback; dry cells use terrain block material.
 pub fn selectCellMaterial(data: *const LODSimplifiedData, atlas: *const TextureAtlas, gx: u32, gz: u32) TextureAtlas.BlockTiles {
     const top_block = blockForLODQuad(data, gx, gz);
     const side_block = sideBlockForLODQuad(data, gx, gz, top_block);
@@ -990,8 +988,8 @@ pub fn selectCellMaterial(data: *const LODSimplifiedData, atlas: *const TextureA
     };
 }
 
-/// Selects side block for l o d quad for a representative LOD terrain cell.
-/// The selection folds fine terrain samples into stable coarse LOD material output.
+/// Chooses the block material to use for vertical sides of a coarse LOD quad.
+/// It prefers subsurface or neighboring solid material so water and air do not create invisible side walls.
 pub fn sideBlockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32, top_block: BlockType) BlockType {
     if (top_block != .water) return top_block;
 
@@ -1015,14 +1013,14 @@ pub fn sideBlockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32, top
     return blockForLODCell(data, gx, gz);
 }
 
-/// Reports whether should render l o d tree for a sampled LOD cell or span.
-/// The query is deterministic and does not mutate the supplied simplified data.
+/// Reports whether a block type should produce LOD vegetation geometry.
+/// Only leaf-like/tree surface materials participate in distant tree impostors.
 pub fn shouldRenderLODTree(top_block: BlockType) bool {
     return top_block != .water and top_block != .air;
 }
 
-/// Reports whether is leaf block for a sampled LOD cell or span.
-/// The query is deterministic and does not mutate the supplied simplified data.
+/// Reports whether a block type is one of the leaf materials handled by LOD vegetation code.
+/// Used to decide tinting and canopy representation.
 pub fn isLeafBlock(block: BlockType) bool {
     return switch (block) {
         .leaves,
@@ -1036,15 +1034,15 @@ pub fn isLeafBlock(block: BlockType) bool {
     };
 }
 
-/// Derives representative vegetation for l o d for distant vegetation representation.
-/// The result is based on simplified vegetation hints and LOD level.
+/// Returns vegetation hints using direct or coarse sampling for the requested LOD level.
+/// Fine levels use one sample; coarser levels combine the local 2x2 vegetation hints.
 pub fn representativeVegetationForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) world_core.LODVegetationHint {
     if (isFineSampleLOD(lod_level)) return data.vegetation[cellIndex(data, gx, gz)];
     return representativeVegetation(data, gx, gz);
 }
 
-/// Derives representative vegetation for distant vegetation representation.
-/// The result is based on simplified vegetation hints and LOD level.
+/// Combines a 2x2 neighborhood of vegetation hints into one representative hint.
+/// Coverage uses the strongest sample while average height is averaged across non-empty tree samples.
 pub fn representativeVegetation(data: *const LODSimplifiedData, gx: u32, gz: u32) world_core.LODVegetationHint {
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -1073,8 +1071,8 @@ pub fn representativeVegetation(data: *const LODSimplifiedData, gx: u32, gz: u32
     return best;
 }
 
-/// Computes average water coverage from water coverage samples.
-/// The function treats missing or dry samples as non-water and does not mutate source data.
+/// Returns average water coverage for the 2x2 neighborhood around a coarse cell.
+/// Dry or invalid water samples contribute zero coverage.
 pub fn averageWaterCoverage(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return waterCoverageStats(data, gx, gz).average_coverage;
 }
@@ -1085,8 +1083,8 @@ pub const WaterCoverageStats = struct {
     representative_depth: f32,
 };
 
-/// Computes water coverage stats from water coverage samples.
-/// The function treats missing or dry samples as non-water and does not mutate source data.
+/// Computes water coverage, wet-sample count, and coverage-weighted representative depth for a coarse cell.
+/// Only positive-coverage water surfaces with meaningful depth count as wet samples.
 pub fn waterCoverageStats(data: *const LODSimplifiedData, gx: u32, gz: u32) WaterCoverageStats {
     if (data.width == 0) return .{ .average_coverage = 0.0, .wet_samples = 0, .representative_depth = 0.0 };
     const x0 = @min(gx, data.width - 1);
@@ -1120,8 +1118,8 @@ pub fn waterCoverageStats(data: *const LODSimplifiedData, gx: u32, gz: u32) Wate
     };
 }
 
-/// Reports whether should emit water span for l o d for a sampled LOD cell or span.
-/// The query is deterministic and does not mutate the supplied simplified data.
+/// Reports whether water should produce a visible span for the requested LOD cell.
+/// Fine LODs always emit water when present; coarse LODs require enough coverage or wet samples.
 pub fn shouldEmitWaterSpanForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, water: world_core.LODWaterState) bool {
     if (!water.is_surface or water.coverage <= 0.0 or water.depth <= 0.01) return false;
     if (isFineSampleLOD(lod_level)) return true;
@@ -1131,8 +1129,8 @@ pub fn shouldEmitWaterSpanForLOD(data: *const LODSimplifiedData, gx: u32, gz: u3
     return stats.wet_samples >= 2 and stats.average_coverage >= 0.25 and stats.representative_depth >= 1.5;
 }
 
-/// Computes stitched height from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns a heightmap sample adjusted to match neighboring LOD region boundaries.
+/// Boundary samples may be clamped toward adjacent values to reduce visible cracks.
 pub fn stitchedHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const height = data.getHeight(gx, gz);
     if (data.width < 5) return height;
@@ -1150,8 +1148,8 @@ pub fn stitchedHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return height * (1.0 - blend) + coarse_height * blend;
 }
 
-/// Computes max stitched height adjustment from LOD terrain and water samples.
-/// Returned heights are in world/block units and may be quantized for seam stability.
+/// Returns the maximum seam-height adjustment allowed for a point in the sample grid.
+/// Interior points allow no adjustment; boundary points allow bounded correction.
 pub fn maxStitchedHeightAdjustment(data: *const LODSimplifiedData) f32 {
     if (data.width < 5) return 0.0;
 
@@ -1167,26 +1165,26 @@ pub fn maxStitchedHeightAdjustment(data: *const LODSimplifiedData) f32 {
 }
 
 // Helper functions for unpacking colors
-/// Computes unpack r for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Extracts the red channel from a packed 0xRRGGBB color as a normalized float.
+/// The result is in `[0, 1]` for direct use in vertex color data.
 pub fn unpackR(color: u32) f32 {
     return @as(f32, @floatFromInt((color >> 16) & 0xFF)) / 255.0;
 }
 
-/// Computes unpack g for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Extracts the green channel from a packed 0xRRGGBB color as a normalized float.
+/// The result is in `[0, 1]` for direct use in vertex color data.
 pub fn unpackG(color: u32) f32 {
     return @as(f32, @floatFromInt((color >> 8) & 0xFF)) / 255.0;
 }
 
-/// Computes unpack b for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Extracts the blue channel from a packed 0xRRGGBB color as a normalized float.
+/// The result is in `[0, 1]` for direct use in vertex color data.
 pub fn unpackB(color: u32) f32 {
     return @as(f32, @floatFromInt(color & 0xFF)) / 255.0;
 }
 
-/// Computes average color for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Averages four packed RGB colors channel-by-channel.
+/// The returned packed color is used for coarse-cell material and skirt shading.
 pub fn averageColor(c00: u32, c10: u32, c01: u32, c11: u32) u32 {
     const r = ((c00 >> 16) & 0xFF) + ((c10 >> 16) & 0xFF) + ((c01 >> 16) & 0xFF) + ((c11 >> 16) & 0xFF);
     const g = ((c00 >> 8) & 0xFF) + ((c10 >> 8) & 0xFF) + ((c01 >> 8) & 0xFF) + ((c11 >> 8) & 0xFF);
@@ -1197,8 +1195,8 @@ pub fn averageColor(c00: u32, c10: u32, c01: u32, c11: u32) u32 {
     return (r_avg << 16) | (g_avg << 8) | b_avg;
 }
 
-/// Computes average ambient occlusion for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Averages ambient-occlusion values from a clamped 2x2 sample neighborhood.
+/// Used by coarse LODs to avoid single-sample lighting artifacts.
 pub fn averageAmbientOcclusion(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -1211,8 +1209,8 @@ pub fn averageAmbientOcclusion(data: *const LODSimplifiedData, gx: u32, gz: u32)
     return (a00 + a10 + a01 + a11) * 0.25;
 }
 
-/// Computes apply color brightness for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Applies a scalar brightness factor to a packed RGB color.
+/// Channels are clamped to 255 and repacked as 0xRRGGBB.
 pub fn applyColorBrightness(color: u32, brightness: f32) u32 {
     const clamped = std.math.clamp(brightness, 0.0, 1.0);
     const r: u32 = @intFromFloat(@round(@as(f32, @floatFromInt((color >> 16) & 0xFF)) * clamped));
@@ -1223,8 +1221,8 @@ pub fn applyColorBrightness(color: u32, brightness: f32) u32 {
 
 pub const LODTextureFace = enum { top, side, bottom };
 
-/// Computes tint color for lod face for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Chooses biome tinting for LOD top/side/bottom faces when a block type needs tint.
+/// Grass tops, water, and leaves use averaged biome tint; other blocks keep the fallback color.
 pub fn tintColorForLodFace(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, block: BlockType, face: LODTextureFace, fallback: u32) u32 {
     if (block == .grass and face == .top) return averageBiomeBlockTint(data, gx, gz, lod_level, block);
     if (block == .water) return averageBiomeBlockTint(data, gx, gz, lod_level, block);
@@ -1232,8 +1230,8 @@ pub fn tintColorForLodFace(data: *const LODSimplifiedData, gx: u32, gz: u32, lod
     return fallback;
 }
 
-/// Computes average biome block tint for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Averages biome tint colors for the requested block over the LOD sample neighborhood.
+/// Fine LODs use one biome; coarse LODs blend four neighboring biome tints.
 pub fn averageBiomeBlockTint(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, block: BlockType) u32 {
     if (isFineSampleLOD(lod_level)) {
         return biome_mod.getBlockTintColor(data.biomes[cellIndex(data, gx, gz)], block);
@@ -1246,8 +1244,8 @@ pub fn averageBiomeBlockTint(data: *const LODSimplifiedData, gx: u32, gz: u32, l
     return averageColor(c00, c10, c01, c11);
 }
 
-/// Computes apply texture luminance for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Modulates a material color by the average texture luminance for a block face.
+/// This keeps LOD fallback colors closer to the atlas texture brightness.
 pub fn applyTextureLuminance(color: u32, block: BlockType, face: LODTextureFace, atlas: *const TextureAtlas) u32 {
     if (block == .air or block == .water) return color;
     const texture_color = averageTextureColorForFace(block, face, atlas) orelse {
@@ -1264,8 +1262,8 @@ pub fn applyTextureLuminance(color: u32, block: BlockType, face: LODTextureFace,
     return multiplyColors(texture_color, shaderLikeTintColor(color));
 }
 
-/// Computes average texture color for face for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Returns the average atlas color for a block face when texture statistics are available.
+/// The face selects top, side, or bottom color according to block texture metadata.
 pub fn averageTextureColorForFace(block: BlockType, face: LODTextureFace, atlas: *const TextureAtlas) ?u32 {
     const tiles = atlas.getTilesForBlock(@intFromEnum(block));
     const tile_id = switch (face) {
@@ -1283,16 +1281,16 @@ pub fn averageTextureColorForFace(block: BlockType, face: LODTextureFace, atlas:
     };
 }
 
-/// Reports whether should tint lod face for a sampled LOD cell or span.
-/// The query is deterministic and does not mutate the supplied simplified data.
+/// Reports whether a block face should receive biome tint in the LOD mesh.
+/// Tinting is limited to materials whose in-game shader also applies biome coloration.
 pub fn shouldTintLodFace(block: BlockType, face: LODTextureFace) bool {
     if (block == .grass) return face == .top;
     if (block == .water) return true;
     return isLeafBlock(block);
 }
 
-/// Computes multiply colors for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Multiplies two packed RGB colors channel-by-channel.
+/// Used to combine biome tint and texture color in shader-like LOD material paths.
 pub fn multiplyColors(base: u32, tint: u32) u32 {
     const r: u32 = @intFromFloat(@round(unpackR(base) * unpackR(tint) * 255.0));
     const g: u32 = @intFromFloat(@round(unpackG(base) * unpackG(tint) * 255.0));
@@ -1303,8 +1301,8 @@ pub fn multiplyColors(base: u32, tint: u32) u32 {
     return (rr << 16) | (gg << 8) | bb;
 }
 
-/// Computes shader like tint color for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Approximates the runtime shader tint result for an LOD block face.
+/// It blends biome tint, texture luminance, and fallback color without sampling shaders at runtime.
 pub fn shaderLikeTintColor(color: u32) u32 {
     const r: u32 = (color >> 16) & 0xFF;
     const g: u32 = (color >> 8) & 0xFF;
@@ -1329,15 +1327,15 @@ pub fn shaderLikeTintColor(color: u32) u32 {
     return (rr << 16) | (gg << 8) | bb;
 }
 
-/// Computes smoothstep for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Applies cubic Hermite interpolation between two edges.
+/// Returns 0 below `edge0`, 1 above `edge1`, and a smooth transition between them.
 pub fn smoothstep(edge0: f32, edge1: f32, x: f32) f32 {
     const t = std.math.clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
     return t * t * (3.0 - 2.0 * t);
 }
 
-/// Computes scale color for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Scales a packed RGB color by a floating-point factor.
+/// Each channel is clamped before repacking.
 pub fn scaleColor(color: u32, factor: f32) u32 {
     const clamped = std.math.clamp(factor, 0.0, 2.0);
     const r: u32 = @intFromFloat(@round(std.math.clamp(@as(f32, @floatFromInt((color >> 16) & 0xFF)) * clamped, 0.0, 255.0)));
@@ -1346,8 +1344,8 @@ pub fn scaleColor(color: u32, factor: f32) u32 {
     return (r << 16) | (g << 8) | b;
 }
 
-/// Computes pack block default color for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Returns a packed fallback color for a block type when atlas or biome data is unavailable.
+/// `fallback` is used for blocks without a known default LOD color.
 pub fn packBlockDefaultColor(block: BlockType, fallback: u32) u32 {
     if (block == .air) return fallback;
     const color = world_core.block_registry.getBlockDefinition(block).default_color;
@@ -1357,8 +1355,8 @@ pub fn packBlockDefaultColor(block: BlockType, fallback: u32) u32 {
     return (r << 16) | (g << 8) | b;
 }
 
-/// Computes get lod top tile for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Returns the atlas tile id used for the top face of a block in LOD meshes.
+/// Unknown or air blocks fall back to a safe terrain tile.
 pub fn getLodTopTile(block: BlockType, atlas: *const TextureAtlas) u16 {
     if (block == .air) return Vertex.LOD_TILE_ID;
     if (isLeafBlock(block)) return Vertex.LOD_TILE_ID;
@@ -1368,16 +1366,16 @@ pub fn getLodTopTile(block: BlockType, atlas: *const TextureAtlas) u16 {
     return tiles.top;
 }
 
-/// Computes get lod top color for LOD material shading.
-/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
+/// Returns the packed fallback color used for a block top face.
+/// The tile id can influence texture-derived colors when atlas statistics are available.
 pub fn getLodTopColor(block: BlockType, tile_id: u16, fallback_color: u32) u32 {
     _ = block;
     if (tile_id == Vertex.LOD_TILE_ID) return fallback_color;
     return fallback_color;
 }
 
-/// Computes make l o d vertex for LOD mesh generation.
-/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
+/// Packs position, color, normal, UV, and tile id into the shared RHI vertex layout.
+/// The returned vertex is ready for terrain, water, or skirt mesh buffers.
 pub fn makeLODVertex(pos: [3]f32, col: [3]f32, norm: [3]f32, uv: [2]f32, tile_id: u16) Vertex {
     return Vertex{
         .pos = pos,
@@ -1390,7 +1388,8 @@ pub fn makeLODVertex(pos: [3]f32, col: [3]f32, norm: [3]f32, uv: [2]f32, tile_id
     };
 }
 
-/// Add a top-facing quad (two triangles)
+/// Appends the top face for a column or span to the mesh buffers.
+/// The quad uses top-face UVs, upward normal, and material color for the selected block.
 pub fn addTopFaceQuad(allocator: std.mem.Allocator, vertices: *std.ArrayListUnmanaged(Vertex), x: f32, y: f32, z: f32, size: f32, r: f32, g: f32, b: f32, tile_id: u16, world_x: i32, world_z: i32) !void {
     const normal = [3]f32{ 0, 1, 0 };
     const color = [3]f32{ r, g, b };
@@ -1404,8 +1403,8 @@ pub fn addTopFaceQuad(allocator: std.mem.Allocator, vertices: *std.ArrayListUnma
     try vertices.append(allocator, makeLODVertex(.{ x + size, y, z }, color, normal, topFaceUV(.{ x + size, y, z }, world_x, world_z), tile_id));
 }
 
-/// Add a downward-facing bottom quad for floating spans (overhangs) so
-/// caves/arches read correctly from below (issue #752 Phase 3.3).
+/// Appends the bottom face for a vertical span when it is exposed.
+/// The face uses a downward normal and the span material color.
 pub fn addBottomFaceQuad(allocator: std.mem.Allocator, vertices: *std.ArrayListUnmanaged(Vertex), x: f32, y: f32, z: f32, size: f32, r: f32, g: f32, b: f32, tile_id: u16, world_x: i32, world_z: i32) !void {
     const normal = [3]f32{ 0, -1, 0 };
     const color = [3]f32{ r, g, b };
@@ -1419,7 +1418,8 @@ pub fn addBottomFaceQuad(allocator: std.mem.Allocator, vertices: *std.ArrayListU
     try vertices.append(allocator, makeLODVertex(.{ x + size, y, z }, color, normal, topFaceUV(.{ x + size, y, z }, world_x, world_z), tile_id));
 }
 
-/// Add a side-facing quad for cliff faces
+/// Appends one side face for a block/span column.
+/// Face direction controls normal, winding, UV projection, and side brightness.
 pub fn addSideFaceQuad(allocator: std.mem.Allocator, vertices: *std.ArrayListUnmanaged(Vertex), x: f32, y_top: f32, z: f32, size: f32, y_bottom: f32, r: f32, g: f32, b: f32, dir: FaceDir, tile_id: u16, world_x: i32, world_z: i32) !void {
     const color = [3]f32{ r, g, b };
 
@@ -1467,8 +1467,8 @@ pub fn addSideFaceQuad(allocator: std.mem.Allocator, vertices: *std.ArrayListUnm
     try vertices.append(allocator, makeLODVertex(corners[3], color, normal, sideFaceUV(corners[3], dir, world_x, world_z), tile_id));
 }
 
-/// Appends add tree column geometry to the provided mesh buffers.
-/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
+/// Adds simplified trunk and canopy geometry for a distant tree column.
+/// The tree footprint is derived from vegetation hints and clipped against water/neighbor coverage.
 pub fn addTreeColumn(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -1491,8 +1491,8 @@ pub fn addTreeColumn(
     try addTreeCanopyColumn(allocator, vertices, data, gx, gz, lod_level, wx, wz, cell_size, base_height, canopy.min_height, canopy.max_height, vegetation, atlas, world_x, world_z);
 }
 
-/// Appends add tree canopy column geometry to the provided mesh buffers.
-/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
+/// Adds box-like leaf canopy geometry for a distant tree impostor.
+/// Canopy dimensions come from tree height and coverage and are emitted as colored block faces.
 pub fn addTreeCanopyColumn(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -1531,8 +1531,8 @@ pub fn addTreeCanopyColumn(
     }
 }
 
-/// Derives tree canopy footprint for distant vegetation representation.
-/// The result is based on simplified vegetation hints and LOD level.
+/// Computes the horizontal footprint size used for an LOD tree canopy.
+/// Higher coverage and taller trees produce larger but bounded canopy boxes.
 pub fn treeCanopyFootprint(cell_size: f32, vegetation: world_core.LODVegetationHint) f32 {
     const coverage = std.math.clamp(vegetation.tree_coverage, LOD_TREE_COVERAGE_THRESHOLD, 1.0);
     const desired = @max(1.0, vegetation.avg_tree_height * (0.30 + coverage * 0.18));
@@ -1543,8 +1543,8 @@ pub fn treeCanopyFootprint(cell_size: f32, vegetation: world_core.LODVegetationH
 
 pub const TreeFootprintOrigin = struct { x: f32, z: f32 };
 
-/// Derives tree footprint origin for distant vegetation representation.
-/// The result is based on simplified vegetation hints and LOD level.
+/// Computes the local origin for centering a tree footprint inside a cell.
+/// The origin keeps trunk/canopy geometry inside the LOD cell area.
 pub fn treeFootprintOrigin(wx: f32, wz: f32, cell_size: f32, footprint: f32, vegetation: world_core.LODVegetationHint) TreeFootprintOrigin {
     const max_offset = @max(0.0, (cell_size - footprint) * 0.5 - 0.01);
     const offset_x = std.math.clamp(vegetation.offset_x, -max_offset, max_offset);
@@ -1555,8 +1555,8 @@ pub fn treeFootprintOrigin(wx: f32, wz: f32, cell_size: f32, footprint: f32, veg
     };
 }
 
-/// Derives tree canopy interval for distant vegetation representation.
-/// The result is based on simplified vegetation hints and LOD level.
+/// Computes the vertical min/max interval occupied by a tree canopy.
+/// The interval starts above terrain height and scales with average tree height.
 pub fn treeCanopyInterval(base_height: f32, vegetation: world_core.LODVegetationHint) HeightInterval {
     const canopy_height = @max(3.0, vegetation.avg_tree_height);
     const top = base_height + canopy_height;
@@ -1567,8 +1567,8 @@ pub fn treeCanopyInterval(base_height: f32, vegetation: world_core.LODVegetation
     };
 }
 
-/// Appends add tree column sides geometry to the provided mesh buffers.
-/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
+/// Adds side faces for a tree trunk or canopy box.
+/// Neighbor water information can suppress or adjust faces that would intersect water cells.
 pub fn addTreeColumnSides(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -1591,8 +1591,8 @@ pub fn addTreeColumnSides(
     try addTreeColumnSide(allocator, vertices, data, gx, if (gz + 1 >= data.width - 1) null else gz + 1, lod_level, wx, wz, size, canopy, color, tile_id, .south, world_x, world_z);
 }
 
-/// Appends add tree column side geometry to the provided mesh buffers.
-/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
+/// Adds one side face for a tree box column.
+/// The face uses directional normals and material color for a trunk or canopy side.
 pub fn addTreeColumnSide(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -1635,8 +1635,8 @@ pub fn addTreeColumnSide(
     }
 }
 
-/// Appends add box column geometry to the provided mesh buffers.
-/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
+/// Adds a rectangular prism column to the mesh buffers.
+/// Used by vegetation impostors and other box-like LOD details that need all exposed faces.
 pub fn addBoxColumn(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),

--- a/modules/world-lod/src/lod_geometry.zig
+++ b/modules/world-lod/src/lod_geometry.zig
@@ -50,7 +50,8 @@ pub const SkirtParams = struct {
 
 pub const SkirtDir = enum { north, south, east, west };
 
-/// LOD geometry API `makeSkirtQuad` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes make skirt quad for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn makeSkirtQuad(params: SkirtParams, tile_id: u16, world_x: i32, world_z: i32) [4]Vertex {
     const p = params;
     const cr = unpackR(p.avg_c) * p.brightness;
@@ -93,7 +94,8 @@ pub fn makeSkirtQuad(params: SkirtParams, tile_id: u16, world_x: i32, world_z: i
     };
 }
 
-/// LOD geometry API `buildFullDetailHeightmapMesh` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes build full detail heightmap mesh from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn buildFullDetailHeightmapMesh(
     allocator: std.mem.Allocator,
     lod_level: LODLevel,
@@ -206,7 +208,8 @@ pub const SEA_LEVEL_WATER_EPSILON: f32 = 2.0;
 pub const SYNTHETIC_SEAFLOOR_SKIRT: f32 = 8.0;
 pub const LOD_TREE_COVERAGE_THRESHOLD: f32 = 0.08;
 
-/// LOD geometry API `isLODWaterCell` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reports whether is l o d water cell for a sampled LOD cell or span.
+/// The query is deterministic and does not mutate the supplied simplified data.
 pub fn isLODWaterCell(data: *const LODSimplifiedData, gx: u32, gz: u32) bool {
     const stats = waterCoverageStats(data, gx, gz);
     const water_coverage = stats.average_coverage;
@@ -214,17 +217,20 @@ pub fn isLODWaterCell(data: *const LODSimplifiedData, gx: u32, gz: u32) bool {
     return stats.wet_samples >= 2 and water_coverage >= 0.25 and stats.representative_depth >= 1.5;
 }
 
-/// LOD geometry API `isFineSampleLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reports whether is fine sample l o d for a sampled LOD cell or span.
+/// The query is deterministic and does not mutate the supplied simplified data.
 pub fn isFineSampleLOD(lod_level: LODLevel) bool {
     return @intFromEnum(lod_level) <= @intFromEnum(LODLevel.lod1);
 }
 
-/// LOD geometry API `cellIndex` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reads cell index from the clamped LOD sample grid.
+/// Coordinates are clamped to the simplified data width.
 pub fn cellIndex(data: *const LODSimplifiedData, gx: u32, gz: u32) u32 {
     return @min(gx, data.width - 1) + @min(gz, data.width - 1) * data.width;
 }
 
-/// LOD geometry API `cellColorForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes cell color for l o d for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn cellColorForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) u32 {
     if (isFineSampleLOD(lod_level)) return data.colors[cellIndex(data, gx, gz)];
     const c00 = data.colors[cellIndex(data, gx, gz)];
@@ -234,13 +240,15 @@ pub fn cellColorForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_lev
     return averageColor(c00, c10, c01, c11);
 }
 
-/// LOD geometry API `ambientOcclusionForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reads ambient occlusion for l o d from the clamped LOD sample grid.
+/// Coordinates are clamped to the simplified data width.
 pub fn ambientOcclusionForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
     if (isFineSampleLOD(lod_level)) return data.lighting[cellIndex(data, gx, gz)].ambient_occlusion;
     return averageAmbientOcclusion(data, gx, gz);
 }
 
-/// LOD geometry API `isLODWaterCellForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reports whether is l o d water cell for l o d for a sampled LOD cell or span.
+/// The query is deterministic and does not mutate the supplied simplified data.
 pub fn isLODWaterCellForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) bool {
     if (isFineSampleLOD(lod_level)) {
         const water = data.water[cellIndex(data, gx, gz)];
@@ -249,12 +257,14 @@ pub fn isLODWaterCellForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lo
     return isLODWaterCell(data, gx, gz);
 }
 
-/// LOD geometry API `quantizedHeight` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes quantized height from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn quantizedHeight(height: f32) f32 {
     return @round(height);
 }
 
-/// LOD geometry API `terrainHeightForPoint` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes terrain height for point from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn terrainHeightForPoint(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const clamped_x = @min(gx, data.width - 1);
     const clamped_z = @min(gz, data.width - 1);
@@ -270,47 +280,55 @@ pub fn terrainHeightForPoint(data: *const LODSimplifiedData, gx: u32, gz: u32) f
     return @min(height, floor_height);
 }
 
-/// LOD geometry API `terrainSurfaceHeightForPoint` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes terrain surface height for point from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn terrainSurfaceHeightForPoint(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const clamped_x = @min(gx, data.width - 1);
     const clamped_z = @min(gz, data.width - 1);
     return stitchedHeight(data, clamped_x, clamped_z);
 }
 
-/// LOD geometry API `quantizedTerrainHeightForPoint` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes quantized terrain height for point from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn quantizedTerrainHeightForPoint(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return quantizedHeight(terrainHeightForPoint(data, gx, gz));
 }
 
-/// LOD geometry API `quantizedCellTerrainHeight` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes quantized cell terrain height from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn quantizedCellTerrainHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return quantizedHeight(terrainHeightForPoint(data, gx, gz));
 }
 
-/// LOD geometry API `quantizedCellSurfaceHeight` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes quantized cell surface height from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn quantizedCellSurfaceHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return quantizedHeight(terrainSurfaceHeightForPoint(data, gx, gz));
 }
 
-/// LOD geometry API `quantizedCellTerrainHeightForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes quantized cell terrain height for l o d from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn quantizedCellTerrainHeightForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
     if (isFineSampleLOD(lod_level)) return quantizedTerrainHeightForPoint(data, gx, gz);
     return quantizedCellTerrainHeight(data, gx, gz);
 }
 
-/// LOD geometry API `quantizedCellVisualTerrainHeightForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes quantized cell visual terrain height for l o d from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn quantizedCellVisualTerrainHeightForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, is_water_cell: bool) f32 {
     if (is_water_cell) return quantizedCellTerrainHeightForLOD(data, gx, gz, lod_level);
     if (isFineSampleLOD(lod_level)) return quantizedHeight(terrainSurfaceHeightForPoint(data, gx, gz));
     return quantizedCellSurfaceHeight(data, gx, gz);
 }
 
-/// LOD geometry API `maxWaterSurfaceHeightForCell` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes max water surface height for cell from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn maxWaterSurfaceHeightForCell(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) ?f32 {
     return representativeWaterSurfaceHeightForCell(data, gx, gz, lod_level);
 }
 
-/// LOD geometry API `representativeWaterSurfaceHeightForCell` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes representative water surface height for cell from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn representativeWaterSurfaceHeightForCell(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) ?f32 {
     if (isFineSampleLOD(lod_level)) {
         const idx = cellIndex(data, gx, gz);
@@ -339,7 +357,8 @@ pub fn representativeWaterSurfaceHeightForCell(data: *const LODSimplifiedData, g
     return null;
 }
 
-/// LOD geometry API `normalizedWaterSurfaceHeight` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes normalized water surface height from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn normalizedWaterSurfaceHeight(data: *const LODSimplifiedData, idx: u32, water: world_core.LODWaterState) f32 {
     if (isOceanBiome(data.biomes[idx]) and @abs(water.surface_height - WORLDGEN_SEA_LEVEL) <= SEA_LEVEL_WATER_EPSILON) {
         return WORLDGEN_SEA_LEVEL;
@@ -347,7 +366,8 @@ pub fn normalizedWaterSurfaceHeight(data: *const LODSimplifiedData, idx: u32, wa
     return water.surface_height;
 }
 
-/// LOD geometry API `isOceanBiome` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reports whether is ocean biome for a sampled LOD cell or span.
+/// The query is deterministic and does not mutate the supplied simplified data.
 pub fn isOceanBiome(biome: BiomeId) bool {
     return switch (biome) {
         .deep_ocean, .ocean, .warm_ocean, .frozen_ocean, .cold_ocean => true,
@@ -355,13 +375,15 @@ pub fn isOceanBiome(biome: BiomeId) bool {
     };
 }
 
-/// LOD geometry API `quantizedWaterSurfaceHeightForCell` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes quantized water surface height for cell from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn quantizedWaterSurfaceHeightForCell(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
     if (maxWaterSurfaceHeightForCell(data, gx, gz, lod_level)) |height| return quantizedHeight(height);
     return quantizedCellTerrainHeightForLOD(data, gx, gz, lod_level);
 }
 
-/// LOD geometry API `quantizedWaterSurfaceHeightForSpan` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes quantized water surface height for span from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn quantizedWaterSurfaceHeightForSpan(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, fallback_height: f32) f32 {
     if (maxWaterSurfaceHeightForCell(data, gx, gz, lod_level)) |height| return quantizedHeight(height);
     return quantizedHeight(fallback_height);
@@ -373,18 +395,21 @@ pub const FoldedCanopyColumn = struct {
     color: u32,
 };
 
-/// LOD geometry API `shouldFoldCanopyIntoTerrain` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reports whether should fold canopy into terrain for a sampled LOD cell or span.
+/// The query is deterministic and does not mutate the supplied simplified data.
 pub fn shouldFoldCanopyIntoTerrain(lod_level: LODLevel) bool {
     _ = lod_level;
     return false;
 }
 
-/// LOD geometry API `shouldRenderLODTreeTrunk` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reports whether should render l o d tree trunk for a sampled LOD cell or span.
+/// The query is deterministic and does not mutate the supplied simplified data.
 pub fn shouldRenderLODTreeTrunk(lod_level: LODLevel) bool {
     return @intFromEnum(lod_level) <= @intFromEnum(LODLevel.lod3);
 }
 
-/// LOD geometry API `foldedCanopyColumnForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes folded canopy column for l o d for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn foldedCanopyColumnForLOD(
     data: *const LODSimplifiedData,
     gx: u32,
@@ -409,7 +434,8 @@ pub fn foldedCanopyColumnForLOD(
     };
 }
 
-/// LOD geometry API `quantizedVisualColumnHeightForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes quantized visual column height for l o d from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn quantizedVisualColumnHeightForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
     const is_water_cell = isLODWaterCellForLOD(data, gx, gz, lod_level);
     const terrain_block = terrainBlockForLODQuadForLOD(data, gx, gz, is_water_cell, lod_level);
@@ -420,7 +446,8 @@ pub fn quantizedVisualColumnHeightForLOD(data: *const LODSimplifiedData, gx: u32
     return base_height;
 }
 
-/// LOD geometry API `terrainBlockForLODQuad` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Selects terrain block for l o d quad for a representative LOD terrain cell.
+/// The selection folds fine terrain samples into stable coarse LOD material output.
 pub fn terrainBlockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32, is_water_cell: bool) BlockType {
     if (!is_water_cell) return blockForLODQuad(data, gx, gz);
 
@@ -434,7 +461,8 @@ pub fn terrainBlockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32, 
     return data.biomes[idx].getOceanFloorBlock(representativeWaterDepth(data, gx, gz));
 }
 
-/// LOD geometry API `terrainBlockForLODQuadForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Selects terrain block for l o d quad for l o d for a representative LOD terrain cell.
+/// The selection folds fine terrain samples into stable coarse LOD material output.
 pub fn terrainBlockForLODQuadForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, is_water_cell: bool, lod_level: LODLevel) BlockType {
     if (!isFineSampleLOD(lod_level)) return terrainBlockForLODQuad(data, gx, gz, is_water_cell);
     if (!is_water_cell) return blockForLODCell(data, gx, gz);
@@ -447,7 +475,8 @@ pub fn terrainBlockForLODQuadForLOD(data: *const LODSimplifiedData, gx: u32, gz:
     return data.biomes[idx].getOceanFloorBlock(data.water[idx].depth);
 }
 
-/// LOD geometry API `getLodSideTile` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes get lod side tile for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn getLodSideTile(block: BlockType, atlas: *const TextureAtlas) u16 {
     if (block == .air) return Vertex.LOD_TILE_ID;
     if (isLeafBlock(block)) return Vertex.LOD_TILE_ID;
@@ -456,12 +485,14 @@ pub fn getLodSideTile(block: BlockType, atlas: *const TextureAtlas) u16 {
     return tiles.side;
 }
 
-/// LOD geometry API `boundarySkirtDepth` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes boundary skirt depth for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn boundarySkirtDepth(size: f32) f32 {
     return std.math.clamp(size, 16.0, 32.0);
 }
 
-/// LOD geometry API `heightfieldSideBrightness` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes heightfield side brightness from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn heightfieldSideBrightness(dir: FaceDir) f32 {
     return switch (dir) {
         .west, .east => 0.8,
@@ -469,7 +500,8 @@ pub fn heightfieldSideBrightness(dir: FaceDir) f32 {
     };
 }
 
-/// LOD geometry API `addSteppedHeightfieldSides` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Appends add stepped heightfield sides geometry to the provided mesh buffers.
+/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
 pub fn addSteppedHeightfieldSides(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -492,7 +524,8 @@ pub fn addSteppedHeightfieldSides(
     try addHeightfieldSide(allocator, vertices, wx, wz, size, column_height, if (gz + 1 >= data.width - 1) null else quantizedVisualColumnHeightForLOD(data, gx, gz + 1, lod_level), color, side_tile, .south, world_x, world_z);
 }
 
-/// LOD geometry API `addHeightfieldSide` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Appends add heightfield side geometry to the provided mesh buffers.
+/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
 pub fn addHeightfieldSide(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -526,7 +559,8 @@ pub const HeightInterval = struct {
     max_height: f32,
 };
 
-/// LOD geometry API `collectColumnSpans` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes collect column spans for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn collectColumnSpans(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, out: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]LODColumnSpan) usize {
     var count: usize = 0;
     var has_water_span = false;
@@ -604,7 +638,8 @@ pub fn collectColumnSpans(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_
     return count;
 }
 
-/// LOD geometry API `syntheticSeafloorMinHeight` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes synthetic seafloor min height from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn syntheticSeafloorMinHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const x_min = if (gx == 0) gx else gx - 1;
     const z_min = if (gz == 0) gz else gz - 1;
@@ -623,7 +658,8 @@ pub fn syntheticSeafloorMinHeight(data: *const LODSimplifiedData, gx: u32, gz: u
     return @max(0.0, min_height - SYNTHETIC_SEAFLOOR_SKIRT);
 }
 
-/// LOD geometry API `foldCanopyIntoSpansForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes fold canopy into spans for l o d for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn foldCanopyIntoSpansForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, spans: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]LODColumnSpan, count: *usize) void {
     if (!shouldFoldCanopyIntoTerrain(lod_level) or count.* == 0) return;
 
@@ -666,19 +702,22 @@ pub fn foldCanopyIntoSpansForLOD(data: *const LODSimplifiedData, gx: u32, gz: u3
     });
 }
 
-/// LOD geometry API `isDetachedCanopySpan` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reports whether is detached canopy span for a sampled LOD cell or span.
+/// The query is deterministic and does not mutate the supplied simplified data.
 pub fn isDetachedCanopySpan(span: LODColumnSpan, base_height: f32) bool {
     return isLeafBlock(span.block) and span.min_height > base_height + 0.5;
 }
 
-/// LOD geometry API `representativeSpanBlock` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Selects representative span block for a representative LOD terrain cell.
+/// The selection folds fine terrain samples into stable coarse LOD material output.
 pub fn representativeSpanBlock(layers: world_core.LODMaterialLayers) BlockType {
     if (layers.surface != .air) return layers.surface;
     if (layers.subsurface != .air) return layers.subsurface;
     return layers.foundation;
 }
 
-/// LOD geometry API `insertColumnSpan` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Appends insert column span geometry to the provided mesh buffers.
+/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
 pub fn insertColumnSpan(out: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]LODColumnSpan, count: *usize, span: LODColumnSpan) void {
     if (count.* >= out.len) return;
     var dst = count.*;
@@ -689,7 +728,8 @@ pub fn insertColumnSpan(out: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]LODColumnSp
     out[dst] = span;
 }
 
-/// LOD geometry API `highestSolidSpanIndex` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes highest solid span index for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn highestSolidSpanIndex(spans: []const LODColumnSpan) ?usize {
     var i = spans.len;
     while (i > 0) {
@@ -699,7 +739,8 @@ pub fn highestSolidSpanIndex(spans: []const LODColumnSpan) ?usize {
     return null;
 }
 
-/// LOD geometry API `addExposedSpanFaces` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Appends add exposed span faces geometry to the provided mesh buffers.
+/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
 pub fn addExposedSpanFaces(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -722,7 +763,8 @@ pub fn addExposedSpanFaces(
     try addExposedSpanFace(allocator, vertices, data, gx, gz, gx, if (gz + 1 >= data.width - 1) null else gz + 1, lod_level, span, wx, wz, size, color, tile_id, .south, world_x, world_z);
 }
 
-/// LOD geometry API `addExposedSpanFace` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Appends add exposed span face geometry to the provided mesh buffers.
+/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
 pub fn addExposedSpanFace(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -775,7 +817,8 @@ pub fn addExposedSpanFace(
     }
 }
 
-/// LOD geometry API `subtractCoveredInterval` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes subtract covered interval for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn subtractCoveredInterval(intervals: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]HeightInterval, count: *usize, cover_min: f32, cover_max: f32) void {
     var i: usize = 0;
     while (i < count.*) {
@@ -817,12 +860,14 @@ pub fn subtractCoveredInterval(intervals: *[world_core.MAX_LOD_VERTICAL_SPANS + 
 pub const LOD_UV_BLOCK_SCALE: f32 = 1.0;
 pub const LOD_UV_WRAP_BLOCKS: i32 = 256;
 
-/// LOD geometry API `lodUVOffset` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes lod u v offset for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn lodUVOffset(coord: i32) f32 {
     return @floatFromInt(@mod(coord, LOD_UV_WRAP_BLOCKS));
 }
 
-/// LOD geometry API `topFaceUV` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes top face u v for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn topFaceUV(pos: [3]f32, world_x: i32, world_z: i32) [2]f32 {
     return .{
         (lodUVOffset(world_x) + pos[0]) * LOD_UV_BLOCK_SCALE,
@@ -830,7 +875,8 @@ pub fn topFaceUV(pos: [3]f32, world_x: i32, world_z: i32) [2]f32 {
     };
 }
 
-/// LOD geometry API `sideFaceUV` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes side face u v for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn sideFaceUV(pos: [3]f32, dir: FaceDir, world_x: i32, world_z: i32) [2]f32 {
     const horizontal = switch (dir) {
         .north, .south => lodUVOffset(world_x) + pos[0],
@@ -839,7 +885,8 @@ pub fn sideFaceUV(pos: [3]f32, dir: FaceDir, world_x: i32, world_z: i32) [2]f32 
     return .{ horizontal * LOD_UV_BLOCK_SCALE, pos[1] * LOD_UV_BLOCK_SCALE };
 }
 
-/// LOD geometry API `skirtDirToFaceDir` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes skirt dir to face dir for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn skirtDirToFaceDir(dir: SkirtDir) FaceDir {
     return switch (dir) {
         .north => .north,
@@ -849,7 +896,8 @@ pub fn skirtDirToFaceDir(dir: SkirtDir) FaceDir {
     };
 }
 
-/// LOD geometry API `blockForLODCell` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Selects block for l o d cell for a representative LOD terrain cell.
+/// The selection folds fine terrain samples into stable coarse LOD material output.
 pub fn blockForLODCell(data: *const LODSimplifiedData, gx: u32, gz: u32) BlockType {
     const clamped_x = @min(gx, data.width - 1);
     const clamped_z = @min(gz, data.width - 1);
@@ -860,13 +908,15 @@ pub fn blockForLODCell(data: *const LODSimplifiedData, gx: u32, gz: u32) BlockTy
     return data.biomes[idx].getSurfaceBlock();
 }
 
-/// LOD geometry API `blockForLODQuad` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Selects block for l o d quad for a representative LOD terrain cell.
+/// The selection folds fine terrain samples into stable coarse LOD material output.
 pub fn blockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32) BlockType {
     if (isLODWaterCell(data, gx, gz)) return .water;
     return representativeSurfaceBlock(data, gx, gz);
 }
 
-/// LOD geometry API `representativeSurfaceBlock` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Selects representative surface block for a representative LOD terrain cell.
+/// The selection folds fine terrain samples into stable coarse LOD material output.
 pub fn representativeSurfaceBlock(data: *const LODSimplifiedData, gx: u32, gz: u32) BlockType {
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -900,7 +950,8 @@ pub fn representativeSurfaceBlock(data: *const LODSimplifiedData, gx: u32, gz: u
     return blockForLODCell(data, gx, gz);
 }
 
-/// LOD geometry API `representativeWaterDepth` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes representative water depth from water coverage samples.
+/// The function treats missing or dry samples as non-water and does not mutate source data.
 pub fn representativeWaterDepth(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -925,7 +976,8 @@ pub fn representativeWaterDepth(data: *const LODSimplifiedData, gx: u32, gz: u32
     return weighted_depth / coverage;
 }
 
-/// LOD geometry API `selectCellMaterial` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Selects select cell material for a representative LOD terrain cell.
+/// The selection folds fine terrain samples into stable coarse LOD material output.
 pub fn selectCellMaterial(data: *const LODSimplifiedData, atlas: *const TextureAtlas, gx: u32, gz: u32) TextureAtlas.BlockTiles {
     const top_block = blockForLODQuad(data, gx, gz);
     const side_block = sideBlockForLODQuad(data, gx, gz, top_block);
@@ -938,7 +990,8 @@ pub fn selectCellMaterial(data: *const LODSimplifiedData, atlas: *const TextureA
     };
 }
 
-/// LOD geometry API `sideBlockForLODQuad` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Selects side block for l o d quad for a representative LOD terrain cell.
+/// The selection folds fine terrain samples into stable coarse LOD material output.
 pub fn sideBlockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32, top_block: BlockType) BlockType {
     if (top_block != .water) return top_block;
 
@@ -962,12 +1015,14 @@ pub fn sideBlockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32, top
     return blockForLODCell(data, gx, gz);
 }
 
-/// LOD geometry API `shouldRenderLODTree` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reports whether should render l o d tree for a sampled LOD cell or span.
+/// The query is deterministic and does not mutate the supplied simplified data.
 pub fn shouldRenderLODTree(top_block: BlockType) bool {
     return top_block != .water and top_block != .air;
 }
 
-/// LOD geometry API `isLeafBlock` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reports whether is leaf block for a sampled LOD cell or span.
+/// The query is deterministic and does not mutate the supplied simplified data.
 pub fn isLeafBlock(block: BlockType) bool {
     return switch (block) {
         .leaves,
@@ -981,13 +1036,15 @@ pub fn isLeafBlock(block: BlockType) bool {
     };
 }
 
-/// LOD geometry API `representativeVegetationForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Derives representative vegetation for l o d for distant vegetation representation.
+/// The result is based on simplified vegetation hints and LOD level.
 pub fn representativeVegetationForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) world_core.LODVegetationHint {
     if (isFineSampleLOD(lod_level)) return data.vegetation[cellIndex(data, gx, gz)];
     return representativeVegetation(data, gx, gz);
 }
 
-/// LOD geometry API `representativeVegetation` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Derives representative vegetation for distant vegetation representation.
+/// The result is based on simplified vegetation hints and LOD level.
 pub fn representativeVegetation(data: *const LODSimplifiedData, gx: u32, gz: u32) world_core.LODVegetationHint {
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -1016,7 +1073,8 @@ pub fn representativeVegetation(data: *const LODSimplifiedData, gx: u32, gz: u32
     return best;
 }
 
-/// LOD geometry API `averageWaterCoverage` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes average water coverage from water coverage samples.
+/// The function treats missing or dry samples as non-water and does not mutate source data.
 pub fn averageWaterCoverage(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return waterCoverageStats(data, gx, gz).average_coverage;
 }
@@ -1027,7 +1085,8 @@ pub const WaterCoverageStats = struct {
     representative_depth: f32,
 };
 
-/// LOD geometry API `waterCoverageStats` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes water coverage stats from water coverage samples.
+/// The function treats missing or dry samples as non-water and does not mutate source data.
 pub fn waterCoverageStats(data: *const LODSimplifiedData, gx: u32, gz: u32) WaterCoverageStats {
     if (data.width == 0) return .{ .average_coverage = 0.0, .wet_samples = 0, .representative_depth = 0.0 };
     const x0 = @min(gx, data.width - 1);
@@ -1061,7 +1120,8 @@ pub fn waterCoverageStats(data: *const LODSimplifiedData, gx: u32, gz: u32) Wate
     };
 }
 
-/// LOD geometry API `shouldEmitWaterSpanForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reports whether should emit water span for l o d for a sampled LOD cell or span.
+/// The query is deterministic and does not mutate the supplied simplified data.
 pub fn shouldEmitWaterSpanForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, water: world_core.LODWaterState) bool {
     if (!water.is_surface or water.coverage <= 0.0 or water.depth <= 0.01) return false;
     if (isFineSampleLOD(lod_level)) return true;
@@ -1071,7 +1131,8 @@ pub fn shouldEmitWaterSpanForLOD(data: *const LODSimplifiedData, gx: u32, gz: u3
     return stats.wet_samples >= 2 and stats.average_coverage >= 0.25 and stats.representative_depth >= 1.5;
 }
 
-/// LOD geometry API `stitchedHeight` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes stitched height from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn stitchedHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const height = data.getHeight(gx, gz);
     if (data.width < 5) return height;
@@ -1089,7 +1150,8 @@ pub fn stitchedHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return height * (1.0 - blend) + coarse_height * blend;
 }
 
-/// LOD geometry API `maxStitchedHeightAdjustment` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes max stitched height adjustment from LOD terrain and water samples.
+/// Returned heights are in world/block units and may be quantized for seam stability.
 pub fn maxStitchedHeightAdjustment(data: *const LODSimplifiedData) f32 {
     if (data.width < 5) return 0.0;
 
@@ -1105,22 +1167,26 @@ pub fn maxStitchedHeightAdjustment(data: *const LODSimplifiedData) f32 {
 }
 
 // Helper functions for unpacking colors
-/// LOD geometry API `unpackR` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes unpack r for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn unpackR(color: u32) f32 {
     return @as(f32, @floatFromInt((color >> 16) & 0xFF)) / 255.0;
 }
 
-/// LOD geometry API `unpackG` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes unpack g for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn unpackG(color: u32) f32 {
     return @as(f32, @floatFromInt((color >> 8) & 0xFF)) / 255.0;
 }
 
-/// LOD geometry API `unpackB` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes unpack b for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn unpackB(color: u32) f32 {
     return @as(f32, @floatFromInt(color & 0xFF)) / 255.0;
 }
 
-/// LOD geometry API `averageColor` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes average color for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn averageColor(c00: u32, c10: u32, c01: u32, c11: u32) u32 {
     const r = ((c00 >> 16) & 0xFF) + ((c10 >> 16) & 0xFF) + ((c01 >> 16) & 0xFF) + ((c11 >> 16) & 0xFF);
     const g = ((c00 >> 8) & 0xFF) + ((c10 >> 8) & 0xFF) + ((c01 >> 8) & 0xFF) + ((c11 >> 8) & 0xFF);
@@ -1131,7 +1197,8 @@ pub fn averageColor(c00: u32, c10: u32, c01: u32, c11: u32) u32 {
     return (r_avg << 16) | (g_avg << 8) | b_avg;
 }
 
-/// LOD geometry API `averageAmbientOcclusion` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes average ambient occlusion for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn averageAmbientOcclusion(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -1144,7 +1211,8 @@ pub fn averageAmbientOcclusion(data: *const LODSimplifiedData, gx: u32, gz: u32)
     return (a00 + a10 + a01 + a11) * 0.25;
 }
 
-/// LOD geometry API `applyColorBrightness` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes apply color brightness for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn applyColorBrightness(color: u32, brightness: f32) u32 {
     const clamped = std.math.clamp(brightness, 0.0, 1.0);
     const r: u32 = @intFromFloat(@round(@as(f32, @floatFromInt((color >> 16) & 0xFF)) * clamped));
@@ -1155,7 +1223,8 @@ pub fn applyColorBrightness(color: u32, brightness: f32) u32 {
 
 pub const LODTextureFace = enum { top, side, bottom };
 
-/// LOD geometry API `tintColorForLodFace` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes tint color for lod face for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn tintColorForLodFace(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, block: BlockType, face: LODTextureFace, fallback: u32) u32 {
     if (block == .grass and face == .top) return averageBiomeBlockTint(data, gx, gz, lod_level, block);
     if (block == .water) return averageBiomeBlockTint(data, gx, gz, lod_level, block);
@@ -1163,7 +1232,8 @@ pub fn tintColorForLodFace(data: *const LODSimplifiedData, gx: u32, gz: u32, lod
     return fallback;
 }
 
-/// LOD geometry API `averageBiomeBlockTint` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes average biome block tint for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn averageBiomeBlockTint(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, block: BlockType) u32 {
     if (isFineSampleLOD(lod_level)) {
         return biome_mod.getBlockTintColor(data.biomes[cellIndex(data, gx, gz)], block);
@@ -1176,7 +1246,8 @@ pub fn averageBiomeBlockTint(data: *const LODSimplifiedData, gx: u32, gz: u32, l
     return averageColor(c00, c10, c01, c11);
 }
 
-/// LOD geometry API `applyTextureLuminance` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes apply texture luminance for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn applyTextureLuminance(color: u32, block: BlockType, face: LODTextureFace, atlas: *const TextureAtlas) u32 {
     if (block == .air or block == .water) return color;
     const texture_color = averageTextureColorForFace(block, face, atlas) orelse {
@@ -1193,7 +1264,8 @@ pub fn applyTextureLuminance(color: u32, block: BlockType, face: LODTextureFace,
     return multiplyColors(texture_color, shaderLikeTintColor(color));
 }
 
-/// LOD geometry API `averageTextureColorForFace` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes average texture color for face for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn averageTextureColorForFace(block: BlockType, face: LODTextureFace, atlas: *const TextureAtlas) ?u32 {
     const tiles = atlas.getTilesForBlock(@intFromEnum(block));
     const tile_id = switch (face) {
@@ -1211,14 +1283,16 @@ pub fn averageTextureColorForFace(block: BlockType, face: LODTextureFace, atlas:
     };
 }
 
-/// LOD geometry API `shouldTintLodFace` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Reports whether should tint lod face for a sampled LOD cell or span.
+/// The query is deterministic and does not mutate the supplied simplified data.
 pub fn shouldTintLodFace(block: BlockType, face: LODTextureFace) bool {
     if (block == .grass) return face == .top;
     if (block == .water) return true;
     return isLeafBlock(block);
 }
 
-/// LOD geometry API `multiplyColors` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes multiply colors for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn multiplyColors(base: u32, tint: u32) u32 {
     const r: u32 = @intFromFloat(@round(unpackR(base) * unpackR(tint) * 255.0));
     const g: u32 = @intFromFloat(@round(unpackG(base) * unpackG(tint) * 255.0));
@@ -1229,7 +1303,8 @@ pub fn multiplyColors(base: u32, tint: u32) u32 {
     return (rr << 16) | (gg << 8) | bb;
 }
 
-/// LOD geometry API `shaderLikeTintColor` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes shader like tint color for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn shaderLikeTintColor(color: u32) u32 {
     const r: u32 = (color >> 16) & 0xFF;
     const g: u32 = (color >> 8) & 0xFF;
@@ -1254,13 +1329,15 @@ pub fn shaderLikeTintColor(color: u32) u32 {
     return (rr << 16) | (gg << 8) | bb;
 }
 
-/// LOD geometry API `smoothstep` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes smoothstep for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn smoothstep(edge0: f32, edge1: f32, x: f32) f32 {
     const t = std.math.clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
     return t * t * (3.0 - 2.0 * t);
 }
 
-/// LOD geometry API `scaleColor` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes scale color for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn scaleColor(color: u32, factor: f32) u32 {
     const clamped = std.math.clamp(factor, 0.0, 2.0);
     const r: u32 = @intFromFloat(@round(std.math.clamp(@as(f32, @floatFromInt((color >> 16) & 0xFF)) * clamped, 0.0, 255.0)));
@@ -1269,7 +1346,8 @@ pub fn scaleColor(color: u32, factor: f32) u32 {
     return (r << 16) | (g << 8) | b;
 }
 
-/// LOD geometry API `packBlockDefaultColor` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes pack block default color for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn packBlockDefaultColor(block: BlockType, fallback: u32) u32 {
     if (block == .air) return fallback;
     const color = world_core.block_registry.getBlockDefinition(block).default_color;
@@ -1279,7 +1357,8 @@ pub fn packBlockDefaultColor(block: BlockType, fallback: u32) u32 {
     return (r << 16) | (g << 8) | b;
 }
 
-/// LOD geometry API `getLodTopTile` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes get lod top tile for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn getLodTopTile(block: BlockType, atlas: *const TextureAtlas) u16 {
     if (block == .air) return Vertex.LOD_TILE_ID;
     if (isLeafBlock(block)) return Vertex.LOD_TILE_ID;
@@ -1289,14 +1368,16 @@ pub fn getLodTopTile(block: BlockType, atlas: *const TextureAtlas) u16 {
     return tiles.top;
 }
 
-/// LOD geometry API `getLodTopColor` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes get lod top color for LOD material shading.
+/// Inputs are packed RGB or biome/material samples; the result is safe to store in mesh vertices.
 pub fn getLodTopColor(block: BlockType, tile_id: u16, fallback_color: u32) u32 {
     _ = block;
     if (tile_id == Vertex.LOD_TILE_ID) return fallback_color;
     return fallback_color;
 }
 
-/// LOD geometry API `makeLODVertex` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Computes make l o d vertex for LOD mesh generation.
+/// The function is pure with respect to caller-owned world data unless output buffers are explicit parameters.
 pub fn makeLODVertex(pos: [3]f32, col: [3]f32, norm: [3]f32, uv: [2]f32, tile_id: u16) Vertex {
     return Vertex{
         .pos = pos,
@@ -1386,7 +1467,8 @@ pub fn addSideFaceQuad(allocator: std.mem.Allocator, vertices: *std.ArrayListUnm
     try vertices.append(allocator, makeLODVertex(corners[3], color, normal, sideFaceUV(corners[3], dir, world_x, world_z), tile_id));
 }
 
-/// LOD geometry API `addTreeColumn` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Appends add tree column geometry to the provided mesh buffers.
+/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
 pub fn addTreeColumn(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -1409,7 +1491,8 @@ pub fn addTreeColumn(
     try addTreeCanopyColumn(allocator, vertices, data, gx, gz, lod_level, wx, wz, cell_size, base_height, canopy.min_height, canopy.max_height, vegetation, atlas, world_x, world_z);
 }
 
-/// LOD geometry API `addTreeCanopyColumn` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Appends add tree canopy column geometry to the provided mesh buffers.
+/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
 pub fn addTreeCanopyColumn(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -1448,7 +1531,8 @@ pub fn addTreeCanopyColumn(
     }
 }
 
-/// LOD geometry API `treeCanopyFootprint` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Derives tree canopy footprint for distant vegetation representation.
+/// The result is based on simplified vegetation hints and LOD level.
 pub fn treeCanopyFootprint(cell_size: f32, vegetation: world_core.LODVegetationHint) f32 {
     const coverage = std.math.clamp(vegetation.tree_coverage, LOD_TREE_COVERAGE_THRESHOLD, 1.0);
     const desired = @max(1.0, vegetation.avg_tree_height * (0.30 + coverage * 0.18));
@@ -1459,7 +1543,8 @@ pub fn treeCanopyFootprint(cell_size: f32, vegetation: world_core.LODVegetationH
 
 pub const TreeFootprintOrigin = struct { x: f32, z: f32 };
 
-/// LOD geometry API `treeFootprintOrigin` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Derives tree footprint origin for distant vegetation representation.
+/// The result is based on simplified vegetation hints and LOD level.
 pub fn treeFootprintOrigin(wx: f32, wz: f32, cell_size: f32, footprint: f32, vegetation: world_core.LODVegetationHint) TreeFootprintOrigin {
     const max_offset = @max(0.0, (cell_size - footprint) * 0.5 - 0.01);
     const offset_x = std.math.clamp(vegetation.offset_x, -max_offset, max_offset);
@@ -1470,7 +1555,8 @@ pub fn treeFootprintOrigin(wx: f32, wz: f32, cell_size: f32, footprint: f32, veg
     };
 }
 
-/// LOD geometry API `treeCanopyInterval` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Derives tree canopy interval for distant vegetation representation.
+/// The result is based on simplified vegetation hints and LOD level.
 pub fn treeCanopyInterval(base_height: f32, vegetation: world_core.LODVegetationHint) HeightInterval {
     const canopy_height = @max(3.0, vegetation.avg_tree_height);
     const top = base_height + canopy_height;
@@ -1481,7 +1567,8 @@ pub fn treeCanopyInterval(base_height: f32, vegetation: world_core.LODVegetation
     };
 }
 
-/// LOD geometry API `addTreeColumnSides` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Appends add tree column sides geometry to the provided mesh buffers.
+/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
 pub fn addTreeColumnSides(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -1504,7 +1591,8 @@ pub fn addTreeColumnSides(
     try addTreeColumnSide(allocator, vertices, data, gx, if (gz + 1 >= data.width - 1) null else gz + 1, lod_level, wx, wz, size, canopy, color, tile_id, .south, world_x, world_z);
 }
 
-/// LOD geometry API `addTreeColumnSide` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Appends add tree column side geometry to the provided mesh buffers.
+/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
 pub fn addTreeColumnSide(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -1547,7 +1635,8 @@ pub fn addTreeColumnSide(
     }
 }
 
-/// LOD geometry API `addBoxColumn` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+/// Appends add box column geometry to the provided mesh buffers.
+/// The caller owns the vertex/index lists and receives allocation errors from growth operations.
 pub fn addBoxColumn(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),

--- a/modules/world-lod/src/lod_geometry.zig
+++ b/modules/world-lod/src/lod_geometry.zig
@@ -50,6 +50,7 @@ pub const SkirtParams = struct {
 
 pub const SkirtDir = enum { north, south, east, west };
 
+/// LOD geometry API `makeSkirtQuad` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn makeSkirtQuad(params: SkirtParams, tile_id: u16, world_x: i32, world_z: i32) [4]Vertex {
     const p = params;
     const cr = unpackR(p.avg_c) * p.brightness;
@@ -92,6 +93,7 @@ pub fn makeSkirtQuad(params: SkirtParams, tile_id: u16, world_x: i32, world_z: i
     };
 }
 
+/// LOD geometry API `buildFullDetailHeightmapMesh` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn buildFullDetailHeightmapMesh(
     allocator: std.mem.Allocator,
     lod_level: LODLevel,
@@ -204,47 +206,55 @@ pub const SEA_LEVEL_WATER_EPSILON: f32 = 2.0;
 pub const SYNTHETIC_SEAFLOOR_SKIRT: f32 = 8.0;
 pub const LOD_TREE_COVERAGE_THRESHOLD: f32 = 0.08;
 
-pub fn is_lod_water_cell(data: *const LODSimplifiedData, gx: u32, gz: u32) bool {
-    const stats = water_coverage_stats(data, gx, gz);
+/// LOD geometry API `isLODWaterCell` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+pub fn isLODWaterCell(data: *const LODSimplifiedData, gx: u32, gz: u32) bool {
+    const stats = waterCoverageStats(data, gx, gz);
     const water_coverage = stats.average_coverage;
     if (water_coverage >= 0.35) return true;
     return stats.wet_samples >= 2 and water_coverage >= 0.25 and stats.representative_depth >= 1.5;
 }
 
-pub fn is_fine_sample_lod(lod_level: LODLevel) bool {
+/// LOD geometry API `isFineSampleLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+pub fn isFineSampleLOD(lod_level: LODLevel) bool {
     return @intFromEnum(lod_level) <= @intFromEnum(LODLevel.lod1);
 }
 
-pub fn cell_index(data: *const LODSimplifiedData, gx: u32, gz: u32) u32 {
+/// LOD geometry API `cellIndex` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+pub fn cellIndex(data: *const LODSimplifiedData, gx: u32, gz: u32) u32 {
     return @min(gx, data.width - 1) + @min(gz, data.width - 1) * data.width;
 }
 
-pub fn cell_color_for_lod(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) u32 {
-    if (is_fine_sample_lod(lod_level)) return data.colors[cell_index(data, gx, gz)];
-    const c00 = data.colors[cell_index(data, gx, gz)];
-    const c10 = data.colors[cell_index(data, gx + 1, gz)];
-    const c01 = data.colors[cell_index(data, gx, gz + 1)];
-    const c11 = data.colors[cell_index(data, gx + 1, gz + 1)];
+/// LOD geometry API `cellColorForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+pub fn cellColorForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) u32 {
+    if (isFineSampleLOD(lod_level)) return data.colors[cellIndex(data, gx, gz)];
+    const c00 = data.colors[cellIndex(data, gx, gz)];
+    const c10 = data.colors[cellIndex(data, gx + 1, gz)];
+    const c01 = data.colors[cellIndex(data, gx, gz + 1)];
+    const c11 = data.colors[cellIndex(data, gx + 1, gz + 1)];
     return averageColor(c00, c10, c01, c11);
 }
 
-pub fn ambient_occlusion_for_lod(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
-    if (is_fine_sample_lod(lod_level)) return data.lighting[cell_index(data, gx, gz)].ambient_occlusion;
+/// LOD geometry API `ambientOcclusionForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+pub fn ambientOcclusionForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
+    if (isFineSampleLOD(lod_level)) return data.lighting[cellIndex(data, gx, gz)].ambient_occlusion;
     return averageAmbientOcclusion(data, gx, gz);
 }
 
-pub fn is_lod_water_cell_for_lod(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) bool {
-    if (is_fine_sample_lod(lod_level)) {
-        const water = data.water[cell_index(data, gx, gz)];
+/// LOD geometry API `isLODWaterCellForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+pub fn isLODWaterCellForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) bool {
+    if (isFineSampleLOD(lod_level)) {
+        const water = data.water[cellIndex(data, gx, gz)];
         return water.is_surface and water.coverage > 0.0 and water.depth >= 0.25;
     }
-    return is_lod_water_cell(data, gx, gz);
+    return isLODWaterCell(data, gx, gz);
 }
 
+/// LOD geometry API `quantizedHeight` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn quantizedHeight(height: f32) f32 {
     return @round(height);
 }
 
+/// LOD geometry API `terrainHeightForPoint` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn terrainHeightForPoint(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const clamped_x = @min(gx, data.width - 1);
     const clamped_z = @min(gz, data.width - 1);
@@ -260,42 +270,50 @@ pub fn terrainHeightForPoint(data: *const LODSimplifiedData, gx: u32, gz: u32) f
     return @min(height, floor_height);
 }
 
+/// LOD geometry API `terrainSurfaceHeightForPoint` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn terrainSurfaceHeightForPoint(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const clamped_x = @min(gx, data.width - 1);
     const clamped_z = @min(gz, data.width - 1);
     return stitchedHeight(data, clamped_x, clamped_z);
 }
 
+/// LOD geometry API `quantizedTerrainHeightForPoint` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn quantizedTerrainHeightForPoint(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return quantizedHeight(terrainHeightForPoint(data, gx, gz));
 }
 
+/// LOD geometry API `quantizedCellTerrainHeight` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn quantizedCellTerrainHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return quantizedHeight(terrainHeightForPoint(data, gx, gz));
 }
 
+/// LOD geometry API `quantizedCellSurfaceHeight` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn quantizedCellSurfaceHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return quantizedHeight(terrainSurfaceHeightForPoint(data, gx, gz));
 }
 
+/// LOD geometry API `quantizedCellTerrainHeightForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn quantizedCellTerrainHeightForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
-    if (is_fine_sample_lod(lod_level)) return quantizedTerrainHeightForPoint(data, gx, gz);
+    if (isFineSampleLOD(lod_level)) return quantizedTerrainHeightForPoint(data, gx, gz);
     return quantizedCellTerrainHeight(data, gx, gz);
 }
 
+/// LOD geometry API `quantizedCellVisualTerrainHeightForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn quantizedCellVisualTerrainHeightForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, is_water_cell: bool) f32 {
     if (is_water_cell) return quantizedCellTerrainHeightForLOD(data, gx, gz, lod_level);
-    if (is_fine_sample_lod(lod_level)) return quantizedHeight(terrainSurfaceHeightForPoint(data, gx, gz));
+    if (isFineSampleLOD(lod_level)) return quantizedHeight(terrainSurfaceHeightForPoint(data, gx, gz));
     return quantizedCellSurfaceHeight(data, gx, gz);
 }
 
+/// LOD geometry API `maxWaterSurfaceHeightForCell` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn maxWaterSurfaceHeightForCell(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) ?f32 {
     return representativeWaterSurfaceHeightForCell(data, gx, gz, lod_level);
 }
 
+/// LOD geometry API `representativeWaterSurfaceHeightForCell` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn representativeWaterSurfaceHeightForCell(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) ?f32 {
-    if (is_fine_sample_lod(lod_level)) {
-        const idx = cell_index(data, gx, gz);
+    if (isFineSampleLOD(lod_level)) {
+        const idx = cellIndex(data, gx, gz);
         const water = data.water[idx];
         if (!water.is_surface or water.coverage <= 0.0) return null;
         return normalizedWaterSurfaceHeight(data, idx, water);
@@ -321,6 +339,7 @@ pub fn representativeWaterSurfaceHeightForCell(data: *const LODSimplifiedData, g
     return null;
 }
 
+/// LOD geometry API `normalizedWaterSurfaceHeight` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn normalizedWaterSurfaceHeight(data: *const LODSimplifiedData, idx: u32, water: world_core.LODWaterState) f32 {
     if (isOceanBiome(data.biomes[idx]) and @abs(water.surface_height - WORLDGEN_SEA_LEVEL) <= SEA_LEVEL_WATER_EPSILON) {
         return WORLDGEN_SEA_LEVEL;
@@ -328,6 +347,7 @@ pub fn normalizedWaterSurfaceHeight(data: *const LODSimplifiedData, idx: u32, wa
     return water.surface_height;
 }
 
+/// LOD geometry API `isOceanBiome` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn isOceanBiome(biome: BiomeId) bool {
     return switch (biome) {
         .deep_ocean, .ocean, .warm_ocean, .frozen_ocean, .cold_ocean => true,
@@ -335,11 +355,13 @@ pub fn isOceanBiome(biome: BiomeId) bool {
     };
 }
 
+/// LOD geometry API `quantizedWaterSurfaceHeightForCell` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn quantizedWaterSurfaceHeightForCell(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
     if (maxWaterSurfaceHeightForCell(data, gx, gz, lod_level)) |height| return quantizedHeight(height);
     return quantizedCellTerrainHeightForLOD(data, gx, gz, lod_level);
 }
 
+/// LOD geometry API `quantizedWaterSurfaceHeightForSpan` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn quantizedWaterSurfaceHeightForSpan(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, fallback_height: f32) f32 {
     if (maxWaterSurfaceHeightForCell(data, gx, gz, lod_level)) |height| return quantizedHeight(height);
     return quantizedHeight(fallback_height);
@@ -351,15 +373,18 @@ pub const FoldedCanopyColumn = struct {
     color: u32,
 };
 
+/// LOD geometry API `shouldFoldCanopyIntoTerrain` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn shouldFoldCanopyIntoTerrain(lod_level: LODLevel) bool {
     _ = lod_level;
     return false;
 }
 
+/// LOD geometry API `shouldRenderLODTreeTrunk` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn shouldRenderLODTreeTrunk(lod_level: LODLevel) bool {
     return @intFromEnum(lod_level) <= @intFromEnum(LODLevel.lod3);
 }
 
+/// LOD geometry API `foldedCanopyColumnForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn foldedCanopyColumnForLOD(
     data: *const LODSimplifiedData,
     gx: u32,
@@ -384,8 +409,9 @@ pub fn foldedCanopyColumnForLOD(
     };
 }
 
+/// LOD geometry API `quantizedVisualColumnHeightForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn quantizedVisualColumnHeightForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) f32 {
-    const is_water_cell = is_lod_water_cell_for_lod(data, gx, gz, lod_level);
+    const is_water_cell = isLODWaterCellForLOD(data, gx, gz, lod_level);
     const terrain_block = terrainBlockForLODQuadForLOD(data, gx, gz, is_water_cell, lod_level);
     const base_height = quantizedCellVisualTerrainHeightForLOD(data, gx, gz, lod_level, is_water_cell);
     if (foldedCanopyColumnForLOD(data, gx, gz, lod_level, base_height, terrain_block, is_water_cell)) |folded| {
@@ -394,6 +420,7 @@ pub fn quantizedVisualColumnHeightForLOD(data: *const LODSimplifiedData, gx: u32
     return base_height;
 }
 
+/// LOD geometry API `terrainBlockForLODQuad` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn terrainBlockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32, is_water_cell: bool) BlockType {
     if (!is_water_cell) return blockForLODQuad(data, gx, gz);
 
@@ -407,11 +434,12 @@ pub fn terrainBlockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32, 
     return data.biomes[idx].getOceanFloorBlock(representativeWaterDepth(data, gx, gz));
 }
 
+/// LOD geometry API `terrainBlockForLODQuadForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn terrainBlockForLODQuadForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, is_water_cell: bool, lod_level: LODLevel) BlockType {
-    if (!is_fine_sample_lod(lod_level)) return terrainBlockForLODQuad(data, gx, gz, is_water_cell);
+    if (!isFineSampleLOD(lod_level)) return terrainBlockForLODQuad(data, gx, gz, is_water_cell);
     if (!is_water_cell) return blockForLODCell(data, gx, gz);
 
-    const idx = cell_index(data, gx, gz);
+    const idx = cellIndex(data, gx, gz);
     const subsurface = data.material_layers[idx].subsurface;
     if (subsurface != .air and subsurface != .water) return subsurface;
     const surface = data.material_layers[idx].surface;
@@ -419,6 +447,7 @@ pub fn terrainBlockForLODQuadForLOD(data: *const LODSimplifiedData, gx: u32, gz:
     return data.biomes[idx].getOceanFloorBlock(data.water[idx].depth);
 }
 
+/// LOD geometry API `getLodSideTile` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn getLodSideTile(block: BlockType, atlas: *const TextureAtlas) u16 {
     if (block == .air) return Vertex.LOD_TILE_ID;
     if (isLeafBlock(block)) return Vertex.LOD_TILE_ID;
@@ -427,10 +456,12 @@ pub fn getLodSideTile(block: BlockType, atlas: *const TextureAtlas) u16 {
     return tiles.side;
 }
 
+/// LOD geometry API `boundarySkirtDepth` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn boundarySkirtDepth(size: f32) f32 {
     return std.math.clamp(size, 16.0, 32.0);
 }
 
+/// LOD geometry API `heightfieldSideBrightness` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn heightfieldSideBrightness(dir: FaceDir) f32 {
     return switch (dir) {
         .west, .east => 0.8,
@@ -438,6 +469,7 @@ pub fn heightfieldSideBrightness(dir: FaceDir) f32 {
     };
 }
 
+/// LOD geometry API `addSteppedHeightfieldSides` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn addSteppedHeightfieldSides(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -460,6 +492,7 @@ pub fn addSteppedHeightfieldSides(
     try addHeightfieldSide(allocator, vertices, wx, wz, size, column_height, if (gz + 1 >= data.width - 1) null else quantizedVisualColumnHeightForLOD(data, gx, gz + 1, lod_level), color, side_tile, .south, world_x, world_z);
 }
 
+/// LOD geometry API `addHeightfieldSide` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn addHeightfieldSide(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -493,6 +526,7 @@ pub const HeightInterval = struct {
     max_height: f32,
 };
 
+/// LOD geometry API `collectColumnSpans` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn collectColumnSpans(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, out: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]LODColumnSpan) usize {
     var count: usize = 0;
     var has_water_span = false;
@@ -570,6 +604,7 @@ pub fn collectColumnSpans(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_
     return count;
 }
 
+/// LOD geometry API `syntheticSeafloorMinHeight` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn syntheticSeafloorMinHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const x_min = if (gx == 0) gx else gx - 1;
     const z_min = if (gz == 0) gz else gz - 1;
@@ -588,10 +623,11 @@ pub fn syntheticSeafloorMinHeight(data: *const LODSimplifiedData, gx: u32, gz: u
     return @max(0.0, min_height - SYNTHETIC_SEAFLOOR_SKIRT);
 }
 
+/// LOD geometry API `foldCanopyIntoSpansForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn foldCanopyIntoSpansForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, spans: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]LODColumnSpan, count: *usize) void {
     if (!shouldFoldCanopyIntoTerrain(lod_level) or count.* == 0) return;
 
-    const is_water_cell = is_lod_water_cell_for_lod(data, gx, gz, lod_level);
+    const is_water_cell = isLODWaterCellForLOD(data, gx, gz, lod_level);
     const terrain_block = terrainBlockForLODQuadForLOD(data, gx, gz, is_water_cell, lod_level);
     const base_height = quantizedCellVisualTerrainHeightForLOD(data, gx, gz, lod_level, is_water_cell);
     const folded = foldedCanopyColumnForLOD(data, gx, gz, lod_level, base_height, terrain_block, is_water_cell) orelse return;
@@ -626,20 +662,23 @@ pub fn foldCanopyIntoSpansForLOD(data: *const LODSimplifiedData, gx: u32, gz: u3
         .max_height = folded.height,
         .block = folded.block,
         .color = folded.color,
-        .ambient_occlusion = ambient_occlusion_for_lod(data, gx, gz, lod_level),
+        .ambient_occlusion = ambientOcclusionForLOD(data, gx, gz, lod_level),
     });
 }
 
+/// LOD geometry API `isDetachedCanopySpan` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn isDetachedCanopySpan(span: LODColumnSpan, base_height: f32) bool {
     return isLeafBlock(span.block) and span.min_height > base_height + 0.5;
 }
 
+/// LOD geometry API `representativeSpanBlock` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn representativeSpanBlock(layers: world_core.LODMaterialLayers) BlockType {
     if (layers.surface != .air) return layers.surface;
     if (layers.subsurface != .air) return layers.subsurface;
     return layers.foundation;
 }
 
+/// LOD geometry API `insertColumnSpan` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn insertColumnSpan(out: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]LODColumnSpan, count: *usize, span: LODColumnSpan) void {
     if (count.* >= out.len) return;
     var dst = count.*;
@@ -650,6 +689,7 @@ pub fn insertColumnSpan(out: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]LODColumnSp
     out[dst] = span;
 }
 
+/// LOD geometry API `highestSolidSpanIndex` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn highestSolidSpanIndex(spans: []const LODColumnSpan) ?usize {
     var i = spans.len;
     while (i > 0) {
@@ -659,6 +699,7 @@ pub fn highestSolidSpanIndex(spans: []const LODColumnSpan) ?usize {
     return null;
 }
 
+/// LOD geometry API `addExposedSpanFaces` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn addExposedSpanFaces(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -681,6 +722,7 @@ pub fn addExposedSpanFaces(
     try addExposedSpanFace(allocator, vertices, data, gx, gz, gx, if (gz + 1 >= data.width - 1) null else gz + 1, lod_level, span, wx, wz, size, color, tile_id, .south, world_x, world_z);
 }
 
+/// LOD geometry API `addExposedSpanFace` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn addExposedSpanFace(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -733,6 +775,7 @@ pub fn addExposedSpanFace(
     }
 }
 
+/// LOD geometry API `subtractCoveredInterval` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn subtractCoveredInterval(intervals: *[world_core.MAX_LOD_VERTICAL_SPANS + 1]HeightInterval, count: *usize, cover_min: f32, cover_max: f32) void {
     var i: usize = 0;
     while (i < count.*) {
@@ -774,10 +817,12 @@ pub fn subtractCoveredInterval(intervals: *[world_core.MAX_LOD_VERTICAL_SPANS + 
 pub const LOD_UV_BLOCK_SCALE: f32 = 1.0;
 pub const LOD_UV_WRAP_BLOCKS: i32 = 256;
 
+/// LOD geometry API `lodUVOffset` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn lodUVOffset(coord: i32) f32 {
     return @floatFromInt(@mod(coord, LOD_UV_WRAP_BLOCKS));
 }
 
+/// LOD geometry API `topFaceUV` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn topFaceUV(pos: [3]f32, world_x: i32, world_z: i32) [2]f32 {
     return .{
         (lodUVOffset(world_x) + pos[0]) * LOD_UV_BLOCK_SCALE,
@@ -785,6 +830,7 @@ pub fn topFaceUV(pos: [3]f32, world_x: i32, world_z: i32) [2]f32 {
     };
 }
 
+/// LOD geometry API `sideFaceUV` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn sideFaceUV(pos: [3]f32, dir: FaceDir, world_x: i32, world_z: i32) [2]f32 {
     const horizontal = switch (dir) {
         .north, .south => lodUVOffset(world_x) + pos[0],
@@ -793,6 +839,7 @@ pub fn sideFaceUV(pos: [3]f32, dir: FaceDir, world_x: i32, world_z: i32) [2]f32 
     return .{ horizontal * LOD_UV_BLOCK_SCALE, pos[1] * LOD_UV_BLOCK_SCALE };
 }
 
+/// LOD geometry API `skirtDirToFaceDir` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn skirtDirToFaceDir(dir: SkirtDir) FaceDir {
     return switch (dir) {
         .north => .north,
@@ -802,6 +849,7 @@ pub fn skirtDirToFaceDir(dir: SkirtDir) FaceDir {
     };
 }
 
+/// LOD geometry API `blockForLODCell` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn blockForLODCell(data: *const LODSimplifiedData, gx: u32, gz: u32) BlockType {
     const clamped_x = @min(gx, data.width - 1);
     const clamped_z = @min(gz, data.width - 1);
@@ -812,11 +860,13 @@ pub fn blockForLODCell(data: *const LODSimplifiedData, gx: u32, gz: u32) BlockTy
     return data.biomes[idx].getSurfaceBlock();
 }
 
+/// LOD geometry API `blockForLODQuad` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn blockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32) BlockType {
-    if (is_lod_water_cell(data, gx, gz)) return .water;
+    if (isLODWaterCell(data, gx, gz)) return .water;
     return representativeSurfaceBlock(data, gx, gz);
 }
 
+/// LOD geometry API `representativeSurfaceBlock` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn representativeSurfaceBlock(data: *const LODSimplifiedData, gx: u32, gz: u32) BlockType {
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -850,6 +900,7 @@ pub fn representativeSurfaceBlock(data: *const LODSimplifiedData, gx: u32, gz: u
     return blockForLODCell(data, gx, gz);
 }
 
+/// LOD geometry API `representativeWaterDepth` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn representativeWaterDepth(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -874,6 +925,7 @@ pub fn representativeWaterDepth(data: *const LODSimplifiedData, gx: u32, gz: u32
     return weighted_depth / coverage;
 }
 
+/// LOD geometry API `selectCellMaterial` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn selectCellMaterial(data: *const LODSimplifiedData, atlas: *const TextureAtlas, gx: u32, gz: u32) TextureAtlas.BlockTiles {
     const top_block = blockForLODQuad(data, gx, gz);
     const side_block = sideBlockForLODQuad(data, gx, gz, top_block);
@@ -886,6 +938,7 @@ pub fn selectCellMaterial(data: *const LODSimplifiedData, atlas: *const TextureA
     };
 }
 
+/// LOD geometry API `sideBlockForLODQuad` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn sideBlockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32, top_block: BlockType) BlockType {
     if (top_block != .water) return top_block;
 
@@ -909,10 +962,12 @@ pub fn sideBlockForLODQuad(data: *const LODSimplifiedData, gx: u32, gz: u32, top
     return blockForLODCell(data, gx, gz);
 }
 
+/// LOD geometry API `shouldRenderLODTree` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn shouldRenderLODTree(top_block: BlockType) bool {
     return top_block != .water and top_block != .air;
 }
 
+/// LOD geometry API `isLeafBlock` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn isLeafBlock(block: BlockType) bool {
     return switch (block) {
         .leaves,
@@ -926,11 +981,13 @@ pub fn isLeafBlock(block: BlockType) bool {
     };
 }
 
+/// LOD geometry API `representativeVegetationForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn representativeVegetationForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel) world_core.LODVegetationHint {
-    if (is_fine_sample_lod(lod_level)) return data.vegetation[cell_index(data, gx, gz)];
+    if (isFineSampleLOD(lod_level)) return data.vegetation[cellIndex(data, gx, gz)];
     return representativeVegetation(data, gx, gz);
 }
 
+/// LOD geometry API `representativeVegetation` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn representativeVegetation(data: *const LODSimplifiedData, gx: u32, gz: u32) world_core.LODVegetationHint {
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -959,8 +1016,9 @@ pub fn representativeVegetation(data: *const LODSimplifiedData, gx: u32, gz: u32
     return best;
 }
 
+/// LOD geometry API `averageWaterCoverage` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn averageWaterCoverage(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
-    return water_coverage_stats(data, gx, gz).average_coverage;
+    return waterCoverageStats(data, gx, gz).average_coverage;
 }
 
 pub const WaterCoverageStats = struct {
@@ -969,7 +1027,8 @@ pub const WaterCoverageStats = struct {
     representative_depth: f32,
 };
 
-pub fn water_coverage_stats(data: *const LODSimplifiedData, gx: u32, gz: u32) WaterCoverageStats {
+/// LOD geometry API `waterCoverageStats` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
+pub fn waterCoverageStats(data: *const LODSimplifiedData, gx: u32, gz: u32) WaterCoverageStats {
     if (data.width == 0) return .{ .average_coverage = 0.0, .wet_samples = 0, .representative_depth = 0.0 };
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -1002,15 +1061,17 @@ pub fn water_coverage_stats(data: *const LODSimplifiedData, gx: u32, gz: u32) Wa
     };
 }
 
+/// LOD geometry API `shouldEmitWaterSpanForLOD` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn shouldEmitWaterSpanForLOD(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, water: world_core.LODWaterState) bool {
     if (!water.is_surface or water.coverage <= 0.0 or water.depth <= 0.01) return false;
-    if (is_fine_sample_lod(lod_level)) return true;
+    if (isFineSampleLOD(lod_level)) return true;
     if (water.coverage >= 0.35) return true;
 
-    const stats = water_coverage_stats(data, gx, gz);
+    const stats = waterCoverageStats(data, gx, gz);
     return stats.wet_samples >= 2 and stats.average_coverage >= 0.25 and stats.representative_depth >= 1.5;
 }
 
+/// LOD geometry API `stitchedHeight` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn stitchedHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const height = data.getHeight(gx, gz);
     if (data.width < 5) return height;
@@ -1028,6 +1089,7 @@ pub fn stitchedHeight(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     return height * (1.0 - blend) + coarse_height * blend;
 }
 
+/// LOD geometry API `maxStitchedHeightAdjustment` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn maxStitchedHeightAdjustment(data: *const LODSimplifiedData) f32 {
     if (data.width < 5) return 0.0;
 
@@ -1043,18 +1105,22 @@ pub fn maxStitchedHeightAdjustment(data: *const LODSimplifiedData) f32 {
 }
 
 // Helper functions for unpacking colors
+/// LOD geometry API `unpackR` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn unpackR(color: u32) f32 {
     return @as(f32, @floatFromInt((color >> 16) & 0xFF)) / 255.0;
 }
 
+/// LOD geometry API `unpackG` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn unpackG(color: u32) f32 {
     return @as(f32, @floatFromInt((color >> 8) & 0xFF)) / 255.0;
 }
 
+/// LOD geometry API `unpackB` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn unpackB(color: u32) f32 {
     return @as(f32, @floatFromInt(color & 0xFF)) / 255.0;
 }
 
+/// LOD geometry API `averageColor` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn averageColor(c00: u32, c10: u32, c01: u32, c11: u32) u32 {
     const r = ((c00 >> 16) & 0xFF) + ((c10 >> 16) & 0xFF) + ((c01 >> 16) & 0xFF) + ((c11 >> 16) & 0xFF);
     const g = ((c00 >> 8) & 0xFF) + ((c10 >> 8) & 0xFF) + ((c01 >> 8) & 0xFF) + ((c11 >> 8) & 0xFF);
@@ -1065,6 +1131,7 @@ pub fn averageColor(c00: u32, c10: u32, c01: u32, c11: u32) u32 {
     return (r_avg << 16) | (g_avg << 8) | b_avg;
 }
 
+/// LOD geometry API `averageAmbientOcclusion` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn averageAmbientOcclusion(data: *const LODSimplifiedData, gx: u32, gz: u32) f32 {
     const x0 = @min(gx, data.width - 1);
     const z0 = @min(gz, data.width - 1);
@@ -1077,6 +1144,7 @@ pub fn averageAmbientOcclusion(data: *const LODSimplifiedData, gx: u32, gz: u32)
     return (a00 + a10 + a01 + a11) * 0.25;
 }
 
+/// LOD geometry API `applyColorBrightness` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn applyColorBrightness(color: u32, brightness: f32) u32 {
     const clamped = std.math.clamp(brightness, 0.0, 1.0);
     const r: u32 = @intFromFloat(@round(@as(f32, @floatFromInt((color >> 16) & 0xFF)) * clamped));
@@ -1087,6 +1155,7 @@ pub fn applyColorBrightness(color: u32, brightness: f32) u32 {
 
 pub const LODTextureFace = enum { top, side, bottom };
 
+/// LOD geometry API `tintColorForLodFace` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn tintColorForLodFace(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, block: BlockType, face: LODTextureFace, fallback: u32) u32 {
     if (block == .grass and face == .top) return averageBiomeBlockTint(data, gx, gz, lod_level, block);
     if (block == .water) return averageBiomeBlockTint(data, gx, gz, lod_level, block);
@@ -1094,18 +1163,20 @@ pub fn tintColorForLodFace(data: *const LODSimplifiedData, gx: u32, gz: u32, lod
     return fallback;
 }
 
+/// LOD geometry API `averageBiomeBlockTint` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn averageBiomeBlockTint(data: *const LODSimplifiedData, gx: u32, gz: u32, lod_level: LODLevel, block: BlockType) u32 {
-    if (is_fine_sample_lod(lod_level)) {
-        return biome_mod.getBlockTintColor(data.biomes[cell_index(data, gx, gz)], block);
+    if (isFineSampleLOD(lod_level)) {
+        return biome_mod.getBlockTintColor(data.biomes[cellIndex(data, gx, gz)], block);
     }
 
-    const c00 = biome_mod.getBlockTintColor(data.biomes[cell_index(data, gx, gz)], block);
-    const c10 = biome_mod.getBlockTintColor(data.biomes[cell_index(data, gx + 1, gz)], block);
-    const c01 = biome_mod.getBlockTintColor(data.biomes[cell_index(data, gx, gz + 1)], block);
-    const c11 = biome_mod.getBlockTintColor(data.biomes[cell_index(data, gx + 1, gz + 1)], block);
+    const c00 = biome_mod.getBlockTintColor(data.biomes[cellIndex(data, gx, gz)], block);
+    const c10 = biome_mod.getBlockTintColor(data.biomes[cellIndex(data, gx + 1, gz)], block);
+    const c01 = biome_mod.getBlockTintColor(data.biomes[cellIndex(data, gx, gz + 1)], block);
+    const c11 = biome_mod.getBlockTintColor(data.biomes[cellIndex(data, gx + 1, gz + 1)], block);
     return averageColor(c00, c10, c01, c11);
 }
 
+/// LOD geometry API `applyTextureLuminance` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn applyTextureLuminance(color: u32, block: BlockType, face: LODTextureFace, atlas: *const TextureAtlas) u32 {
     if (block == .air or block == .water) return color;
     const texture_color = averageTextureColorForFace(block, face, atlas) orelse {
@@ -1122,6 +1193,7 @@ pub fn applyTextureLuminance(color: u32, block: BlockType, face: LODTextureFace,
     return multiplyColors(texture_color, shaderLikeTintColor(color));
 }
 
+/// LOD geometry API `averageTextureColorForFace` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn averageTextureColorForFace(block: BlockType, face: LODTextureFace, atlas: *const TextureAtlas) ?u32 {
     const tiles = atlas.getTilesForBlock(@intFromEnum(block));
     const tile_id = switch (face) {
@@ -1139,12 +1211,14 @@ pub fn averageTextureColorForFace(block: BlockType, face: LODTextureFace, atlas:
     };
 }
 
+/// LOD geometry API `shouldTintLodFace` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn shouldTintLodFace(block: BlockType, face: LODTextureFace) bool {
     if (block == .grass) return face == .top;
     if (block == .water) return true;
     return isLeafBlock(block);
 }
 
+/// LOD geometry API `multiplyColors` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn multiplyColors(base: u32, tint: u32) u32 {
     const r: u32 = @intFromFloat(@round(unpackR(base) * unpackR(tint) * 255.0));
     const g: u32 = @intFromFloat(@round(unpackG(base) * unpackG(tint) * 255.0));
@@ -1155,6 +1229,7 @@ pub fn multiplyColors(base: u32, tint: u32) u32 {
     return (rr << 16) | (gg << 8) | bb;
 }
 
+/// LOD geometry API `shaderLikeTintColor` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn shaderLikeTintColor(color: u32) u32 {
     const r: u32 = (color >> 16) & 0xFF;
     const g: u32 = (color >> 8) & 0xFF;
@@ -1179,11 +1254,13 @@ pub fn shaderLikeTintColor(color: u32) u32 {
     return (rr << 16) | (gg << 8) | bb;
 }
 
+/// LOD geometry API `smoothstep` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn smoothstep(edge0: f32, edge1: f32, x: f32) f32 {
     const t = std.math.clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
     return t * t * (3.0 - 2.0 * t);
 }
 
+/// LOD geometry API `scaleColor` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn scaleColor(color: u32, factor: f32) u32 {
     const clamped = std.math.clamp(factor, 0.0, 2.0);
     const r: u32 = @intFromFloat(@round(std.math.clamp(@as(f32, @floatFromInt((color >> 16) & 0xFF)) * clamped, 0.0, 255.0)));
@@ -1192,6 +1269,7 @@ pub fn scaleColor(color: u32, factor: f32) u32 {
     return (r << 16) | (g << 8) | b;
 }
 
+/// LOD geometry API `packBlockDefaultColor` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn packBlockDefaultColor(block: BlockType, fallback: u32) u32 {
     if (block == .air) return fallback;
     const color = world_core.block_registry.getBlockDefinition(block).default_color;
@@ -1201,6 +1279,7 @@ pub fn packBlockDefaultColor(block: BlockType, fallback: u32) u32 {
     return (r << 16) | (g << 8) | b;
 }
 
+/// LOD geometry API `getLodTopTile` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn getLodTopTile(block: BlockType, atlas: *const TextureAtlas) u16 {
     if (block == .air) return Vertex.LOD_TILE_ID;
     if (isLeafBlock(block)) return Vertex.LOD_TILE_ID;
@@ -1210,12 +1289,14 @@ pub fn getLodTopTile(block: BlockType, atlas: *const TextureAtlas) u16 {
     return tiles.top;
 }
 
+/// LOD geometry API `getLodTopColor` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn getLodTopColor(block: BlockType, tile_id: u16, fallback_color: u32) u32 {
     _ = block;
     if (tile_id == Vertex.LOD_TILE_ID) return fallback_color;
     return fallback_color;
 }
 
+/// LOD geometry API `makeLODVertex` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn makeLODVertex(pos: [3]f32, col: [3]f32, norm: [3]f32, uv: [2]f32, tile_id: u16) Vertex {
     return Vertex{
         .pos = pos,
@@ -1305,6 +1386,7 @@ pub fn addSideFaceQuad(allocator: std.mem.Allocator, vertices: *std.ArrayListUnm
     try vertices.append(allocator, makeLODVertex(corners[3], color, normal, sideFaceUV(corners[3], dir, world_x, world_z), tile_id));
 }
 
+/// LOD geometry API `addTreeColumn` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn addTreeColumn(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -1327,6 +1409,7 @@ pub fn addTreeColumn(
     try addTreeCanopyColumn(allocator, vertices, data, gx, gz, lod_level, wx, wz, cell_size, base_height, canopy.min_height, canopy.max_height, vegetation, atlas, world_x, world_z);
 }
 
+/// LOD geometry API `addTreeCanopyColumn` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn addTreeCanopyColumn(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -1365,6 +1448,7 @@ pub fn addTreeCanopyColumn(
     }
 }
 
+/// LOD geometry API `treeCanopyFootprint` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn treeCanopyFootprint(cell_size: f32, vegetation: world_core.LODVegetationHint) f32 {
     const coverage = std.math.clamp(vegetation.tree_coverage, LOD_TREE_COVERAGE_THRESHOLD, 1.0);
     const desired = @max(1.0, vegetation.avg_tree_height * (0.30 + coverage * 0.18));
@@ -1375,6 +1459,7 @@ pub fn treeCanopyFootprint(cell_size: f32, vegetation: world_core.LODVegetationH
 
 pub const TreeFootprintOrigin = struct { x: f32, z: f32 };
 
+/// LOD geometry API `treeFootprintOrigin` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn treeFootprintOrigin(wx: f32, wz: f32, cell_size: f32, footprint: f32, vegetation: world_core.LODVegetationHint) TreeFootprintOrigin {
     const max_offset = @max(0.0, (cell_size - footprint) * 0.5 - 0.01);
     const offset_x = std.math.clamp(vegetation.offset_x, -max_offset, max_offset);
@@ -1385,6 +1470,7 @@ pub fn treeFootprintOrigin(wx: f32, wz: f32, cell_size: f32, footprint: f32, veg
     };
 }
 
+/// LOD geometry API `treeCanopyInterval` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn treeCanopyInterval(base_height: f32, vegetation: world_core.LODVegetationHint) HeightInterval {
     const canopy_height = @max(3.0, vegetation.avg_tree_height);
     const top = base_height + canopy_height;
@@ -1395,6 +1481,7 @@ pub fn treeCanopyInterval(base_height: f32, vegetation: world_core.LODVegetation
     };
 }
 
+/// LOD geometry API `addTreeColumnSides` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn addTreeColumnSides(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -1417,6 +1504,7 @@ pub fn addTreeColumnSides(
     try addTreeColumnSide(allocator, vertices, data, gx, if (gz + 1 >= data.width - 1) null else gz + 1, lod_level, wx, wz, size, canopy, color, tile_id, .south, world_x, world_z);
 }
 
+/// LOD geometry API `addTreeColumnSide` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn addTreeColumnSide(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),
@@ -1442,7 +1530,7 @@ pub fn addTreeColumnSide(
         if (neighbor_gz) |nz| {
             const neighbor_veg = representativeVegetationForLOD(data, nx, nz, lod_level);
             if (neighbor_veg.tree_coverage >= LOD_TREE_COVERAGE_THRESHOLD) {
-                const neighbor_is_water_cell = is_lod_water_cell_for_lod(data, nx, nz, lod_level);
+                const neighbor_is_water_cell = isLODWaterCellForLOD(data, nx, nz, lod_level);
                 const neighbor_base = quantizedCellVisualTerrainHeightForLOD(data, nx, nz, lod_level, neighbor_is_water_cell);
                 const neighbor_canopy = treeCanopyInterval(neighbor_base, neighbor_veg);
                 subtractCoveredInterval(&exposed, &exposed_count, neighbor_canopy.min_height, neighbor_canopy.max_height);
@@ -1459,6 +1547,7 @@ pub fn addTreeColumnSide(
     }
 }
 
+/// LOD geometry API `addBoxColumn` derives distant-terrain mesh data from simplified chunk samples without mutating caller-owned inputs.
 pub fn addBoxColumn(
     allocator: std.mem.Allocator,
     vertices: *std.ArrayListUnmanaged(Vertex),

--- a/modules/world-lod/src/lod_manager.zig
+++ b/modules/world-lod/src/lod_manager.zig
@@ -102,14 +102,14 @@ pub const LODIngestionQueue = struct {
     edit_cooldown: f32 = 0.0,
     drain_per_frame: u32 = 4,
 
-    /// Constructs an LOD manager through `init`.
-    /// The manager owns scheduling, cache, mesh, and upload state until `deinit`.
+    /// Creates an empty ingestion queue for chunk-derived LOD source updates.
+    /// The caller owns the queue and must call `deinit` with the same allocator before discarding it.
     pub fn init(allocator: std.mem.Allocator) LODIngestionQueue {
         return .{ .edit_dirty = ChunkCoordSet.init(allocator) };
     }
 
-    /// Releases LOD manager queues, caches, meshes, and worker-owned resources.
-    /// Call after pending LOD work has been quiesced or made safe to discard.
+    /// Releases pending ingestion records and dirty-edit tracking owned by the queue.
+    /// The caller must ensure no other thread is appending to or draining this queue.
     pub fn deinit(self: *LODIngestionQueue, allocator: std.mem.Allocator) void {
         self.pending_ingestions.deinit(allocator);
         self.edit_dirty.deinit();
@@ -222,14 +222,14 @@ pub const LODManager = struct {
         return lod_manager_cache_ops.initCacheTestManager(allocator, cache_dir_path);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `storePlayerChunkPos`.
-    /// Call from the world/update thread that owns the manager.
+    /// Stores the player's current chunk position for scheduler and stale-job checks.
+    /// Safe for worker reads through atomics; write from the world update thread.
     pub fn storePlayerChunkPos(self: *Self, cx: i32, cz: i32) void {
         return lod_manager_core.storePlayerChunkPos(self, cx, cz);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `loadPlayerChunkPos`.
-    /// Call from the world/update thread that owns the manager.
+    /// Loads the most recently stored player chunk position.
+    /// Worker jobs use this snapshot to decide whether generated LOD work is still relevant.
     pub fn loadPlayerChunkPos(self: *const Self) PlayerChunkPos {
         return lod_manager_core.loadPlayerChunkPos(self);
     }
@@ -240,38 +240,38 @@ pub const LODManager = struct {
         return lod_manager_core.deinit(self);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `update`.
-    /// Call from the world/update thread that owns the manager.
+    /// Advances LOD scheduling, ingestion, generation, uploads, transitions, cache flushes, and eviction for one frame.
+    /// Call from the world update thread; errors report failed queueing, mesh creation, or budget/eviction work.
     pub fn update(self: *Self, player_pos: Vec3, player_velocity: Vec3, chunk_checker: ?ChunkChecker, checker_ctx: ?*anyopaque) !void {
         return lod_manager_core.update(self, player_pos, player_velocity, chunk_checker, checker_ctx);
     }
 
-    /// Queries LOD manager state via `getStats`.
-    /// This does not mutate scheduling state except for diagnostics explicitly documented by the implementation.
+    /// Returns a snapshot of LOD scheduling, cache, generation, upload, and renderability counters.
+    /// The returned data is diagnostic only and does not hold locks after the call returns.
     pub fn getStats(self: *Self) LODStats {
         return lod_manager_core.getStats(self);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `pause`.
-    /// Call from the world/update thread that owns the manager.
+    /// Pauses new LOD generation and scheduling work.
+    /// Existing regions and meshes remain available for rendering while paused.
     pub fn pause(self: *Self) void {
         return lod_manager_core.pause(self);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `unpause`.
-    /// Call from the world/update thread that owns the manager.
+    /// Resumes LOD scheduling after a pause.
+    /// Pending queues may be processed by subsequent `update` calls.
     pub fn unpause(self: *Self) void {
         return lod_manager_core.unpause(self);
     }
 
-    /// Queries LOD manager state via `getLODForDistance`.
-    /// This does not mutate scheduling state except for diagnostics explicitly documented by the implementation.
+    /// Selects the configured LOD level for a chunk coordinate relative to the stored player position.
+    /// This is a read-only policy query used by streaming and debug code.
     pub fn getLODForDistance(self: *const Self, chunk_x: i32, chunk_z: i32) LODLevel {
         return lod_manager_core.getLODForDistance(self, chunk_x, chunk_z);
     }
 
-    /// Queries LOD manager state via `isInRange`.
-    /// This does not mutate scheduling state except for diagnostics explicitly documented by the implementation.
+    /// Returns whether a chunk coordinate falls inside the configured LOD horizon.
+    /// This is a read-only culling/scheduling query based on the current player chunk position.
     pub fn isInRange(self: *const Self, chunk_x: i32, chunk_z: i32) bool {
         return lod_manager_core.isInRange(self, chunk_x, chunk_z);
     }
@@ -282,296 +282,296 @@ pub const LODManager = struct {
         return lod_manager_core.render(self, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, layer);
     }
 
-    /// Manages persistent LOD cache data through `enableCache`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Enables persistent source-data caching for LOD regions below `save_dir_path`.
+    /// Allocates and stores the cache path; errors indicate allocation or filesystem setup failure.
     pub fn enableCache(self: *Self, save_dir_path: []const u8) !void {
         return lod_manager_cache_ops.enableCache(self, save_dir_path);
     }
 
-    /// Manages persistent LOD cache data through `flushDirtyStores`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Writes dirty cached source-data containers to persistent storage.
+    /// Intended for the world update/shutdown path; IO failures are logged and leave data eligible for retry.
     pub fn flushDirtyStores(self: *Self) void {
         return lod_manager_cache_ops.flushDirtyStores(self);
     }
 
-    /// Manages persistent LOD cache data through `cacheKey`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Builds the persistent cache key for an LOD region using generator identity and LOD coordinates.
+    /// The returned key is deterministic for the same generator seed/version and region key.
     pub fn cacheKey(self: *const Self, key: LODRegionKey) lod_cache.Key {
         return lod_manager_cache_ops.cacheKey(self, key);
     }
 
-    /// Manages persistent LOD cache data through `legacyCacheFilePath`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Constructs the legacy single-region cache file path for migration or cleanup.
+    /// The returned path is heap allocated and must be freed by the caller.
     pub fn legacyCacheFilePath(self: *Self, save_dir_path: []const u8, key: lod_cache.Key) ![]u8 {
         return lod_manager_cache_ops.legacyCacheFilePath(self, save_dir_path, key);
     }
 
-    /// Manages persistent LOD cache data through `logLegacyCacheNotice`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Logs the one-time notice that legacy LOD cache data was detected.
+    /// This mutates only the cache-store diagnostic flag to avoid repeated log spam.
     pub fn logLegacyCacheNotice(self: *Self) void {
         return lod_manager_cache_ops.logLegacyCacheNotice(self);
     }
 
-    /// Manages persistent LOD cache data through `cacheDirPathSnapshot`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Returns a heap-owned snapshot of the configured cache directory path.
+    /// Returns `null` when caching is disabled or allocation fails.
     pub fn cacheDirPathSnapshot(self: *Self) ?[]u8 {
         return lod_manager_cache_ops.cacheDirPathSnapshot(self);
     }
 
-    /// Manages persistent LOD cache data through `cacheEnabled`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Reports whether persistent LOD source-data caching is currently configured.
+    /// This is a read-only query protected by the cache-store synchronization.
     pub fn cacheEnabled(self: *Self) bool {
         return lod_manager_cache_ops.cacheEnabled(self);
     }
 
-    /// Manages persistent LOD cache data through `readStorePayload`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Reads a serialized LOD cache payload from the container store.
+    /// Returns `null` for cache misses; errors report filesystem or allocation failures.
     pub fn readStorePayload(self: *Self, save_dir_path: []const u8, cache_key: lod_cache.Key) !?[]u8 {
         return lod_manager_cache_ops.readStorePayload(self, save_dir_path, cache_key);
     }
 
-    /// Manages persistent LOD cache data through `writeStorePayload`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Writes a serialized LOD cache payload to the container store.
+    /// Errors report filesystem, allocation, or store-encoding failures.
     pub fn writeStorePayload(self: *Self, save_dir_path: []const u8, cache_key: lod_cache.Key, bytes: []const u8) !void {
         return lod_manager_cache_ops.writeStorePayload(self, save_dir_path, cache_key, bytes);
     }
 
-    /// Manages persistent LOD cache data through `deleteStorePayload`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Deletes one payload from the LOD cache store if it exists.
+    /// Missing payloads are ignored because cache deletion is best-effort cleanup.
     pub fn deleteStorePayload(self: *Self, save_dir_path: []const u8, cache_key: lod_cache.Key) void {
         return lod_manager_cache_ops.deleteStorePayload(self, save_dir_path, cache_key);
     }
 
-    /// Manages persistent LOD cache data through `deleteStoreContainer`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Deletes an entire LOD cache store container path.
+    /// Used by cleanup and migration paths; failures are intentionally non-fatal.
     pub fn deleteStoreContainer(self: *Self, path: []const u8) void {
         return lod_manager_cache_ops.deleteStoreContainer(self, path);
     }
 
-    /// Manages persistent LOD cache data through `loadCachedSourceData`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Loads simplified source data for an LOD region from cache when available and valid.
+    /// Returns `null` for misses, invalid payloads, disabled cache, or generator-version mismatch.
     pub fn loadCachedSourceData(self: *Self, key: LODRegionKey) ?LODSimplifiedData {
         return lod_manager_cache_ops.loadCachedSourceData(self, key);
     }
 
-    /// Manages persistent LOD cache data through `recordCacheHit`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Increments cache-hit counters used by LOD diagnostics.
+    /// This does not mutate cached data or scheduling state.
     pub fn recordCacheHit(self: *Self) void {
         return lod_manager_cache_ops.recordCacheHit(self);
     }
 
-    /// Manages persistent LOD cache data through `recordCacheMiss`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Increments cache-miss counters used by LOD diagnostics.
+    /// This is called when no reusable source data was found for a region.
     pub fn recordCacheMiss(self: *Self) void {
         return lod_manager_cache_ops.recordCacheMiss(self);
     }
 
-    /// Manages persistent LOD cache data through `saveCachedSourceData`.
-    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
+    /// Serializes and stores simplified source data for a completed LOD region.
+    /// The input data is borrowed for the call; persistence failures are logged for later diagnosis.
     pub fn saveCachedSourceData(self: *Self, key: LODRegionKey, data: *const LODSimplifiedData) void {
         return lod_manager_cache_ops.saveCachedSourceData(self, key, data);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `setChunkResolver`.
-    /// Call from the world/update thread that owns the manager.
+    /// Installs the callback used to resolve full-detail chunks for ingestion retries.
+    /// Call from the world update thread before requesting deferred ingestion.
     pub fn setChunkResolver(self: *Self, resolver: ChunkResolver) void {
         return lod_manager_ingestion_ops.setChunkResolver(self, resolver);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `ingestChunk`.
-    /// Call from the world/update thread that owns the manager.
+    /// Folds one full-detail chunk into every matching LOD region's simplified source data.
+    /// Marks affected source data dirty so meshes and cache payloads can be refreshed.
     pub fn ingestChunk(self: *Self, cx: i32, cz: i32, chunk: *const Chunk, provenance: LODColumnProvenance) void {
         return lod_manager_ingestion_ops.ingestChunk(self, cx, cz, chunk, provenance);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `requestIngestion`.
-    /// Call from the world/update thread that owns the manager.
+    /// Queues ingestion for a chunk whose target LOD regions may not exist yet.
+    /// The request is retried by later update ticks until it expires or applies.
     pub fn requestIngestion(self: *Self, cx: i32, cz: i32, provenance: LODColumnProvenance) void {
         return lod_manager_ingestion_ops.requestIngestion(self, cx, cz, provenance);
     }
 
-    /// Records LOD manager bookkeeping via `markChunkEdited`.
-    /// Used to keep cache, transition, and readiness state consistent with world edits.
+    /// Marks a full-detail chunk as edited so its containing LOD regions can be refreshed.
+    /// The edit is debounced and flushed into ingestion work from the update thread.
     pub fn markChunkEdited(self: *Self, cx: i32, cz: i32) void {
         return lod_manager_ingestion_ops.markChunkEdited(self, cx, cz);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `applyIngestionToRegions`.
-    /// Call from the world/update thread that owns the manager.
+    /// Applies chunk-derived source samples to currently loaded LOD regions.
+    /// Returns a bitmask describing which LOD levels accepted the update.
     pub fn applyIngestionToRegions(self: *Self, cx: i32, cz: i32, chunk: *const Chunk, provenance: LODColumnProvenance) u8 {
         return lod_manager_ingestion_ops.applyIngestionToRegions(self, cx, cz, chunk, provenance);
     }
 
-    /// Records LOD manager bookkeeping via `recordPendingLocked`.
-    /// Used to keep cache, transition, and readiness state consistent with world edits.
+    /// Records a deferred ingestion request while the ingestion mutex is already held.
+    /// `mask` tracks which LOD levels still need the chunk once regions become available.
     pub fn recordPendingLocked(self: *Self, cx: i32, cz: i32, provenance: LODColumnProvenance, mask: u8) void {
         return lod_manager_ingestion_ops.recordPendingLocked(self, cx, cz, provenance, mask);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `rerecordPending`.
-    /// Call from the world/update thread that owns the manager.
+    /// Refreshes an existing deferred ingestion request with a new mask and time-to-live.
+    /// Used when chunk edits arrive faster than regions can be regenerated.
     pub fn rerecordPending(self: *Self, cx: i32, cz: i32, provenance: LODColumnProvenance, mask: u8, ttl: u16) void {
         return lod_manager_ingestion_ops.rerecordPending(self, cx, cz, provenance, mask, ttl);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `decayPendingLocked`.
-    /// Call from the world/update thread that owns the manager.
+    /// Decrements pending-ingestion TTL counters while the ingestion mutex is held.
+    /// Expired requests are dropped to avoid unbounded retry queues.
     pub fn decayPendingLocked(self: *Self) void {
         return lod_manager_ingestion_ops.decayPendingLocked(self);
     }
 
-    /// Advances LOD work scheduling through `drainPendingIngestions`.
-    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
+    /// Resolves and applies a bounded number of deferred ingestion requests for this frame.
+    /// Uses the installed chunk resolver and leaves unresolved requests queued for later ticks.
     pub fn drainPendingIngestions(self: *Self) void {
         return lod_manager_ingestion_ops.drainPendingIngestions(self);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `flushEditedChunks`.
-    /// Call from the world/update thread that owns the manager.
+    /// Converts debounced edited-chunk coordinates into ingestion requests.
+    /// Clears the dirty-edit set once requests have been queued or applied.
     pub fn flushEditedChunks(self: *Self) void {
         return lod_manager_ingestion_ops.flushEditedChunks(self);
     }
 
-    /// Advances LOD work scheduling through `queueLODRegions`.
-    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
+    /// Queues missing or dirty regions for generation at one LOD level.
+    /// Errors report allocation or job-queue failures; call from the world update thread.
     pub fn queueLODRegions(self: *Self, lod: LODLevel, velocity: Vec3, chunk_checker: ?ChunkChecker, checker_ctx: ?*anyopaque) !void {
         return lod_manager_generation_ops.queueLODRegions(self, lod, velocity, chunk_checker, checker_ctx);
     }
 
-    /// Advances LOD work scheduling through `processQueuedGenerations`.
-    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
+    /// Drains completed generation jobs and schedules mesh work for accepted source data.
+    /// Errors report mesh allocation or queueing failures.
     pub fn processQueuedGenerations(self: *Self, velocity: Vec3) !void {
         return lod_manager_generation_ops.processQueuedGenerations(self, velocity);
     }
 
-    /// Advances LOD work scheduling through `processStateTransitions`.
-    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
+    /// Advances LOD region lifecycle transitions such as generated-to-meshing and meshing-to-uploading.
+    /// Errors report failed mesh creation or upload queue insertion.
     pub fn processStateTransitions(self: *Self, velocity: Vec3) !void {
         return lod_manager_generation_ops.processStateTransitions(self, velocity);
     }
 
-    /// Queries LOD manager state via `getOrCreateMesh`.
-    /// This does not mutate scheduling state except for diagnostics explicitly documented by the implementation.
+    /// Returns the mesh object for a region, allocating it when absent.
+    /// The returned mesh is manager-owned and remains valid until eviction or manager teardown.
     pub fn getOrCreateMesh(self: *Self, key: LODRegionKey) !*LODMesh {
         return lod_manager_generation_ops.getOrCreateMesh(self, key);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `buildMeshForChunk`.
-    /// Call from the world/update thread that owns the manager.
+    /// Builds CPU mesh data for one LOD chunk from its current source data.
+    /// Errors report allocation or meshing failures; successful builds enqueue upload work.
     pub fn buildMeshForChunk(self: *Self, chunk: *LODChunk) !void {
         return lod_manager_generation_ops.buildMeshForChunk(self, chunk);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `effectiveMeshPath`.
-    /// Call from the world/update thread that owns the manager.
+    /// Selects the mesh-building path to use for a particular LOD level.
+    /// The result combines global config with per-level fallbacks for performance and quality.
     pub fn effectiveMeshPath(self: *Self, lod: LODLevel) lod_chunk.LODMeshPath {
         return lod_manager_generation_ops.effectiveMeshPath(self, lod);
     }
 
-    /// Advances LOD work scheduling through `processUploads`.
-    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
+    /// Uploads queued LOD meshes using the configured per-frame upload budget.
+    /// Must run on the render/update thread that owns the GPU bridge.
     pub fn processUploads(self: *Self) void {
         return lod_manager_upload_ops.processUploads(self);
     }
 
-    /// Advances LOD work scheduling through `processUploadsWithBudget`.
-    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
+    /// Uploads queued LOD meshes until `upload_budget_bytes` is exhausted.
+    /// Chunks that cannot be uploaded within the budget are left queued for later frames.
     pub fn processUploadsWithBudget(self: *Self, upload_budget_bytes: usize) void {
         return lod_manager_upload_ops.processUploadsWithBudget(self, upload_budget_bytes);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `requeueUpload`.
-    /// Call from the world/update thread that owns the manager.
+    /// Places an LOD chunk back onto an upload queue after a deferred or failed upload attempt.
+    /// The chunk remains manager-owned and must stay pinned as required by the caller path.
     pub fn requeueUpload(self: *Self, lod_idx: usize, chunk: *LODChunk) void {
         return lod_manager_upload_ops.requeueUpload(self, lod_idx, chunk);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `countRenderableChildren`.
-    /// Call from the world/update thread that owns the manager.
+    /// Counts direct finer child regions that are currently renderable for a parent region.
+    /// Used to decide parent fallback visibility and transition fades.
     pub fn countRenderableChildren(self: *Self, key: LODRegionKey) u8 {
         return lod_manager_upload_ops.countRenderableChildren(self, key);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `regionContributesGeometry`.
-    /// Call from the world/update thread that owns the manager.
+    /// Reports whether a region should contribute visible geometry in the current hierarchy state.
+    /// Excludes empty, covered, or non-renderable regions that should not affect parent readiness.
     pub fn regionContributesGeometry(self: *Self, key: LODRegionKey, chunk: *const LODChunk) bool {
         return lod_manager_upload_ops.regionContributesGeometry(self, key, chunk);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `adjustParentReadyChildren`.
-    /// Call from the world/update thread that owns the manager.
+    /// Adjusts a parent region's renderable-child count after child visibility changes.
+    /// This may start or cancel transition fades used to hide parent fallback terrain.
     pub fn adjustParentReadyChildren(self: *Self, key: LODRegionKey, delta: i8) void {
         return lod_manager_upload_ops.adjustParentReadyChildren(self, key, delta);
     }
 
-    /// Records LOD manager bookkeeping via `markRegionRenderable`.
-    /// Used to keep cache, transition, and readiness state consistent with world edits.
+    /// Marks a region renderable after its mesh upload completes.
+    /// Updates parent readiness and transition state so hierarchy blending remains consistent.
     pub fn markRegionRenderable(self: *Self, key: LODRegionKey, chunk: *LODChunk) void {
         return lod_manager_upload_ops.markRegionRenderable(self, key, chunk);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `decayTransitionFrames`.
-    /// Call from the world/update thread that owns the manager.
+    /// Decrements active transition fade counters for renderable regions.
+    /// Call once per update tick before rendering fade-dependent LOD hierarchy state.
     pub fn decayTransitionFrames(self: *Self) void {
         return lod_manager_upload_ops.decayTransitionFrames(self);
     }
 
-    /// Records LOD manager bookkeeping via `noteRegionRemoved`.
-    /// Used to keep cache, transition, and readiness state consistent with world edits.
+    /// Updates hierarchy bookkeeping when a region is removed or evicted.
+    /// Parent ready-child counts are reduced if the removed region contributed geometry.
     pub fn noteRegionRemoved(self: *Self, key: LODRegionKey, chunk: *const LODChunk) void {
         return lod_manager_upload_ops.noteRegionRemoved(self, key, chunk);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `demoteRegionForRemesh`.
-    /// Call from the world/update thread that owns the manager.
+    /// Demotes a renderable region back to mesh/upload work after its source data changes.
+    /// Parent readiness is updated before the region leaves the renderable set.
     pub fn demoteRegionForRemesh(self: *Self, key: LODRegionKey, chunk: *LODChunk) void {
         return lod_manager_upload_ops.demoteRegionForRemesh(self, key, chunk);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `unloadDistantRegions`.
-    /// Call from the world/update thread that owns the manager.
+    /// Evicts LOD regions outside their configured radii and queues their meshes for destruction.
+    /// Errors report allocation or bookkeeping failures during eviction.
     pub fn unloadDistantRegions(self: *Self) !void {
         return lod_manager_eviction_ops.unloadDistantRegions(self);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `unloadDistantForLevel`.
-    /// Call from the world/update thread that owns the manager.
+    /// Evicts regions for one LOD level beyond `max_radius` chunks from the player.
+    /// Pinned or in-flight regions are preserved until background work releases them.
     pub fn unloadDistantForLevel(self: *Self, lod: LODLevel, max_radius: i32) !void {
         return lod_manager_eviction_ops.unloadDistantForLevel(self, lod, max_radius);
     }
 
-    /// Advances LOD work scheduling through `queueMeshDeletion`.
-    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
+    /// Defers GPU mesh destruction so the backend is not forced to free resources mid-frame.
+    /// The mesh pointer must remain valid until `processMeshDeletions` consumes it.
     pub fn queueMeshDeletion(self: *Self, mesh: *LODMesh) void {
         return lod_manager_eviction_ops.queueMeshDeletion(self, mesh);
     }
 
-    /// Advances LOD work scheduling through `processMeshDeletions`.
-    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
+    /// Destroys up to `max_count` deferred LOD meshes through the GPU bridge.
+    /// Intended to amortize resource deletion across frames.
     pub fn processMeshDeletions(self: *Self, max_count: usize) void {
         return lod_manager_eviction_ops.processMeshDeletions(self, max_count);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `enforceMemoryBudget`.
-    /// Call from the world/update thread that owns the manager.
+    /// Enforces the configured LOD memory budget by shrinking radii or evicting regions.
+    /// Errors report eviction failures; call from the world update thread.
     pub fn enforceMemoryBudget(self: *Self) !void {
         return lod_manager_eviction_ops.enforceMemoryBudget(self);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `updateStats`.
-    /// Call from the world/update thread that owns the manager.
+    /// Recomputes diagnostic stats from current LOD maps, queues, cache counters, and memory state.
+    /// This mutates only the stats snapshot exposed by `getStats`.
     pub fn updateStats(self: *Self) void {
         return lod_manager_eviction_ops.updateStats(self);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `unloadLODWhereChunksLoaded`.
-    /// Call from the world/update thread that owns the manager.
+    /// Removes LOD fallback regions fully covered by loaded full-detail chunks.
+    /// Uses `checker` to avoid drawing duplicate distant terrain inside the high-detail area.
     pub fn unloadLODWhereChunksLoaded(self: *Self, checker: ChunkChecker, ctx: *anyopaque) void {
         return lod_manager_eviction_ops.unloadLODWhereChunksLoaded(self, checker, ctx);
     }
 
-    /// Updates LOD manager lifecycle or scheduling state through `areAllChunksLoaded`.
-    /// Call from the world/update thread that owns the manager.
+    /// Tests whether every full-detail chunk inside `bounds` is loaded and renderable.
+    /// Used before unloading an overlapping LOD region to prevent visible holes.
     pub fn areAllChunksLoaded(self: *Self, bounds: LODChunk.WorldBounds, checker: ChunkChecker, ctx: *anyopaque) bool {
         return lod_manager_eviction_ops.areAllChunksLoaded(self, bounds, checker, ctx);
     }

--- a/modules/world-lod/src/lod_manager.zig
+++ b/modules/world-lod/src/lod_manager.zig
@@ -102,12 +102,14 @@ pub const LODIngestionQueue = struct {
     edit_cooldown: f32 = 0.0,
     drain_per_frame: u32 = 4,
 
-    /// LOD manager API `init` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Constructs an LOD manager through `init`.
+    /// The manager owns scheduling, cache, mesh, and upload state until `deinit`.
     pub fn init(allocator: std.mem.Allocator) LODIngestionQueue {
         return .{ .edit_dirty = ChunkCoordSet.init(allocator) };
     }
 
-    /// LOD manager API `deinit` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Releases LOD manager queues, caches, meshes, and worker-owned resources.
+    /// Call after pending LOD work has been quiesced or made safe to discard.
     pub fn deinit(self: *LODIngestionQueue, allocator: std.mem.Allocator) void {
         self.pending_ingestions.deinit(allocator);
         self.edit_dirty.deinit();
@@ -220,297 +222,356 @@ pub const LODManager = struct {
         return lod_manager_cache_ops.initCacheTestManager(allocator, cache_dir_path);
     }
 
-    /// LOD manager API `storePlayerChunkPos` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `storePlayerChunkPos`.
+    /// Call from the world/update thread that owns the manager.
     pub fn storePlayerChunkPos(self: *Self, cx: i32, cz: i32) void {
         return lod_manager_core.storePlayerChunkPos(self, cx, cz);
     }
 
-    /// LOD manager API `loadPlayerChunkPos` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `loadPlayerChunkPos`.
+    /// Call from the world/update thread that owns the manager.
     pub fn loadPlayerChunkPos(self: *const Self) PlayerChunkPos {
         return lod_manager_core.loadPlayerChunkPos(self);
     }
 
-    /// LOD manager API `deinit` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Releases LOD manager queues, caches, meshes, and worker-owned resources.
+    /// Call after pending LOD work has been quiesced or made safe to discard.
     pub fn deinit(self: *Self) void {
         return lod_manager_core.deinit(self);
     }
 
-    /// LOD manager API `update` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `update`.
+    /// Call from the world/update thread that owns the manager.
     pub fn update(self: *Self, player_pos: Vec3, player_velocity: Vec3, chunk_checker: ?ChunkChecker, checker_ctx: ?*anyopaque) !void {
         return lod_manager_core.update(self, player_pos, player_velocity, chunk_checker, checker_ctx);
     }
 
-    /// LOD manager API `getStats` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Queries LOD manager state via `getStats`.
+    /// This does not mutate scheduling state except for diagnostics explicitly documented by the implementation.
     pub fn getStats(self: *Self) LODStats {
         return lod_manager_core.getStats(self);
     }
 
-    /// LOD manager API `pause` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `pause`.
+    /// Call from the world/update thread that owns the manager.
     pub fn pause(self: *Self) void {
         return lod_manager_core.pause(self);
     }
 
-    /// LOD manager API `unpause` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `unpause`.
+    /// Call from the world/update thread that owns the manager.
     pub fn unpause(self: *Self) void {
         return lod_manager_core.unpause(self);
     }
 
-    /// LOD manager API `getLODForDistance` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Queries LOD manager state via `getLODForDistance`.
+    /// This does not mutate scheduling state except for diagnostics explicitly documented by the implementation.
     pub fn getLODForDistance(self: *const Self, chunk_x: i32, chunk_z: i32) LODLevel {
         return lod_manager_core.getLODForDistance(self, chunk_x, chunk_z);
     }
 
-    /// LOD manager API `isInRange` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Queries LOD manager state via `isInRange`.
+    /// This does not mutate scheduling state except for diagnostics explicitly documented by the implementation.
     pub fn isInRange(self: *const Self, chunk_x: i32, chunk_z: i32) bool {
         return lod_manager_core.isInRange(self, chunk_x, chunk_z);
     }
 
-    /// LOD manager API `render` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Renders currently renderable LOD regions through the configured renderer.
+    /// Generation and upload queues are not drained by this call.
     pub fn render(self: *Self, view_proj: Mat4, camera_pos: Vec3, chunk_checker: ?ChunkChecker, checker_ctx: ?*anyopaque, use_frustum: bool, max_distance_chunks: ?i32, layer: LODRenderLayer) void {
         return lod_manager_core.render(self, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, layer);
     }
 
-    /// LOD manager API `enableCache` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `enableCache`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn enableCache(self: *Self, save_dir_path: []const u8) !void {
         return lod_manager_cache_ops.enableCache(self, save_dir_path);
     }
 
-    /// LOD manager API `flushDirtyStores` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `flushDirtyStores`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn flushDirtyStores(self: *Self) void {
         return lod_manager_cache_ops.flushDirtyStores(self);
     }
 
-    /// LOD manager API `cacheKey` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `cacheKey`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn cacheKey(self: *const Self, key: LODRegionKey) lod_cache.Key {
         return lod_manager_cache_ops.cacheKey(self, key);
     }
 
-    /// LOD manager API `legacyCacheFilePath` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `legacyCacheFilePath`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn legacyCacheFilePath(self: *Self, save_dir_path: []const u8, key: lod_cache.Key) ![]u8 {
         return lod_manager_cache_ops.legacyCacheFilePath(self, save_dir_path, key);
     }
 
-    /// LOD manager API `logLegacyCacheNotice` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `logLegacyCacheNotice`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn logLegacyCacheNotice(self: *Self) void {
         return lod_manager_cache_ops.logLegacyCacheNotice(self);
     }
 
-    /// LOD manager API `cacheDirPathSnapshot` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `cacheDirPathSnapshot`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn cacheDirPathSnapshot(self: *Self) ?[]u8 {
         return lod_manager_cache_ops.cacheDirPathSnapshot(self);
     }
 
-    /// LOD manager API `cacheEnabled` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `cacheEnabled`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn cacheEnabled(self: *Self) bool {
         return lod_manager_cache_ops.cacheEnabled(self);
     }
 
-    /// LOD manager API `readStorePayload` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `readStorePayload`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn readStorePayload(self: *Self, save_dir_path: []const u8, cache_key: lod_cache.Key) !?[]u8 {
         return lod_manager_cache_ops.readStorePayload(self, save_dir_path, cache_key);
     }
 
-    /// LOD manager API `writeStorePayload` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `writeStorePayload`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn writeStorePayload(self: *Self, save_dir_path: []const u8, cache_key: lod_cache.Key, bytes: []const u8) !void {
         return lod_manager_cache_ops.writeStorePayload(self, save_dir_path, cache_key, bytes);
     }
 
-    /// LOD manager API `deleteStorePayload` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `deleteStorePayload`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn deleteStorePayload(self: *Self, save_dir_path: []const u8, cache_key: lod_cache.Key) void {
         return lod_manager_cache_ops.deleteStorePayload(self, save_dir_path, cache_key);
     }
 
-    /// LOD manager API `deleteStoreContainer` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `deleteStoreContainer`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn deleteStoreContainer(self: *Self, path: []const u8) void {
         return lod_manager_cache_ops.deleteStoreContainer(self, path);
     }
 
-    /// LOD manager API `loadCachedSourceData` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `loadCachedSourceData`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn loadCachedSourceData(self: *Self, key: LODRegionKey) ?LODSimplifiedData {
         return lod_manager_cache_ops.loadCachedSourceData(self, key);
     }
 
-    /// LOD manager API `recordCacheHit` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `recordCacheHit`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn recordCacheHit(self: *Self) void {
         return lod_manager_cache_ops.recordCacheHit(self);
     }
 
-    /// LOD manager API `recordCacheMiss` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `recordCacheMiss`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn recordCacheMiss(self: *Self) void {
         return lod_manager_cache_ops.recordCacheMiss(self);
     }
 
-    /// LOD manager API `saveCachedSourceData` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Manages persistent LOD cache data through `saveCachedSourceData`.
+    /// Cache paths and payloads are owned by the manager; IO failures are reported or recorded by the caller path.
     pub fn saveCachedSourceData(self: *Self, key: LODRegionKey, data: *const LODSimplifiedData) void {
         return lod_manager_cache_ops.saveCachedSourceData(self, key, data);
     }
 
-    /// LOD manager API `setChunkResolver` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `setChunkResolver`.
+    /// Call from the world/update thread that owns the manager.
     pub fn setChunkResolver(self: *Self, resolver: ChunkResolver) void {
         return lod_manager_ingestion_ops.setChunkResolver(self, resolver);
     }
 
-    /// LOD manager API `ingestChunk` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `ingestChunk`.
+    /// Call from the world/update thread that owns the manager.
     pub fn ingestChunk(self: *Self, cx: i32, cz: i32, chunk: *const Chunk, provenance: LODColumnProvenance) void {
         return lod_manager_ingestion_ops.ingestChunk(self, cx, cz, chunk, provenance);
     }
 
-    /// LOD manager API `requestIngestion` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `requestIngestion`.
+    /// Call from the world/update thread that owns the manager.
     pub fn requestIngestion(self: *Self, cx: i32, cz: i32, provenance: LODColumnProvenance) void {
         return lod_manager_ingestion_ops.requestIngestion(self, cx, cz, provenance);
     }
 
-    /// LOD manager API `markChunkEdited` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Records LOD manager bookkeeping via `markChunkEdited`.
+    /// Used to keep cache, transition, and readiness state consistent with world edits.
     pub fn markChunkEdited(self: *Self, cx: i32, cz: i32) void {
         return lod_manager_ingestion_ops.markChunkEdited(self, cx, cz);
     }
 
-    /// LOD manager API `applyIngestionToRegions` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `applyIngestionToRegions`.
+    /// Call from the world/update thread that owns the manager.
     pub fn applyIngestionToRegions(self: *Self, cx: i32, cz: i32, chunk: *const Chunk, provenance: LODColumnProvenance) u8 {
         return lod_manager_ingestion_ops.applyIngestionToRegions(self, cx, cz, chunk, provenance);
     }
 
-    /// LOD manager API `recordPendingLocked` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Records LOD manager bookkeeping via `recordPendingLocked`.
+    /// Used to keep cache, transition, and readiness state consistent with world edits.
     pub fn recordPendingLocked(self: *Self, cx: i32, cz: i32, provenance: LODColumnProvenance, mask: u8) void {
         return lod_manager_ingestion_ops.recordPendingLocked(self, cx, cz, provenance, mask);
     }
 
-    /// LOD manager API `rerecordPending` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `rerecordPending`.
+    /// Call from the world/update thread that owns the manager.
     pub fn rerecordPending(self: *Self, cx: i32, cz: i32, provenance: LODColumnProvenance, mask: u8, ttl: u16) void {
         return lod_manager_ingestion_ops.rerecordPending(self, cx, cz, provenance, mask, ttl);
     }
 
-    /// LOD manager API `decayPendingLocked` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `decayPendingLocked`.
+    /// Call from the world/update thread that owns the manager.
     pub fn decayPendingLocked(self: *Self) void {
         return lod_manager_ingestion_ops.decayPendingLocked(self);
     }
 
-    /// LOD manager API `drainPendingIngestions` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Advances LOD work scheduling through `drainPendingIngestions`.
+    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
     pub fn drainPendingIngestions(self: *Self) void {
         return lod_manager_ingestion_ops.drainPendingIngestions(self);
     }
 
-    /// LOD manager API `flushEditedChunks` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `flushEditedChunks`.
+    /// Call from the world/update thread that owns the manager.
     pub fn flushEditedChunks(self: *Self) void {
         return lod_manager_ingestion_ops.flushEditedChunks(self);
     }
 
-    /// LOD manager API `queueLODRegions` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Advances LOD work scheduling through `queueLODRegions`.
+    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
     pub fn queueLODRegions(self: *Self, lod: LODLevel, velocity: Vec3, chunk_checker: ?ChunkChecker, checker_ctx: ?*anyopaque) !void {
         return lod_manager_generation_ops.queueLODRegions(self, lod, velocity, chunk_checker, checker_ctx);
     }
 
-    /// LOD manager API `processQueuedGenerations` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Advances LOD work scheduling through `processQueuedGenerations`.
+    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
     pub fn processQueuedGenerations(self: *Self, velocity: Vec3) !void {
         return lod_manager_generation_ops.processQueuedGenerations(self, velocity);
     }
 
-    /// LOD manager API `processStateTransitions` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Advances LOD work scheduling through `processStateTransitions`.
+    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
     pub fn processStateTransitions(self: *Self, velocity: Vec3) !void {
         return lod_manager_generation_ops.processStateTransitions(self, velocity);
     }
 
-    /// LOD manager API `getOrCreateMesh` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Queries LOD manager state via `getOrCreateMesh`.
+    /// This does not mutate scheduling state except for diagnostics explicitly documented by the implementation.
     pub fn getOrCreateMesh(self: *Self, key: LODRegionKey) !*LODMesh {
         return lod_manager_generation_ops.getOrCreateMesh(self, key);
     }
 
-    /// LOD manager API `buildMeshForChunk` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `buildMeshForChunk`.
+    /// Call from the world/update thread that owns the manager.
     pub fn buildMeshForChunk(self: *Self, chunk: *LODChunk) !void {
         return lod_manager_generation_ops.buildMeshForChunk(self, chunk);
     }
 
-    /// LOD manager API `effectiveMeshPath` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `effectiveMeshPath`.
+    /// Call from the world/update thread that owns the manager.
     pub fn effectiveMeshPath(self: *Self, lod: LODLevel) lod_chunk.LODMeshPath {
         return lod_manager_generation_ops.effectiveMeshPath(self, lod);
     }
 
-    /// LOD manager API `processUploads` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Advances LOD work scheduling through `processUploads`.
+    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
     pub fn processUploads(self: *Self) void {
         return lod_manager_upload_ops.processUploads(self);
     }
 
-    /// LOD manager API `processUploadsWithBudget` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Advances LOD work scheduling through `processUploadsWithBudget`.
+    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
     pub fn processUploadsWithBudget(self: *Self, upload_budget_bytes: usize) void {
         return lod_manager_upload_ops.processUploadsWithBudget(self, upload_budget_bytes);
     }
 
-    /// LOD manager API `requeueUpload` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `requeueUpload`.
+    /// Call from the world/update thread that owns the manager.
     pub fn requeueUpload(self: *Self, lod_idx: usize, chunk: *LODChunk) void {
         return lod_manager_upload_ops.requeueUpload(self, lod_idx, chunk);
     }
 
-    /// LOD manager API `countRenderableChildren` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `countRenderableChildren`.
+    /// Call from the world/update thread that owns the manager.
     pub fn countRenderableChildren(self: *Self, key: LODRegionKey) u8 {
         return lod_manager_upload_ops.countRenderableChildren(self, key);
     }
 
-    /// LOD manager API `regionContributesGeometry` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `regionContributesGeometry`.
+    /// Call from the world/update thread that owns the manager.
     pub fn regionContributesGeometry(self: *Self, key: LODRegionKey, chunk: *const LODChunk) bool {
         return lod_manager_upload_ops.regionContributesGeometry(self, key, chunk);
     }
 
-    /// LOD manager API `adjustParentReadyChildren` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `adjustParentReadyChildren`.
+    /// Call from the world/update thread that owns the manager.
     pub fn adjustParentReadyChildren(self: *Self, key: LODRegionKey, delta: i8) void {
         return lod_manager_upload_ops.adjustParentReadyChildren(self, key, delta);
     }
 
-    /// LOD manager API `markRegionRenderable` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Records LOD manager bookkeeping via `markRegionRenderable`.
+    /// Used to keep cache, transition, and readiness state consistent with world edits.
     pub fn markRegionRenderable(self: *Self, key: LODRegionKey, chunk: *LODChunk) void {
         return lod_manager_upload_ops.markRegionRenderable(self, key, chunk);
     }
 
-    /// LOD manager API `decayTransitionFrames` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `decayTransitionFrames`.
+    /// Call from the world/update thread that owns the manager.
     pub fn decayTransitionFrames(self: *Self) void {
         return lod_manager_upload_ops.decayTransitionFrames(self);
     }
 
-    /// LOD manager API `noteRegionRemoved` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Records LOD manager bookkeeping via `noteRegionRemoved`.
+    /// Used to keep cache, transition, and readiness state consistent with world edits.
     pub fn noteRegionRemoved(self: *Self, key: LODRegionKey, chunk: *const LODChunk) void {
         return lod_manager_upload_ops.noteRegionRemoved(self, key, chunk);
     }
 
-    /// LOD manager API `demoteRegionForRemesh` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `demoteRegionForRemesh`.
+    /// Call from the world/update thread that owns the manager.
     pub fn demoteRegionForRemesh(self: *Self, key: LODRegionKey, chunk: *LODChunk) void {
         return lod_manager_upload_ops.demoteRegionForRemesh(self, key, chunk);
     }
 
-    /// LOD manager API `unloadDistantRegions` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `unloadDistantRegions`.
+    /// Call from the world/update thread that owns the manager.
     pub fn unloadDistantRegions(self: *Self) !void {
         return lod_manager_eviction_ops.unloadDistantRegions(self);
     }
 
-    /// LOD manager API `unloadDistantForLevel` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `unloadDistantForLevel`.
+    /// Call from the world/update thread that owns the manager.
     pub fn unloadDistantForLevel(self: *Self, lod: LODLevel, max_radius: i32) !void {
         return lod_manager_eviction_ops.unloadDistantForLevel(self, lod, max_radius);
     }
 
-    /// LOD manager API `queueMeshDeletion` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Advances LOD work scheduling through `queueMeshDeletion`.
+    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
     pub fn queueMeshDeletion(self: *Self, mesh: *LODMesh) void {
         return lod_manager_eviction_ops.queueMeshDeletion(self, mesh);
     }
 
-    /// LOD manager API `processMeshDeletions` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Advances LOD work scheduling through `processMeshDeletions`.
+    /// May enqueue generation, upload, deletion, or state-transition work for later frames.
     pub fn processMeshDeletions(self: *Self, max_count: usize) void {
         return lod_manager_eviction_ops.processMeshDeletions(self, max_count);
     }
 
-    /// LOD manager API `enforceMemoryBudget` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `enforceMemoryBudget`.
+    /// Call from the world/update thread that owns the manager.
     pub fn enforceMemoryBudget(self: *Self) !void {
         return lod_manager_eviction_ops.enforceMemoryBudget(self);
     }
 
-    /// LOD manager API `updateStats` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `updateStats`.
+    /// Call from the world/update thread that owns the manager.
     pub fn updateStats(self: *Self) void {
         return lod_manager_eviction_ops.updateStats(self);
     }
 
-    /// LOD manager API `unloadLODWhereChunksLoaded` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `unloadLODWhereChunksLoaded`.
+    /// Call from the world/update thread that owns the manager.
     pub fn unloadLODWhereChunksLoaded(self: *Self, checker: ChunkChecker, ctx: *anyopaque) void {
         return lod_manager_eviction_ops.unloadLODWhereChunksLoaded(self, checker, ctx);
     }
 
-    /// LOD manager API `areAllChunksLoaded` updates distant-terrain scheduling, cache state, or render coordination for the active world.
+    /// Updates LOD manager lifecycle or scheduling state through `areAllChunksLoaded`.
+    /// Call from the world/update thread that owns the manager.
     pub fn areAllChunksLoaded(self: *Self, bounds: LODChunk.WorldBounds, checker: ChunkChecker, ctx: *anyopaque) bool {
         return lod_manager_eviction_ops.areAllChunksLoaded(self, bounds, checker, ctx);
     }

--- a/modules/world-lod/src/lod_manager.zig
+++ b/modules/world-lod/src/lod_manager.zig
@@ -102,10 +102,12 @@ pub const LODIngestionQueue = struct {
     edit_cooldown: f32 = 0.0,
     drain_per_frame: u32 = 4,
 
+    /// LOD manager API `init` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn init(allocator: std.mem.Allocator) LODIngestionQueue {
         return .{ .edit_dirty = ChunkCoordSet.init(allocator) };
     }
 
+    /// LOD manager API `deinit` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn deinit(self: *LODIngestionQueue, allocator: std.mem.Allocator) void {
         self.pending_ingestions.deinit(allocator);
         self.edit_dirty.deinit();
@@ -218,238 +220,297 @@ pub const LODManager = struct {
         return lod_manager_cache_ops.initCacheTestManager(allocator, cache_dir_path);
     }
 
+    /// LOD manager API `storePlayerChunkPos` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn storePlayerChunkPos(self: *Self, cx: i32, cz: i32) void {
         return lod_manager_core.storePlayerChunkPos(self, cx, cz);
     }
 
+    /// LOD manager API `loadPlayerChunkPos` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn loadPlayerChunkPos(self: *const Self) PlayerChunkPos {
         return lod_manager_core.loadPlayerChunkPos(self);
     }
 
+    /// LOD manager API `deinit` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn deinit(self: *Self) void {
         return lod_manager_core.deinit(self);
     }
 
+    /// LOD manager API `update` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn update(self: *Self, player_pos: Vec3, player_velocity: Vec3, chunk_checker: ?ChunkChecker, checker_ctx: ?*anyopaque) !void {
         return lod_manager_core.update(self, player_pos, player_velocity, chunk_checker, checker_ctx);
     }
 
+    /// LOD manager API `getStats` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn getStats(self: *Self) LODStats {
         return lod_manager_core.getStats(self);
     }
 
+    /// LOD manager API `pause` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn pause(self: *Self) void {
         return lod_manager_core.pause(self);
     }
 
+    /// LOD manager API `unpause` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn unpause(self: *Self) void {
         return lod_manager_core.unpause(self);
     }
 
+    /// LOD manager API `getLODForDistance` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn getLODForDistance(self: *const Self, chunk_x: i32, chunk_z: i32) LODLevel {
         return lod_manager_core.getLODForDistance(self, chunk_x, chunk_z);
     }
 
+    /// LOD manager API `isInRange` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn isInRange(self: *const Self, chunk_x: i32, chunk_z: i32) bool {
         return lod_manager_core.isInRange(self, chunk_x, chunk_z);
     }
 
+    /// LOD manager API `render` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn render(self: *Self, view_proj: Mat4, camera_pos: Vec3, chunk_checker: ?ChunkChecker, checker_ctx: ?*anyopaque, use_frustum: bool, max_distance_chunks: ?i32, layer: LODRenderLayer) void {
         return lod_manager_core.render(self, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, layer);
     }
 
+    /// LOD manager API `enableCache` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn enableCache(self: *Self, save_dir_path: []const u8) !void {
         return lod_manager_cache_ops.enableCache(self, save_dir_path);
     }
 
+    /// LOD manager API `flushDirtyStores` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn flushDirtyStores(self: *Self) void {
         return lod_manager_cache_ops.flushDirtyStores(self);
     }
 
+    /// LOD manager API `cacheKey` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn cacheKey(self: *const Self, key: LODRegionKey) lod_cache.Key {
         return lod_manager_cache_ops.cacheKey(self, key);
     }
 
+    /// LOD manager API `legacyCacheFilePath` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn legacyCacheFilePath(self: *Self, save_dir_path: []const u8, key: lod_cache.Key) ![]u8 {
         return lod_manager_cache_ops.legacyCacheFilePath(self, save_dir_path, key);
     }
 
+    /// LOD manager API `logLegacyCacheNotice` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn logLegacyCacheNotice(self: *Self) void {
         return lod_manager_cache_ops.logLegacyCacheNotice(self);
     }
 
+    /// LOD manager API `cacheDirPathSnapshot` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn cacheDirPathSnapshot(self: *Self) ?[]u8 {
         return lod_manager_cache_ops.cacheDirPathSnapshot(self);
     }
 
+    /// LOD manager API `cacheEnabled` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn cacheEnabled(self: *Self) bool {
         return lod_manager_cache_ops.cacheEnabled(self);
     }
 
+    /// LOD manager API `readStorePayload` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn readStorePayload(self: *Self, save_dir_path: []const u8, cache_key: lod_cache.Key) !?[]u8 {
         return lod_manager_cache_ops.readStorePayload(self, save_dir_path, cache_key);
     }
 
+    /// LOD manager API `writeStorePayload` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn writeStorePayload(self: *Self, save_dir_path: []const u8, cache_key: lod_cache.Key, bytes: []const u8) !void {
         return lod_manager_cache_ops.writeStorePayload(self, save_dir_path, cache_key, bytes);
     }
 
+    /// LOD manager API `deleteStorePayload` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn deleteStorePayload(self: *Self, save_dir_path: []const u8, cache_key: lod_cache.Key) void {
         return lod_manager_cache_ops.deleteStorePayload(self, save_dir_path, cache_key);
     }
 
+    /// LOD manager API `deleteStoreContainer` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn deleteStoreContainer(self: *Self, path: []const u8) void {
         return lod_manager_cache_ops.deleteStoreContainer(self, path);
     }
 
+    /// LOD manager API `loadCachedSourceData` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn loadCachedSourceData(self: *Self, key: LODRegionKey) ?LODSimplifiedData {
         return lod_manager_cache_ops.loadCachedSourceData(self, key);
     }
 
+    /// LOD manager API `recordCacheHit` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn recordCacheHit(self: *Self) void {
         return lod_manager_cache_ops.recordCacheHit(self);
     }
 
+    /// LOD manager API `recordCacheMiss` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn recordCacheMiss(self: *Self) void {
         return lod_manager_cache_ops.recordCacheMiss(self);
     }
 
+    /// LOD manager API `saveCachedSourceData` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn saveCachedSourceData(self: *Self, key: LODRegionKey, data: *const LODSimplifiedData) void {
         return lod_manager_cache_ops.saveCachedSourceData(self, key, data);
     }
 
+    /// LOD manager API `setChunkResolver` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn setChunkResolver(self: *Self, resolver: ChunkResolver) void {
         return lod_manager_ingestion_ops.setChunkResolver(self, resolver);
     }
 
+    /// LOD manager API `ingestChunk` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn ingestChunk(self: *Self, cx: i32, cz: i32, chunk: *const Chunk, provenance: LODColumnProvenance) void {
         return lod_manager_ingestion_ops.ingestChunk(self, cx, cz, chunk, provenance);
     }
 
+    /// LOD manager API `requestIngestion` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn requestIngestion(self: *Self, cx: i32, cz: i32, provenance: LODColumnProvenance) void {
         return lod_manager_ingestion_ops.requestIngestion(self, cx, cz, provenance);
     }
 
+    /// LOD manager API `markChunkEdited` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn markChunkEdited(self: *Self, cx: i32, cz: i32) void {
         return lod_manager_ingestion_ops.markChunkEdited(self, cx, cz);
     }
 
+    /// LOD manager API `applyIngestionToRegions` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn applyIngestionToRegions(self: *Self, cx: i32, cz: i32, chunk: *const Chunk, provenance: LODColumnProvenance) u8 {
         return lod_manager_ingestion_ops.applyIngestionToRegions(self, cx, cz, chunk, provenance);
     }
 
+    /// LOD manager API `recordPendingLocked` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn recordPendingLocked(self: *Self, cx: i32, cz: i32, provenance: LODColumnProvenance, mask: u8) void {
         return lod_manager_ingestion_ops.recordPendingLocked(self, cx, cz, provenance, mask);
     }
 
+    /// LOD manager API `rerecordPending` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn rerecordPending(self: *Self, cx: i32, cz: i32, provenance: LODColumnProvenance, mask: u8, ttl: u16) void {
         return lod_manager_ingestion_ops.rerecordPending(self, cx, cz, provenance, mask, ttl);
     }
 
+    /// LOD manager API `decayPendingLocked` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn decayPendingLocked(self: *Self) void {
         return lod_manager_ingestion_ops.decayPendingLocked(self);
     }
 
+    /// LOD manager API `drainPendingIngestions` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn drainPendingIngestions(self: *Self) void {
         return lod_manager_ingestion_ops.drainPendingIngestions(self);
     }
 
+    /// LOD manager API `flushEditedChunks` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn flushEditedChunks(self: *Self) void {
         return lod_manager_ingestion_ops.flushEditedChunks(self);
     }
 
+    /// LOD manager API `queueLODRegions` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn queueLODRegions(self: *Self, lod: LODLevel, velocity: Vec3, chunk_checker: ?ChunkChecker, checker_ctx: ?*anyopaque) !void {
         return lod_manager_generation_ops.queueLODRegions(self, lod, velocity, chunk_checker, checker_ctx);
     }
 
+    /// LOD manager API `processQueuedGenerations` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn processQueuedGenerations(self: *Self, velocity: Vec3) !void {
         return lod_manager_generation_ops.processQueuedGenerations(self, velocity);
     }
 
+    /// LOD manager API `processStateTransitions` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn processStateTransitions(self: *Self, velocity: Vec3) !void {
         return lod_manager_generation_ops.processStateTransitions(self, velocity);
     }
 
+    /// LOD manager API `getOrCreateMesh` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn getOrCreateMesh(self: *Self, key: LODRegionKey) !*LODMesh {
         return lod_manager_generation_ops.getOrCreateMesh(self, key);
     }
 
+    /// LOD manager API `buildMeshForChunk` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn buildMeshForChunk(self: *Self, chunk: *LODChunk) !void {
         return lod_manager_generation_ops.buildMeshForChunk(self, chunk);
     }
 
+    /// LOD manager API `effectiveMeshPath` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn effectiveMeshPath(self: *Self, lod: LODLevel) lod_chunk.LODMeshPath {
         return lod_manager_generation_ops.effectiveMeshPath(self, lod);
     }
 
+    /// LOD manager API `processUploads` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn processUploads(self: *Self) void {
         return lod_manager_upload_ops.processUploads(self);
     }
 
+    /// LOD manager API `processUploadsWithBudget` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn processUploadsWithBudget(self: *Self, upload_budget_bytes: usize) void {
         return lod_manager_upload_ops.processUploadsWithBudget(self, upload_budget_bytes);
     }
 
+    /// LOD manager API `requeueUpload` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn requeueUpload(self: *Self, lod_idx: usize, chunk: *LODChunk) void {
         return lod_manager_upload_ops.requeueUpload(self, lod_idx, chunk);
     }
 
+    /// LOD manager API `countRenderableChildren` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn countRenderableChildren(self: *Self, key: LODRegionKey) u8 {
         return lod_manager_upload_ops.countRenderableChildren(self, key);
     }
 
+    /// LOD manager API `regionContributesGeometry` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn regionContributesGeometry(self: *Self, key: LODRegionKey, chunk: *const LODChunk) bool {
         return lod_manager_upload_ops.regionContributesGeometry(self, key, chunk);
     }
 
+    /// LOD manager API `adjustParentReadyChildren` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn adjustParentReadyChildren(self: *Self, key: LODRegionKey, delta: i8) void {
         return lod_manager_upload_ops.adjustParentReadyChildren(self, key, delta);
     }
 
+    /// LOD manager API `markRegionRenderable` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn markRegionRenderable(self: *Self, key: LODRegionKey, chunk: *LODChunk) void {
         return lod_manager_upload_ops.markRegionRenderable(self, key, chunk);
     }
 
+    /// LOD manager API `decayTransitionFrames` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn decayTransitionFrames(self: *Self) void {
         return lod_manager_upload_ops.decayTransitionFrames(self);
     }
 
+    /// LOD manager API `noteRegionRemoved` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn noteRegionRemoved(self: *Self, key: LODRegionKey, chunk: *const LODChunk) void {
         return lod_manager_upload_ops.noteRegionRemoved(self, key, chunk);
     }
 
+    /// LOD manager API `demoteRegionForRemesh` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn demoteRegionForRemesh(self: *Self, key: LODRegionKey, chunk: *LODChunk) void {
         return lod_manager_upload_ops.demoteRegionForRemesh(self, key, chunk);
     }
 
+    /// LOD manager API `unloadDistantRegions` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn unloadDistantRegions(self: *Self) !void {
         return lod_manager_eviction_ops.unloadDistantRegions(self);
     }
 
+    /// LOD manager API `unloadDistantForLevel` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn unloadDistantForLevel(self: *Self, lod: LODLevel, max_radius: i32) !void {
         return lod_manager_eviction_ops.unloadDistantForLevel(self, lod, max_radius);
     }
 
+    /// LOD manager API `queueMeshDeletion` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn queueMeshDeletion(self: *Self, mesh: *LODMesh) void {
         return lod_manager_eviction_ops.queueMeshDeletion(self, mesh);
     }
 
+    /// LOD manager API `processMeshDeletions` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn processMeshDeletions(self: *Self, max_count: usize) void {
         return lod_manager_eviction_ops.processMeshDeletions(self, max_count);
     }
 
+    /// LOD manager API `enforceMemoryBudget` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn enforceMemoryBudget(self: *Self) !void {
         return lod_manager_eviction_ops.enforceMemoryBudget(self);
     }
 
+    /// LOD manager API `updateStats` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn updateStats(self: *Self) void {
         return lod_manager_eviction_ops.updateStats(self);
     }
 
+    /// LOD manager API `unloadLODWhereChunksLoaded` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn unloadLODWhereChunksLoaded(self: *Self, checker: ChunkChecker, ctx: *anyopaque) void {
         return lod_manager_eviction_ops.unloadLODWhereChunksLoaded(self, checker, ctx);
     }
 
+    /// LOD manager API `areAllChunksLoaded` updates distant-terrain scheduling, cache state, or render coordination for the active world.
     pub fn areAllChunksLoaded(self: *Self, bounds: LODChunk.WorldBounds, checker: ChunkChecker, ctx: *anyopaque) bool {
         return lod_manager_eviction_ops.areAllChunksLoaded(self, bounds, checker, ctx);
     }

--- a/modules/world-lod/src/lod_materials.zig
+++ b/modules/world-lod/src/lod_materials.zig
@@ -4,12 +4,12 @@ const geom = @import("lod_geometry.zig");
 
 pub const LODTextureFace = geom.LODTextureFace;
 
-pub const ambient_occlusion_for_lod = geom.ambient_occlusion_for_lod;
+pub const ambientOcclusionForLOD = geom.ambientOcclusionForLOD;
 pub const applyColorBrightness = geom.applyColorBrightness;
 pub const applyTextureLuminance = geom.applyTextureLuminance;
 pub const averageColor = geom.averageColor;
 pub const blockForLODQuad = geom.blockForLODQuad;
-pub const cell_color_for_lod = geom.cell_color_for_lod;
+pub const cellColorForLOD = geom.cellColorForLOD;
 pub const getLodSideTile = geom.getLodSideTile;
 pub const getLodTopColor = geom.getLodTopColor;
 pub const getLodTopTile = geom.getLodTopTile;

--- a/modules/world-lod/src/lod_mesh.zig
+++ b/modules/world-lod/src/lod_mesh.zig
@@ -50,11 +50,11 @@ const addExposedSpanFaces = geom.addExposedSpanFaces;
 const addTreeColumn = geom.addTreeColumn;
 const addTreeCanopyColumn = geom.addTreeCanopyColumn;
 const averageColor = geom.averageColor;
-const ambient_occlusion_for_lod = geom.ambient_occlusion_for_lod;
+const ambientOcclusionForLOD = geom.ambientOcclusionForLOD;
 const applyColorBrightness = geom.applyColorBrightness;
 const applyTextureLuminance = geom.applyTextureLuminance;
 const blockForLODQuad = geom.blockForLODQuad;
-const cell_color_for_lod = geom.cell_color_for_lod;
+const cellColorForLOD = geom.cellColorForLOD;
 const collectColumnSpans = geom.collectColumnSpans;
 const foldedCanopyColumnForLOD = geom.foldedCanopyColumnForLOD;
 const getLodSideTile = geom.getLodSideTile;
@@ -62,7 +62,7 @@ const getLodTopColor = geom.getLodTopColor;
 const getLodTopTile = geom.getLodTopTile;
 const highestSolidSpanIndex = geom.highestSolidSpanIndex;
 const isLeafBlock = geom.isLeafBlock;
-const is_lod_water_cell_for_lod = geom.is_lod_water_cell_for_lod;
+const isLODWaterCellForLOD = geom.isLODWaterCellForLOD;
 const LODColumnSpan = geom.LODColumnSpan;
 const LOD_TREE_COVERAGE_THRESHOLD = geom.LOD_TREE_COVERAGE_THRESHOLD;
 const maxStitchedHeightAdjustment = geom.maxStitchedHeightAdjustment;
@@ -295,13 +295,13 @@ pub const LODMesh = struct {
         while (gz + 1 < data.width) : (gz += 1) {
             var gx: u32 = 0;
             while (gx + 1 < data.width) : (gx += 1) {
-                const cell_color = cell_color_for_lod(data, gx, gz, self.lod_level);
-                const lit_cell_color = applyColorBrightness(cell_color, ambient_occlusion_for_lod(data, gx, gz, self.lod_level));
+                const cell_color = cellColorForLOD(data, gx, gz, self.lod_level);
+                const lit_cell_color = applyColorBrightness(cell_color, ambientOcclusionForLOD(data, gx, gz, self.lod_level));
                 const wx = @as(f32, @floatFromInt(gx)) * cell_size;
                 const wz = @as(f32, @floatFromInt(gz)) * cell_size;
                 const size = cell_size;
 
-                const is_water_cell = is_lod_water_cell_for_lod(data, gx, gz, self.lod_level);
+                const is_water_cell = isLODWaterCellForLOD(data, gx, gz, self.lod_level);
                 const base_block = terrainBlockForLODQuadForLOD(data, gx, gz, is_water_cell, self.lod_level);
                 const base_height = quantizedCellVisualTerrainHeightForLOD(data, gx, gz, self.lod_level, is_water_cell);
                 const folded_canopy = foldedCanopyColumnForLOD(data, gx, gz, self.lod_level, base_height, base_block, is_water_cell);
@@ -310,7 +310,7 @@ pub const LODMesh = struct {
                 const top_tile = if (folded_canopy != null) Vertex.LOD_TILE_ID else getLodTopTile(top_block, atlas);
                 const side_tile = if (folded_canopy != null) Vertex.LOD_TILE_ID else getLodSideTile(top_block, atlas);
                 const base_top_color = if (folded_canopy) |folded|
-                    applyColorBrightness(folded.color, ambient_occlusion_for_lod(data, gx, gz, self.lod_level))
+                    applyColorBrightness(folded.color, ambientOcclusionForLOD(data, gx, gz, self.lod_level))
                 else
                     getLodTopColor(top_block, top_tile, lit_cell_color);
                 const top_color = applyTextureLuminance(tintColorForLodFace(data, gx, gz, self.lod_level, top_block, .top, base_top_color), top_block, .top, atlas);
@@ -437,7 +437,7 @@ pub const LODMesh = struct {
                         if (vegetation.leaves == .air) vegetation.leaves = span.block;
                         if (vegetation.tree_coverage < LOD_TREE_COVERAGE_THRESHOLD) vegetation.tree_coverage = LOD_TREE_COVERAGE_THRESHOLD;
                         if (vegetation.avg_tree_height < 2.0) vegetation.avg_tree_height = @max(2.0, span.max_height - span.min_height);
-                        const tree_is_water_cell = is_lod_water_cell_for_lod(data, gx, gz, self.lod_level);
+                        const tree_is_water_cell = isLODWaterCellForLOD(data, gx, gz, self.lod_level);
                         const tree_base_height = quantizedCellVisualTerrainHeightForLOD(data, gx, gz, self.lod_level, tree_is_water_cell);
                         try addTreeCanopyColumn(self.allocator, &vertices, data, gx, gz, self.lod_level, wx, wz, cell_size, tree_base_height, span.min_height, span.max_height, vegetation, atlas, world_x, world_z);
                         continue;

--- a/modules/world-lod/src/lod_renderer.zig
+++ b/modules/world-lod/src/lod_renderer.zig
@@ -102,7 +102,8 @@ pub fn LODRenderer(comptime RHI: type) type {
         gpu_culling_requested: bool,
         gpu_culling_fallback_logged: bool,
 
-        /// LOD renderer API `init` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
+        /// Allocates LOD renderer GPU buffers and per-frame indirect draw resources.
+        /// The renderer owns created buffers until `deinit`; allocation failures are returned to the caller.
         pub fn init(allocator: std.mem.Allocator, rhi: RHI) !*Self {
             const renderer = try allocator.create(Self);
             errdefer allocator.destroy(renderer);
@@ -151,7 +152,8 @@ pub fn LODRenderer(comptime RHI: type) type {
             return renderer;
         }
 
-        /// LOD renderer API `deinit` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
+        /// Destroys GPU buffers owned by the LOD renderer and releases CPU-side storage.
+        /// Call once when the world LOD renderer is no longer used.
         pub fn deinit(self: *Self) void {
             self.rhi.waitIdle();
             const resources = if (@hasDecl(RHI, "resourceManager")) self.rhi.resourceManager() else self.rhi;
@@ -692,22 +694,17 @@ test "LODRenderer init/deinit lifecycle" {
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(self: @This(), _: usize, _: anytype) !u32 {
             self.state.buffers_created += 1;
             return self.state.buffers_created;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(self: @This(), _: u32) void {
             self.state.buffers_destroyed += 1;
         }
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(_: @This(), _: Mat4, _: Vec3, _: f32) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(_: @This(), _: u32, _: u32, _: anytype) void {}
     };
 
@@ -742,16 +739,13 @@ test "LODRenderer batches pooled meshes into per-LOD indirect draws" {
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(self: @This(), _: usize, usage: anytype) !u32 {
             _ = usage;
             const handle = self.state.next_handle;
             self.state.next_handle += 1;
             return handle;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
-        /// LOD renderer API `updateBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn updateBuffer(self: @This(), _: u32, _: usize, data: []const u8) !void {
             if (data.len % @sizeOf(rhi_types.InstanceData) == 0 and data.len != @sizeOf(rhi_types.DrawIndirectCommand)) {
                 self.state.instance_updates += 1;
@@ -759,27 +753,18 @@ test "LODRenderer batches pooled meshes into per-LOD indirect draws" {
                 self.state.indirect_updates += 1;
             }
         }
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `supportsIndirectFirstInstance` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn supportsIndirectFirstInstance(_: @This()) bool {
             return true;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(_: @This(), _: Mat4, _: Vec3, _: f32) void {}
-        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `setInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(_: @This(), _: u32, _: u32, _: anytype) void {}
-        /// LOD renderer API `drawOffset` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn drawOffset(_: @This(), _: u32, _: u32, _: anytype, _: usize) void {}
-        /// LOD renderer API `drawIndirect` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn drawIndirect(self: @This(), _: u32, _: u32, _: usize, draw_count: u32, _: u32) void {
             self.state.draw_indirect_calls += 1;
             self.state.last_draw_count += draw_count;
@@ -889,25 +874,18 @@ test "LODRenderer render draw path" {
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, _: f32) void {
             self.state.set_matrix_calls += 1;
         }
-        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), handle: u32, count: u32, _: anytype) void {
             self.state.draw_calls += 1;
             self.state.last_buffer_handle = handle;
@@ -993,25 +971,18 @@ test "LODRenderer keeps coarse LOD visible while finer bands stream" {
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, _: f32) void {
             self.state.set_matrix_calls += 1;
         }
-        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1072,25 +1043,18 @@ test "LODRenderer disables mask when chunks are missing inside chunk render radi
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, mask_radius: f32) void {
             self.state.last_mask_radius = mask_radius;
         }
-        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1153,25 +1117,18 @@ test "LODRenderer chunk mask uses chunk render radius instead of LOD0 radius" {
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, mask_radius: f32) void {
             self.state.last_mask_radius = mask_radius;
         }
-        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1240,25 +1197,18 @@ test "LODRenderer keeps mask when only outside-radius chunks are uncovered" {
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, mask_radius: f32) void {
             self.state.last_mask_radius = mask_radius;
         }
-        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1321,25 +1271,18 @@ test "LODRenderer keeps mask for partially covered chunk regions" {
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, mask_radius: f32) void {
             self.state.last_mask_radius = mask_radius;
         }
-        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1401,23 +1344,16 @@ test "LODRenderer skips coarse LOD when finer coverage is ready" {
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(_: @This(), _: Mat4, _: Vec3, _: f32) void {}
-        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1493,23 +1429,16 @@ test "LODRenderer always renders ready LOD0 regions" {
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(_: @This(), _: Mat4, _: Vec3, _: f32) void {}
-        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1568,23 +1497,16 @@ test "LODRenderer keeps coarse LOD when a finer child is missing" {
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(_: @This(), _: Mat4, _: Vec3, _: f32) void {}
-        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), handle: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
             self.state.handle_sum += handle;
@@ -1659,23 +1581,16 @@ test "LODRenderer resolves finer coverage across negative region boundaries" {
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(_: @This(), _: Mat4, _: Vec3, _: f32) void {}
-        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), handle: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
             self.state.handle_sum += handle;
@@ -1754,34 +1669,26 @@ test "LODRenderer createGPUBridge and toInterface round-trip" {
     const MockRHI = struct {
         state: *MockRHIState,
 
-        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(self: @This(), _: usize, _: anytype) !u32 {
             _ = self;
             return 1;
         }
-        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(self: @This(), _: u32) void {
             self.state.destroy_calls += 1;
         }
-        /// LOD renderer API `uploadBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn uploadBuffer(self: @This(), _: u32, _: []const u8) !void {
             self.state.upload_calls += 1;
         }
-        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
-        /// LOD renderer API `waitIdle` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn waitIdle(self: @This()) void {
             self.state.wait_idle_calls += 1;
         }
-        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, _: f32) void {
             self.state.set_matrix_calls += 1;
         }
-        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
-        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }

--- a/modules/world-lod/src/lod_renderer.zig
+++ b/modules/world-lod/src/lod_renderer.zig
@@ -102,6 +102,7 @@ pub fn LODRenderer(comptime RHI: type) type {
         gpu_culling_requested: bool,
         gpu_culling_fallback_logged: bool,
 
+        /// LOD renderer API `init` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn init(allocator: std.mem.Allocator, rhi: RHI) !*Self {
             const renderer = try allocator.create(Self);
             errdefer allocator.destroy(renderer);
@@ -150,6 +151,7 @@ pub fn LODRenderer(comptime RHI: type) type {
             return renderer;
         }
 
+        /// LOD renderer API `deinit` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn deinit(self: *Self) void {
             self.rhi.waitIdle();
             const resources = if (@hasDecl(RHI, "resourceManager")) self.rhi.resourceManager() else self.rhi;
@@ -690,17 +692,22 @@ test "LODRenderer init/deinit lifecycle" {
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(self: @This(), _: usize, _: anytype) !u32 {
             self.state.buffers_created += 1;
             return self.state.buffers_created;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(self: @This(), _: u32) void {
             self.state.buffers_destroyed += 1;
         }
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(_: @This(), _: Mat4, _: Vec3, _: f32) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(_: @This(), _: u32, _: u32, _: anytype) void {}
     };
 
@@ -735,13 +742,16 @@ test "LODRenderer batches pooled meshes into per-LOD indirect draws" {
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(self: @This(), _: usize, usage: anytype) !u32 {
             _ = usage;
             const handle = self.state.next_handle;
             self.state.next_handle += 1;
             return handle;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
+        /// LOD renderer API `updateBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn updateBuffer(self: @This(), _: u32, _: usize, data: []const u8) !void {
             if (data.len % @sizeOf(rhi_types.InstanceData) == 0 and data.len != @sizeOf(rhi_types.DrawIndirectCommand)) {
                 self.state.instance_updates += 1;
@@ -749,18 +759,27 @@ test "LODRenderer batches pooled meshes into per-LOD indirect draws" {
                 self.state.indirect_updates += 1;
             }
         }
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `supportsIndirectFirstInstance` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn supportsIndirectFirstInstance(_: @This()) bool {
             return true;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(_: @This(), _: Mat4, _: Vec3, _: f32) void {}
+        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `setInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(_: @This(), _: u32, _: u32, _: anytype) void {}
+        /// LOD renderer API `drawOffset` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn drawOffset(_: @This(), _: u32, _: u32, _: anytype, _: usize) void {}
+        /// LOD renderer API `drawIndirect` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn drawIndirect(self: @This(), _: u32, _: u32, _: usize, draw_count: u32, _: u32) void {
             self.state.draw_indirect_calls += 1;
             self.state.last_draw_count += draw_count;
@@ -870,18 +889,25 @@ test "LODRenderer render draw path" {
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, _: f32) void {
             self.state.set_matrix_calls += 1;
         }
+        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), handle: u32, count: u32, _: anytype) void {
             self.state.draw_calls += 1;
             self.state.last_buffer_handle = handle;
@@ -967,18 +993,25 @@ test "LODRenderer keeps coarse LOD visible while finer bands stream" {
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, _: f32) void {
             self.state.set_matrix_calls += 1;
         }
+        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1039,18 +1072,25 @@ test "LODRenderer disables mask when chunks are missing inside chunk render radi
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, mask_radius: f32) void {
             self.state.last_mask_radius = mask_radius;
         }
+        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1113,18 +1153,25 @@ test "LODRenderer chunk mask uses chunk render radius instead of LOD0 radius" {
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, mask_radius: f32) void {
             self.state.last_mask_radius = mask_radius;
         }
+        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1193,18 +1240,25 @@ test "LODRenderer keeps mask when only outside-radius chunks are uncovered" {
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, mask_radius: f32) void {
             self.state.last_mask_radius = mask_radius;
         }
+        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1267,18 +1321,25 @@ test "LODRenderer keeps mask for partially covered chunk regions" {
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, mask_radius: f32) void {
             self.state.last_mask_radius = mask_radius;
         }
+        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1340,16 +1401,23 @@ test "LODRenderer skips coarse LOD when finer coverage is ready" {
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(_: @This(), _: Mat4, _: Vec3, _: f32) void {}
+        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1425,16 +1493,23 @@ test "LODRenderer always renders ready LOD0 regions" {
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(_: @This(), _: Mat4, _: Vec3, _: f32) void {}
+        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }
@@ -1493,16 +1568,23 @@ test "LODRenderer keeps coarse LOD when a finer child is missing" {
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(_: @This(), _: Mat4, _: Vec3, _: f32) void {}
+        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), handle: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
             self.state.handle_sum += handle;
@@ -1577,16 +1659,23 @@ test "LODRenderer resolves finer coverage across negative region boundaries" {
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(_: @This(), _: usize, _: anytype) !u32 {
             return 1;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(_: @This(), _: u32) void {}
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(_: @This(), _: Mat4, _: Vec3, _: f32) void {}
+        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `setSelectionMode` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setSelectionMode(_: @This(), _: bool) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), handle: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
             self.state.handle_sum += handle;
@@ -1665,26 +1754,34 @@ test "LODRenderer createGPUBridge and toInterface round-trip" {
     const MockRHI = struct {
         state: *MockRHIState,
 
+        /// LOD renderer API `createBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn createBuffer(self: @This(), _: usize, _: anytype) !u32 {
             _ = self;
             return 1;
         }
+        /// LOD renderer API `destroyBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn destroyBuffer(self: @This(), _: u32) void {
             self.state.destroy_calls += 1;
         }
+        /// LOD renderer API `uploadBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn uploadBuffer(self: @This(), _: u32, _: []const u8) !void {
             self.state.upload_calls += 1;
         }
+        /// LOD renderer API `getFrameIndex` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn getFrameIndex(_: @This()) usize {
             return 0;
         }
+        /// LOD renderer API `waitIdle` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn waitIdle(self: @This()) void {
             self.state.wait_idle_calls += 1;
         }
+        /// LOD renderer API `setModelMatrix` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setModelMatrix(self: @This(), _: Mat4, _: Vec3, _: f32) void {
             self.state.set_matrix_calls += 1;
         }
+        /// LOD renderer API `setLODInstanceBuffer` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn setLODInstanceBuffer(_: @This(), _: anytype) void {}
+        /// LOD renderer API `draw` manages distant-terrain render resources or draw-time state owned by the LOD renderer.
         pub fn draw(self: @This(), _: u32, _: u32, _: anytype) void {
             self.state.draw_calls += 1;
         }

--- a/modules/world-runtime/src/world.zig
+++ b/modules/world-runtime/src/world.zig
@@ -58,14 +58,16 @@ pub const GpuMeshDispatch = struct {
 };
 
 pub const WorldOrchestration = struct {
-    /// World facade operation `update` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Advances world streaming, generation, meshing, autosave, and runtime queues for one frame.
+    /// `player_pos` drives chunk residency; `dt` is frame time in seconds. Propagates errors from streaming, persistence, meshing, or mutation subsystems.
     pub fn update(renderer: anytype, streamer: anytype, world: anytype, player_pos: Vec3, dt: f32) !void {
         renderer.beginFrame();
         try streamer.updateFrame(player_pos, dt);
         world.checkAutoSave();
     }
 
-    /// World facade operation `render` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Renders all enabled world layers for the current camera.
+    /// LOD rendering is controlled by `render_lod` and the world configuration; call after `update` has advanced queues.
     pub fn render(renderer: anytype, streamer: anytype, lod_manager: anytype, lod_enabled: bool, view_proj: Mat4, camera_pos: Vec3, render_lod: bool, layer: anytype) void {
         const allow_lod = lod_enabled and render_lod;
         renderer.render(view_proj, camera_pos, streamer.getActiveRenderDistance(), lod_manager, allow_lod, layer);
@@ -153,187 +155,224 @@ pub const IWorld = struct {
         getGpuMeshDispatch: *const fn (ptr: *anyopaque) GpuMeshDispatch,
     };
 
-    /// World facade operation `update` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Advances world streaming, generation, meshing, autosave, and runtime queues for one frame.
+    /// `player_pos` drives chunk residency; `dt` is frame time in seconds. Propagates errors from streaming, persistence, meshing, or mutation subsystems.
     pub fn update(self: IWorld, player_pos: Vec3, dt: f32) !void {
         try self.vtable.update(self.ptr, player_pos, dt);
     }
 
-    /// World facade operation `render` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Renders all enabled world layers for the current camera.
+    /// LOD rendering is controlled by `render_lod` and the world configuration; call after `update` has advanced queues.
     pub fn render(self: IWorld, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         self.vtable.render(self.ptr, view_proj, camera_pos, render_lod);
     }
 
-    /// World facade operation `renderOpaque` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Renders opaque terrain and world geometry for the current camera.
+    /// Fluid and transparent passes are intentionally excluded.
     pub fn renderOpaque(self: IWorld, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         self.vtable.renderOpaque(self.ptr, view_proj, camera_pos, render_lod);
     }
 
-    /// World facade operation `renderFluid` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Renders fluid surfaces for the current camera.
+    /// Opaque depth and reflection resources should already be prepared by the renderer.
     pub fn renderFluid(self: IWorld, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         self.vtable.renderFluid(self.ptr, view_proj, camera_pos, render_lod);
     }
 
-    /// World facade operation `deinit` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Stops world jobs and releases streaming, meshing, LOD, rendering, and persistence resources.
+    /// No borrowed world sub-interfaces may be used after this returns.
     pub fn deinit(self: IWorld) void {
         self.vtable.deinit(self.ptr);
     }
 
-    /// World facade operation `getRenderStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns renderer counters for the latest world render work.
+    /// Used by HUDs and diagnostics; values are snapshots, not live references.
     pub fn getRenderStats(self: IWorld) RenderStats {
         return self.vtable.getRenderStats(self.ptr);
     }
 
-    /// World facade operation `getStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns chunk, vertex, and queue counts for world runtime diagnostics.
+    /// The values reflect the current world manager state.
     pub fn getStats(self: IWorld) WorldStatsData {
         return self.vtable.getStats(self.ptr);
     }
 
-    /// World facade operation `getLODStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns distant-terrain LOD statistics when LOD is available.
+    /// Returns `null` when the world has no active LOD manager.
     pub fn getLODStats(self: IWorld) ?@import("world-lod").LODStats {
         return self.vtable.getLODStats(self.ptr);
     }
 
-    /// World facade operation `isLODEnabled` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Reports whether the world was constructed with LOD support.
+    /// This is a capability flag, separate from runtime LOD render toggles.
     pub fn isLODEnabled(self: IWorld) bool {
         return self.vtable.isLODEnabled(self.ptr);
     }
 
-    /// World facade operation `shadowScene` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the world shadow-scene interface used by the shadow renderer.
+    /// The returned interface borrows the world and must not outlive it.
     pub fn shadowScene(self: IWorld) IShadowScene {
         return self.vtable.shadowScene(self.ptr);
     }
 
-    /// World facade operation `enableSaveManager` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Attaches persistence to the world using a save directory and world name.
+    /// May load metadata or create save structures; call before relying on autosave. Propagates errors from streaming, persistence, meshing, or mutation subsystems.
     pub fn enableSaveManager(self: IWorld, save_dir_path: []const u8, world_name: []const u8) !void {
         try self.vtable.enableSaveManager(self.ptr, save_dir_path, world_name);
     }
 
-    /// World facade operation `takeSaveFailureWarningCount` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns and clears the accumulated save-failure warning count.
+    /// Use to surface persistence warnings without repeating already-consumed failures.
     pub fn takeSaveFailureWarningCount(self: IWorld) usize {
         return self.vtable.takeSaveFailureWarningCount(self.ptr);
     }
 
-    /// World facade operation `pauseGeneration` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Pauses background chunk generation and streaming work.
+    /// Already loaded chunks remain accessible and renderable.
     pub fn pauseGeneration(self: IWorld) void {
         self.vtable.pauseGeneration(self.ptr);
     }
 
-    /// World facade operation `isPaused` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Reports whether chunk generation is currently paused.
+    /// Rendering and loaded-chunk queries may still continue while paused.
     pub fn isPaused(self: IWorld) bool {
         return self.vtable.isPaused(self.ptr);
     }
 
-    /// World facade operation `collisionWorld` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the voxel collision query interface for loaded world data.
+    /// The interface borrows world storage and follows world lifetime.
     pub fn collisionWorld(self: IWorld) VoxelCollisionWorld {
         return self.vtable.collisionWorld(self.ptr);
     }
 
-    /// World facade operation `getBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the block type at world-space coordinates.
+    /// Returns air or generated fallback behavior when the target chunk is unavailable.
     pub fn getBlock(self: IWorld, world_x: i32, world_y: i32, world_z: i32) BlockType {
         return self.vtable.getBlock(self.ptr, world_x, world_y, world_z);
     }
 
-    /// World facade operation `setBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Applies a block mutation at world-space coordinates.
+    /// Updates chunk data and schedules affected mesh/render state refreshes. Propagates errors from streaming, persistence, meshing, or mutation subsystems.
     pub fn setBlock(self: IWorld, world_x: i32, world_y: i32, world_z: i32, block: BlockType) !void {
         try self.vtable.setBlock(self.ptr, world_x, world_y, world_z, block);
     }
 
-    /// World facade operation `getColumnInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns generator column metadata for a world X/Z column.
+    /// Does not require the chunk to be resident.
     pub fn getColumnInfo(self: IWorld, world_x: i32, world_z: i32) gen_interface.ColumnInfo {
         return self.vtable.getColumnInfo(self.ptr, world_x, world_z);
     }
 
-    /// World facade operation `getDebugLightInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns packed light debug data for a world-space voxel when available.
+    /// Returns `null` when the target chunk or light sample is unavailable.
     pub fn getDebugLightInfo(self: IWorld, world_x: i32, world_y: i32, world_z: i32) ?DebugLightInfo {
         return self.vtable.getDebugLightInfo(self.ptr, world_x, world_y, world_z);
     }
 
-    /// World facade operation `getRegionInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns generator region metadata for a world X/Z location.
+    /// Used by debug UI and terrain diagnostics.
     pub fn getRegionInfo(self: IWorld, world_x: i32, world_z: i32) gen_interface.RegionInfo {
         return self.vtable.getRegionInfo(self.ptr, world_x, world_z);
     }
 
-    /// World facade operation `getGenerator` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the active world generator interface.
+    /// The generator is owned by the world runtime.
     pub fn getGenerator(self: IWorld) Generator {
         return self.vtable.getGenerator(self.ptr);
     }
 
-    /// World facade operation `getGeneratorName` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the display name of the active world generator.
+    /// The slice is owned by the generator metadata.
     pub fn getGeneratorName(self: IWorld) []const u8 {
         return self.vtable.getGeneratorName(self.ptr);
     }
 
-    /// World facade operation `getRenderDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the active chunk render distance in chunks.
+    /// Used by streaming, renderer masks, and settings UI.
     pub fn getRenderDistance(self: IWorld) i32 {
         return self.vtable.getRenderDistance(self.ptr);
     }
 
-    /// World facade operation `setRenderDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Changes the active chunk render distance.
+    /// The streamer reconciles loaded chunks on subsequent updates.
     pub fn setRenderDistance(self: IWorld, distance: i32) void {
         self.vtable.setRenderDistance(self.ptr, distance);
     }
 
-    /// World facade operation `getHorizonDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the distant-terrain horizon distance in chunks.
+    /// Used by LOD scheduling and settings UI.
     pub fn getHorizonDistance(self: IWorld) i32 {
         return self.vtable.getHorizonDistance(self.ptr);
     }
 
-    /// World facade operation `setHorizonDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Changes the distant-terrain horizon distance.
+    /// LOD queues and visibility update on subsequent world ticks.
     pub fn setHorizonDistance(self: IWorld, distance: i32) void {
         self.vtable.setHorizonDistance(self.ptr, distance);
     }
 
-    /// World facade operation `isLODRenderingEnabled` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Reports whether LOD drawing is currently enabled.
+    /// This runtime toggle is separate from LOD subsystem availability.
     pub fn isLODRenderingEnabled(self: IWorld) bool {
         return self.vtable.isLODRenderingEnabled(self.ptr);
     }
 
-    /// World facade operation `toggleLODRendering` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Toggles LOD drawing and returns the new enabled state.
+    /// Does not destroy LOD data; it only changes render participation.
     pub fn toggleLODRendering(self: IWorld) bool {
         return self.vtable.toggleLODRendering(self.ptr);
     }
 
-    /// World facade operation `getChunkStateCounts` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns counts of chunks in each streaming/meshing state.
+    /// Used for diagnostics and startup-busy checks.
     pub fn getChunkStateCounts(self: IWorld) ChunkStateCounts {
         return self.vtable.getChunkStateCounts(self.ptr);
     }
 
-    /// World facade operation `isStartupBusy` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Reports whether startup generation or streaming still has visible work pending.
+    /// Used by smoke tests and startup diagnostics.
     pub fn isStartupBusy(self: IWorld) bool {
         return self.vtable.isStartupBusy(self.ptr);
     }
 
-    /// World facade operation `getWorldStateData` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns compact world state telemetry for UI and diagnostics.
+    /// The returned struct is a snapshot of runtime state.
     pub fn getWorldStateData(self: IWorld) WorldStateData {
         return self.vtable.getWorldStateData(self.ptr);
     }
 
-    /// World facade operation `lpvWorld` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the world data interface used by LPV lighting injection.
+    /// The returned interface borrows the world and must not outlive it.
     pub fn lpvWorld(self: IWorld) ILPVWorld {
         return self.vtable.lpvWorld(self.ptr);
     }
 
-    /// World facade operation `graphicsRenderView` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the graphics-facing world render view.
+    /// Use for renderer systems that need chunk buffers without full world mutation access.
     pub fn graphicsRenderView(self: IWorld) GraphicsWorldRenderView {
         return self.vtable.graphicsRenderView(self.ptr);
     }
 
-    /// World facade operation `getGpuMeshDispatch` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the optional GPU meshing dispatch hook.
+    /// The hook is null when GPU meshing is unavailable.
     pub fn getGpuMeshDispatch(self: IWorld) GpuMeshDispatch {
         return self.vtable.getGpuMeshDispatch(self.ptr);
     }
 
-    /// World facade operation `simulation` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Narrows the world facade to simulation and mutation operations.
+    /// Use to avoid giving consumers render or telemetry access.
     pub fn simulation(self: IWorld) IWorldSimulation {
         return .{ .world = self };
     }
 
-    /// World facade operation `renderView` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Narrows the world facade to render-facing operations.
+    /// Use by graphics systems that should not mutate simulation state.
     pub fn renderView(self: IWorld) IWorldRenderView {
         return .{ .world = self };
     }
 
-    /// World facade operation `telemetry` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Narrows the world facade to diagnostics and settings operations.
+    /// Use by UI/debug systems that only need world state snapshots.
     pub fn telemetry(self: IWorld) IWorldTelemetry {
         return .{ .world = self };
     }
@@ -342,47 +381,56 @@ pub const IWorld = struct {
 pub const IWorldSimulation = struct {
     world: IWorld,
 
-    /// World facade operation `update` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Advances world streaming, generation, meshing, autosave, and runtime queues for one frame.
+    /// `player_pos` drives chunk residency; `dt` is frame time in seconds. Propagates errors from streaming, persistence, meshing, or mutation subsystems.
     pub fn update(self: IWorldSimulation, player_pos: Vec3, dt: f32) !void {
         try self.world.update(player_pos, dt);
     }
 
-    /// World facade operation `deinit` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Stops world jobs and releases streaming, meshing, LOD, rendering, and persistence resources.
+    /// No borrowed world sub-interfaces may be used after this returns.
     pub fn deinit(self: IWorldSimulation) void {
         self.world.deinit();
     }
 
-    /// World facade operation `enableSaveManager` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Attaches persistence to the world using a save directory and world name.
+    /// May load metadata or create save structures; call before relying on autosave. Propagates errors from streaming, persistence, meshing, or mutation subsystems.
     pub fn enableSaveManager(self: IWorldSimulation, save_dir_path: []const u8, world_name: []const u8) !void {
         try self.world.enableSaveManager(save_dir_path, world_name);
     }
 
-    /// World facade operation `pauseGeneration` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Pauses background chunk generation and streaming work.
+    /// Already loaded chunks remain accessible and renderable.
     pub fn pauseGeneration(self: IWorldSimulation) void {
         self.world.pauseGeneration();
     }
 
-    /// World facade operation `isPaused` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Reports whether chunk generation is currently paused.
+    /// Rendering and loaded-chunk queries may still continue while paused.
     pub fn isPaused(self: IWorldSimulation) bool {
         return self.world.isPaused();
     }
 
-    /// World facade operation `collisionWorld` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the voxel collision query interface for loaded world data.
+    /// The interface borrows world storage and follows world lifetime.
     pub fn collisionWorld(self: IWorldSimulation) VoxelCollisionWorld {
         return self.world.collisionWorld();
     }
 
-    /// World facade operation `getBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the block type at world-space coordinates.
+    /// Returns air or generated fallback behavior when the target chunk is unavailable.
     pub fn getBlock(self: IWorldSimulation, world_x: i32, world_y: i32, world_z: i32) BlockType {
         return self.world.getBlock(world_x, world_y, world_z);
     }
 
-    /// World facade operation `setBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Applies a block mutation at world-space coordinates.
+    /// Updates chunk data and schedules affected mesh/render state refreshes. Propagates errors from streaming, persistence, meshing, or mutation subsystems.
     pub fn setBlock(self: IWorldSimulation, world_x: i32, world_y: i32, world_z: i32, block: BlockType) !void {
         try self.world.setBlock(world_x, world_y, world_z, block);
     }
 
-    /// World facade operation `getColumnInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns generator column metadata for a world X/Z column.
+    /// Does not require the chunk to be resident.
     pub fn getColumnInfo(self: IWorldSimulation, world_x: i32, world_z: i32) gen_interface.ColumnInfo {
         return self.world.getColumnInfo(world_x, world_z);
     }
@@ -391,37 +439,44 @@ pub const IWorldSimulation = struct {
 pub const IWorldRenderView = struct {
     world: IWorld,
 
-    /// World facade operation `render` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Renders all enabled world layers for the current camera.
+    /// LOD rendering is controlled by `render_lod` and the world configuration; call after `update` has advanced queues.
     pub fn render(self: IWorldRenderView, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         self.world.render(view_proj, camera_pos, render_lod);
     }
 
-    /// World facade operation `renderOpaque` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Renders opaque terrain and world geometry for the current camera.
+    /// Fluid and transparent passes are intentionally excluded.
     pub fn renderOpaque(self: IWorldRenderView, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         self.world.renderOpaque(view_proj, camera_pos, render_lod);
     }
 
-    /// World facade operation `renderFluid` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Renders fluid surfaces for the current camera.
+    /// Opaque depth and reflection resources should already be prepared by the renderer.
     pub fn renderFluid(self: IWorldRenderView, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         self.world.renderFluid(view_proj, camera_pos, render_lod);
     }
 
-    /// World facade operation `shadowScene` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the world shadow-scene interface used by the shadow renderer.
+    /// The returned interface borrows the world and must not outlive it.
     pub fn shadowScene(self: IWorldRenderView) IShadowScene {
         return self.world.shadowScene();
     }
 
-    /// World facade operation `lpvWorld` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the world data interface used by LPV lighting injection.
+    /// The returned interface borrows the world and must not outlive it.
     pub fn lpvWorld(self: IWorldRenderView) ILPVWorld {
         return self.world.lpvWorld();
     }
 
-    /// World facade operation `graphicsRenderView` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the graphics-facing world render view.
+    /// Use for renderer systems that need chunk buffers without full world mutation access.
     pub fn graphicsRenderView(self: IWorldRenderView) GraphicsWorldRenderView {
         return self.world.graphicsRenderView();
     }
 
-    /// World facade operation `getGpuMeshDispatch` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the optional GPU meshing dispatch hook.
+    /// The hook is null when GPU meshing is unavailable.
     pub fn getGpuMeshDispatch(self: IWorldRenderView) GpuMeshDispatch {
         return self.world.getGpuMeshDispatch();
     }
@@ -430,92 +485,110 @@ pub const IWorldRenderView = struct {
 pub const IWorldTelemetry = struct {
     world: IWorld,
 
-    /// World facade operation `getRenderStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns renderer counters for the latest world render work.
+    /// Used by HUDs and diagnostics; values are snapshots, not live references.
     pub fn getRenderStats(self: IWorldTelemetry) RenderStats {
         return self.world.getRenderStats();
     }
 
-    /// World facade operation `getStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns chunk, vertex, and queue counts for world runtime diagnostics.
+    /// The values reflect the current world manager state.
     pub fn getStats(self: IWorldTelemetry) WorldStatsData {
         return self.world.getStats();
     }
 
-    /// World facade operation `getLODStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns distant-terrain LOD statistics when LOD is available.
+    /// Returns `null` when the world has no active LOD manager.
     pub fn getLODStats(self: IWorldTelemetry) ?@import("world-lod").LODStats {
         return self.world.getLODStats();
     }
 
-    /// World facade operation `isLODEnabled` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Reports whether the world was constructed with LOD support.
+    /// This is a capability flag, separate from runtime LOD render toggles.
     pub fn isLODEnabled(self: IWorldTelemetry) bool {
         return self.world.isLODEnabled();
     }
 
-    /// World facade operation `getRenderDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the active chunk render distance in chunks.
+    /// Used by streaming, renderer masks, and settings UI.
     pub fn getRenderDistance(self: IWorldTelemetry) i32 {
         return self.world.getRenderDistance();
     }
 
-    /// World facade operation `setRenderDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Changes the active chunk render distance.
+    /// The streamer reconciles loaded chunks on subsequent updates.
     pub fn setRenderDistance(self: IWorldTelemetry, distance: i32) void {
         self.world.setRenderDistance(distance);
     }
 
-    /// World facade operation `getHorizonDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the distant-terrain horizon distance in chunks.
+    /// Used by LOD scheduling and settings UI.
     pub fn getHorizonDistance(self: IWorldTelemetry) i32 {
         return self.world.getHorizonDistance();
     }
 
-    /// World facade operation `setHorizonDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Changes the distant-terrain horizon distance.
+    /// LOD queues and visibility update on subsequent world ticks.
     pub fn setHorizonDistance(self: IWorldTelemetry, distance: i32) void {
         self.world.setHorizonDistance(distance);
     }
 
-    /// World facade operation `isLODRenderingEnabled` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Reports whether LOD drawing is currently enabled.
+    /// This runtime toggle is separate from LOD subsystem availability.
     pub fn isLODRenderingEnabled(self: IWorldTelemetry) bool {
         return self.world.isLODRenderingEnabled();
     }
 
-    /// World facade operation `toggleLODRendering` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Toggles LOD drawing and returns the new enabled state.
+    /// Does not destroy LOD data; it only changes render participation.
     pub fn toggleLODRendering(self: IWorldTelemetry) bool {
         return self.world.toggleLODRendering();
     }
 
-    /// World facade operation `getChunkStateCounts` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns counts of chunks in each streaming/meshing state.
+    /// Used for diagnostics and startup-busy checks.
     pub fn getChunkStateCounts(self: IWorldTelemetry) ChunkStateCounts {
         return self.world.getChunkStateCounts();
     }
 
-    /// World facade operation `isStartupBusy` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Reports whether startup generation or streaming still has visible work pending.
+    /// Used by smoke tests and startup diagnostics.
     pub fn isStartupBusy(self: IWorldTelemetry) bool {
         return self.world.isStartupBusy();
     }
 
-    /// World facade operation `getWorldStateData` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns compact world state telemetry for UI and diagnostics.
+    /// The returned struct is a snapshot of runtime state.
     pub fn getWorldStateData(self: IWorldTelemetry) WorldStateData {
         return self.world.getWorldStateData();
     }
 
-    /// World facade operation `getGeneratorName` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the display name of the active world generator.
+    /// The slice is owned by the generator metadata.
     pub fn getGeneratorName(self: IWorldTelemetry) []const u8 {
         return self.world.getGeneratorName();
     }
 
-    /// World facade operation `getBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the block type at world-space coordinates.
+    /// Returns air or generated fallback behavior when the target chunk is unavailable.
     pub fn getBlock(self: IWorldTelemetry, world_x: i32, world_y: i32, world_z: i32) BlockType {
         return self.world.getBlock(world_x, world_y, world_z);
     }
 
-    /// World facade operation `getDebugLightInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns packed light debug data for a world-space voxel when available.
+    /// Returns `null` when the target chunk or light sample is unavailable.
     pub fn getDebugLightInfo(self: IWorldTelemetry, world_x: i32, world_y: i32, world_z: i32) ?DebugLightInfo {
         return self.world.getDebugLightInfo(world_x, world_y, world_z);
     }
 
-    /// World facade operation `getRegionInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns generator region metadata for a world X/Z location.
+    /// Used by debug UI and terrain diagnostics.
     pub fn getRegionInfo(self: IWorldTelemetry, world_x: i32, world_z: i32) gen_interface.RegionInfo {
         return self.world.getRegionInfo(world_x, world_z);
     }
 
-    /// World facade operation `getGenerator` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the active world generator interface.
+    /// The generator is owned by the world runtime.
     pub fn getGenerator(self: IWorldTelemetry) Generator {
         return self.world.getGenerator();
     }
@@ -562,7 +635,8 @@ pub const World = struct {
     // LPV lighting grid builder (Issue #789)
     lpv_grid_builder: LpvGridBuilder,
 
-    /// World facade operation `init` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Creates a world runtime with chunk storage, streaming, meshing, rendering, and optional LOD support.
+    /// The allocator, generator, and RHI-backed resources must remain valid for the world lifetime. Propagates errors from streaming, persistence, meshing, or mutation subsystems.
     pub fn init(options: InitOptions) !*World {
         const allocator = options.allocator;
         const world = try allocator.create(World);
@@ -639,7 +713,8 @@ pub const World = struct {
         return world;
     }
 
-    /// World facade operation `deinit` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Stops world jobs and releases streaming, meshing, LOD, rendering, and persistence resources.
+    /// No borrowed world sub-interfaces may be used after this returns.
     pub fn deinit(self: *World) void {
         // Pause generation first: clears the gen/mesh/LOD job queues so worker
         // threads stop pulling new jobs. (In-flight LOD heightmap jobs are
@@ -670,7 +745,8 @@ pub const World = struct {
         self.allocator.destroy(self);
     }
 
-    /// World facade operation `pauseGeneration` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Pauses background chunk generation and streaming work.
+    /// Already loaded chunks remain accessible and renderable.
     pub fn pauseGeneration(self: *World) void {
         self.paused = true;
         self.streamer.setPaused(true);
@@ -680,7 +756,8 @@ pub const World = struct {
         }
     }
 
-    /// World facade operation `resumeGeneration` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Resumes background chunk generation after a pause.
+    /// Queued work may continue on subsequent `update` calls.
     pub fn resumeGeneration(self: *World) void {
         self.paused = false;
         self.streamer.setPaused(false);
@@ -690,7 +767,8 @@ pub const World = struct {
         }
     }
 
-    /// World facade operation `enableSaveManager` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Attaches persistence to the world using a save directory and world name.
+    /// May load metadata or create save structures; call before relying on autosave. Propagates errors from streaming, persistence, meshing, or mutation subsystems.
     pub fn enableSaveManager(self: *World, save_dir_path: []const u8, world_name: []const u8) !void {
         const seed = self.generator.getSeed();
         const gen_name = self.generator.info.name;
@@ -701,7 +779,8 @@ pub const World = struct {
         }
     }
 
-    /// World facade operation `takeSaveFailureWarningCount` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns and clears the accumulated save-failure warning count.
+    /// Use to surface persistence warnings without repeating already-consumed failures.
     pub fn takeSaveFailureWarningCount(self: *World) usize {
         const sm = self.save_manager orelse return 0;
         return sm.takePersistedFailedSaveCount();
@@ -741,7 +820,8 @@ pub const World = struct {
         self.storage.chunks_mutex.unlock();
     }
 
-    /// World facade operation `saveAllModifiedChunks` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Synchronously saves chunks marked dirty by mutations or streaming.
+    /// Returns errors from persistence and leaves unsaved chunks dirty for later retry.
     pub fn saveAllModifiedChunks(self: *World) void {
         const sm = self.save_manager orelse return;
 
@@ -756,7 +836,8 @@ pub const World = struct {
         self.remarkFailedSaves(failed);
     }
 
-    /// World facade operation `checkAutoSave` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Runs autosave bookkeeping and persists dirty chunks when the save interval has elapsed.
+    /// No work occurs when persistence is disabled.
     pub fn checkAutoSave(self: *World) void {
         const sm = self.save_manager orelse return;
         if (!sm.shouldAutoSave()) return;
@@ -773,7 +854,8 @@ pub const World = struct {
         self.remarkFailedSaves(failed);
     }
 
-    /// World facade operation `loadChunkFromSave` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Attempts to load a chunk from persistent storage.
+    /// Returns `null` when no saved data exists for the requested chunk.
     pub fn loadChunkFromSave(self: *World, cx: i32, cz: i32, out_chunk: *Chunk) LoadResult {
         const sm = self.save_manager orelse return .not_found;
         return sm.loadChunk(cx, cz, out_chunk);
@@ -800,7 +882,8 @@ pub const World = struct {
         }
     }
 
-    /// World facade operation `setHorizonDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Changes the distant-terrain horizon distance.
+    /// LOD queues and visibility update on subsequent world ticks.
     pub fn setHorizonDistance(self: *World, distance: i32) void {
         const target = @max(distance, self.render_distance);
         if (self.horizon_distance == target) return;
@@ -812,12 +895,14 @@ pub const World = struct {
         }
     }
 
-    /// World facade operation `getOrCreateChunk` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns a resident chunk or creates storage for it.
+    /// May allocate chunk data and enqueue follow-up generation or meshing work. Propagates errors from streaming, persistence, meshing, or mutation subsystems.
     pub fn getOrCreateChunk(self: *World, chunk_x: i32, chunk_z: i32) !*ChunkData {
         return self.storage.getOrCreate(chunk_x, chunk_z);
     }
 
-    /// World facade operation `getBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the block type at world-space coordinates.
+    /// Returns air or generated fallback behavior when the target chunk is unavailable.
     pub fn getBlock(self: *World, world_x: i32, world_y: i32, world_z: i32) BlockType {
         if (world_y < 0 or world_y >= CHUNK_SIZE_Y) return .air;
         const cp = worldToChunk(world_x, world_z);
@@ -826,7 +911,8 @@ pub const World = struct {
         return data.chunk.getBlock(local.x, @intCast(world_y), local.z);
     }
 
-    /// World facade operation `getDebugLightInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns packed light debug data for a world-space voxel when available.
+    /// Returns `null` when the target chunk or light sample is unavailable.
     pub fn getDebugLightInfo(self: *World, world_x: i32, world_y: i32, world_z: i32) ?DebugLightInfo {
         if (world_y < 0 or world_y >= CHUNK_SIZE_Y) return null;
         const cp = worldToChunk(world_x, world_z);
@@ -840,17 +926,20 @@ pub const World = struct {
         };
     }
 
-    /// World facade operation `getColumnInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns generator column metadata for a world X/Z column.
+    /// Does not require the chunk to be resident.
     pub fn getColumnInfo(self: *const World, world_x: i32, world_z: i32) gen_interface.ColumnInfo {
         return self.generator.getColumnInfo(@floatFromInt(world_x), @floatFromInt(world_z));
     }
 
-    /// World facade operation `getRegionInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns generator region metadata for a world X/Z location.
+    /// Used by debug UI and terrain diagnostics.
     pub fn getRegionInfo(self: *const World, world_x: i32, world_z: i32) gen_interface.RegionInfo {
         return self.generator.getRegionInfo(world_x, world_z);
     }
 
-    /// World facade operation `setBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Applies a block mutation at world-space coordinates.
+    /// Updates chunk data and schedules affected mesh/render state refreshes. Propagates errors from streaming, persistence, meshing, or mutation subsystems.
     pub fn setBlock(self: *World, world_x: i32, world_y: i32, world_z: i32, block: BlockType) !void {
         _ = try self.mutation.applyBlockMutation(world_x, world_y, world_z, block);
         // Notify the LOD system so distant terrain reflects player edits after
@@ -869,35 +958,41 @@ pub const World = struct {
         return self.storage.get(cx, cz);
     }
 
-    /// World facade operation `update` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Advances world streaming, generation, meshing, autosave, and runtime queues for one frame.
+    /// `player_pos` drives chunk residency; `dt` is frame time in seconds. Propagates errors from streaming, persistence, meshing, or mutation subsystems.
     pub fn update(self: *World, player_pos: Vec3, dt: f32) !void {
         try WorldOrchestration.update(self.renderer, self.streamer, self, player_pos, dt);
     }
 
-    /// World facade operation `render` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Renders all enabled world layers for the current camera.
+    /// LOD rendering is controlled by `render_lod` and the world configuration; call after `update` has advanced queues.
     pub fn render(self: *World, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         const lod_mgr: ?*LODManager = if (self.lod) |lod| lod.manager else null;
         WorldOrchestration.render(self.renderer, self.streamer, lod_mgr, self.lod_enabled, view_proj, camera_pos, render_lod, .all);
     }
 
-    /// World facade operation `renderOpaque` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Renders opaque terrain and world geometry for the current camera.
+    /// Fluid and transparent passes are intentionally excluded.
     pub fn renderOpaque(self: *World, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         const lod_mgr: ?*LODManager = if (self.lod) |lod| lod.manager else null;
         WorldOrchestration.render(self.renderer, self.streamer, lod_mgr, self.lod_enabled, view_proj, camera_pos, render_lod, .terrain);
     }
 
-    /// World facade operation `renderFluid` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Renders fluid surfaces for the current camera.
+    /// Opaque depth and reflection resources should already be prepared by the renderer.
     pub fn renderFluid(self: *World, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         const lod_mgr: ?*LODManager = if (self.lod) |lod| lod.manager else null;
         WorldOrchestration.render(self.renderer, self.streamer, lod_mgr, self.lod_enabled, view_proj, camera_pos, render_lod, .fluid);
     }
 
-    /// World facade operation `renderShadowPass` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Renders world geometry into the active shadow pass.
+    /// Call from the shadow renderer with valid view-projection and shadow config.
     pub fn renderShadowPass(self: *World, light_space_matrix: Mat4, camera_pos: Vec3, shadow_config: ShadowConfig) void {
         self.renderer.renderShadowPass(light_space_matrix, camera_pos, shadow_config.caster_distance);
     }
 
-    /// World facade operation `shadowScene` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the world shadow-scene interface used by the shadow renderer.
+    /// The returned interface borrows the world and must not outlive it.
     pub fn shadowScene(self: *World) IShadowScene {
         return .{
             .ptr = self,
@@ -912,17 +1007,20 @@ pub const World = struct {
         self.renderShadowPass(light_space_matrix, camera_pos, shadow_config);
     }
 
-    /// World facade operation `getRenderStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns renderer counters for the latest world render work.
+    /// Used by HUDs and diagnostics; values are snapshots, not live references.
     pub fn getRenderStats(self: *const World) RenderStats {
         return self.renderer.last_render_stats;
     }
 
-    /// World facade operation `collisionWorld` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the voxel collision query interface for loaded world data.
+    /// The interface borrows world storage and follows world lifetime.
     pub fn collisionWorld(self: *World) VoxelCollisionWorld {
         return .{ .ptr = self, .vtable = &COLLISION_VTABLE };
     }
 
-    /// World facade operation `lpvWorld` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the world data interface used by LPV lighting injection.
+    /// The returned interface borrows the world and must not outlive it.
     pub fn lpvWorld(self: *World) ILPVWorld {
         return self.lpv_grid_builder.interface();
     }
@@ -933,7 +1031,8 @@ pub const World = struct {
         return self.renderer.last_shadow_stats;
     }
 
-    /// World facade operation `resetShadowStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Clears accumulated shadow rendering counters.
+    /// Use before measuring a fresh shadow pass or diagnostic interval.
     pub fn resetShadowStats(self: *World) void {
         self.renderer.resetShadowStats();
     }
@@ -963,7 +1062,8 @@ pub const World = struct {
         return counts;
     }
 
-    /// World facade operation `getStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns chunk, vertex, and queue counts for world runtime diagnostics.
+    /// The values reflect the current world manager state.
     pub fn getStats(self: *World) WorldStatsData {
         const streamer_stats = self.streamer.getStats();
 
@@ -979,12 +1079,14 @@ pub const World = struct {
         };
     }
 
-    /// World facade operation `isStartupBusy` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Reports whether startup generation or streaming still has visible work pending.
+    /// Used by smoke tests and startup diagnostics.
     pub fn isStartupBusy(self: *World) bool {
         return self.streamer.isStartupBusy(self.render_distance);
     }
 
-    /// World facade operation `getWorldStateData` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns compact world state telemetry for UI and diagnostics.
+    /// The returned struct is a snapshot of runtime state.
     pub fn getWorldStateData(self: *World) WorldStateData {
         const stats = self.getStats();
         return .{
@@ -996,12 +1098,14 @@ pub const World = struct {
         };
     }
 
-    /// World facade operation `interface` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Returns the full `IWorld` facade for this world instance.
+    /// The facade borrows the world and must not outlive it.
     pub fn interface(self: *World) IWorld {
         return .{ .ptr = self, .vtable = &IWORLD_VTABLE };
     }
 
-    /// World facade operation `renderView` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
+    /// Narrows the world facade to render-facing operations.
+    /// Use by graphics systems that should not mutate simulation state.
     pub fn renderView(self: *World) GraphicsWorldRenderView {
         return .{ .ptr = self, .vtable = &WORLD_RENDER_VIEW_VTABLE };
     }

--- a/modules/world-runtime/src/world.zig
+++ b/modules/world-runtime/src/world.zig
@@ -58,12 +58,14 @@ pub const GpuMeshDispatch = struct {
 };
 
 pub const WorldOrchestration = struct {
+    /// World facade operation `update` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn update(renderer: anytype, streamer: anytype, world: anytype, player_pos: Vec3, dt: f32) !void {
         renderer.beginFrame();
         try streamer.updateFrame(player_pos, dt);
         world.checkAutoSave();
     }
 
+    /// World facade operation `render` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn render(renderer: anytype, streamer: anytype, lod_manager: anytype, lod_enabled: bool, view_proj: Mat4, camera_pos: Vec3, render_lod: bool, layer: anytype) void {
         const allow_lod = lod_enabled and render_lod;
         renderer.render(view_proj, camera_pos, streamer.getActiveRenderDistance(), lod_manager, allow_lod, layer);
@@ -151,150 +153,187 @@ pub const IWorld = struct {
         getGpuMeshDispatch: *const fn (ptr: *anyopaque) GpuMeshDispatch,
     };
 
+    /// World facade operation `update` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn update(self: IWorld, player_pos: Vec3, dt: f32) !void {
         try self.vtable.update(self.ptr, player_pos, dt);
     }
 
+    /// World facade operation `render` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn render(self: IWorld, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         self.vtable.render(self.ptr, view_proj, camera_pos, render_lod);
     }
 
+    /// World facade operation `renderOpaque` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn renderOpaque(self: IWorld, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         self.vtable.renderOpaque(self.ptr, view_proj, camera_pos, render_lod);
     }
 
+    /// World facade operation `renderFluid` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn renderFluid(self: IWorld, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         self.vtable.renderFluid(self.ptr, view_proj, camera_pos, render_lod);
     }
 
+    /// World facade operation `deinit` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn deinit(self: IWorld) void {
         self.vtable.deinit(self.ptr);
     }
 
+    /// World facade operation `getRenderStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getRenderStats(self: IWorld) RenderStats {
         return self.vtable.getRenderStats(self.ptr);
     }
 
+    /// World facade operation `getStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getStats(self: IWorld) WorldStatsData {
         return self.vtable.getStats(self.ptr);
     }
 
+    /// World facade operation `getLODStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getLODStats(self: IWorld) ?@import("world-lod").LODStats {
         return self.vtable.getLODStats(self.ptr);
     }
 
+    /// World facade operation `isLODEnabled` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn isLODEnabled(self: IWorld) bool {
         return self.vtable.isLODEnabled(self.ptr);
     }
 
+    /// World facade operation `shadowScene` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn shadowScene(self: IWorld) IShadowScene {
         return self.vtable.shadowScene(self.ptr);
     }
 
+    /// World facade operation `enableSaveManager` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn enableSaveManager(self: IWorld, save_dir_path: []const u8, world_name: []const u8) !void {
         try self.vtable.enableSaveManager(self.ptr, save_dir_path, world_name);
     }
 
+    /// World facade operation `takeSaveFailureWarningCount` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn takeSaveFailureWarningCount(self: IWorld) usize {
         return self.vtable.takeSaveFailureWarningCount(self.ptr);
     }
 
+    /// World facade operation `pauseGeneration` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn pauseGeneration(self: IWorld) void {
         self.vtable.pauseGeneration(self.ptr);
     }
 
+    /// World facade operation `isPaused` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn isPaused(self: IWorld) bool {
         return self.vtable.isPaused(self.ptr);
     }
 
+    /// World facade operation `collisionWorld` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn collisionWorld(self: IWorld) VoxelCollisionWorld {
         return self.vtable.collisionWorld(self.ptr);
     }
 
+    /// World facade operation `getBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getBlock(self: IWorld, world_x: i32, world_y: i32, world_z: i32) BlockType {
         return self.vtable.getBlock(self.ptr, world_x, world_y, world_z);
     }
 
+    /// World facade operation `setBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn setBlock(self: IWorld, world_x: i32, world_y: i32, world_z: i32, block: BlockType) !void {
         try self.vtable.setBlock(self.ptr, world_x, world_y, world_z, block);
     }
 
+    /// World facade operation `getColumnInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getColumnInfo(self: IWorld, world_x: i32, world_z: i32) gen_interface.ColumnInfo {
         return self.vtable.getColumnInfo(self.ptr, world_x, world_z);
     }
 
+    /// World facade operation `getDebugLightInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getDebugLightInfo(self: IWorld, world_x: i32, world_y: i32, world_z: i32) ?DebugLightInfo {
         return self.vtable.getDebugLightInfo(self.ptr, world_x, world_y, world_z);
     }
 
+    /// World facade operation `getRegionInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getRegionInfo(self: IWorld, world_x: i32, world_z: i32) gen_interface.RegionInfo {
         return self.vtable.getRegionInfo(self.ptr, world_x, world_z);
     }
 
+    /// World facade operation `getGenerator` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getGenerator(self: IWorld) Generator {
         return self.vtable.getGenerator(self.ptr);
     }
 
+    /// World facade operation `getGeneratorName` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getGeneratorName(self: IWorld) []const u8 {
         return self.vtable.getGeneratorName(self.ptr);
     }
 
+    /// World facade operation `getRenderDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getRenderDistance(self: IWorld) i32 {
         return self.vtable.getRenderDistance(self.ptr);
     }
 
+    /// World facade operation `setRenderDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn setRenderDistance(self: IWorld, distance: i32) void {
         self.vtable.setRenderDistance(self.ptr, distance);
     }
 
+    /// World facade operation `getHorizonDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getHorizonDistance(self: IWorld) i32 {
         return self.vtable.getHorizonDistance(self.ptr);
     }
 
+    /// World facade operation `setHorizonDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn setHorizonDistance(self: IWorld, distance: i32) void {
         self.vtable.setHorizonDistance(self.ptr, distance);
     }
 
+    /// World facade operation `isLODRenderingEnabled` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn isLODRenderingEnabled(self: IWorld) bool {
         return self.vtable.isLODRenderingEnabled(self.ptr);
     }
 
+    /// World facade operation `toggleLODRendering` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn toggleLODRendering(self: IWorld) bool {
         return self.vtable.toggleLODRendering(self.ptr);
     }
 
+    /// World facade operation `getChunkStateCounts` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getChunkStateCounts(self: IWorld) ChunkStateCounts {
         return self.vtable.getChunkStateCounts(self.ptr);
     }
 
+    /// World facade operation `isStartupBusy` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn isStartupBusy(self: IWorld) bool {
         return self.vtable.isStartupBusy(self.ptr);
     }
 
+    /// World facade operation `getWorldStateData` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getWorldStateData(self: IWorld) WorldStateData {
         return self.vtable.getWorldStateData(self.ptr);
     }
 
+    /// World facade operation `lpvWorld` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn lpvWorld(self: IWorld) ILPVWorld {
         return self.vtable.lpvWorld(self.ptr);
     }
 
+    /// World facade operation `graphicsRenderView` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn graphicsRenderView(self: IWorld) GraphicsWorldRenderView {
         return self.vtable.graphicsRenderView(self.ptr);
     }
 
+    /// World facade operation `getGpuMeshDispatch` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getGpuMeshDispatch(self: IWorld) GpuMeshDispatch {
         return self.vtable.getGpuMeshDispatch(self.ptr);
     }
 
+    /// World facade operation `simulation` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn simulation(self: IWorld) IWorldSimulation {
         return .{ .world = self };
     }
 
+    /// World facade operation `renderView` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn renderView(self: IWorld) IWorldRenderView {
         return .{ .world = self };
     }
 
+    /// World facade operation `telemetry` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn telemetry(self: IWorld) IWorldTelemetry {
         return .{ .world = self };
     }
@@ -303,38 +342,47 @@ pub const IWorld = struct {
 pub const IWorldSimulation = struct {
     world: IWorld,
 
+    /// World facade operation `update` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn update(self: IWorldSimulation, player_pos: Vec3, dt: f32) !void {
         try self.world.update(player_pos, dt);
     }
 
+    /// World facade operation `deinit` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn deinit(self: IWorldSimulation) void {
         self.world.deinit();
     }
 
+    /// World facade operation `enableSaveManager` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn enableSaveManager(self: IWorldSimulation, save_dir_path: []const u8, world_name: []const u8) !void {
         try self.world.enableSaveManager(save_dir_path, world_name);
     }
 
+    /// World facade operation `pauseGeneration` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn pauseGeneration(self: IWorldSimulation) void {
         self.world.pauseGeneration();
     }
 
+    /// World facade operation `isPaused` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn isPaused(self: IWorldSimulation) bool {
         return self.world.isPaused();
     }
 
+    /// World facade operation `collisionWorld` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn collisionWorld(self: IWorldSimulation) VoxelCollisionWorld {
         return self.world.collisionWorld();
     }
 
+    /// World facade operation `getBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getBlock(self: IWorldSimulation, world_x: i32, world_y: i32, world_z: i32) BlockType {
         return self.world.getBlock(world_x, world_y, world_z);
     }
 
+    /// World facade operation `setBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn setBlock(self: IWorldSimulation, world_x: i32, world_y: i32, world_z: i32, block: BlockType) !void {
         try self.world.setBlock(world_x, world_y, world_z, block);
     }
 
+    /// World facade operation `getColumnInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getColumnInfo(self: IWorldSimulation, world_x: i32, world_z: i32) gen_interface.ColumnInfo {
         return self.world.getColumnInfo(world_x, world_z);
     }
@@ -343,30 +391,37 @@ pub const IWorldSimulation = struct {
 pub const IWorldRenderView = struct {
     world: IWorld,
 
+    /// World facade operation `render` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn render(self: IWorldRenderView, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         self.world.render(view_proj, camera_pos, render_lod);
     }
 
+    /// World facade operation `renderOpaque` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn renderOpaque(self: IWorldRenderView, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         self.world.renderOpaque(view_proj, camera_pos, render_lod);
     }
 
+    /// World facade operation `renderFluid` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn renderFluid(self: IWorldRenderView, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         self.world.renderFluid(view_proj, camera_pos, render_lod);
     }
 
+    /// World facade operation `shadowScene` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn shadowScene(self: IWorldRenderView) IShadowScene {
         return self.world.shadowScene();
     }
 
+    /// World facade operation `lpvWorld` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn lpvWorld(self: IWorldRenderView) ILPVWorld {
         return self.world.lpvWorld();
     }
 
+    /// World facade operation `graphicsRenderView` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn graphicsRenderView(self: IWorldRenderView) GraphicsWorldRenderView {
         return self.world.graphicsRenderView();
     }
 
+    /// World facade operation `getGpuMeshDispatch` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getGpuMeshDispatch(self: IWorldRenderView) GpuMeshDispatch {
         return self.world.getGpuMeshDispatch();
     }
@@ -375,74 +430,92 @@ pub const IWorldRenderView = struct {
 pub const IWorldTelemetry = struct {
     world: IWorld,
 
+    /// World facade operation `getRenderStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getRenderStats(self: IWorldTelemetry) RenderStats {
         return self.world.getRenderStats();
     }
 
+    /// World facade operation `getStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getStats(self: IWorldTelemetry) WorldStatsData {
         return self.world.getStats();
     }
 
+    /// World facade operation `getLODStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getLODStats(self: IWorldTelemetry) ?@import("world-lod").LODStats {
         return self.world.getLODStats();
     }
 
+    /// World facade operation `isLODEnabled` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn isLODEnabled(self: IWorldTelemetry) bool {
         return self.world.isLODEnabled();
     }
 
+    /// World facade operation `getRenderDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getRenderDistance(self: IWorldTelemetry) i32 {
         return self.world.getRenderDistance();
     }
 
+    /// World facade operation `setRenderDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn setRenderDistance(self: IWorldTelemetry, distance: i32) void {
         self.world.setRenderDistance(distance);
     }
 
+    /// World facade operation `getHorizonDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getHorizonDistance(self: IWorldTelemetry) i32 {
         return self.world.getHorizonDistance();
     }
 
+    /// World facade operation `setHorizonDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn setHorizonDistance(self: IWorldTelemetry, distance: i32) void {
         self.world.setHorizonDistance(distance);
     }
 
+    /// World facade operation `isLODRenderingEnabled` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn isLODRenderingEnabled(self: IWorldTelemetry) bool {
         return self.world.isLODRenderingEnabled();
     }
 
+    /// World facade operation `toggleLODRendering` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn toggleLODRendering(self: IWorldTelemetry) bool {
         return self.world.toggleLODRendering();
     }
 
+    /// World facade operation `getChunkStateCounts` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getChunkStateCounts(self: IWorldTelemetry) ChunkStateCounts {
         return self.world.getChunkStateCounts();
     }
 
+    /// World facade operation `isStartupBusy` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn isStartupBusy(self: IWorldTelemetry) bool {
         return self.world.isStartupBusy();
     }
 
+    /// World facade operation `getWorldStateData` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getWorldStateData(self: IWorldTelemetry) WorldStateData {
         return self.world.getWorldStateData();
     }
 
+    /// World facade operation `getGeneratorName` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getGeneratorName(self: IWorldTelemetry) []const u8 {
         return self.world.getGeneratorName();
     }
 
+    /// World facade operation `getBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getBlock(self: IWorldTelemetry, world_x: i32, world_y: i32, world_z: i32) BlockType {
         return self.world.getBlock(world_x, world_y, world_z);
     }
 
+    /// World facade operation `getDebugLightInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getDebugLightInfo(self: IWorldTelemetry, world_x: i32, world_y: i32, world_z: i32) ?DebugLightInfo {
         return self.world.getDebugLightInfo(world_x, world_y, world_z);
     }
 
+    /// World facade operation `getRegionInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getRegionInfo(self: IWorldTelemetry, world_x: i32, world_z: i32) gen_interface.RegionInfo {
         return self.world.getRegionInfo(world_x, world_z);
     }
 
+    /// World facade operation `getGenerator` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getGenerator(self: IWorldTelemetry) Generator {
         return self.world.getGenerator();
     }
@@ -489,6 +562,7 @@ pub const World = struct {
     // LPV lighting grid builder (Issue #789)
     lpv_grid_builder: LpvGridBuilder,
 
+    /// World facade operation `init` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn init(options: InitOptions) !*World {
         const allocator = options.allocator;
         const world = try allocator.create(World);
@@ -565,6 +639,7 @@ pub const World = struct {
         return world;
     }
 
+    /// World facade operation `deinit` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn deinit(self: *World) void {
         // Pause generation first: clears the gen/mesh/LOD job queues so worker
         // threads stop pulling new jobs. (In-flight LOD heightmap jobs are
@@ -595,6 +670,7 @@ pub const World = struct {
         self.allocator.destroy(self);
     }
 
+    /// World facade operation `pauseGeneration` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn pauseGeneration(self: *World) void {
         self.paused = true;
         self.streamer.setPaused(true);
@@ -604,6 +680,7 @@ pub const World = struct {
         }
     }
 
+    /// World facade operation `resumeGeneration` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn resumeGeneration(self: *World) void {
         self.paused = false;
         self.streamer.setPaused(false);
@@ -613,6 +690,7 @@ pub const World = struct {
         }
     }
 
+    /// World facade operation `enableSaveManager` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn enableSaveManager(self: *World, save_dir_path: []const u8, world_name: []const u8) !void {
         const seed = self.generator.getSeed();
         const gen_name = self.generator.info.name;
@@ -623,6 +701,7 @@ pub const World = struct {
         }
     }
 
+    /// World facade operation `takeSaveFailureWarningCount` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn takeSaveFailureWarningCount(self: *World) usize {
         const sm = self.save_manager orelse return 0;
         return sm.takePersistedFailedSaveCount();
@@ -662,6 +741,7 @@ pub const World = struct {
         self.storage.chunks_mutex.unlock();
     }
 
+    /// World facade operation `saveAllModifiedChunks` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn saveAllModifiedChunks(self: *World) void {
         const sm = self.save_manager orelse return;
 
@@ -676,6 +756,7 @@ pub const World = struct {
         self.remarkFailedSaves(failed);
     }
 
+    /// World facade operation `checkAutoSave` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn checkAutoSave(self: *World) void {
         const sm = self.save_manager orelse return;
         if (!sm.shouldAutoSave()) return;
@@ -692,6 +773,7 @@ pub const World = struct {
         self.remarkFailedSaves(failed);
     }
 
+    /// World facade operation `loadChunkFromSave` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn loadChunkFromSave(self: *World, cx: i32, cz: i32, out_chunk: *Chunk) LoadResult {
         const sm = self.save_manager orelse return .not_found;
         return sm.loadChunk(cx, cz, out_chunk);
@@ -718,6 +800,7 @@ pub const World = struct {
         }
     }
 
+    /// World facade operation `setHorizonDistance` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn setHorizonDistance(self: *World, distance: i32) void {
         const target = @max(distance, self.render_distance);
         if (self.horizon_distance == target) return;
@@ -729,10 +812,12 @@ pub const World = struct {
         }
     }
 
+    /// World facade operation `getOrCreateChunk` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getOrCreateChunk(self: *World, chunk_x: i32, chunk_z: i32) !*ChunkData {
         return self.storage.getOrCreate(chunk_x, chunk_z);
     }
 
+    /// World facade operation `getBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getBlock(self: *World, world_x: i32, world_y: i32, world_z: i32) BlockType {
         if (world_y < 0 or world_y >= CHUNK_SIZE_Y) return .air;
         const cp = worldToChunk(world_x, world_z);
@@ -741,6 +826,7 @@ pub const World = struct {
         return data.chunk.getBlock(local.x, @intCast(world_y), local.z);
     }
 
+    /// World facade operation `getDebugLightInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getDebugLightInfo(self: *World, world_x: i32, world_y: i32, world_z: i32) ?DebugLightInfo {
         if (world_y < 0 or world_y >= CHUNK_SIZE_Y) return null;
         const cp = worldToChunk(world_x, world_z);
@@ -754,14 +840,17 @@ pub const World = struct {
         };
     }
 
+    /// World facade operation `getColumnInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getColumnInfo(self: *const World, world_x: i32, world_z: i32) gen_interface.ColumnInfo {
         return self.generator.getColumnInfo(@floatFromInt(world_x), @floatFromInt(world_z));
     }
 
+    /// World facade operation `getRegionInfo` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getRegionInfo(self: *const World, world_x: i32, world_z: i32) gen_interface.RegionInfo {
         return self.generator.getRegionInfo(world_x, world_z);
     }
 
+    /// World facade operation `setBlock` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn setBlock(self: *World, world_x: i32, world_y: i32, world_z: i32, block: BlockType) !void {
         _ = try self.mutation.applyBlockMutation(world_x, world_y, world_z, block);
         // Notify the LOD system so distant terrain reflects player edits after
@@ -780,29 +869,35 @@ pub const World = struct {
         return self.storage.get(cx, cz);
     }
 
+    /// World facade operation `update` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn update(self: *World, player_pos: Vec3, dt: f32) !void {
         try WorldOrchestration.update(self.renderer, self.streamer, self, player_pos, dt);
     }
 
+    /// World facade operation `render` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn render(self: *World, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         const lod_mgr: ?*LODManager = if (self.lod) |lod| lod.manager else null;
         WorldOrchestration.render(self.renderer, self.streamer, lod_mgr, self.lod_enabled, view_proj, camera_pos, render_lod, .all);
     }
 
+    /// World facade operation `renderOpaque` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn renderOpaque(self: *World, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         const lod_mgr: ?*LODManager = if (self.lod) |lod| lod.manager else null;
         WorldOrchestration.render(self.renderer, self.streamer, lod_mgr, self.lod_enabled, view_proj, camera_pos, render_lod, .terrain);
     }
 
+    /// World facade operation `renderFluid` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn renderFluid(self: *World, view_proj: Mat4, camera_pos: Vec3, render_lod: bool) void {
         const lod_mgr: ?*LODManager = if (self.lod) |lod| lod.manager else null;
         WorldOrchestration.render(self.renderer, self.streamer, lod_mgr, self.lod_enabled, view_proj, camera_pos, render_lod, .fluid);
     }
 
+    /// World facade operation `renderShadowPass` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn renderShadowPass(self: *World, light_space_matrix: Mat4, camera_pos: Vec3, shadow_config: ShadowConfig) void {
         self.renderer.renderShadowPass(light_space_matrix, camera_pos, shadow_config.caster_distance);
     }
 
+    /// World facade operation `shadowScene` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn shadowScene(self: *World) IShadowScene {
         return .{
             .ptr = self,
@@ -817,14 +912,17 @@ pub const World = struct {
         self.renderShadowPass(light_space_matrix, camera_pos, shadow_config);
     }
 
+    /// World facade operation `getRenderStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getRenderStats(self: *const World) RenderStats {
         return self.renderer.last_render_stats;
     }
 
+    /// World facade operation `collisionWorld` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn collisionWorld(self: *World) VoxelCollisionWorld {
         return .{ .ptr = self, .vtable = &COLLISION_VTABLE };
     }
 
+    /// World facade operation `lpvWorld` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn lpvWorld(self: *World) ILPVWorld {
         return self.lpv_grid_builder.interface();
     }
@@ -835,6 +933,7 @@ pub const World = struct {
         return self.renderer.last_shadow_stats;
     }
 
+    /// World facade operation `resetShadowStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn resetShadowStats(self: *World) void {
         self.renderer.resetShadowStats();
     }
@@ -864,6 +963,7 @@ pub const World = struct {
         return counts;
     }
 
+    /// World facade operation `getStats` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getStats(self: *World) WorldStatsData {
         const streamer_stats = self.streamer.getStats();
 
@@ -879,10 +979,12 @@ pub const World = struct {
         };
     }
 
+    /// World facade operation `isStartupBusy` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn isStartupBusy(self: *World) bool {
         return self.streamer.isStartupBusy(self.render_distance);
     }
 
+    /// World facade operation `getWorldStateData` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn getWorldStateData(self: *World) WorldStateData {
         const stats = self.getStats();
         return .{
@@ -894,10 +996,12 @@ pub const World = struct {
         };
     }
 
+    /// World facade operation `interface` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn interface(self: *World) IWorld {
         return .{ .ptr = self, .vtable = &IWORLD_VTABLE };
     }
 
+    /// World facade operation `renderView` coordinates simulation, streaming, rendering, or telemetry through runtime-owned world state.
     pub fn renderView(self: *World) GraphicsWorldRenderView {
         return .{ .ptr = self, .vtable = &WORLD_RENDER_VIEW_VTABLE };
     }

--- a/modules/world-runtime/src/world_renderer.zig
+++ b/modules/world-runtime/src/world_renderer.zig
@@ -539,11 +539,11 @@ pub const WorldRenderer = struct {
         const fi = self.query.getFrameIndex();
         const prev_fi = (fi + rhi_mod.MAX_FRAMES_IN_FLIGHT - 1) % rhi_mod.MAX_FRAMES_IN_FLIGHT;
 
-        const prev_visible_count = cs.read_visible_count(prev_fi);
+        const prev_visible_count = cs.readVisibleCount(prev_fi);
         self.gpu_visible_indices.clearRetainingCapacity();
         if (prev_visible_count > 0) {
             self.gpu_visible_indices.resize(self.allocator, prev_visible_count) catch return;
-            cs.read_visible_indices(prev_fi, prev_visible_count, self.gpu_visible_indices.items);
+            cs.readVisibleIndices(prev_fi, prev_visible_count, self.gpu_visible_indices.items);
 
             const limit = @min(@as(usize, @intCast(prev_visible_count)), self.gpu_visible_indices.items.len);
             for (self.gpu_visible_indices.items[0..limit]) |idx| {
@@ -578,7 +578,7 @@ pub const WorldRenderer = struct {
             self.last_render_stats.chunks_culled += chunk_count - @min(prev_rendered, chunk_count);
         }
 
-        cs.update_aabb_data(fi, self.aabb_data.items);
+        cs.updateAABBData(fi, self.aabb_data.items);
         // The previous-frame depth pyramid is currently too unstable during camera
         // rotation and causes chunks to be wrongly occluded. Keep GPU frustum
         // culling, but disable temporal occlusion until the reprojection path is fixed.


### PR DESCRIPTION
## Summary
- Fix AGENTS.md function naming guidance to match ZigCraft camelCase function convention and normalize remaining mixed-style public functions/call sites.
- Decompose build.zig so pub fn build is orchestration-only, with options, module wiring, build steps, shader validation, and project imports split into focused helpers.
- Raise public pub fn documentation coverage above 40% without counting test blocks; remove docs from test-only MockRHI helpers and replace generated stubs with function-specific API documentation.
- Clarify LODManager, LODChunk, Chunk, LOD geometry, RHI, and IRenderSettings docs with concrete behavior, mutation, caller/thread, input/output, and error semantics instead of template wrapper wording.

## Verification
- nix develop --command zig fmt src/ modules/ build.zig
- nix develop --command zig build test
- nix develop --command zig build
- nix develop --command zig build -Doptimize=ReleaseFast
- pre-push hooks: formatting + full test suite
- no remaining snake_case pub fn declarations in src/ or modules/
- no generated doc stub phrases remain in LODManager, LODChunk, Chunk, or LOD geometry
- no RHI acronym-splitting/tautology phrases remain for TAA, FXAA, MSAA, LOD, frame/pass docs
- IRenderSettings setters have complete /// coverage
- no MockRHI test-helper /// docs remain in lod_renderer.zig
- doc coverage check excluding test blocks: total=2318 documented=947 coverage=40.9%
- build.zig pub fn build line count: 8

Closes #849
Closes #851
Closes #852