### PR TITLE
fix: resolve Vulkan CI validation shutdown leaks

### DIFF
--- a/modules/engine-graphics/src/vulkan/rhi_init_deinit.zig
+++ b/modules/engine-graphics/src/vulkan/rhi_init_deinit.zig
@@ -218,6 +218,7 @@ pub fn deinit(ctx: anytype) void {
         lifecycle.destroyFXAAResources(ctx);
         lifecycle.destroyTAAResources(ctx);
         lifecycle.destroyBloomResources(ctx);
+        lifecycle.destroyUpscaleResources(ctx);
         lifecycle.destroyVelocityResources(ctx);
         lifecycle.destroyPostProcessResources(ctx);
         lifecycle.destroyGPassResources(ctx);

--- a/modules/engine-graphics/src/vulkan_device.zig
+++ b/modules/engine-graphics/src/vulkan_device.zig
@@ -272,11 +272,13 @@ pub const VulkanDevice = struct {
         var queue_create_infos: [2]c.VkDeviceQueueCreateInfo = .{std.mem.zeroes(c.VkDeviceQueueCreateInfo)} ** 2;
         var queue_create_count: u32 = 1;
 
+        queue_create_infos[0].sType = c.VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
         queue_create_infos[0].queueFamilyIndex = self.graphics_family;
         queue_create_infos[0].queueCount = 1;
         queue_create_infos[0].pQueuePriorities = &queue_priority;
 
         if (self.has_dedicated_transfer_queue) {
+            queue_create_infos[1].sType = c.VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
             queue_create_infos[1].queueFamilyIndex = self.transfer_family;
             queue_create_infos[1].queueCount = 1;
             queue_create_infos[1].pQueuePriorities = &queue_priority;


### PR DESCRIPTION
## Summary\n- initializes Vulkan queue create info structures before device creation\n- destroys dynamic-resolution upscale image resources during Vulkan shutdown\n\n## Verification\n- nix develop --command zig fmt modules/engine-graphics/src/vulkan/rhi_init_deinit.zig\n- CI-style Lavapipe validation smoke: nix develop .#ci-graphics --command zig build run -Dskip-present -Dsmoke-test\n- timeout 180 nix develop .#ci-graphics --command zig build test-integration\n- timeout 300 nix develop .#ci-graphics --command bash scripts/run_benchmark.sh --duration 2 --presets low --output-dir /tmp/zigcraft-ci-check --per-preset-timeout 180\n- nix develop --command zig build test\n