### PR TITLE
ci: complete audit B1 readiness checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# Require owner review for high-risk engine, persistence, shader, and CI paths.
-modules/engine-graphics/   @OpenStaticFish
-modules/world-persistence/ @OpenStaticFish
-.github/workflows/         @OpenStaticFish
-assets/shaders/            @OpenStaticFish
+# Suggest owner review for high-risk engine, persistence, shader, and CI paths.
+modules/engine-graphics/**   @OpenStaticFish
+modules/world-persistence/** @OpenStaticFish
+.github/workflows/**         @OpenStaticFish
+assets/shaders/**            @OpenStaticFish

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Require owner review for high-risk engine, persistence, shader, and CI paths.
+modules/engine-graphics/   @OpenStaticFish
+modules/world-persistence/ @OpenStaticFish
+.github/workflows/         @OpenStaticFish
+assets/shaders/            @OpenStaticFish

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,7 +8,7 @@ on:
       duration:
         description: Benchmark duration per preset (seconds)
         required: false
-        default: '30'
+        default: '5'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +25,7 @@ jobs:
       contents: read
       statuses: write
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 90
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
 
@@ -48,14 +48,16 @@ jobs:
       uses: ./.github/actions/run-with-log
       with:
         name: Benchmark
-        timeout: 75m
+        timeout: 20m
         log-file: benchmark.log
-        command: nix develop .#ci-graphics --command bash scripts/run_benchmark.sh --duration "$BENCHMARK_DURATION" --presets low,medium,high --output-dir benchmark-results
+        command: mkdir -p "$MESA_SHADER_CACHE_DIR" && nix develop .#ci-graphics --command bash scripts/run_benchmark.sh --duration "$BENCHMARK_DURATION" --presets low,medium,high --output-dir benchmark-results
       env:
         XDG_RUNTIME_DIR: /tmp/runtime-runner
         WAYLAND_DISPLAY: headless
+        MESA_SHADER_CACHE_DIR: /tmp/mesa_shader_cache
+        SDL_AUDIODRIVER: dummy
         ZIGCRAFT_SAFE_MODE: '1'
-        BENCHMARK_DURATION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || '30' }}
+        BENCHMARK_DURATION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || '5' }}
 
     - name: Stop headless Wayland compositor
       if: always()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,7 +50,7 @@ jobs:
         name: Benchmark
         timeout: 20m
         log-file: benchmark.log
-        command: mkdir -p "$MESA_SHADER_CACHE_DIR" && nix develop .#ci-graphics --command bash scripts/run_benchmark.sh --duration "$BENCHMARK_DURATION" --presets low,medium,high --output-dir benchmark-results
+        command: mkdir -p "$MESA_SHADER_CACHE_DIR" && nix develop .#ci-graphics --command bash scripts/run_benchmark.sh --duration "$BENCHMARK_DURATION" --presets low,medium,high --output-dir benchmark-results --per-preset-timeout 600
       env:
         XDG_RUNTIME_DIR: /tmp/runtime-runner
         WAYLAND_DISPLAY: headless

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -93,7 +93,7 @@ jobs:
           const description = failed
             ? 'Benchmark regression or runtime failure'
             : compareOutcome === 'skipped'
-              ? 'Benchmark completed (baseline placeholder)'
+              ? 'Benchmark comparison skipped'
               : 'Benchmark completed';
 
           await github.rest.repos.createCommitStatus({

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -94,9 +94,7 @@ jobs:
           const failed = runOutcome === 'failure' || compareOutcome === 'failure';
           const description = failed
             ? 'Benchmark regression or runtime failure'
-            : compareOutcome === 'skipped'
-              ? 'Benchmark comparison skipped'
-              : 'Benchmark completed';
+            : 'Benchmark completed';
 
           await github.rest.repos.createCommitStatus({
             owner: context.repo.owner,

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+name: Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Log stale decisions without labeling or closing issues/PRs
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark and close stale issues and PRs
+        uses: actions/stale@v10
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,roadmap,production-readiness,audit-b1,audit-b2,audit-b3,audit-b4,audit-b5,audit-b6,security,help wanted
+          exempt-pr-labels: pinned,roadmap,production-readiness,audit-b1,audit-b2,audit-b3,audit-b4,audit-b5,audit-b6,security,help wanted
+          stale-issue-message: This issue has had no activity for 60 days. It will be closed in 14 days unless there is new activity or an exemption label is added.
+          stale-pr-message: This pull request has had no activity for 60 days. It will be closed in 14 days unless there is new activity or an exemption label is added.
+          close-issue-message: Closing this issue because it remained stale for 14 days without new activity.
+          close-pr-message: Closing this pull request because it remained stale for 14 days without new activity.
+          operations-per-run: 100
+          enable-statistics: true
+          debug-only: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true' }}

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -7,12 +7,16 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
       - 'scripts/*.sh'
+      - '.shellcheckrc'
+      - 'flake.nix'
   pull_request:
     branches: [ dev ]
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
       - 'scripts/*.sh'
+      - '.shellcheckrc'
+      - 'flake.nix'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -38,6 +42,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+
       - name: Parse workflow YAML
         run: |
           ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].sort.each { |f| YAML.load_file(f); puts "OK #{f}" }'
@@ -47,4 +54,7 @@ jobs:
           ruby -e 'require "yaml"; Dir[".github/actions/**/action.{yml,yaml}"].sort.each { |f| YAML.load_file(f); puts "OK #{f}" }'
 
       - name: Check shell script syntax
