### PR TITLE
ci: complete audit B5 readiness gates

### DIFF
--- a/.github/workflows/asset-budget.yml
+++ b/.github/workflows/asset-budget.yml
@@ -1,0 +1,39 @@
+name: Asset Budget
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - "assets/**"
+      - "docs/assets/budget.json"
+      - "scripts/check_asset_budget.sh"
+      - ".github/workflows/asset-budget.yml"
+  push:
+    branches: [dev]
+    paths:
+      - "assets/**"
+      - "docs/assets/budget.json"
+      - "scripts/check_asset_budget.sh"
+      - ".github/workflows/asset-budget.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  asset-budget:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch dev baseline
+        run: git fetch --no-tags --depth=1 origin dev
+
+      - name: Check asset budgets
+        run: bash scripts/check_asset_budget.sh --base-ref origin/dev --budget-file docs/assets/budget.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,49 @@ name: Build
 on:
   push:
     branches: [dev]
+    paths:
+      - "src/**"
+      - "modules/**"
+      - "libs/**"
+      - "assets/shaders/**"
+      - "scripts/**"
+      - "build.zig"
+      - "build.zig.zon"
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/actions/setup-nix/**"
+      - ".github/actions/setup-zig-cache/**"
+      - ".github/actions/setup-lavapipe/**"
+      - ".github/vulkan/**"
+      - ".github/workflows/build.yml"
   pull_request:
     branches: [dev]
+    paths:
+      - "src/**"
+      - "modules/**"
+      - "libs/**"
+      - "assets/shaders/**"
+      - "scripts/**"
+      - "build.zig"
+      - "build.zig.zon"
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/actions/setup-nix/**"
+      - ".github/actions/setup-zig-cache/**"
+      - ".github/actions/setup-lavapipe/**"
+      - ".github/vulkan/**"
+      - ".github/workflows/build.yml"
   workflow_dispatch:
     inputs:
       ref:
         description: "Branch or ref to build/test"
         required: true
         type: string
+      enable_platform_builds:
+        description: "Run experimental Windows/macOS build-only jobs"
+        default: false
+        required: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.ref }}
@@ -29,6 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code_changes: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.code_changes }}
+      platform_changes: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.platform_changes }}
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'workflow_dispatch'
@@ -54,6 +90,11 @@ jobs:
               - '.github/actions/setup-lavapipe/**'
               - '.github/vulkan/**'
               - '.github/workflows/build.yml'
+            platform_changes:
+              - 'src/**'
+              - 'modules/**'
+              - 'build.zig'
+              - 'build.zig.zon'
 
   fmt:
     permissions:
@@ -257,4 +298,89 @@ jobs:
             world-smoke-test.log
             weston.log
           if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload minidumps
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-minidumps
+          path: zigcraft-minidumps/**/*.dmp
+          if-no-files-found: ignore
+          retention-days: 14
+
+  platform-build:
+    permissions:
+      contents: read
+    needs: [changes]
+    if: github.event_name == 'workflow_dispatch' && inputs.enable_platform_builds == true && needs.changes.outputs.platform_changes == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            artifact_name: zigcraft-windows
+            binary_path: zig-out/bin/zigcraft.exe
+          - os: macos-latest
+            artifact_name: zigcraft-macos-build-only
+            binary_path: zig-out/bin/zigcraft
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Setup MSYS2
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          path-type: inherit
+          update: true
+
+      - name: Install Windows Vulkan SDK
+        if: runner.os == 'Windows'
+        run: choco install vulkan-sdk --no-progress -y
+
+      - name: Install Windows dependencies
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: pacman --noconfirm -S --needed mingw-w64-ucrt-x86_64-sdl3 mingw-w64-ucrt-x86_64-vulkan-loader mingw-w64-ucrt-x86_64-vulkan-headers
+
+      - name: Expose Windows Vulkan import library
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: |
+          if [ -f /ucrt64/lib/libvulkan.dll.a ] && [ ! -f /ucrt64/lib/libvulkan.a ]; then
+            cp /ucrt64/lib/libvulkan.dll.a /ucrt64/lib/libvulkan.a
+          fi
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install sdl3 molten-vk vulkan-loader
+
+      - name: Build Windows
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        env:
+          CPATH: /ucrt64/include
+          LIBRARY_PATH: /ucrt64/lib
+        run: zig build --search-prefix /ucrt64 -Dimgui=false
+
+      - name: Build macOS
+        if: runner.os == 'macOS'
+        run: zig build -Dimgui=false
+
+      - name: Upload platform binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.binary_path }}
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -1,0 +1,92 @@
+name: Profiling
+
+on:
+  schedule:
+    - cron: "43 4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
+jobs:
+  nightly-profile:
+    permissions:
+      contents: read
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+
+      - name: Setup Zig cache
+        uses: ./.github/actions/setup-zig-cache
+        with:
+          cache-key-prefix: zig-ci-profile
+
+      - name: Start headless Wayland compositor
+        uses: ./.github/actions/start-weston
+
+      - name: Setup Lavapipe Vulkan
+        uses: ./.github/actions/setup-lavapipe
+
+      - name: Capture fixed-world profiling run
+        uses: ./.github/actions/run-with-log
+        with:
+          name: Profiling Capture
+          timeout: 20m
+          log-file: profiling.log
+          command: |
+            mkdir -p profiling-artifacts
+            nix develop .#ci-graphics --command zig build benchmark -Doptimize=ReleaseFast -Dbenchmark-preset=medium -Dbenchmark-duration=10 -Dbenchmark-output=profiling-artifacts/fixed-world-profile.json
+            ruby -rjson -e '
+              profile = JSON.parse(File.read("profiling-artifacts/fixed-world-profile.json"))
+              duration_us = (profile.fetch("duration_s").to_f * 1_000_000).to_i
+              cpu_us = (profile.fetch("cpu_ms_avg").to_f * 1_000).to_i
+              gpu_us = (profile.fetch("gpu_ms").fetch("total_avg").to_f * 1_000).to_i
+              events = [
+                {"name"=>"fixed-world-profile", "cat"=>"benchmark", "ph"=>"X", "ts"=>0, "dur"=>duration_us, "pid"=>1, "tid"=>1, "args"=>profile},
+                {"name"=>"cpu-frame-avg", "cat"=>"frame", "ph"=>"X", "ts"=>0, "dur"=>cpu_us, "pid"=>1, "tid"=>2},
+                {"name"=>"gpu-frame-avg", "cat"=>"frame", "ph"=>"X", "ts"=>cpu_us, "dur"=>gpu_us, "pid"=>1, "tid"=>3}
+              ]
+              trace = {"traceEvents"=>events, "displayTimeUnit"=>"ms"}
+              File.write("profiling-artifacts/perfetto-trace.json", JSON.pretty_generate(trace))
+              File.write("profiling-artifacts/tracy-frame.json", JSON.pretty_generate({"format"=>"zigcraft-tracy-frame-v1", "source"=>"fixed-world-profile", "events"=>events}))
+            '
+        env:
+          XDG_RUNTIME_DIR: /tmp/runtime-runner
+          WAYLAND_DISPLAY: headless
+          SDL_AUDIODRIVER: dummy
+          ZIGCRAFT_SAFE_MODE: "1"
+
+      - name: Write nightly summary
+        if: always()
+        run: |
+          {
+            printf "## ZigCraft nightly profiling\n\n"
+            printf 'Run: %s\n\n' "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            printf "Artifacts: \`profiling-artifacts\` contains fixed-world benchmark JSON plus generated Tracy/Perfetto trace artifacts.\n"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Stop headless Wayland compositor
+        if: always()
+        uses: ./.github/actions/stop-weston
+
+      - name: Upload profiling artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: profiling-artifacts
+          path: |
+            profiling-artifacts
+            profiling.log
+            weston.log
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/assets/budget.json
+++ b/docs/assets/budget.json
@@ -1,0 +1,8 @@
+{
+  "rationale": "Keep committed game assets small enough for fast CI checkout and bounded release artifacts. 4K source textures are already ignored; these limits catch accidental large binary commits.",
+  "per_asset": {
+    "texture_bytes": 4194304,
+    "model_bytes": 8388608
+  },
+  "total_assets_growth_bytes": 16777216
+}

--- a/docs/platform-ci.md
+++ b/docs/platform-ci.md
@@ -1,0 +1,12 @@
+# Platform CI
+
+`.github/workflows/build.yml` runs Linux/Lavapipe as the canonical correctness gate: formatting, debug/release-safe unit tests, shader validation, integration smoke, and world smoke.
+
+The Windows and macOS jobs are build-only and manual opt-in in this first iteration. They are kept in the workflow behind the `enable_platform_builds` dispatch input so the dependency setup and artifact paths are ready for stabilization without blocking PRs on non-Linux runner drift.
+
+Known limitations:
+
+- Windows is manual build-only until SDL/Vulkan library discovery and a stable headless Vulkan smoke path are available on GitHub-hosted Windows runners.
+- macOS uses MoltenVK plus the Vulkan loader and is manual build-only until a repeatable headless smoke test is defined for GitHub-hosted macOS runners.
+- Optional ImGui linkage remains covered by Linux/Nix CI; non-Linux build-only legs disable it until cimgui package availability is standardized there.
+- Linux/Lavapipe remains the required correctness signal for tests and validation logs.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,17 @@
+# Profiling Captures
+
+`.github/workflows/profiling.yml` runs nightly and on manual dispatch. It captures a bounded fixed-world profiling run on the same Lavapipe graphics stack used by benchmark CI.
+
+The current capture command is:
+
+```bash
+nix develop .#ci-graphics --command zig build benchmark -Doptimize=ReleaseFast -Dbenchmark-preset=medium -Dbenchmark-duration=10 -Dbenchmark-output=profiling-artifacts/fixed-world-profile.json
+```
+
+Artifacts are uploaded as `profiling-artifacts` and linked from the run summary:
+
+- `fixed-world-profile.json`: raw deterministic benchmark metrics.
+- `perfetto-trace.json`: Chrome/Perfetto trace-event JSON synthesized from the benchmark frame metrics.
+- `tracy-frame.json`: stable ZigCraft Tracy-frame interchange JSON containing the same fixed-run frame events.
+
+The generated trace artifacts are intentionally derived from the fixed-world benchmark output so every nightly run leaves inspectable timing evidence even before native Tracy/Perfetto exporters are added to the engine. The workflow is nightly-only to keep pull-request cost bounded.

--- a/modules/engine-core/src/crash_handler.zig
+++ b/modules/engine-core/src/crash_handler.zig
@@ -1,0 +1,193 @@
+//! Minimal local crash dump capture for CI and tester builds.
+//!
+//! Dumps intentionally contain process metadata only: signal/reason, pid, and a
+//! timestamp. They do not include environment variables, command-line arguments,
+//! memory pages, or file contents.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const fs = @import("fs");
+const runtime_env = @import("runtime_env.zig");
+const time = @import("time.zig");
+
+pub const default_dump_dir = "zigcraft-minidumps";
+
+var installed = false;
+var signal_dump_fd: i32 = -1;
+
+pub fn init() void {
+    if (installed) return;
+    installed = true;
+
+    if (builtin.os.tag != .windows) {
+        prepareSignalDumpFile();
+        installPosixSignal(.ABRT);
+        installPosixSignal(.TERM);
+        installPosixSignal(.QUIT);
+        installPosixSignal(.SEGV);
+        installPosixSignal(.BUS);
+        installPosixSignal(.ILL);
+        installPosixSignal(.FPE);
+    }
+}
+
+pub fn writePanicDump(first_trace_addr: ?usize) void {
+    writeDump(.{ .kind = "panic", .signal = null, .first_trace_addr = first_trace_addr });
+}
+
+const DumpRequest = struct {
+    kind: []const u8,
+    signal: ?u32,
+    first_trace_addr: ?usize,
+};
+
+fn dumpDir() []const u8 {
+    return runtime_env.getenv("ZIGCRAFT_MINIDUMP_DIR") orelse default_dump_dir;
+}
+
+fn writeDump(request: DumpRequest) void {
+    const dir_path = dumpDir();
+    fs.cwd().makePath(dir_path) catch return;
+
+    var path_buf: [512]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/zigcraft-{d}-{d}.dmp", .{
+        dir_path,
+        timestampSeconds(),
+        processId(),
+    }) catch return;
+
+    const file = fs.cwd().createFile(path, .{ .exclusive = true }) catch return;
+    defer file.close();
+
+    var dump_buf: [512]u8 = undefined;
+    const dump = std.fmt.bufPrint(&dump_buf,
+        \\format=zigcraft-minidump-v1
+        \\kind={s}
+        \\pid={d}
+        \\timestamp_unix={d}
+        \\signal={?d}
+        \\first_trace_addr={?x}
+        \\pii_policy=metadata-only-no-env-no-argv-no-memory
+        \\
+    , .{
+        request.kind,
+        processId(),
+        timestampSeconds(),
+        request.signal,
+        request.first_trace_addr,
+    }) catch return;
+    file.writeAll(dump) catch return;
+}
+
+fn prepareSignalDumpFile() void {
+    const dir_path = dumpDir();
+    fs.cwd().makePath(dir_path) catch return;
+
+    var path_buf: [512]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/zigcraft-signal-{d}-{d}.dmp", .{
+        dir_path,
+        timestampSeconds(),
+        processId(),
+    }) catch return;
+
+    const file = fs.cwd().createFile(path, .{ .exclusive = true }) catch return;
+    signal_dump_fd = @intCast(file.inner.handle);
+
+    const header = std.fmt.bufPrint(&path_buf,
+        \\format=zigcraft-minidump-v1
+        \\kind=signal
+        \\pid={d}
+        \\timestamp_unix={d}
+        \\pii_policy=metadata-only-no-env-no-argv-no-memory
+        \\signal=
+    , .{
+        processId(),
+        timestampSeconds(),
+    }) catch return;
+    file.writeAll(header) catch return;
+}
+
+fn processId() u32 {
+    return switch (builtin.os.tag) {
+        .windows => std.os.windows.GetCurrentProcessId(),
+        .linux => @intCast(std.os.linux.getpid()),
+        else => @intCast(std.c.getpid()),
+    };
+}
+
+fn timestampSeconds() i64 {
+    return @divFloor(time.timestampMs(), 1000);
+}
+
+fn installPosixSignal(comptime signal: std.posix.SIG) void {
+    const action: std.posix.Sigaction = .{
+        .handler = .{ .handler = handlePosixSignal },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(signal, &action, null);
+}
+
+fn handlePosixSignal(signal: std.posix.SIG) callconv(.c) void {
+    writeSignalDump(signal);
+
+    const default_action: std.posix.Sigaction = .{
+        .handler = .{ .handler = std.posix.SIG.DFL },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(signal, &default_action, null);
+    std.posix.raise(signal) catch {};
+}
+
+fn writeSignalDump(signal: std.posix.SIG) void {
+    const fd = signal_dump_fd;
+    if (fd < 0) return;
+
+    var buf: [64]u8 = undefined;
+    var len: usize = 0;
+    len = appendDecimal(&buf, len, @intFromEnum(signal));
+    len = appendBytes(&buf, len, "\nfirst_trace_addr=null\n");
+    signalSafeWrite(fd, buf[0..len]);
+}
+
+fn appendBytes(buf: *[64]u8, start: usize, bytes: []const u8) usize {
+    var len = start;
+    for (bytes) |byte| {
+        if (len >= buf.len) break;
+        buf[len] = byte;
+        len += 1;
+    }
+    return len;
+}
+
+fn appendDecimal(buf: *[64]u8, start: usize, value: u32) usize {
+    var digits: [10]u8 = undefined;
+    var digit_count: usize = 0;
+    var remaining = value;
+
+    while (true) {
+        digits[digit_count] = @intCast('0' + (remaining % 10));
+        digit_count += 1;
+        remaining /= 10;
+        if (remaining == 0) break;
+    }
+
+    var len = start;
+    while (digit_count > 0 and len < buf.len) {
+        digit_count -= 1;
+        buf[len] = digits[digit_count];
+        len += 1;
+    }
+    return len;
+}
+
+fn signalSafeWrite(fd: i32, bytes: []const u8) void {
+    if (bytes.len == 0) return;
+
+    switch (builtin.os.tag) {
+        .linux => _ = std.os.linux.write(fd, bytes.ptr, bytes.len),
+        else => _ = std.c.write(@intCast(fd), bytes.ptr, bytes.len),
+    }
+}

--- a/modules/engine-core/src/root.zig
+++ b/modules/engine-core/src/root.zig
@@ -1,4 +1,5 @@
 pub const fs = @import("fs");
+pub const crash_handler = @import("crash_handler.zig");
 pub const interfaces = @import("interfaces.zig");
 pub const job_system = @import("job_system.zig");
 pub const log = @import("log.zig");
@@ -22,6 +23,7 @@ pub const REPRIORITIZE_THRESHOLD = job_system.REPRIORITIZE_THRESHOLD;
 pub const Time = time.Time;
 pub const WorkerPool = job_system.WorkerPool;
 pub const WindowManager = window.WindowManager;
+pub const initCrashHandler = crash_handler.init;
 pub const timestampMs = time.timestampMs;
 pub const envFlag = runtime_env.envFlag;
 pub const getenv = runtime_env.getenv;

--- a/scripts/check_asset_budget.sh
+++ b/scripts/check_asset_budget.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="origin/dev"
+budget_file="docs/assets/budget.json"
+assets_dir="assets"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base-ref)
+            base_ref="$2"
+            shift 2
+            ;;
+        --budget-file)
+            budget_file="$2"
+            shift 2
+            ;;
+        *)
+            printf 'Unknown argument: %s\n' "$1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! -f "$budget_file" ]]; then
+    printf 'Asset budget config not found: %s\n' "$budget_file" >&2
+    exit 2
+fi
+
+texture_budget=$(ruby -rjson -e 'puts JSON.parse(File.read(ARGV[0])).fetch("per_asset").fetch("texture_bytes")' "$budget_file")
+model_budget=$(ruby -rjson -e 'puts JSON.parse(File.read(ARGV[0])).fetch("per_asset").fetch("model_bytes")' "$budget_file")
+total_growth_budget=$(ruby -rjson -e 'puts JSON.parse(File.read(ARGV[0])).fetch("total_assets_growth_bytes")' "$budget_file")
+
+failure=0
+
+is_texture() {
+    local path
+    path=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+
+    case "$path" in
+        *.png|*.jpg|*.jpeg|*.tga|*.bmp|*.webp|*.ktx|*.ktx2|*.dds) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_model() {
+    local path
+    path=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+
+    case "$path" in
+        *.obj|*.gltf|*.glb|*.fbx|*.dae|*.blend) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+size_bytes() {
+    if stat -c '%s' "$1" >/dev/null 2>&1; then
+        stat -c '%s' "$1"
+    else
+        stat -f '%z' "$1"
+    fi
+}
+
+changed_assets=$(git diff --name-only --diff-filter=AM "$base_ref" -- "$assets_dir" || true)
+
+while IFS= read -r asset; do
+    [[ -n "$asset" && -f "$asset" ]] || continue
+    bytes=$(size_bytes "$asset")
+
+    if is_texture "$asset" && (( bytes > texture_budget )); then
+        printf 'Asset budget exceeded: texture %s is %d bytes, limit is %d bytes.\n' "$asset" "$bytes" "$texture_budget" >&2
+        failure=1
+    elif is_model "$asset" && (( bytes > model_budget )); then
+        printf 'Asset budget exceeded: model %s is %d bytes, limit is %d bytes.\n' "$asset" "$bytes" "$model_budget" >&2
+        failure=1
+    fi
+done <<< "$changed_assets"
+
+current_total=0
+while IFS= read -r -d '' asset; do
+    [[ -f "$asset" ]] || continue
+    bytes=$(size_bytes "$asset")
+    current_total=$(( current_total + bytes ))
+done < <(git ls-files -z "$assets_dir")
+
+base_total=$(git ls-tree -r -l "$base_ref" "$assets_dir" 2>/dev/null | awk '{ total += $4 } END { print total + 0 }')
+growth=$(( current_total - base_total ))
+
+if (( growth > total_growth_budget )); then
+    printf 'Asset budget exceeded: assets/ grew by %d bytes vs %s, limit is %d bytes.\n' "$growth" "$base_ref" "$total_growth_budget" >&2
+    failure=1
+fi
+
+if (( failure != 0 )); then
+    exit 1
+fi
+
+printf 'Asset budgets passed: %d bytes total, growth %d bytes vs %s.\n' "$current_total" "$growth" "$base_ref"

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,11 +1,21 @@
 const std = @import("std");
 const App = @import("game/app.zig").App;
-const log = @import("engine-core").log;
+const engine_core = @import("engine-core");
+const log = engine_core.log;
+
+pub const panic = std.debug.FullPanic(crashPanic);
+
+fn crashPanic(msg: []const u8, first_trace_addr: ?usize) noreturn {
+    engine_core.crash_handler.writePanicDump(first_trace_addr);
+    std.debug.defaultPanic(msg, first_trace_addr);
+}
 
 pub fn main() !void {
     var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
+
+    engine_core.initCrashHandler();
 
     log.initDefaultFile() catch |err| {
         std.debug.print("[WARN] failed to initialize file logging: {}\n", .{err});


### PR DESCRIPTION
## Summary
- add local metadata-only crash dump capture and upload minidumps on failing integration/world-smoke runs
- add Windows build and macOS build-only CI legs while keeping Linux/Lavapipe as the correctness gate
- add nightly profiling workflow with fixed-world benchmark trace artifacts and docs
- add asset budget workflow, committed budget config, and clear budget failure script

## Verification
- `nix develop --command zig fmt src/ modules/`
- `nix develop --command zig build`
- `nix develop --command zig build test`
- `nix develop --command shellcheck scripts/*.sh`
- workflow YAML parse via Ruby
- `bash scripts/check_asset_budget.sh --base-ref HEAD --budget-file docs/assets/budget.json`
- git push pre-push hooks passed

Closes #877
Closes #878
Closes #879
Closes #880