### PR TITLE
ci: complete audit B3 issue gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,6 +233,16 @@ jobs:
           ZIGCRAFT_SMOKE_FRAMES: "3"
           ZIGCRAFT_SAFE_MODE: "1"
 
+      - name: Fail on Vulkan validation log errors
+        if: needs.changes.outputs.code_changes == 'true'
+        run: |
+          set -euo pipefail
+          if grep -E "Vulkan validation error|Validation Error:|VUID-" integration-test.log world-smoke-test.log; then
+            echo "Vulkan validation errors were found in integration logs." >&2
+            exit 1
+          fi
+          echo "No Vulkan validation errors found in integration logs."
+
       - name: Stop headless Wayland compositor
         if: always() && needs.changes.outputs.code_changes == 'true'
         uses: ./.github/actions/stop-weston

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,6 +16,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      issues: write
+      pull-requests: write
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 35
     steps:
@@ -33,6 +35,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p coverage/kcov
+          # kcov currently provides the stable line-coverage signal for Zig tests;
+          # branch coverage and required thresholds are deferred until a baseline exists.
           nix develop .#ci-unit --command kcov \
             --include-path=src,modules,libs \
             --exclude-path=.zig-cache,zig-cache,assets,docs \
@@ -55,3 +59,25 @@ jobs:
           name: zigcraft-kcov
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Comment non-blocking coverage status
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- zigcraft-kcov-status -->';
+            const body = `${marker}\n### kcov coverage\n\nLine coverage ran for this PR and uploaded a non-blocking report artifact named \`kcov-report\`. Codecov upload is configured as non-blocking while the project captures a stable baseline.`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.user.type === 'Bot' && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/docs/ci-test-guardrails.md
+++ b/docs/ci-test-guardrails.md
@@ -12,7 +12,7 @@ nix develop --command zig build -Doptimize=ReleaseSafe test
 
 ## Coverage
 
-The `Coverage` workflow runs kcov against the unit suite and uploads the generated report to Codecov. This is a non-blocking Phase 1 signal: upload failures do not fail the PR, and the report is intended to establish a stable baseline before a future blocking threshold is enabled.
+The `Coverage` workflow runs kcov against the unit suite, uploads the generated report to Codecov, and posts a non-blocking PR comment pointing reviewers to the coverage artifact. This is a Phase 1 signal: upload/comment failures do not fail the PR, and the report is intended to establish a stable baseline before a future blocking threshold is enabled.
 
 Run locally:
 
@@ -38,4 +38,4 @@ The project is pinned to Zig 0.16.0. That compiler exposes `-fsanitize-c` and `-
 
 ## Vulkan Validation
 
-The integration and world-smoke CI steps run under Lavapipe with `VK_LAYER_KHRONOS_validation`, core validation, and best-practices validation enabled. Integration tests assert that the RHI reports zero validation errors, and smoke-test builds exit non-zero if validation errors are observed before shutdown.
+The integration and world-smoke CI steps run under Lavapipe with `VK_LAYER_KHRONOS_validation`, core validation, and best-practices validation enabled. Integration tests assert that the RHI reports zero validation errors, smoke-test builds exit non-zero if validation errors are observed before shutdown, and the workflow scans both logs for validation-layer error markers as a final fail-on-error gate.


### PR DESCRIPTION
## Summary
- add an explicit Vulkan validation log scan after integration/world-smoke CI runs
- post a non-blocking kcov coverage PR comment and document the behavior
- document the final fail-on-validation-error coverage for the B3 CI guardrails

## Issue Coverage
- ReleaseSafe Debug/ReleaseSafe matrix for unit tests is already present in build.yml; no ReleaseSafe-only failures found locally.
- kcov coverage runs on PR/push to dev, uploads the report artifact/Codecov non-blockingly, and now posts a non-blocking PR comment.
- ASAN/sanitizer workflow runs scheduled/manual Debug and ReleaseSafe legs through the existing -Dsanitize=address entrypoint; local sanitizer test passed.
- Vulkan validation uses Lavapipe validation layers, debug-utils error counting, smoke-test non-zero exit on errors, and now workflow log scanning for validation-layer error markers.

Closes #869
Closes #870
Closes #871
Closes #872

## Verification
- nix develop --command zig fmt --check src/ modules/
- nix develop --command zig build test
- nix develop --command zig build -Doptimize=ReleaseSafe test
- nix develop --command zig build -Dsanitize=address test
- nix develop --command zig build -Dskip-present
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/build.yml .github/workflows/coverage.yml .github/workflows/sanitize.yml .github/actions/setup-lavapipe/action.yml
- git diff --check
- pre-push hook: formatting + full test suite

## Notes
- Local offscreen world-load/smoke runtime checks exceeded 60s on this runner before producing a result; the CI-specific unit, ReleaseSafe, sanitizer, build, YAML, and pre-push checks passed.
- Replaces #886, which had the same diff but failed DCO due to a missing signoff.