-        run: bash -n scripts/*.sh
+        run: nix develop .#ci-unit --command bash -n scripts/*.sh
+
+      - name: Run ShellCheck
+        run: nix develop .#ci-unit --command shellcheck scripts/*.sh

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+enable=add-default-case,deprecate-which,quote-safe-variables
+severity=warning

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall community.
+
+Examples of unacceptable behavior include:
+- The use of sexualized language or imagery, and sexual attention or advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or email address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+Examples of representing our community include using an official email address, posting through an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the repository owner through the contact paths listed in `SECURITY.md` or GitHub repository moderation tools. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+Community Impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+Community Impact: A violation through a single incident or series of actions.
+
+Consequence: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+Community Impact: A serious violation of community standards, including sustained inappropriate behavior.
+
+Consequence: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+Community Impact: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+Consequence: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ nix develop  # glslang is included in the dev shell
 |----------|----------|
 | **Discussions** | [GitHub Discussions](https://github.com/OpenStaticFish/ZigCraft/discussions) |
 | **Issues** | [GitHub Issues](https://github.com/OpenStaticFish/ZigCraft/issues) |
+| **Security** | [Security Policy](SECURITY.md) |
 | **License** | [MIT License](LICENSE) |
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported Versions
+
+ZigCraft is pre-1.0 software. Security fixes are provided for the current `dev` branch and the latest `main` release branch when one exists.
+
+| Version | Supported |
+| ------- | --------- |
+| `dev` | Yes |
+| latest `main` | Yes |
+| older branches | No |
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately through GitHub Security Advisories for this repository. If private advisories are unavailable, contact the repository owner directly and do not open a public issue with exploit details.
+
+Include:
+- Affected commit, branch, or release.
+- Steps to reproduce or proof-of-concept details.
+- Impact assessment and any known mitigations.
+- Whether the issue is already public.
+
+## Response SLA
+
+- Initial acknowledgement: within 7 calendar days.
+- Triage update: within 14 calendar days after acknowledgement.
+- Fix or mitigation target: as soon as practical based on severity and exploitability.
+
+## Scope
+
+In scope:
+- Engine code, build scripts, CI workflows, release artifacts, and bundled assets in this repository.
+- Vulnerabilities that can cause code execution, data loss, unsafe file access, dependency compromise, or CI credential exposure.
+
+Out of scope:
+- Vulnerabilities requiring local administrative access before exploitation.
+- Issues in third-party tools unless ZigCraft pins or packages them insecurely.
+- Denial-of-service reports without a practical security impact beyond normal development instability.
+
+Coordinated disclosure is expected. Please allow maintainers time to investigate and prepare fixes before public disclosure.

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -1,0 +1,39 @@
+# Benchmark Baselines
+
+ZigCraft benchmark gating compares every `dev` benchmark run against `baseline.json`.
+
+## Reference Hardware
+
+Baselines are captured on the GitHub Actions benchmark job runner:
+
+- Runner label: `blacksmith-2vcpu-ubuntu-2404`
+- Workflow: `.github/workflows/benchmark.yml`
+- Graphics backend: Mesa Lavapipe via `.github/actions/setup-lavapipe`
+- Zig version: `0.16.0`, provided by the Nix flake
+- Build mode: `ReleaseFast`
+- Presets: `low`, `medium`, `high`
+- Duration: 30 seconds per preset
+
+Lavapipe and Zig versions are pinned by the Nix inputs used by the workflow. If the flake lock changes, refresh this baseline so performance drift is tied to a known toolchain.
+
+## Capture Procedure
+
+Run the benchmark workflow on the baseline branch or on `dev`:
+
+```bash
+gh workflow run benchmark.yml --repo OpenStaticFish/ZigCraft --ref <branch> -f duration=30
+```
+
+After the run finishes, download the `benchmark-results` artifact and replace the corresponding `low`, `medium`, and `high` entries in `baseline.json` with the captured JSON payloads. Keep `generated` set to `true`.
+
+## Tolerance Policy
+
+`scripts/compare_benchmarks.sh` applies an explicit tolerance per metric:
+
+- Warning threshold: 5% regression.
+- Failure threshold: 10% regression.
+- Lower `fps.p1` is a regression.
+- Higher `gpu_ms.total_avg` is a regression.
+- Higher `draw_calls_avg` is a regression.
+
+The p1 FPS metric is the primary user-visible smoothness guard. GPU time and draw calls catch rendering-cost regressions even when FPS is noisy on virtualized runners.

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -12,7 +12,7 @@ Baselines are captured on the GitHub Actions benchmark job runner:
 - Zig version: `0.16.0`, provided by the Nix flake
 - Build mode: `ReleaseFast`
 - Presets: `low`, `medium`, `high`
-- Duration: 30 seconds per preset
+- Duration: 5 seconds per preset for the CI canary gate
 
 Lavapipe and Zig versions are pinned by the Nix inputs used by the workflow. If the flake lock changes, refresh this baseline so performance drift is tied to a known toolchain.
 
@@ -21,10 +21,12 @@ Lavapipe and Zig versions are pinned by the Nix inputs used by the workflow. If 
 Run the benchmark workflow on the baseline branch or on `dev`:
 
 ```bash
-gh workflow run benchmark.yml --repo OpenStaticFish/ZigCraft --ref <branch> -f duration=30
+gh workflow run benchmark.yml --repo OpenStaticFish/ZigCraft --ref <branch> -f duration=5
 ```
 
 After the run finishes, download the `benchmark-results` artifact and replace the corresponding `low`, `medium`, and `high` entries in `baseline.json` with the captured JSON payloads. Keep `generated` set to `true`.
+
+This gate is intentionally a short canary so every `dev` push gets a bounded performance signal without consuming long runner time. Longer profiling runs should use the manual workflow input with a larger duration and should not replace the CI canary baseline unless that policy changes deliberately.
 
 ## Tolerance Policy
 

--- a/flake.nix
+++ b/flake.nix
@@ -330,6 +330,7 @@
               pkgs.zls
               pkgs.pkg-config
               pkgs.glslang
+              pkgs.shellcheck
               pkgs.weston
             ];
 
@@ -353,6 +354,7 @@
               zig
               pkgs.pkg-config
               pkgs.glslang
+              pkgs.shellcheck
             ];
 
             buildInputs = [
@@ -373,6 +375,7 @@
               zig
               pkgs.pkg-config
               pkgs.glslang
+              pkgs.shellcheck
               pkgs.weston
             ];
 

--- a/scripts/compare_benchmarks.sh
+++ b/scripts/compare_benchmarks.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-warn_threshold=10
-fail_threshold=20
+warn_threshold=5
+fail_threshold=10
 preset=""
 
 if [[ $# -lt 2 ]]; then
@@ -42,13 +42,17 @@ read_json() {
 baseline_source="$baseline"
 baseline_generated=$(read_json '.generated' "$baseline")
 if [[ "$baseline_generated" != "true" ]]; then
-    printf 'Baseline placeholder detected, skipping comparison.\n'
-    exit 0
+    printf 'Baseline placeholder detected; refusing to skip benchmark regression gating.\n' >&2
+    exit 1
 fi
 
 if [[ -n "$preset" ]]; then
     baseline_source=$(mktemp)
     jq -c --arg preset "$preset" '.presets[$preset]' "$baseline" > "$baseline_source"
+    if [[ "$(read_json 'type' "$baseline_source")" == "null" ]]; then
+        printf 'Baseline preset not found: %s\n' "$preset" >&2
+        exit 2
+    fi
 fi
 
 cleanup() {
@@ -67,28 +71,49 @@ pct_change() {
     }'
 }
 
-baseline_fps=$(read_json '.fps.avg' "$baseline_source")
-new_fps=$(read_json '.fps.avg' "$new")
+baseline_fps_avg=$(read_json '.fps.avg' "$baseline_source")
+new_fps_avg=$(read_json '.fps.avg' "$new")
+baseline_fps_p1=$(read_json '.fps.p1' "$baseline_source")
+new_fps_p1=$(read_json '.fps.p1' "$new")
 baseline_gpu=$(read_json '.gpu_ms.total_avg' "$baseline_source")
 new_gpu=$(read_json '.gpu_ms.total_avg' "$new")
 baseline_draws=$(read_json '.draw_calls_avg' "$baseline_source")
 new_draws=$(read_json '.draw_calls_avg' "$new")
 
-fps_change=$(pct_change "$baseline_fps" "$new_fps")
+fps_avg_change=$(pct_change "$baseline_fps_avg" "$new_fps_avg")
+fps_p1_change=$(pct_change "$baseline_fps_p1" "$new_fps_p1")
 gpu_change=$(pct_change "$baseline_gpu" "$new_gpu")
 draw_change=$(pct_change "$baseline_draws" "$new_draws")
 
-printf 'FPS avg: %s -> %s (%s%%)\n' "$baseline_fps" "$new_fps" "$fps_change"
+printf 'FPS avg: %s -> %s (%s%%)\n' "$baseline_fps_avg" "$new_fps_avg" "$fps_avg_change"
+printf 'FPS p1: %s -> %s (%s%%)\n' "$baseline_fps_p1" "$new_fps_p1" "$fps_p1_change"
 printf 'GPU total avg: %s -> %s (%s%%)\n' "$baseline_gpu" "$new_gpu" "$gpu_change"
 printf 'Draw calls avg: %s -> %s (%s%%)\n' "$baseline_draws" "$new_draws" "$draw_change"
 
-fps_drop=$(awk -v change="$fps_change" 'BEGIN { if (change < 0) printf "%.2f", -change; else print 0 }')
+fps_p1_drop=$(awk -v change="$fps_p1_change" 'BEGIN { if (change < 0) printf "%.2f", -change; else print 0 }')
+gpu_increase=$(awk -v change="$gpu_change" 'BEGIN { if (change > 0) printf "%.2f", change; else print 0 }')
+draw_increase=$(awk -v change="$draw_change" 'BEGIN { if (change > 0) printf "%.2f", change; else print 0 }')
 
-if awk -v drop="$fps_drop" -v warn="$warn_threshold" 'BEGIN { exit !(drop >= warn) }'; then
-    printf 'Warning: FPS regressed by %s%%\n' "$fps_drop"
-fi
+regressed=0
 
-if awk -v drop="$fps_drop" -v fail="$fail_threshold" 'BEGIN { exit !(drop >= fail) }'; then
-    printf 'Regression exceeds failure threshold (%s%% >= %s%%)\n' "$fps_drop" "$fail_threshold" >&2
+check_metric() {
+    local name=$1
+    local regression=$2
+
+    if awk -v value="$regression" -v warn="$warn_threshold" 'BEGIN { exit !(value >= warn) }'; then
+        printf 'Warning: %s regressed by %s%%\n' "$name" "$regression"
+    fi
+
+    if awk -v value="$regression" -v fail="$fail_threshold" 'BEGIN { exit !(value >= fail) }'; then
+        printf 'Regression exceeds failure threshold for %s (%s%% >= %s%%)\n' "$name" "$regression" "$fail_threshold" >&2
+        regressed=1
+    fi
+}
+
+check_metric "FPS p1" "$fps_p1_drop"
+check_metric "GPU total avg" "$gpu_increase"
+check_metric "draw calls avg" "$draw_increase"
+
+if [[ "$regressed" -ne 0 ]]; then
     exit 1
 fi

--- a/scripts/process_textures.sh
+++ b/scripts/process_textures.sh
@@ -9,14 +9,15 @@ set -e
 TARGET_RES=${2:-512}
 MAGICK_CMD="magick"
 
-if ! command -v $MAGICK_CMD &> /dev/null; then
+if ! command -v "$MAGICK_CMD" &> /dev/null; then
     echo "Error: ImageMagick (magick) not found. Please install it."
     exit 1
 fi
 
 process_dir() {
     local dir=$1
-    local block_name=$(basename "$dir")
+    local block_name
+    block_name=$(basename "$dir")
     
     echo "Processing directory: $dir (Block: $block_name)"
     
@@ -30,8 +31,10 @@ process_dir() {
     )
     
     for mapping in "${mappings[@]}"; do
-        local suffix=$(echo "$mapping" | cut -d'|' -f1)
-        local patterns_str=$(echo "$mapping" | cut -d'|' -f2-)
+        local suffix
+        local patterns_str
+        suffix=$(echo "$mapping" | cut -d'|' -f1)
+        patterns_str=$(echo "$mapping" | cut -d'|' -f2-)
         
         # Try to find a matching file
         local found=""
@@ -41,7 +44,8 @@ process_dir() {
         
         for pattern in "${pattern_list[@]}"; do
             # Case-insensitive search for image files matching the pattern, excluding already processed ones
-            local match=$(find "$dir" -maxdepth 1 -type f -iname "*${pattern}*" \
+            local match
+            match=$(find "$dir" -maxdepth 1 -type f -iname "*${pattern}*" \
                 -not -name "${block_name}_${suffix}.png" \
                 \( -name "*.jpg" -o -name "*.png" -o -name "*.exr" -o -name "*.tga" -o -name "*.jpeg" -o -name "*.webp" \) | head -n 1)
             
@@ -76,9 +80,9 @@ if [ -d "$TARGET_PATH" ]; then
     
     if [ -n "$subdirs" ]; then
         echo "Detected pack root. Processing subdirectories..."
-        for d in $subdirs; do
+        while IFS= read -r d; do
             process_dir "$d"
-        done
+        done <<< "$subdirs"
     else
         process_dir "$TARGET_PATH"
     fi

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 duration=60
 presets="low,medium,high"
 output_dir="docs/benchmarks/results"
+per_preset_timeout=600
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -17,6 +18,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --output-dir)
             output_dir="$2"
+            shift 2
+            ;;
+        --per-preset-timeout)
+            per_preset_timeout="$2"
             shift 2
             ;;
         *)
@@ -35,8 +40,8 @@ for preset in "${preset_list[@]}"; do
     printf 'Running benchmark preset %s -> %s\n' "$preset" "$output_file"
     benchmark_cmd=(zig build benchmark -Doptimize=ReleaseFast -Dbenchmark-preset="$preset" -Dbenchmark-duration="$duration" -Dbenchmark-output="$output_file")
     if [[ -n "${IN_NIX_SHELL:-}" ]]; then
-        ZIGCRAFT_SAFE_MODE=1 "${benchmark_cmd[@]}"
+        ZIGCRAFT_SAFE_MODE=1 timeout --preserve-status "${per_preset_timeout}s" "${benchmark_cmd[@]}"
     else
-        ZIGCRAFT_SAFE_MODE=1 nix develop --command "${benchmark_cmd[@]}"
+        ZIGCRAFT_SAFE_MODE=1 timeout --preserve-status "${per_preset_timeout}s" nix develop --command "${benchmark_cmd[@]}"
     fi
 done

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -33,5 +33,10 @@ IFS=',' read -r -a preset_list <<< "$presets"
 for preset in "${preset_list[@]}"; do
     output_file="$output_dir/$preset.json"
     printf 'Running benchmark preset %s -> %s\n' "$preset" "$output_file"
-    ZIGCRAFT_SAFE_MODE=1 nix develop --command zig build benchmark -Doptimize=ReleaseFast -Dbenchmark-preset="$preset" -Dbenchmark-duration="$duration" -Dbenchmark-output="$output_file"
+    benchmark_cmd=(zig build benchmark -Doptimize=ReleaseFast -Dbenchmark-preset="$preset" -Dbenchmark-duration="$duration" -Dbenchmark-output="$output_file")
+    if [[ -n "${IN_NIX_SHELL:-}" ]]; then
+        ZIGCRAFT_SAFE_MODE=1 "${benchmark_cmd[@]}"
+    else
+        ZIGCRAFT_SAFE_MODE=1 nix develop --command "${benchmark_cmd[@]}"
+    fi
 done

--- a/scripts/stale_branch_cleanup.sh
+++ b/scripts/stale_branch_cleanup.sh
@@ -12,7 +12,7 @@ if ! command -v gh &>/dev/null; then
     exit 1
 fi
 
-stale_epoch=$(date -d "-${STALE_DAYS} days" +%s 2>/dev/null || date -v-${STALE_DAYS}d +%s 2>/dev/null || true)
+stale_epoch=$(date -d "-${STALE_DAYS} days" +%s 2>/dev/null || date -v-"${STALE_DAYS}"d +%s 2>/dev/null || true)
 if [[ -z "${stale_epoch:-}" ]]; then
     echo "error: unable to calculate stale cutoff date" >&2
     exit 1
@@ -106,13 +106,13 @@ if [[ ${#deleted[@]} -gt 0 ]]; then
     gh label create automation --color "#0366d6" --description "Automated processes" 2>/dev/null || true
 
     body=$(printf '### Stale Branch Cleanup Report\n\n')
-    body+=$(printf '**%d** branch(es) deleted (stale, behind `%s`, and 0 commits ahead):\n\n' "${#deleted[@]}" "$HEAD_BRANCH")
+    body+=$(printf "**%d** branch(es) deleted (stale, behind \`%s\`, and 0 commits ahead):\n\n" "${#deleted[@]}" "$HEAD_BRANCH")
     for d in "${deleted[@]}"; do
-        body+=$(printf -- '- `%s`\n' "$d")
+        body+=$(printf -- "- \`%s\`\n" "$d")
     done
     body+=$(printf '\nSkipped **%d** branch(es):\n\n' "${#skipped[@]}")
     for s in "${skipped[@]}"; do
-        body+=$(printf -- '- `%s`\n' "$s")
+        body+=$(printf -- "- \`%s\`\n" "$s")
     done
 
     today=$(date +%Y-%m-%d)


### PR DESCRIPTION
## Summary
- Adds ShellCheck validation via Nix, commits .shellcheckrc, and fixes reported script warnings.
- Makes benchmark comparison fail on placeholder baselines and regressions beyond explicit 5% warning / 10% failure thresholds.
- Shrinks the benchmark workflow to a bounded 5-second canary per low/medium/high preset, avoids nested Nix, sets dummy SDL audio, uses a writable Mesa cache, and adds per-preset hard timeouts.
- Adds SECURITY.md, CODEOWNERS, Contributor Covenant 2.1, README security link, and actions/stale workflow.

## Issue Links
Closes #860
Closes #861
Closes #862
Closes #863

## Verification
- nix develop .#ci-unit --command shellcheck scripts/*.sh
- nix develop .#ci-unit --command bash -n scripts/*.sh
- git pre-push hook passed: nix develop --command zig fmt --check src/
- git pre-push hook passed: nix develop --command zig build test

## Operations Notes
- Branch protection should require CODEOWNERS review for the paths in .github/CODEOWNERS.
- actions/stale dry-run is available via manual workflow_dispatch with dry-run=true.
- Benchmark workflow was reduced from a long default run to a short canary to avoid expensive dev-push slowdown; longer profiling remains available by passing a larger manual duration.