### PR TITLE
fix: initialize vulkan queue create infos

### DIFF
--- a/modules/engine-graphics/src/vulkan_device.zig
+++ b/modules/engine-graphics/src/vulkan_device.zig
@@ -272,11 +272,13 @@ pub const VulkanDevice = struct {
         var queue_create_infos: [2]c.VkDeviceQueueCreateInfo = .{std.mem.zeroes(c.VkDeviceQueueCreateInfo)} ** 2;
         var queue_create_count: u32 = 1;
 
+        queue_create_infos[0].sType = c.VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
         queue_create_infos[0].queueFamilyIndex = self.graphics_family;
         queue_create_infos[0].queueCount = 1;
         queue_create_infos[0].pQueuePriorities = &queue_priority;
 
         if (self.has_dedicated_transfer_queue) {
+            queue_create_infos[1].sType = c.VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
             queue_create_infos[1].queueFamilyIndex = self.transfer_family;
             queue_create_infos[1].queueCount = 1;
             queue_create_infos[1].pQueuePriorities = &queue_priority;


### PR DESCRIPTION
## Summary
- Set VkDeviceQueueCreateInfo.sType before vkCreateDevice for graphics and dedicated transfer queues.
- Fixes the Vulkan validation error observed in the post-merge #888 benchmark/integration runs.

## Verification
- nix develop --command zig fmt modules/engine-graphics/src/vulkan_device.zig
- timeout 180 nix develop .#ci-graphics --command zig build test-integration
- timeout 300 nix develop .#ci-graphics --command bash scripts/run_benchmark.sh --duration 2 --presets low --output-dir /tmp/zigcraft-ci-check --per-preset-timeout 180
- nix develop --command zig build test
- pre-push checks