### PR TITLE
perf: remove LOD CPU and submission hot spots

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -18,6 +18,7 @@ const BuildOptions = struct {
     window_no_focus: bool,
     shadow_test_variant: []const u8,
     benchmark_preset: []const u8,
+    benchmark_scenario: []const u8,
     benchmark_duration: u32,
     benchmark_output: []const u8,
     benchmark_render_distance: i32,
@@ -65,7 +66,7 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const opts = defineBuildOptions(b);
+    const opts = defineBuildOptions(b, optimize);
     const modules = defineModules(b, target, optimize, opts);
     defineBuildSteps(b, target, optimize, opts, modules);
 }
@@ -418,6 +419,7 @@ fn defineBuildSteps(
     const window_video_driver = opts.window_video_driver;
     const window_no_focus = opts.window_no_focus;
     const benchmark_preset = opts.benchmark_preset;
+    const benchmark_scenario = opts.benchmark_scenario;
     const benchmark_duration = opts.benchmark_duration;
     const benchmark_output = opts.benchmark_output;
     const sanitize_c = opts.sanitize_c;
@@ -512,9 +514,11 @@ fn defineBuildSteps(
     benchmark_options.addOption([]const u8, "shadow_test_variant", "dug-cave");
     benchmark_options.addOption(bool, "benchmark", true);
     benchmark_options.addOption([]const u8, "benchmark_preset", benchmark_preset);
+    benchmark_options.addOption([]const u8, "benchmark_scenario", benchmark_scenario);
     benchmark_options.addOption(u32, "benchmark_duration", benchmark_duration);
     benchmark_options.addOption([]const u8, "benchmark_output", benchmark_output);
     benchmark_options.addOption(i32, "benchmark_render_distance", opts.benchmark_render_distance);
+    benchmark_options.addOption([]const u8, "benchmark_build_mode", @tagName(optimize));
 
     const benchmark_root_module = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
@@ -558,6 +562,7 @@ fn defineBuildSteps(
     benchmark_run_cmd.step.dependOn(b.getInstallStep());
     benchmark_run_cmd.step.dependOn(&shader_cmd.step);
     benchmark_run_cmd.setCwd(b.path("."));
+    benchmark_run_cmd.setEnvironmentVariable("ZIGCRAFT_LOD_PROFILE", "1");
 
     const benchmark_step = b.step("benchmark", "Run benchmark harness");
     benchmark_step.dependOn(&benchmark_run_cmd.step);
@@ -788,7 +793,7 @@ fn defineBuildSteps(
     defineShaderValidation(b, test_step);
 }
 
-fn defineBuildOptions(b: *std.Build) BuildOptions {
+fn defineBuildOptions(b: *std.Build, optimize: std.builtin.OptimizeMode) BuildOptions {
     const options = b.addOptions();
     const enable_debug_shadows = b.option(bool, "debug_shadows", "Enable debug shadow visualization resources") orelse false;
     options.addOption(bool, "debug_shadows", enable_debug_shadows);
@@ -859,9 +864,20 @@ fn defineBuildOptions(b: *std.Build) BuildOptions {
 
     const benchmark = b.option(bool, "benchmark", "Enable benchmark mode") orelse false;
     options.addOption(bool, "benchmark", benchmark);
+    // Benchmark runs opt into LOD CPU/pressure collection without requiring a
+    // process-wide environment mutation. Normal runs remain opt-in through
+    // ZIGCRAFT_LOD_PROFILE.
+    world_lod_options.addOption(bool, "benchmark_lod_profile", benchmark);
 
     const benchmark_preset = b.option([]const u8, "benchmark-preset", "Graphics preset to benchmark (low, medium, high, ultra, extreme)") orelse "medium";
     options.addOption([]const u8, "benchmark_preset", benchmark_preset);
+
+    const benchmark_scenario = b.option([]const u8, "benchmark-scenario", "Benchmark pose scenario (stationary, traversal, rapid-turn, teleport-eviction)") orelse "traversal";
+    if (!isBenchmarkScenario(benchmark_scenario)) {
+        std.log.err("unsupported -Dbenchmark-scenario value '{s}' (expected stationary, traversal, rapid-turn, or teleport-eviction)", .{benchmark_scenario});
+        b.invalid_user_input = true;
+    }
+    options.addOption([]const u8, "benchmark_scenario", benchmark_scenario);
 
     const benchmark_duration = b.option(u32, "benchmark-duration", "Benchmark duration in seconds") orelse 60;
     options.addOption(u32, "benchmark_duration", benchmark_duration);
@@ -871,6 +887,7 @@ fn defineBuildOptions(b: *std.Build) BuildOptions {
 
     const benchmark_render_distance = b.option(i32, "benchmark-render-distance", "Override benchmark render and LOD horizon distance; 0 uses selected preset") orelse 0;
     options.addOption(i32, "benchmark_render_distance", benchmark_render_distance);
+    options.addOption([]const u8, "benchmark_build_mode", @tagName(optimize));
 
     const sanitize = b.option([]const u8, "sanitize", "Sanitizer profile for test builds (none, address)") orelse "none";
     const sanitize_c = resolveSanitizeC(b, sanitize);
@@ -893,11 +910,19 @@ fn defineBuildOptions(b: *std.Build) BuildOptions {
         .window_no_focus = window_no_focus,
         .shadow_test_variant = shadow_test_variant,
         .benchmark_preset = benchmark_preset,
+        .benchmark_scenario = benchmark_scenario,
         .benchmark_duration = benchmark_duration,
         .benchmark_output = benchmark_output,
         .benchmark_render_distance = benchmark_render_distance,
         .sanitize_c = sanitize_c,
     };
+}
+
+fn isBenchmarkScenario(scenario: []const u8) bool {
+    return std.mem.eql(u8, scenario, "stationary") or
+        std.mem.eql(u8, scenario, "traversal") or
+        std.mem.eql(u8, scenario, "rapid-turn") or
+        std.mem.eql(u8, scenario, "teleport-eviction");
 }
 
 fn resolveSanitizeC(b: *std.Build, sanitize: []const u8) ?std.zig.SanitizeC {

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -28,6 +28,58 @@ After the run finishes, download the `benchmark-results` artifact and replace th
 
 This gate is intentionally a short canary so every `dev` push gets a bounded performance signal without consuming long runner time. The benchmark warmup is excluded from samples so startup shader/resource transitions do not dominate steady-state regression checks. Longer profiling runs should use the manual workflow input with a larger duration and should not replace the CI canary baseline unless that policy changes deliberately.
 
+## Reproducible scenarios
+
+`-Dbenchmark-scenario` selects a deterministic, bounded camera path. The
+default is `traversal`, which is the original benchmark path and remains the
+only scenario used by the current CI baseline.
+
+| Scenario | Path | Intended signal |
+| --- | --- | --- |
+| `stationary` | Holds the camera at `(8, 100, 8)`. | Steady-state LOD and renderer cost. |
+| `traversal` | The original 60-second, smoothly interpolated six-waypoint loop. | Streaming and normal movement; default. |
+| `rapid-turn` | Holds position at `(8, 100, 8)` while cycling its view every second. | Frustum, visibility, and coverage churn without streaming movement. |
+| `teleport-eviction` | Jumps every four seconds between five fixed positions within ±1,536 blocks. | Streaming, cache, deferred-destruction, and eviction pressure. |
+
+Every benchmark starts the `overworld` generator with fixed seed `12345`, runs
+headless at 1920×1080, and records the scenario, seed, and build metadata in
+the result JSON. The `build` object records the Zig optimize mode, headless
+status, and fixed resolution, so artifacts can be compared only when their
+configuration is compatible.
+
+Run each bounded scenario with these commands (15 sampled seconds plus the
+one-second warmup; the external timeout also bounds a stalled process):
+
+```bash
+timeout --preserve-status 90s nix develop --command zig build benchmark -Doptimize=ReleaseFast -Dbenchmark-duration=15 -Dbenchmark-scenario=stationary -Dbenchmark-output=docs/benchmarks/results/stationary.json
+timeout --preserve-status 90s nix develop --command zig build benchmark -Doptimize=ReleaseFast -Dbenchmark-duration=15 -Dbenchmark-scenario=traversal -Dbenchmark-output=docs/benchmarks/results/traversal.json
+timeout --preserve-status 90s nix develop --command zig build benchmark -Doptimize=ReleaseFast -Dbenchmark-duration=15 -Dbenchmark-scenario=rapid-turn -Dbenchmark-output=docs/benchmarks/results/rapid-turn.json
+timeout --preserve-status 90s nix develop --command zig build benchmark -Doptimize=ReleaseFast -Dbenchmark-duration=15 -Dbenchmark-scenario=teleport-eviction -Dbenchmark-output=docs/benchmarks/results/teleport-eviction.json
+```
+
+Use the same preset and render-distance override for before/after comparison.
+For example, append `-Dbenchmark-preset=high -Dbenchmark-render-distance=16`
+to both commands. Unknown scenario values fail at build configuration time.
+
+## Visual baseline capture matrix
+
+When a LOD rendering change needs visual evidence, capture before and after
+images using the matching fixed seed, preset, render distance, and scenario.
+The benchmark runner is headless; this table defines the required evidence
+rather than storing screenshots in this repository.
+
+| Visual concern | Scenario | Capture points | Inspect |
+| --- | --- | --- | --- |
+| Terrain seams | `stationary` | After one-second warmup; after full-detail chunks settle. | Cracks, gaps, normal discontinuities, and material changes at LOD boundaries. |
+| LOD transitions | `traversal` | Before, during, and after each terrain-ring handoff. | Popping, holes, duplicate terrain, and transition timing. |
+| Water | `traversal` | Near water at an LOD boundary and after the boundary moves. | Shoreline cracks, water/terrain overlap, and missing distant water. |
+| Fog | `rapid-turn` | Each cardinal-view turn, especially toward the horizon. | Fog discontinuities, horizon banding, and terrain visible through fog. |
+| Full-detail handoff | `teleport-eviction` | Immediately after a jump and after detailed chunks replace LOD. | Stale regions, incorrect ownership, and gaps while uploads/evictions overlap. |
+
+Record the generated JSON filename beside each capture set. No screenshot is
+required for routine benchmark changes; use this matrix when visual behavior
+is affected.
+
 ## Tolerance Policy
 
 `scripts/compare_benchmarks.sh` applies an explicit tolerance per metric:

--- a/modules/engine-core/src/time.zig
+++ b/modules/engine-core/src/time.zig
@@ -8,6 +8,26 @@ pub fn timestampMs() i64 {
     return std.Io.Clock.real.now(std.Options.debug_io).toMilliseconds();
 }
 
+/// A lightweight monotonic elapsed-time timer backed by SDL's high-resolution
+/// performance counter. Construct it only at an enabled instrumentation site.
+pub const MonotonicTimer = struct {
+    start_ticks: u64,
+
+    pub fn start() MonotonicTimer {
+        return .{ .start_ticks = c.SDL_GetPerformanceCounter() };
+    }
+
+    pub fn read(self: MonotonicTimer) u64 {
+        const frequency = c.SDL_GetPerformanceFrequency();
+        if (frequency == 0) return 0;
+        const elapsed_ticks = c.SDL_GetPerformanceCounter() - self.start_ticks;
+        // Split quotient/remainder to preserve precision without overflowing
+        // for a process that has been running for a long time.
+        return (elapsed_ticks / frequency) * std.time.ns_per_s +
+            (elapsed_ticks % frequency) * std.time.ns_per_s / frequency;
+    }
+};
+
 pub const Time = struct {
     /// Time since last frame in seconds
     delta_time: f32 = 0,

--- a/modules/engine-graphics/src/vulkan/rhi_timing.zig
+++ b/modules/engine-graphics/src/vulkan/rhi_timing.zig
@@ -12,11 +12,13 @@ const GpuPass = enum {
     lpv_compute,
     sky,
     opaque_pass,
+    lod_terrain,
+    lod_water,
     bloom,
     fxaa,
     post_process,
 
-    pub const COUNT = 12;
+    pub const COUNT = 14;
 };
 
 pub const PASS_COUNT = GpuPass.COUNT;
@@ -32,6 +34,8 @@ fn mapPassName(name: []const u8) ?GpuPass {
     if (std.mem.eql(u8, name, "LPVPass")) return .lpv_compute;
     if (std.mem.eql(u8, name, "SkyPass")) return .sky;
     if (std.mem.eql(u8, name, "OpaquePass")) return .opaque_pass;
+    if (std.mem.eql(u8, name, "LODTerrainPass")) return .lod_terrain;
+    if (std.mem.eql(u8, name, "LODWaterPass")) return .lod_water;
     if (std.mem.eql(u8, name, "BloomPass")) return .bloom;
     if (std.mem.eql(u8, name, "FXAAPass")) return .fxaa;
     if (std.mem.eql(u8, name, "PostProcessPass")) return .post_process;
@@ -101,6 +105,8 @@ pub fn processTimingResults(ctx: anytype) void {
     const lpv = readPassMs(ctx, frame, .lpv_compute, period) orelse return;
     const sky = readPassMs(ctx, frame, .sky, period) orelse return;
     const opaque_ms = readPassMs(ctx, frame, .opaque_pass, period) orelse return;
+    const lod_terrain = readPassMs(ctx, frame, .lod_terrain, period) orelse return;
+    const lod_water = readPassMs(ctx, frame, .lod_water, period) orelse return;
     const bloom = readPassMs(ctx, frame, .bloom, period) orelse return;
     const fxaa = readPassMs(ctx, frame, .fxaa, period) orelse return;
     const post_process = readPassMs(ctx, frame, .post_process, period) orelse return;
@@ -114,6 +120,8 @@ pub fn processTimingResults(ctx: anytype) void {
     ctx.timing.timing_results.lpv_pass_ms = lpv;
     ctx.timing.timing_results.sky_pass_ms = sky;
     ctx.timing.timing_results.opaque_pass_ms = opaque_ms;
+    ctx.timing.timing_results.lod_terrain_pass_ms = lod_terrain;
+    ctx.timing.timing_results.lod_water_pass_ms = lod_water;
     ctx.timing.timing_results.bloom_pass_ms = bloom;
     ctx.timing.timing_results.fxaa_pass_ms = fxaa;
     ctx.timing.timing_results.post_process_pass_ms = post_process;
@@ -130,7 +138,13 @@ pub fn processTimingResults(ctx: anytype) void {
     ctx.timing.timing_results.total_gpu_ms += ctx.timing.timing_results.ssao_pass_ms;
     ctx.timing.timing_results.total_gpu_ms += ctx.timing.timing_results.lpv_pass_ms;
     ctx.timing.timing_results.total_gpu_ms += ctx.timing.timing_results.main_pass_ms;
+    // LOD timings are nested in scene passes and must not be double-counted.
     ctx.timing.timing_results.total_gpu_ms += ctx.timing.timing_results.bloom_pass_ms;
     ctx.timing.timing_results.total_gpu_ms += ctx.timing.timing_results.fxaa_pass_ms;
     ctx.timing.timing_results.total_gpu_ms += ctx.timing.timing_results.post_process_pass_ms;
+}
+
+test "GPU timing maps LOD pass names" {
+    try std.testing.expectEqual(GpuPass.lod_terrain, mapPassName("LODTerrainPass").?);
+    try std.testing.expectEqual(GpuPass.lod_water, mapPassName("LODWaterPass").?);
 }

--- a/modules/engine-rhi/src/rhi_types.zig
+++ b/modules/engine-rhi/src/rhi_types.zig
@@ -372,6 +372,12 @@ pub const GpuTimingResults = struct {
     lpv_pass_ms: f32,
     sky_pass_ms: f32,
     opaque_pass_ms: f32,
+    /// GPU time spent drawing distant-terrain LOD geometry. This is a subset
+    /// of the containing scene pass and is therefore excluded from total_gpu_ms.
+    lod_terrain_pass_ms: f32,
+    /// GPU time spent drawing distant-water LOD geometry. This is a subset
+    /// of the containing scene pass and is therefore excluded from total_gpu_ms.
+    lod_water_pass_ms: f32,
     main_pass_ms: f32, // Overall main pass time (sum of sky and opaque)
     bloom_pass_ms: f32,
     fxaa_pass_ms: f32,

--- a/modules/engine-ui/src/root.zig
+++ b/modules/engine-ui/src/root.zig
@@ -25,6 +25,7 @@ pub const DebugUI = debug_ui.DebugUI;
 pub const FEATURE_INFOS = debug_menu.FEATURE_INFOS;
 pub const FontAtlas = font_atlas.FontAtlas;
 pub const InputEvent = ui_system.InputEvent;
+pub const LODProfilingDisplay = timing_overlay.LODProfilingDisplay;
 pub const LODStatsDisplay = timing_overlay.LODStatsDisplay;
 pub const PerformanceData = timing_overlay.PerformanceData;
 pub const Rect = ui_system.Rect;

--- a/modules/engine-ui/src/timing_overlay.zig
+++ b/modules/engine-ui/src/timing_overlay.zig
@@ -23,7 +23,7 @@ pub const TimingOverlay = struct {
 
         comptime std.debug.assert(rhi.SHADOW_CASCADE_COUNT >= 3);
 
-        var num_lines: f32 = 2 + 1 + 13 + 1 + 6 + 1 + 4 + 1;
+        var num_lines: f32 = 2 + 1 + 15 + 1 + 6 + 1 + 4 + 1;
         if (data.world) |ws| {
             num_lines += 1 + 6;
             if (ws.lod != null) {
@@ -61,6 +61,8 @@ pub const TimingOverlay = struct {
         drawGpuLine(ui, "LPV:", data.gpu.lpv_pass_ms, label_x, value_x, &y, scale, muted);
         drawGpuLine(ui, "SKY:", data.gpu.sky_pass_ms, label_x, value_x, &y, scale, muted);
         drawGpuLine(ui, "OPAQUE:", data.gpu.opaque_pass_ms, label_x, value_x, &y, scale, muted);
+        drawGpuLine(ui, "LOD TERRAIN:", data.gpu.lod_terrain_pass_ms, label_x, value_x, &y, scale, muted);
+        drawGpuLine(ui, "LOD WATER:", data.gpu.lod_water_pass_ms, label_x, value_x, &y, scale, muted);
         drawGpuLine(ui, "MAIN:", data.gpu.main_pass_ms, label_x, value_x, &y, scale, muted);
         drawGpuLine(ui, "BLOOM:", data.gpu.bloom_pass_ms, label_x, value_x, &y, scale, muted);
         drawGpuLine(ui, "FXAA:", data.gpu.fxaa_pass_ms, label_x, value_x, &y, scale, muted);
@@ -172,4 +174,32 @@ pub const WorldStats = struct {
 pub const LODStatsDisplay = struct {
     loaded: [LODLevel.count]u32,
     memory_used_mb: u32,
+    profiling: LODProfilingDisplay = .{},
+};
+
+/// Dependency-neutral projection of the world-lod cumulative profiling snapshot.
+/// Keeping this at the UI boundary lets telemetry consumers avoid a world-lod import.
+pub const LODProfilingDisplay = struct {
+    enabled: bool = false,
+    update_ms: f64 = 0,
+    scheduling_ms: f64 = 0,
+    cache_ms: f64 = 0,
+    generation_dispatch_ms: f64 = 0,
+    state_transition_ms: f64 = 0,
+    upload_prep_ms: f64 = 0,
+    upload_submission_ms: f64 = 0,
+    visibility_ms: f64 = 0,
+    coverage_ms: f64 = 0,
+    eviction_ms: f64 = 0,
+    worker_generation_ms: f64 = 0,
+    worker_mesh_construction_ms: f64 = 0,
+    upload_bytes: u64 = 0,
+    pending_cpu_upload_bytes: u64 = 0,
+    staging_pressure_count: u64 = 0,
+    visible_count: u64 = 0,
+    rejected_count: u64 = 0,
+    coverage_count: u64 = 0,
+    deferred_deletion_bytes: u64 = 0,
+    wait_idle_count: u64 = 0,
+    wait_idle_ms: f64 = 0,
 };

--- a/modules/game-core/src/benchmark.zig
+++ b/modules/game-core/src/benchmark.zig
@@ -5,11 +5,43 @@ const Player = @import("player.zig").Player;
 const Vec3 = @import("engine-math").Vec3;
 const GpuTimingResults = @import("engine-rhi").GpuTimingResults;
 const WorldStats = @import("engine-ui").WorldStats;
+const LODProfilingDisplay = @import("engine-ui").LODProfilingDisplay;
 
 pub const Waypoint = struct {
     pos: Vec3,
     look: Vec3,
     duration: f32,
+};
+
+pub const BENCHMARK_WORLD_SEED: u64 = 12345;
+
+pub const Scenario = enum {
+    stationary,
+    traversal,
+    rapid_turn,
+    teleport_eviction,
+
+    pub fn parse(value: []const u8) !Scenario {
+        if (std.mem.eql(u8, value, "stationary")) return .stationary;
+        if (std.mem.eql(u8, value, "traversal")) return .traversal;
+        if (std.mem.eql(u8, value, "rapid-turn")) return .rapid_turn;
+        if (std.mem.eql(u8, value, "teleport-eviction")) return .teleport_eviction;
+        return error.InvalidBenchmarkScenario;
+    }
+
+    pub fn name(self: Scenario) []const u8 {
+        return switch (self) {
+            .stationary => "stationary",
+            .traversal => "traversal",
+            .rapid_turn => "rapid-turn",
+            .teleport_eviction => "teleport-eviction",
+        };
+    }
+};
+
+const Pose = struct {
+    pos: Vec3,
+    look: Vec3,
 };
 
 pub const BENCH_PATH = [_]Waypoint{
@@ -21,16 +53,65 @@ pub const BENCH_PATH = [_]Waypoint{
     .{ .pos = Vec3.init(900, 160, 700), .look = Vec3.init(0.3, -0.9, -0.1), .duration = 15.0 },
 };
 
+const STATIONARY_PATH = [_]Waypoint{
+    .{ .pos = Vec3.init(8, 100, 8), .look = Vec3.init(1, -0.1, 0), .duration = 60.0 },
+};
+
+const RAPID_TURN_PATH = [_]Waypoint{
+    .{ .pos = Vec3.init(8, 100, 8), .look = Vec3.init(1, 0, 0), .duration = 1.0 },
+    .{ .pos = Vec3.init(8, 100, 8), .look = Vec3.init(0.2, -0.2, 1), .duration = 1.0 },
+    .{ .pos = Vec3.init(8, 100, 8), .look = Vec3.init(-1, 0.1, 0), .duration = 1.0 },
+    .{ .pos = Vec3.init(8, 100, 8), .look = Vec3.init(-0.2, 0.2, -1), .duration = 1.0 },
+};
+
+const TELEPORT_EVICTION_PATH = [_]Waypoint{
+    .{ .pos = Vec3.init(8, 100, 8), .look = Vec3.init(1, -0.1, 0), .duration = 4.0 },
+    .{ .pos = Vec3.init(1_536, 140, 512), .look = Vec3.init(-1, -0.2, 0), .duration = 4.0 },
+    .{ .pos = Vec3.init(-1_536, 120, 1_024), .look = Vec3.init(0, -0.1, -1), .duration = 4.0 },
+    .{ .pos = Vec3.init(-1_024, 160, -1_536), .look = Vec3.init(1, -0.3, 0.2), .duration = 4.0 },
+    .{ .pos = Vec3.init(1_024, 110, -1_024), .look = Vec3.init(0.1, -0.1, 1), .duration = 4.0 },
+};
+
 pub const FrameSample = struct {
     cpu_ms: f32,
     fps: f32,
     gpu_shadow_ms: f32,
     gpu_opaque_ms: f32,
+    gpu_lod_terrain_ms: f32,
+    gpu_lod_water_ms: f32,
     gpu_total_ms: f32,
     draw_calls: u32,
     vertices: u64,
     chunks_rendered: u32,
     gpu_memory_mb: f32,
+    lod: LODFrameSample = .{},
+};
+
+/// One benchmark-frame delta derived from world-lod's cumulative telemetry.
+/// Pending upload and deferred deletion byte values are gauges, not counters.
+pub const LODFrameSample = struct {
+    enabled: bool = false,
+    cpu_ms: f64 = 0,
+    scheduling_ms: f64 = 0,
+    cache_ms: f64 = 0,
+    generation_dispatch_ms: f64 = 0,
+    state_transition_ms: f64 = 0,
+    upload_prep_ms: f64 = 0,
+    upload_submission_ms: f64 = 0,
+    visibility_ms: f64 = 0,
+    coverage_ms: f64 = 0,
+    eviction_ms: f64 = 0,
+    worker_generation_ms: f64 = 0,
+    worker_mesh_construction_ms: f64 = 0,
+    upload_bytes: u64 = 0,
+    pending_cpu_upload_bytes: u64 = 0,
+    staging_pressure_count: u64 = 0,
+    visible_count: u64 = 0,
+    rejected_count: u64 = 0,
+    coverage_count: u64 = 0,
+    deferred_deletion_bytes: u64 = 0,
+    wait_idle_count: u64 = 0,
+    wait_idle_ms: f64 = 0,
 };
 
 pub const SloThresholds = struct {
@@ -55,49 +136,162 @@ pub const Summary = struct {
 pub const GpuSummary = struct {
     shadow_avg: f64,
     opaque_avg: f64,
+    lod_terrain_avg: f64,
+    lod_water_avg: f64,
     total_avg: f64,
+};
+
+pub const TimingTotalAverage = struct {
+    total_ms: f64,
+    avg_ms: f64,
+};
+
+pub const LODCpuCategories = struct {
+    scheduling: TimingTotalAverage,
+    cache: TimingTotalAverage,
+    generation_dispatch: TimingTotalAverage,
+    state_transition: TimingTotalAverage,
+    upload_prep: TimingTotalAverage,
+    upload_submission: TimingTotalAverage,
+    visibility: TimingTotalAverage,
+    coverage: TimingTotalAverage,
+    eviction: TimingTotalAverage,
+};
+
+pub const LODWorkerSummary = struct {
+    generation_total_ms: f64,
+    mesh_construction_total_ms: f64,
+};
+
+pub const ByteGaugeSummary = struct {
+    avg_bytes: f64,
+    max_bytes: u64,
+    last_bytes: u64,
+};
+
+pub const LODMemorySummary = struct {
+    upload_total_bytes: u64,
+    upload_avg_bytes: f64,
+    pending_cpu_upload_bytes: ByteGaugeSummary,
+    deferred_deletion_bytes: ByteGaugeSummary,
+};
+
+pub const LODVisibilitySummary = struct {
+    visible_total: u64,
+    rejected_total: u64,
+    coverage_total: u64,
+};
+
+pub const LODPressureSummary = struct {
+    staging_pressure_total: u64,
+    wait_idle_count_total: u64,
+    wait_idle_ms_total: f64,
+    wait_idle_ms_avg: f64,
+};
+
+pub const LODBenchmarkSummary = struct {
+    profiling_enabled: bool,
+    cpu_frame_ms: Summary,
+    cpu_categories: LODCpuCategories,
+    workers: LODWorkerSummary,
+    memory_bytes: LODMemorySummary,
+    visibility: LODVisibilitySummary,
+    pressure: LODPressureSummary,
+};
+
+pub const WorstFrame = struct {
+    frame_index: u32,
+    frame_ms: f64,
+    gpu_total_ms: f64,
+    gpu_lod_terrain_ms: f64,
+    gpu_lod_water_ms: f64,
+    dominant_gpu_pass: []const u8,
+    dominant_gpu_pass_ms: f64,
+    lod_cpu_ms: f64,
+    dominant_lod_cpu_category: []const u8,
+    dominant_lod_cpu_category_ms: f64,
+    lod_worker_generation_ms: f64,
+    lod_worker_mesh_construction_ms: f64,
+    lod_upload_bytes: u64,
+    lod_pending_cpu_upload_bytes: u64,
+    lod_deferred_deletion_bytes: u64,
+    lod_visible_count: u64,
+    lod_rejected_count: u64,
+    lod_coverage_count: u64,
+    lod_wait_idle_count: u64,
+    lod_wait_idle_ms: f64,
+    lod_staging_pressure_count: u64,
 };
 
 pub const BenchmarkResults = struct {
     preset: []const u8,
+    scenario: []const u8,
+    world_seed: u64,
+    build: BuildMetadata,
     render_distance: i32,
     gpu_memory_mb_avg: f64,
     gpu_memory_mb_max: f64,
     frames: u32,
     duration_s: f32,
     fps: Summary,
+    frame_ms: Summary,
     max_frame_ms: f64,
     cpu_ms_avg: f64,
     gpu_ms: GpuSummary,
     draw_calls_avg: f64,
     vertices_avg: f64,
     chunks_rendered_avg: f64,
+    worst_frame: WorstFrame,
+    lod: LODBenchmarkSummary,
+};
+
+pub const BuildMetadata = struct {
+    mode: []const u8,
+    headless: bool = true,
+    resolution: [2]u32 = .{ 1920, 1080 },
 };
 
 pub const BenchmarkRunner = struct {
     allocator: std.mem.Allocator,
     preset: []const u8,
+    scenario: Scenario,
     render_distance: i32,
     duration_s: f32,
+    world_seed: u64,
+    build: BuildMetadata,
     output_path: []const u8,
     start_ms: i64,
     elapsed_s: f32 = 0,
     sampled_s: f32 = 0,
     warmup_s: f32 = 1.0,
     samples: std.ArrayListUnmanaged(FrameSample) = .empty,
+    previous_lod_profiling: ?LODProfilingDisplay = null,
 
-    pub fn init(allocator: std.mem.Allocator, preset: []const u8, render_distance: i32, duration_s: f32, output_path: []const u8) !BenchmarkRunner {
+    pub fn init(
+        allocator: std.mem.Allocator,
+        preset: []const u8,
+        scenario_name: []const u8,
+        render_distance: i32,
+        duration_s: f32,
+        world_seed: u64,
+        build_mode: []const u8,
+        output_path: []const u8,
+    ) !BenchmarkRunner {
         var runner = BenchmarkRunner{
             .allocator = allocator,
             .preset = preset,
+            .scenario = try Scenario.parse(scenario_name),
             .render_distance = render_distance,
             .duration_s = duration_s,
+            .world_seed = world_seed,
+            .build = .{ .mode = build_mode },
             .output_path = output_path,
             .start_ms = nowMs(),
             .elapsed_s = 0,
             .sampled_s = 0,
             .warmup_s = 1.0,
             .samples = .empty,
+            .previous_lod_profiling = null,
         };
 
         const estimate_frames = @max(@as(usize, 64), @as(usize, @intFromFloat(@ceil(duration_s * 120.0))));
@@ -110,7 +304,7 @@ pub const BenchmarkRunner = struct {
     }
 
     pub fn applyPose(self: *const BenchmarkRunner, player: *Player) void {
-        const pose = poseAtTime(@max(self.elapsed_s - self.warmup_s, 0.0));
+        const pose = poseAtTime(self.scenario, @max(self.elapsed_s - self.warmup_s, 0.0));
         player.fly_mode = true;
         player.can_fly = true;
         player.noclip = true;
@@ -124,6 +318,11 @@ pub const BenchmarkRunner = struct {
 
     pub fn recordFrame(self: *BenchmarkRunner, dt: f32, fps: f32, gpu: GpuTimingResults, world_stats: ?WorldStats, draw_calls: u32, gpu_memory_mb: f32) !void {
         self.elapsed_s += dt;
+        const profiling = if (world_stats) |ws| blk: {
+            if (ws.lod) |ls| break :blk ls.profiling;
+            break :blk null;
+        } else null;
+        const lod = lodFrameDelta(profiling, &self.previous_lod_profiling);
         if (self.elapsed_s < self.warmup_s) return;
 
         const shadow_avg = averageArray(&gpu.shadow_pass_ms);
@@ -136,11 +335,14 @@ pub const BenchmarkRunner = struct {
             .fps = frame_fps,
             .gpu_shadow_ms = shadow_avg,
             .gpu_opaque_ms = gpu.opaque_pass_ms,
+            .gpu_lod_terrain_ms = gpu.lod_terrain_pass_ms,
+            .gpu_lod_water_ms = gpu.lod_water_pass_ms,
             .gpu_total_ms = gpu.total_gpu_ms,
             .draw_calls = draw_calls,
             .vertices = vertices,
             .chunks_rendered = chunks_rendered,
             .gpu_memory_mb = gpu_memory_mb,
+            .lod = lod,
         });
         self.sampled_s += dt;
     }
@@ -168,10 +370,16 @@ pub const BenchmarkRunner = struct {
     pub fn makeResults(self: *const BenchmarkRunner) !BenchmarkResults {
         const fps_values = try self.collectField(fpsField);
         defer self.allocator.free(fps_values);
+        const frame_ms_values = try self.collectField(frameMsField);
+        defer self.allocator.free(frame_ms_values);
+        const lod_cpu_values = try self.collectLodCpuValues();
+        defer self.allocator.free(lod_cpu_values);
 
         var cpu_sum: f64 = 0;
         var shadow_sum: f64 = 0;
         var opaque_sum: f64 = 0;
+        var lod_terrain_sum: f64 = 0;
+        var lod_water_sum: f64 = 0;
         var total_sum: f64 = 0;
         var draw_sum: f64 = 0;
         var vertices_sum: f64 = 0;
@@ -179,22 +387,104 @@ pub const BenchmarkRunner = struct {
         var memory_sum: f64 = 0;
         var memory_max: f64 = 0;
         var max_frame_ms: f64 = 0;
+        var lod_profiling_enabled = false;
+        var lod_scheduling_ms: f64 = 0;
+        var lod_cache_ms: f64 = 0;
+        var lod_generation_dispatch_ms: f64 = 0;
+        var lod_state_transition_ms: f64 = 0;
+        var lod_upload_prep_ms: f64 = 0;
+        var lod_upload_submission_ms: f64 = 0;
+        var lod_visibility_ms: f64 = 0;
+        var lod_coverage_ms: f64 = 0;
+        var lod_eviction_ms: f64 = 0;
+        var lod_worker_generation_ms: f64 = 0;
+        var lod_worker_mesh_construction_ms: f64 = 0;
+        var lod_upload_bytes: u64 = 0;
+        var lod_pending_cpu_upload_bytes_sum: f64 = 0;
+        var lod_pending_cpu_upload_bytes_max: u64 = 0;
+        var lod_pending_cpu_upload_bytes_last: u64 = 0;
+        var lod_deferred_deletion_bytes_sum: f64 = 0;
+        var lod_deferred_deletion_bytes_max: u64 = 0;
+        var lod_deferred_deletion_bytes_last: u64 = 0;
+        var lod_staging_pressure_count: u64 = 0;
+        var lod_visible_count: u64 = 0;
+        var lod_rejected_count: u64 = 0;
+        var lod_coverage_count: u64 = 0;
+        var lod_wait_idle_count: u64 = 0;
+        var lod_wait_idle_ms: f64 = 0;
+        var worst_frame = WorstFrame{
+            .frame_index = 0,
+            .frame_ms = 0,
+            .gpu_total_ms = 0,
+            .gpu_lod_terrain_ms = 0,
+            .gpu_lod_water_ms = 0,
+            .dominant_gpu_pass = "none",
+            .dominant_gpu_pass_ms = 0,
+            .lod_cpu_ms = 0,
+            .dominant_lod_cpu_category = "none",
+            .dominant_lod_cpu_category_ms = 0,
+            .lod_worker_generation_ms = 0,
+            .lod_worker_mesh_construction_ms = 0,
+            .lod_upload_bytes = 0,
+            .lod_pending_cpu_upload_bytes = 0,
+            .lod_deferred_deletion_bytes = 0,
+            .lod_visible_count = 0,
+            .lod_rejected_count = 0,
+            .lod_coverage_count = 0,
+            .lod_wait_idle_count = 0,
+            .lod_wait_idle_ms = 0,
+            .lod_staging_pressure_count = 0,
+        };
 
-        for (self.samples.items) |sample| {
+        for (self.samples.items, 0..) |sample, index| {
             cpu_sum += sample.cpu_ms;
-            max_frame_ms = @max(max_frame_ms, sample.cpu_ms);
+            if (sample.cpu_ms > max_frame_ms) {
+                max_frame_ms = sample.cpu_ms;
+                worst_frame = worstFrameForSample(index, sample);
+            }
             shadow_sum += sample.gpu_shadow_ms;
             opaque_sum += sample.gpu_opaque_ms;
+            lod_terrain_sum += sample.gpu_lod_terrain_ms;
+            lod_water_sum += sample.gpu_lod_water_ms;
             total_sum += sample.gpu_total_ms;
             draw_sum += @floatFromInt(sample.draw_calls);
             vertices_sum += @floatFromInt(sample.vertices);
             chunks_sum += @floatFromInt(sample.chunks_rendered);
             memory_sum += sample.gpu_memory_mb;
             memory_max = @max(memory_max, sample.gpu_memory_mb);
+
+            const lod = sample.lod;
+            lod_profiling_enabled = lod_profiling_enabled or lod.enabled;
+            lod_scheduling_ms += lod.scheduling_ms;
+            lod_cache_ms += lod.cache_ms;
+            lod_generation_dispatch_ms += lod.generation_dispatch_ms;
+            lod_state_transition_ms += lod.state_transition_ms;
+            lod_upload_prep_ms += lod.upload_prep_ms;
+            lod_upload_submission_ms += lod.upload_submission_ms;
+            lod_visibility_ms += lod.visibility_ms;
+            lod_coverage_ms += lod.coverage_ms;
+            lod_eviction_ms += lod.eviction_ms;
+            lod_worker_generation_ms += lod.worker_generation_ms;
+            lod_worker_mesh_construction_ms += lod.worker_mesh_construction_ms;
+            lod_upload_bytes +|= lod.upload_bytes;
+            lod_pending_cpu_upload_bytes_sum += @floatFromInt(lod.pending_cpu_upload_bytes);
+            lod_pending_cpu_upload_bytes_max = @max(lod_pending_cpu_upload_bytes_max, lod.pending_cpu_upload_bytes);
+            lod_pending_cpu_upload_bytes_last = lod.pending_cpu_upload_bytes;
+            lod_deferred_deletion_bytes_sum += @floatFromInt(lod.deferred_deletion_bytes);
+            lod_deferred_deletion_bytes_max = @max(lod_deferred_deletion_bytes_max, lod.deferred_deletion_bytes);
+            lod_deferred_deletion_bytes_last = lod.deferred_deletion_bytes;
+            lod_staging_pressure_count +|= lod.staging_pressure_count;
+            lod_visible_count +|= lod.visible_count;
+            lod_rejected_count +|= lod.rejected_count;
+            lod_coverage_count +|= lod.coverage_count;
+            lod_wait_idle_count +|= lod.wait_idle_count;
+            lod_wait_idle_ms += lod.wait_idle_ms;
         }
 
         const count = @as(f64, @floatFromInt(@max(self.samples.items.len, 1)));
         var fps_summary = try summarizeSeries(self.allocator, fps_values);
+        const frame_ms_summary = try summarizeSeries(self.allocator, frame_ms_values);
+        const lod_cpu_summary = try summarizeSeries(self.allocator, lod_cpu_values);
         const sampled_s = cpu_sum / 1000.0;
         if (sampled_s > 0.0) {
             fps_summary.avg = @as(f64, @floatFromInt(self.samples.items.len)) / sampled_s;
@@ -202,22 +492,73 @@ pub const BenchmarkRunner = struct {
 
         return .{
             .preset = self.preset,
+            .scenario = self.scenario.name(),
+            .world_seed = self.world_seed,
+            .build = self.build,
             .render_distance = self.render_distance,
             .gpu_memory_mb_avg = memory_sum / count,
             .gpu_memory_mb_max = memory_max,
             .frames = @intCast(self.samples.items.len),
             .duration_s = self.duration_s,
             .fps = fps_summary,
+            .frame_ms = frame_ms_summary,
             .max_frame_ms = max_frame_ms,
             .cpu_ms_avg = cpu_sum / count,
             .gpu_ms = .{
                 .shadow_avg = shadow_sum / count,
                 .opaque_avg = opaque_sum / count,
+                .lod_terrain_avg = lod_terrain_sum / count,
+                .lod_water_avg = lod_water_sum / count,
                 .total_avg = total_sum / count,
             },
             .draw_calls_avg = draw_sum / count,
             .vertices_avg = vertices_sum / count,
             .chunks_rendered_avg = chunks_sum / count,
+            .worst_frame = worst_frame,
+            .lod = .{
+                .profiling_enabled = lod_profiling_enabled,
+                .cpu_frame_ms = lod_cpu_summary,
+                .cpu_categories = .{
+                    .scheduling = timingTotalAverage(lod_scheduling_ms, count),
+                    .cache = timingTotalAverage(lod_cache_ms, count),
+                    .generation_dispatch = timingTotalAverage(lod_generation_dispatch_ms, count),
+                    .state_transition = timingTotalAverage(lod_state_transition_ms, count),
+                    .upload_prep = timingTotalAverage(lod_upload_prep_ms, count),
+                    .upload_submission = timingTotalAverage(lod_upload_submission_ms, count),
+                    .visibility = timingTotalAverage(lod_visibility_ms, count),
+                    .coverage = timingTotalAverage(lod_coverage_ms, count),
+                    .eviction = timingTotalAverage(lod_eviction_ms, count),
+                },
+                .workers = .{
+                    .generation_total_ms = lod_worker_generation_ms,
+                    .mesh_construction_total_ms = lod_worker_mesh_construction_ms,
+                },
+                .memory_bytes = .{
+                    .upload_total_bytes = lod_upload_bytes,
+                    .upload_avg_bytes = @as(f64, @floatFromInt(lod_upload_bytes)) / count,
+                    .pending_cpu_upload_bytes = .{
+                        .avg_bytes = lod_pending_cpu_upload_bytes_sum / count,
+                        .max_bytes = lod_pending_cpu_upload_bytes_max,
+                        .last_bytes = lod_pending_cpu_upload_bytes_last,
+                    },
+                    .deferred_deletion_bytes = .{
+                        .avg_bytes = lod_deferred_deletion_bytes_sum / count,
+                        .max_bytes = lod_deferred_deletion_bytes_max,
+                        .last_bytes = lod_deferred_deletion_bytes_last,
+                    },
+                },
+                .visibility = .{
+                    .visible_total = lod_visible_count,
+                    .rejected_total = lod_rejected_count,
+                    .coverage_total = lod_coverage_count,
+                },
+                .pressure = .{
+                    .staging_pressure_total = lod_staging_pressure_count,
+                    .wait_idle_count_total = lod_wait_idle_count,
+                    .wait_idle_ms_total = lod_wait_idle_ms,
+                    .wait_idle_ms_avg = lod_wait_idle_ms / count,
+                },
+            },
         };
     }
 
@@ -225,6 +566,14 @@ pub const BenchmarkRunner = struct {
         var values = try self.allocator.alloc(f32, self.samples.items.len);
         for (self.samples.items, 0..) |sample, i| {
             values[i] = getter(sample);
+        }
+        return values;
+    }
+
+    fn collectLodCpuValues(self: *const BenchmarkRunner) ![]f32 {
+        var values = try self.allocator.alloc(f32, self.samples.items.len);
+        for (self.samples.items, 0..) |sample, i| {
+            values[i] = @floatCast(sample.lod.cpu_ms);
         }
         return values;
     }
@@ -303,18 +652,69 @@ test "benchmark draw-call SLO scales for render-distance override" {
     const base = thresholdsForPreset("medium");
     const results = BenchmarkResults{
         .preset = "medium",
+        .scenario = "traversal",
+        .world_seed = BENCHMARK_WORLD_SEED,
+        .build = .{ .mode = "Debug" },
         .render_distance = 22,
         .gpu_memory_mb_avg = 0,
         .gpu_memory_mb_max = 0,
         .frames = 0,
         .duration_s = 0,
         .fps = .{ .min = 0, .avg = 0, .max = 0, .p1 = 0, .p5 = 0, .p50 = 0, .p95 = 0, .p99 = 0 },
+        .frame_ms = .{ .min = 0, .avg = 0, .max = 0, .p1 = 0, .p5 = 0, .p50 = 0, .p95 = 0, .p99 = 0 },
         .max_frame_ms = 0,
         .cpu_ms_avg = 0,
-        .gpu_ms = .{ .shadow_avg = 0, .opaque_avg = 0, .total_avg = 0 },
+        .gpu_ms = .{ .shadow_avg = 0, .opaque_avg = 0, .lod_terrain_avg = 0, .lod_water_avg = 0, .total_avg = 0 },
         .draw_calls_avg = 0,
         .vertices_avg = 0,
         .chunks_rendered_avg = 0,
+        .worst_frame = .{
+            .frame_index = 0,
+            .frame_ms = 0,
+            .gpu_total_ms = 0,
+            .gpu_lod_terrain_ms = 0,
+            .gpu_lod_water_ms = 0,
+            .dominant_gpu_pass = "none",
+            .dominant_gpu_pass_ms = 0,
+            .lod_cpu_ms = 0,
+            .dominant_lod_cpu_category = "none",
+            .dominant_lod_cpu_category_ms = 0,
+            .lod_worker_generation_ms = 0,
+            .lod_worker_mesh_construction_ms = 0,
+            .lod_upload_bytes = 0,
+            .lod_pending_cpu_upload_bytes = 0,
+            .lod_deferred_deletion_bytes = 0,
+            .lod_visible_count = 0,
+            .lod_rejected_count = 0,
+            .lod_coverage_count = 0,
+            .lod_wait_idle_count = 0,
+            .lod_wait_idle_ms = 0,
+            .lod_staging_pressure_count = 0,
+        },
+        .lod = .{
+            .profiling_enabled = false,
+            .cpu_frame_ms = .{ .min = 0, .avg = 0, .max = 0, .p1 = 0, .p5 = 0, .p50 = 0, .p95 = 0, .p99 = 0 },
+            .cpu_categories = .{
+                .scheduling = .{ .total_ms = 0, .avg_ms = 0 },
+                .cache = .{ .total_ms = 0, .avg_ms = 0 },
+                .generation_dispatch = .{ .total_ms = 0, .avg_ms = 0 },
+                .state_transition = .{ .total_ms = 0, .avg_ms = 0 },
+                .upload_prep = .{ .total_ms = 0, .avg_ms = 0 },
+                .upload_submission = .{ .total_ms = 0, .avg_ms = 0 },
+                .visibility = .{ .total_ms = 0, .avg_ms = 0 },
+                .coverage = .{ .total_ms = 0, .avg_ms = 0 },
+                .eviction = .{ .total_ms = 0, .avg_ms = 0 },
+            },
+            .workers = .{ .generation_total_ms = 0, .mesh_construction_total_ms = 0 },
+            .memory_bytes = .{
+                .upload_total_bytes = 0,
+                .upload_avg_bytes = 0,
+                .pending_cpu_upload_bytes = .{ .avg_bytes = 0, .max_bytes = 0, .last_bytes = 0 },
+                .deferred_deletion_bytes = .{ .avg_bytes = 0, .max_bytes = 0, .last_bytes = 0 },
+            },
+            .visibility = .{ .visible_total = 0, .rejected_total = 0, .coverage_total = 0 },
+            .pressure = .{ .staging_pressure_total = 0, .wait_idle_count_total = 0, .wait_idle_ms_total = 0, .wait_idle_ms_avg = 0 },
+        },
     };
     const adjusted = thresholdsForResults(results);
 
@@ -323,8 +723,330 @@ test "benchmark draw-call SLO scales for render-distance override" {
     try std.testing.expectEqual(base.fps_p1_min, adjusted.fps_p1_min);
 }
 
+test "benchmark reports LOD GPU timing, frame percentiles, and worst-frame attribution" {
+    var runner = try BenchmarkRunner.init(std.testing.allocator, "medium", "traversal", 12, 1, BENCHMARK_WORLD_SEED, "Debug", "unused.json");
+    defer runner.deinit();
+
+    try runner.samples.append(std.testing.allocator, .{
+        .cpu_ms = 10,
+        .fps = 100,
+        .gpu_shadow_ms = 1,
+        .gpu_opaque_ms = 2,
+        .gpu_lod_terrain_ms = 3,
+        .gpu_lod_water_ms = 4,
+        .gpu_total_ms = 8,
+        .draw_calls = 10,
+        .vertices = 100,
+        .chunks_rendered = 1,
+        .gpu_memory_mb = 100,
+    });
+    try runner.samples.append(std.testing.allocator, .{
+        .cpu_ms = 20,
+        .fps = 50,
+        .gpu_shadow_ms = 1,
+        .gpu_opaque_ms = 2,
+        .gpu_lod_terrain_ms = 9,
+        .gpu_lod_water_ms = 4,
+        .gpu_total_ms = 16,
+        .draw_calls = 20,
+        .vertices = 200,
+        .chunks_rendered = 2,
+        .gpu_memory_mb = 200,
+    });
+
+    const results = try runner.makeResults();
+    try std.testing.expectApproxEqAbs(@as(f64, 15), results.frame_ms.p50, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 19.5), results.frame_ms.p95, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 8), results.gpu_ms.lod_terrain_avg, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 4), results.gpu_ms.lod_water_avg, 0.001);
+    try std.testing.expectEqual(@as(u32, 1), results.worst_frame.frame_index);
+    try std.testing.expectEqualStrings("lod_terrain", results.worst_frame.dominant_gpu_pass);
+    try std.testing.expectApproxEqAbs(@as(f64, 9), results.worst_frame.dominant_gpu_pass_ms, 0.001);
+    try std.testing.expectEqualStrings("traversal", results.scenario);
+    try std.testing.expectEqual(BENCHMARK_WORLD_SEED, results.world_seed);
+    try std.testing.expectEqualStrings("Debug", results.build.mode);
+}
+
+test "benchmark projects LOD profiling deltas and accepts cumulative counter resets" {
+    const Test = struct {
+        fn world(profiling: LODProfilingDisplay) WorldStats {
+            return .{
+                .chunks_total = 0,
+                .chunks_rendered = 0,
+                .chunks_culled = 0,
+                .vertices_rendered = 0,
+                .gen_queue = 0,
+                .mesh_queue = 0,
+                .upload_queue = 0,
+                .lod = .{
+                    .loaded = .{ 0, 0, 0, 0, 0 },
+                    .memory_used_mb = 0,
+                    .profiling = profiling,
+                },
+            };
+        }
+    };
+
+    var runner = try BenchmarkRunner.init(std.testing.allocator, "medium", "traversal", 12, 1, BENCHMARK_WORLD_SEED, "Debug", "unused.json");
+    defer runner.deinit();
+    runner.warmup_s = 0;
+    const gpu = std.mem.zeroes(GpuTimingResults);
+
+    try runner.recordFrame(0.01, 100, gpu, Test.world(.{
+        .enabled = true,
+        .update_ms = 10,
+        .scheduling_ms = 5,
+        .cache_ms = 1,
+        .generation_dispatch_ms = 2,
+        .state_transition_ms = 1,
+        .upload_prep_ms = 1,
+        .upload_submission_ms = 1,
+        .visibility_ms = 1,
+        .coverage_ms = 1,
+        .eviction_ms = 1,
+        .worker_generation_ms = 8,
+        .worker_mesh_construction_ms = 4,
+        .upload_bytes = 100,
+        .pending_cpu_upload_bytes = 10,
+        .staging_pressure_count = 3,
+        .visible_count = 10,
+        .rejected_count = 4,
+        .coverage_count = 6,
+        .deferred_deletion_bytes = 30,
+        .wait_idle_count = 5,
+        .wait_idle_ms = 3,
+    }), 0, 0);
+    try runner.recordFrame(0.02, 50, gpu, Test.world(.{
+        .enabled = true,
+        .update_ms = 12,
+        .scheduling_ms = 7,
+        .cache_ms = 2,
+        .generation_dispatch_ms = 3,
+        .state_transition_ms = 2,
+        .upload_prep_ms = 3,
+        .upload_submission_ms = 4,
+        .visibility_ms = 3,
+        .coverage_ms = 2,
+        .eviction_ms = 2,
+        .worker_generation_ms = 12,
+        .worker_mesh_construction_ms = 6,
+        .upload_bytes = 150,
+        .pending_cpu_upload_bytes = 20,
+        .staging_pressure_count = 4,
+        .visible_count = 13,
+        .rejected_count = 5,
+        .coverage_count = 8,
+        .deferred_deletion_bytes = 40,
+        .wait_idle_count = 6,
+        .wait_idle_ms = 5,
+    }), 0, 0);
+    try runner.recordFrame(0.03, 33, gpu, Test.world(.{
+        .enabled = true,
+        .update_ms = 1,
+        .scheduling_ms = 0.5,
+        .cache_ms = 4,
+        .generation_dispatch_ms = 0.25,
+        .state_transition_ms = 0.5,
+        .upload_prep_ms = 0.25,
+        .upload_submission_ms = 0.25,
+        .visibility_ms = 0.5,
+        .coverage_ms = 0.25,
+        .eviction_ms = 0.5,
+        .worker_generation_ms = 3,
+        .worker_mesh_construction_ms = 2,
+        .upload_bytes = 20,
+        .pending_cpu_upload_bytes = 5,
+        .staging_pressure_count = 2,
+        .visible_count = 2,
+        .rejected_count = 1,
+        .coverage_count = 3,
+        .deferred_deletion_bytes = 8,
+        .wait_idle_count = 2,
+        .wait_idle_ms = 0.5,
+    }), 0, 0);
+
+    const results = try runner.makeResults();
+    try std.testing.expect(results.lod.profiling_enabled);
+    try std.testing.expectApproxEqAbs(@as(f64, 1), results.lod.cpu_frame_ms.p50, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1.9), results.lod.cpu_frame_ms.p95, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.5), results.lod.cpu_categories.scheduling.total_ms, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 5), results.lod.cpu_categories.cache.total_ms, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 7), results.lod.workers.generation_total_ms, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 4), results.lod.workers.mesh_construction_total_ms, 0.001);
+    try std.testing.expectEqual(@as(u64, 70), results.lod.memory_bytes.upload_total_bytes);
+    try std.testing.expectEqual(@as(u64, 20), results.lod.memory_bytes.pending_cpu_upload_bytes.max_bytes);
+    try std.testing.expectEqual(@as(u64, 8), results.lod.memory_bytes.deferred_deletion_bytes.last_bytes);
+    try std.testing.expectEqual(@as(u64, 5), results.lod.visibility.visible_total);
+    try std.testing.expectEqual(@as(u64, 2), results.lod.visibility.rejected_total);
+    try std.testing.expectEqual(@as(u64, 5), results.lod.visibility.coverage_total);
+    try std.testing.expectEqual(@as(u64, 3), results.lod.pressure.wait_idle_count_total);
+    try std.testing.expectApproxEqAbs(@as(f64, 2.5), results.lod.pressure.wait_idle_ms_total, 0.001);
+    try std.testing.expectEqual(@as(u64, 3), results.lod.pressure.staging_pressure_total);
+    try std.testing.expectEqual(@as(u32, 2), results.worst_frame.frame_index);
+    try std.testing.expectEqualStrings("cache", results.worst_frame.dominant_lod_cpu_category);
+    try std.testing.expectEqual(@as(u64, 20), results.worst_frame.lod_upload_bytes);
+}
+
+test "benchmark scenarios have stable bounded poses" {
+    try std.testing.expectEqual(Scenario.traversal, try Scenario.parse("traversal"));
+    try std.testing.expectEqual(Scenario.teleport_eviction, try Scenario.parse("teleport-eviction"));
+    try std.testing.expectError(error.InvalidBenchmarkScenario, Scenario.parse("unbounded"));
+
+    const stationary_a = poseAtTime(.stationary, 0);
+    const stationary_b = poseAtTime(.stationary, 37);
+    try std.testing.expectApproxEqAbs(stationary_a.pos.x, stationary_b.pos.x, 0.0001);
+    try std.testing.expectApproxEqAbs(stationary_a.pos.z, stationary_b.pos.z, 0.0001);
+
+    const teleport_a = poseAtTime(.teleport_eviction, 3.9);
+    const teleport_b = poseAtTime(.teleport_eviction, 4.0);
+    try std.testing.expectApproxEqAbs(@as(f32, 8), teleport_a.pos.x, 0.0001);
+    try std.testing.expectApproxEqAbs(@as(f32, 1_536), teleport_b.pos.x, 0.0001);
+
+    const rapid_turn_a = poseAtTime(.rapid_turn, 0);
+    const rapid_turn_b = poseAtTime(.rapid_turn, 1);
+    try std.testing.expect(rapid_turn_a.look.z < rapid_turn_b.look.z);
+}
+
 fn fpsField(sample: FrameSample) f32 {
     return sample.fps;
+}
+
+fn frameMsField(sample: FrameSample) f32 {
+    return sample.cpu_ms;
+}
+
+fn timingTotalAverage(total_ms: f64, frame_count: f64) TimingTotalAverage {
+    return .{ .total_ms = total_ms, .avg_ms = total_ms / frame_count };
+}
+
+/// Calculates a per-frame telemetry sample. A reduced cumulative value means
+/// the LOD collector reset, so the current value is used instead of underflowing.
+fn lodFrameDelta(current: ?LODProfilingDisplay, previous: *?LODProfilingDisplay) LODFrameSample {
+    const snapshot = current orelse {
+        previous.* = null;
+        return .{};
+    };
+    const last = previous.*;
+    previous.* = snapshot;
+
+    const gauges = struct {
+        pending_cpu_upload_bytes: u64,
+        deferred_deletion_bytes: u64,
+    }{
+        .pending_cpu_upload_bytes = snapshot.pending_cpu_upload_bytes,
+        .deferred_deletion_bytes = snapshot.deferred_deletion_bytes,
+    };
+    if (!snapshot.enabled or last == null or !last.?.enabled) {
+        return .{
+            .enabled = snapshot.enabled,
+            .pending_cpu_upload_bytes = gauges.pending_cpu_upload_bytes,
+            .deferred_deletion_bytes = gauges.deferred_deletion_bytes,
+        };
+    }
+
+    const prior = last.?;
+    return .{
+        .enabled = true,
+        // Manager update and render visibility work are separate main-thread
+        // scopes. Coverage is nested in visibility and is not added again.
+        .cpu_ms = cumulativeTimingDelta(snapshot.update_ms, prior.update_ms) + cumulativeTimingDelta(snapshot.visibility_ms, prior.visibility_ms),
+        .scheduling_ms = cumulativeTimingDelta(snapshot.scheduling_ms, prior.scheduling_ms),
+        .cache_ms = cumulativeTimingDelta(snapshot.cache_ms, prior.cache_ms),
+        .generation_dispatch_ms = cumulativeTimingDelta(snapshot.generation_dispatch_ms, prior.generation_dispatch_ms),
+        .state_transition_ms = cumulativeTimingDelta(snapshot.state_transition_ms, prior.state_transition_ms),
+        .upload_prep_ms = cumulativeTimingDelta(snapshot.upload_prep_ms, prior.upload_prep_ms),
+        .upload_submission_ms = cumulativeTimingDelta(snapshot.upload_submission_ms, prior.upload_submission_ms),
+        .visibility_ms = cumulativeTimingDelta(snapshot.visibility_ms, prior.visibility_ms),
+        .coverage_ms = cumulativeTimingDelta(snapshot.coverage_ms, prior.coverage_ms),
+        .eviction_ms = cumulativeTimingDelta(snapshot.eviction_ms, prior.eviction_ms),
+        .worker_generation_ms = cumulativeTimingDelta(snapshot.worker_generation_ms, prior.worker_generation_ms),
+        .worker_mesh_construction_ms = cumulativeTimingDelta(snapshot.worker_mesh_construction_ms, prior.worker_mesh_construction_ms),
+        .upload_bytes = cumulativeCounterDelta(snapshot.upload_bytes, prior.upload_bytes),
+        .pending_cpu_upload_bytes = gauges.pending_cpu_upload_bytes,
+        .staging_pressure_count = cumulativeCounterDelta(snapshot.staging_pressure_count, prior.staging_pressure_count),
+        .visible_count = cumulativeCounterDelta(snapshot.visible_count, prior.visible_count),
+        .rejected_count = cumulativeCounterDelta(snapshot.rejected_count, prior.rejected_count),
+        .coverage_count = cumulativeCounterDelta(snapshot.coverage_count, prior.coverage_count),
+        .deferred_deletion_bytes = gauges.deferred_deletion_bytes,
+        .wait_idle_count = cumulativeCounterDelta(snapshot.wait_idle_count, prior.wait_idle_count),
+        .wait_idle_ms = cumulativeTimingDelta(snapshot.wait_idle_ms, prior.wait_idle_ms),
+    };
+}
+
+fn cumulativeTimingDelta(current: f64, previous: f64) f64 {
+    if (!std.math.isFinite(current) or current < 0) return 0;
+    if (!std.math.isFinite(previous) or previous < 0 or current < previous) return current;
+    return current - previous;
+}
+
+fn cumulativeCounterDelta(current: u64, previous: u64) u64 {
+    return if (current < previous) current else current - previous;
+}
+
+fn worstFrameForSample(index: usize, sample: FrameSample) WorstFrame {
+    var dominant_gpu_pass: []const u8 = "shadow";
+    var dominant_gpu_pass_ms = sample.gpu_shadow_ms;
+    if (sample.gpu_opaque_ms > dominant_gpu_pass_ms) {
+        dominant_gpu_pass = "opaque";
+        dominant_gpu_pass_ms = sample.gpu_opaque_ms;
+    }
+    if (sample.gpu_lod_terrain_ms > dominant_gpu_pass_ms) {
+        dominant_gpu_pass = "lod_terrain";
+        dominant_gpu_pass_ms = sample.gpu_lod_terrain_ms;
+    }
+    if (sample.gpu_lod_water_ms > dominant_gpu_pass_ms) {
+        dominant_gpu_pass = "lod_water";
+        dominant_gpu_pass_ms = sample.gpu_lod_water_ms;
+    }
+
+    const lod_attribution = dominantLodCpuCategory(sample.lod);
+
+    return .{
+        .frame_index = @intCast(index),
+        .frame_ms = sample.cpu_ms,
+        .gpu_total_ms = sample.gpu_total_ms,
+        .gpu_lod_terrain_ms = sample.gpu_lod_terrain_ms,
+        .gpu_lod_water_ms = sample.gpu_lod_water_ms,
+        .dominant_gpu_pass = dominant_gpu_pass,
+        .dominant_gpu_pass_ms = dominant_gpu_pass_ms,
+        .lod_cpu_ms = sample.lod.cpu_ms,
+        .dominant_lod_cpu_category = lod_attribution.name,
+        .dominant_lod_cpu_category_ms = lod_attribution.ms,
+        .lod_worker_generation_ms = sample.lod.worker_generation_ms,
+        .lod_worker_mesh_construction_ms = sample.lod.worker_mesh_construction_ms,
+        .lod_upload_bytes = sample.lod.upload_bytes,
+        .lod_pending_cpu_upload_bytes = sample.lod.pending_cpu_upload_bytes,
+        .lod_deferred_deletion_bytes = sample.lod.deferred_deletion_bytes,
+        .lod_visible_count = sample.lod.visible_count,
+        .lod_rejected_count = sample.lod.rejected_count,
+        .lod_coverage_count = sample.lod.coverage_count,
+        .lod_wait_idle_count = sample.lod.wait_idle_count,
+        .lod_wait_idle_ms = sample.lod.wait_idle_ms,
+        .lod_staging_pressure_count = sample.lod.staging_pressure_count,
+    };
+}
+
+fn dominantLodCpuCategory(sample: LODFrameSample) struct { name: []const u8, ms: f64 } {
+    var name: []const u8 = "none";
+    var ms: f64 = 0;
+    const candidates = [_]struct { name: []const u8, ms: f64 }{
+        .{ .name = "scheduling", .ms = sample.scheduling_ms },
+        .{ .name = "cache", .ms = sample.cache_ms },
+        .{ .name = "generation_dispatch", .ms = sample.generation_dispatch_ms },
+        .{ .name = "state_transition", .ms = sample.state_transition_ms },
+        .{ .name = "upload_prep", .ms = sample.upload_prep_ms },
+        .{ .name = "upload_submission", .ms = sample.upload_submission_ms },
+        .{ .name = "visibility", .ms = sample.visibility_ms },
+        .{ .name = "coverage", .ms = sample.coverage_ms },
+        .{ .name = "eviction", .ms = sample.eviction_ms },
+    };
+    for (candidates) |candidate| {
+        if (candidate.ms > ms) {
+            name = candidate.name;
+            ms = candidate.ms;
+        }
+    }
+    return .{ .name = name, .ms = ms };
 }
 
 fn summarizeSeries(allocator: std.mem.Allocator, values: []f32) !Summary {
@@ -374,18 +1096,35 @@ fn averageArray(values: []const f32) f32 {
     return sum / @as(f32, @floatFromInt(values.len));
 }
 
-fn poseAtTime(time_s: f32) struct { pos: Vec3, look: Vec3 } {
-    const total = pathDuration();
+fn poseAtTime(scenario: Scenario, time_s: f32) Pose {
+    return switch (scenario) {
+        .stationary => poseAtWaypoints(&STATIONARY_PATH, time_s, true),
+        // Keep traversal byte-for-byte equivalent to the benchmark path that
+        // predated scenarios so its existing baseline remains meaningful.
+        .traversal => poseAtWaypoints(&BENCH_PATH, time_s, true),
+        .rapid_turn => poseAtWaypoints(&RAPID_TURN_PATH, time_s, true),
+        // Eviction pressure requires discontinuous player movement rather
+        // than interpolation between distant locations.
+        .teleport_eviction => poseAtWaypoints(&TELEPORT_EVICTION_PATH, time_s, false),
+    };
+}
+
+fn poseAtWaypoints(path: []const Waypoint, time_s: f32, interpolate: bool) Pose {
+    const total = pathDuration(path);
     if (total <= 0.0) {
-        return .{ .pos = BENCH_PATH[0].pos, .look = BENCH_PATH[0].look.normalize() };
+        return .{ .pos = path[0].pos, .look = path[0].look.normalize() };
     }
 
     var t = time_s;
     while (t >= total) t -= total;
     while (t < 0) t += total;
-    for (BENCH_PATH, 0..) |waypoint, i| {
-        const next = BENCH_PATH[(i + 1) % BENCH_PATH.len];
-        if (t <= waypoint.duration or i == BENCH_PATH.len - 1) {
+    for (path, 0..) |waypoint, i| {
+        const next = path[(i + 1) % path.len];
+        const in_segment = if (interpolate) t <= waypoint.duration else t < waypoint.duration;
+        if (in_segment or i == path.len - 1) {
+            if (!interpolate) {
+                return .{ .pos = waypoint.pos, .look = waypoint.look.normalize() };
+            }
             const segment = @max(waypoint.duration, 0.0001);
             const alpha = std.math.clamp(t / segment, 0.0, 1.0);
             const eased = alpha * alpha * (3.0 - 2.0 * alpha);
@@ -397,12 +1136,12 @@ fn poseAtTime(time_s: f32) struct { pos: Vec3, look: Vec3 } {
         t -= waypoint.duration;
     }
 
-    return .{ .pos = BENCH_PATH[0].pos, .look = BENCH_PATH[0].look.normalize() };
+    return .{ .pos = path[0].pos, .look = path[0].look.normalize() };
 }
 
-fn pathDuration() f32 {
+fn pathDuration(path: []const Waypoint) f32 {
     var total: f32 = 0;
-    for (BENCH_PATH) |waypoint| total += waypoint.duration;
+    for (path) |waypoint| total += waypoint.duration;
     return total;
 }
 

--- a/modules/game-core/src/root.zig
+++ b/modules/game-core/src/root.zig
@@ -19,6 +19,7 @@ pub const session_hud = @import("ui/session_hud.zig");
 
 pub const BLOCK_TEXTURE_DEFINITIONS = block_texture_definitions.BLOCK_TEXTURE_DEFINITIONS;
 pub const BenchmarkRunner = benchmark.BenchmarkRunner;
+pub const BENCHMARK_WORLD_SEED = benchmark.BENCHMARK_WORLD_SEED;
 pub const BuildConfig = session.BuildConfig;
 pub const GameSession = session.GameSession;
 pub const InputMapper = input_mapper.InputMapper;

--- a/modules/game-ui/src/screens/world.zig
+++ b/modules/game-ui/src/screens/world.zig
@@ -672,6 +672,30 @@ pub const WorldScreen = struct {
             lod_display = .{
                 .loaded = ls.loaded,
                 .memory_used_mb = ls.memory_used_mb,
+                .profiling = .{
+                    .enabled = ls.profiling.enabled,
+                    .update_ms = ls.profiling.update_ms,
+                    .scheduling_ms = ls.profiling.scheduling_ms,
+                    .cache_ms = ls.profiling.cache_ms,
+                    .generation_dispatch_ms = ls.profiling.generation_dispatch_ms,
+                    .state_transition_ms = ls.profiling.state_transition_ms,
+                    .upload_prep_ms = ls.profiling.upload_prep_ms,
+                    .upload_submission_ms = ls.profiling.upload_submission_ms,
+                    .visibility_ms = ls.profiling.visibility_ms,
+                    .coverage_ms = ls.profiling.coverage_ms,
+                    .eviction_ms = ls.profiling.eviction_ms,
+                    .worker_generation_ms = ls.profiling.worker_generation_ms,
+                    .worker_mesh_construction_ms = ls.profiling.worker_mesh_construction_ms,
+                    .upload_bytes = ls.profiling.upload_bytes,
+                    .pending_cpu_upload_bytes = ls.profiling.pending_cpu_upload_bytes,
+                    .staging_pressure_count = ls.profiling.staging_pressure_count,
+                    .visible_count = ls.profiling.visible_count,
+                    .rejected_count = ls.profiling.rejected_count,
+                    .coverage_count = ls.profiling.coverage_count,
+                    .deferred_deletion_bytes = ls.profiling.deferred_deletion_bytes,
+                    .wait_idle_count = ls.profiling.wait_idle_count,
+                    .wait_idle_ms = ls.profiling.wait_idle_ms,
+                },
             };
         }
         return .{

--- a/modules/world-lod/src/lod_manager.zig
+++ b/modules/world-lod/src/lod_manager.zig
@@ -166,6 +166,7 @@ pub const LODManager = struct {
 
     // Stats
     stats: LODStats,
+    profiling: @import("lod_stats.zig").LODProfilingCollector,
     cache_hits: u32,
     cache_misses: u32,
 

--- a/modules/world-lod/src/lod_manager_core_ops.zig
+++ b/modules/world-lod/src/lod_manager_core_ops.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const lod_options = @import("world_lod_options");
 const Self = @import("lod_manager.zig").LODManager;
 const fs = @import("fs");
 const lod_chunk = @import("lod_chunk.zig");
@@ -132,6 +133,7 @@ pub fn init(allocator: std.mem.Allocator, config: ILODConfig, gpu_bridge: LODGPU
         .player_cx = std.atomic.Value(i32).init(0),
         .player_cz = std.atomic.Value(i32).init(0),
         .stats = .{},
+        .profiling = .init(engine_core.envFlag("ZIGCRAFT_LOD_PROFILE", false) or lod_options.benchmark_lod_profile),
         .cache_hits = 0,
         .cache_misses = 0,
         .mutex = .{},
@@ -228,6 +230,8 @@ pub fn deinit(self: *Self) void {
 
 /// Update LOD system with player position
 pub fn update(self: *Self, player_pos: Vec3, player_velocity: Vec3, chunk_checker: ?ChunkChecker, checker_ctx: ?*anyopaque) !void {
+    const update_timer = self.profiling.begin();
+    defer self.profiling.end(.update, update_timer);
     if (self.paused) return;
 
     // Deferred deletion handling. LOD meshes do not carry frame fences yet,
@@ -280,6 +284,7 @@ pub fn update(self: *Self, player_pos: Vec3, player_velocity: Vec3, chunk_checke
 
     // Queue a small horizon seed first so something appears quickly, then
     // let LOD0/LOD1/LOD2 refinements replace the coarse fallback.
+    const scheduling_timer = self.profiling.begin();
     var order_idx: usize = 0;
     while (order_idx < active_lod_count) : (order_idx += 1) {
         const i = lod_scheduler.priorityLevelIndex(order_idx, active_lod_count);
@@ -287,24 +292,29 @@ pub fn update(self: *Self, player_pos: Vec3, player_velocity: Vec3, chunk_checke
             log.log.warn("LOD queue error for level {}: {} (non-fatal)", .{ i, err });
         };
     }
+    self.profiling.end(.scheduling, scheduling_timer);
 
     self.processQueuedGenerations(player_velocity) catch |err| {
         log.log.warn("LOD cache/generation dispatch error: {} (non-fatal)", .{err});
     };
 
     // Process state transitions
+    const transitions_timer = self.profiling.begin();
     self.processStateTransitions(player_velocity) catch |err| {
         log.log.warn("LOD state transitions error: {} (non-fatal)", .{err});
     };
+    self.profiling.end(.state_transition, transitions_timer);
 
     // Process uploads (limited per frame)
     self.processUploads();
 
     // Update stats
     self.updateStats();
+    const eviction_timer = self.profiling.begin();
     self.enforceMemoryBudget() catch |err| {
         log.log.warn("LOD memory budget eviction error: {} (non-fatal)", .{err});
     };
+    self.profiling.end(.eviction, eviction_timer);
 
     // Periodic WARN-level LOD stats so logs/zigcraft.log shows LOD fill
     // progress by default (no env vars needed). update_tick counts frames;
@@ -327,9 +337,11 @@ pub fn update(self: *Self, player_pos: Vec3, player_velocity: Vec3, chunk_checke
     }
 
     // Unload distant regions
+    const distant_eviction_timer = self.profiling.begin();
     self.unloadDistantRegions() catch |err| {
         log.log.warn("LOD unload error: {} (non-fatal)", .{err});
     };
+    self.profiling.end(.eviction, distant_eviction_timer);
 
     // Chunk-derived ingestion: replay deferred ingestions, flush debounced
     // player edits, and persist any dirty source regions to the store.
@@ -341,7 +353,11 @@ pub fn update(self: *Self, player_pos: Vec3, player_velocity: Vec3, chunk_checke
 
 /// Get current statistics
 pub fn getStats(self: *Self) LODStats {
-    return self.stats;
+    self.mutex.lockShared();
+    defer self.mutex.unlockShared();
+    var snapshot = self.stats;
+    snapshot.profiling = self.profiling.snapshot();
+    return snapshot;
 }
 
 /// Pause all LOD generation
@@ -394,7 +410,9 @@ pub fn render(self: *Self, view_proj: Mat4, camera_pos: Vec3, chunk_checker: ?Ch
     self.mutex.lockShared();
     defer self.mutex.unlockShared();
 
-    self.renderer.render(&self.meshes, &self.regions, self.config, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, layer, &self.stats);
+    const visibility_timer = self.profiling.begin();
+    defer self.profiling.end(.visibility, visibility_timer);
+    self.renderer.render(&self.meshes, &self.regions, self.config, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, layer, &self.stats, if (self.profiling.enabled) &self.profiling else null);
 }
 
 pub fn pointDistanceSquared(x0: i32, z0: i32, x1: i32, z1: i32) i64 {

--- a/modules/world-lod/src/lod_manager_eviction_ops.zig
+++ b/modules/world-lod/src/lod_manager_eviction_ops.zig
@@ -128,7 +128,9 @@ pub fn queueMeshDeletion(self: *Self, mesh: *LODMesh) void {
     self.mesh_disposal.queue.append(self.allocator, mesh) catch {
         self.gpu_bridge.destroy(mesh);
         self.allocator.destroy(mesh);
+        return;
     };
+    self.profiling.addDeferredDeletionBytes(mesh.capacity * @sizeOf(Vertex));
 }
 
 pub fn processMeshDeletions(self: *Self, max_count: usize) void {
@@ -138,11 +140,15 @@ pub fn processMeshDeletions(self: *Self, max_count: usize) void {
     // LODMesh does not carry a per-frame fence today, so destruction still
     // requires GPU idle. Bound each sweep so a memory-pressure eviction burst
     // cannot turn into an unbounded main-thread stall.
+    const wait_idle_timer = self.profiling.begin();
+    self.profiling.addWaitIdle();
     self.gpu_bridge.waitIdle();
+    self.profiling.end(.wait_idle, wait_idle_timer);
     var processed: usize = 0;
     while (processed < count) : (processed += 1) {
         const idx = self.mesh_disposal.queue.items.len - 1;
         const mesh = self.mesh_disposal.queue.items[idx];
+        self.profiling.removeDeferredDeletionBytes(mesh.capacity * @sizeOf(Vertex));
         self.gpu_bridge.destroy(mesh);
         self.allocator.destroy(mesh);
         self.mesh_disposal.queue.items.len = idx;
@@ -264,6 +270,7 @@ pub fn enforceMemoryBudget(self: *Self) !void {
 pub fn updateStats(self: *Self) void {
     self.stats.reset();
     var mem_usage: usize = 0;
+    var pending_cpu_upload_bytes: usize = 0;
 
     self.mutex.lockShared();
     defer self.mutex.unlockShared();
@@ -280,6 +287,11 @@ pub fn updateStats(self: *Self) void {
                     mem_usage += s.totalMemoryBytes();
                 },
                 else => {},
+            }
+            if (chunk.getState() == .uploading) {
+                if (self.meshes[i].get(entry.key_ptr.*)) |mesh| {
+                    pending_cpu_upload_bytes += mesh.pendingUploadBytes();
+                }
             }
         }
 
@@ -302,6 +314,7 @@ pub fn updateStats(self: *Self) void {
     self.stats.cache_hits = self.cache_hits;
     self.stats.cache_misses = self.cache_misses;
     self.memory_governor.used_bytes = mem_usage;
+    self.profiling.setPendingCpuUploadBytes(pending_cpu_upload_bytes);
 
     if (engine_core.envFlag("ZIGCRAFT_LOD_DIAG", false)) {
         const S = struct {

--- a/modules/world-lod/src/lod_manager_generation_ops.zig
+++ b/modules/world-lod/src/lod_manager_generation_ops.zig
@@ -167,7 +167,9 @@ pub fn processQueuedGenerations(self: *Self, velocity: Vec3) !void {
         if (cache_enabled and cache_reads < MAX_CACHE_LOADS_PER_UPDATE) {
             cache_reads += 1;
             attempted_cache = true;
+            const cache_timer = self.profiling.begin();
             cached_data = self.loadCachedSourceData(candidate.key);
+            self.profiling.end(.cache, cache_timer);
             if (cached_data) |*cached| {
                 if (candidate.want_spans and !cached.hasVerticalSpans()) {
                     cached.deinit();
@@ -201,6 +203,7 @@ pub fn processQueuedGenerations(self: *Self, velocity: Vec3) !void {
         candidate.chunk.setState(.generating);
         self.mutex.unlock();
 
+        const dispatch_timer = self.profiling.begin();
         self.job_dispatcher.queues[LODLevel.count - 1].push(.{
             .type = .chunk_generation,
             .dist_sq = candidate.encoded_priority,
@@ -216,6 +219,7 @@ pub fn processQueuedGenerations(self: *Self, velocity: Vec3) !void {
                 },
             },
         }) catch |err| {
+            self.profiling.end(.generation_dispatch, dispatch_timer);
             self.mutex.lock();
             if (candidate.chunk.getState() == .generating and candidate.chunk.job_token == candidate.job_token) {
                 candidate.chunk.setState(.queued_for_generation);
@@ -223,6 +227,7 @@ pub fn processQueuedGenerations(self: *Self, velocity: Vec3) !void {
             self.mutex.unlock();
             return err;
         };
+        self.profiling.end(.generation_dispatch, dispatch_timer);
     }
 }
 
@@ -477,6 +482,8 @@ pub fn processLODJob(ctx: *anyopaque, job: Job) void {
 
     switch (job_type) {
         .chunk_generation => {
+            const generation_timer = self.profiling.begin();
+            defer self.profiling.end(.worker_generation, generation_timer);
             // Initialize simplified data if needed
             if (needs_data_init) {
                 var data = if (use_vertical_spans)
@@ -527,6 +534,8 @@ pub fn processLODJob(ctx: *anyopaque, job: Job) void {
             new_state = .generated;
         },
         .chunk_meshing => {
+            const mesh_timer = self.profiling.begin();
+            defer self.profiling.end(.worker_mesh_construction, mesh_timer);
             // Build mesh (expensive, done without lock)
             // Note: buildMeshForChunk -> getOrCreateMesh acquires its own lock
             self.buildMeshForChunk(chunk) catch |err| {

--- a/modules/world-lod/src/lod_manager_tests.zig
+++ b/modules/world-lod/src/lod_manager_tests.zig
@@ -9,6 +9,7 @@ const world_core = @import("world-core");
 const lod_manager = @import("world-lod").lod_manager;
 const LODManager = lod_manager.LODManager;
 const LODStats = lod_manager.LODStats;
+const LODProfilingCollector = @import("lod_stats.zig").LODProfilingCollector;
 const MAX_LOD_REGIONS = lod_manager.MAX_LOD_REGIONS;
 const lod_chunk = @import("world-lod").lod_chunk;
 const LODLevel = lod_chunk.LODLevel;
@@ -96,7 +97,7 @@ test "LODManager initialization" {
 
     const mock_render = LODRenderInterface{
         .render_fn = struct {
-            fn f(_: *anyopaque, _: *const [LODLevel.count]MeshMap, _: *const [LODLevel.count]RegionMap, _: ILODConfig, _: Mat4, _: Vec3, _: ?LODManager.ChunkChecker, _: ?*anyopaque, _: bool, _: ?i32, _: lod_gpu.LODRenderLayer, _: ?*LODStats) void {}
+            fn f(_: *anyopaque, _: *const [LODLevel.count]MeshMap, _: *const [LODLevel.count]RegionMap, _: ILODConfig, _: Mat4, _: Vec3, _: ?LODManager.ChunkChecker, _: ?*anyopaque, _: bool, _: ?i32, _: lod_gpu.LODRenderLayer, _: ?*LODStats, _: ?*LODProfilingCollector) void {}
         }.f,
         .deinit_fn = struct {
             fn f(_: *anyopaque) void {}
@@ -190,7 +191,7 @@ test "LODManager end-to-end covered cleanup" {
 
     const mock_render = LODRenderInterface{
         .render_fn = struct {
-            fn f(_: *anyopaque, _: *const [LODLevel.count]MeshMap, _: *const [LODLevel.count]RegionMap, _: ILODConfig, _: Mat4, _: Vec3, _: ?LODManager.ChunkChecker, _: ?*anyopaque, _: bool, _: ?i32, _: lod_gpu.LODRenderLayer, _: ?*LODStats) void {}
+            fn f(_: *anyopaque, _: *const [LODLevel.count]MeshMap, _: *const [LODLevel.count]RegionMap, _: ILODConfig, _: Mat4, _: Vec3, _: ?LODManager.ChunkChecker, _: ?*anyopaque, _: bool, _: ?i32, _: lod_gpu.LODRenderLayer, _: ?*LODStats, _: ?*LODProfilingCollector) void {}
         }.f,
         .deinit_fn = struct {
             fn f(_: *anyopaque) void {}
@@ -266,10 +267,12 @@ test "LODStats aggregation" {
 
     stats.addMemory(2 * 1024 * 1024);
     try std.testing.expectEqual(@as(u32, 2), stats.memory_used_mb);
+    stats.profiling.enabled = true;
 
     stats.reset();
     try std.testing.expectEqual(@as(u32, 0), stats.totalLoaded());
     try std.testing.expectEqual(@as(u32, 0), stats.memory_used_mb);
+    try std.testing.expect(!stats.profiling.enabled);
 }
 
 test "LODManager constants" {
@@ -335,7 +338,7 @@ fn buildIngestionManager(allocator: std.mem.Allocator, config: *LODConfig) !*LOD
 
     const mock_render = LODRenderInterface{
         .render_fn = struct {
-            fn f(_: *anyopaque, _: *const [LODLevel.count]MeshMap, _: *const [LODLevel.count]RegionMap, _: ILODConfig, _: Mat4, _: Vec3, _: ?LODManager.ChunkChecker, _: ?*anyopaque, _: bool, _: ?i32, _: lod_gpu.LODRenderLayer, _: ?*LODStats) void {}
+            fn f(_: *anyopaque, _: *const [LODLevel.count]MeshMap, _: *const [LODLevel.count]RegionMap, _: ILODConfig, _: Mat4, _: Vec3, _: ?LODManager.ChunkChecker, _: ?*anyopaque, _: bool, _: ?i32, _: lod_gpu.LODRenderLayer, _: ?*LODStats, _: ?*LODProfilingCollector) void {}
         }.f,
         .deinit_fn = struct {
             fn f(_: *anyopaque) void {}

--- a/modules/world-lod/src/lod_manager_upload_ops.zig
+++ b/modules/world-lod/src/lod_manager_upload_ops.zig
@@ -86,6 +86,7 @@ pub fn processUploadsWithBudget(self: *Self, upload_budget_bytes: usize) void {
     var uploaded_bytes: usize = 0;
 
     while (uploads < max_uploads) {
+        const prep_timer = self.profiling.begin();
         var task: ?UploadTask = null;
         var completed_without_upload = false;
         var made_progress = false;
@@ -103,6 +104,7 @@ pub fn processUploadsWithBudget(self: *Self, upload_budget_bytes: usize) void {
                 if (self.meshes[i].get(key)) |mesh| {
                     const pending_bytes = mesh.pendingUploadBytes();
                     if (wouldExceedUploadBudget(uploaded_bytes, pending_bytes, upload_budget_bytes, uploads)) {
+                        self.profiling.addStagingPressure();
                         self.requeueUpload(i, chunk);
                         stop_processing = true;
                         break;
@@ -125,16 +127,29 @@ pub fn processUploadsWithBudget(self: *Self, upload_budget_bytes: usize) void {
         }
         self.mutex.unlock();
 
-        if (stop_processing or !made_progress) break;
-        if (completed_without_upload) continue;
+        if (stop_processing or !made_progress) {
+            self.profiling.end(.upload_prep, prep_timer);
+            break;
+        }
+        if (completed_without_upload) {
+            self.profiling.end(.upload_prep, prep_timer);
+            continue;
+        }
 
-        const upload_task = task orelse continue;
+        const upload_task = task orelse {
+            self.profiling.end(.upload_prep, prep_timer);
+            continue;
+        };
+        self.profiling.end(.upload_prep, prep_timer);
+        const submission_timer = self.profiling.begin();
         self.gpu_bridge.upload(upload_task.mesh) catch |err| {
+            self.profiling.end(.upload_submission, submission_timer);
             log.log.warn("LOD{} mesh upload failed (will retry): {}", .{ upload_task.lod_idx, err });
             self.mutex.lock();
             self.stats.upload_failures += 1;
             uploads += 1;
             if (isUploadPressureError(err)) {
+                self.profiling.addStagingPressure();
                 self.requeueUpload(upload_task.lod_idx, upload_task.chunk);
                 upload_task.chunk.unpin();
                 self.mutex.unlock();
@@ -145,8 +160,10 @@ pub fn processUploadsWithBudget(self: *Self, upload_budget_bytes: usize) void {
             self.mutex.unlock();
             continue;
         };
+        self.profiling.end(.upload_submission, submission_timer);
 
         uploaded_bytes += upload_task.pending_bytes;
+        self.profiling.addUploadBytes(upload_task.pending_bytes);
         self.mutex.lock();
         self.markRegionRenderable(upload_task.key, upload_task.chunk);
         uploads += 1;

--- a/modules/world-lod/src/lod_renderer.zig
+++ b/modules/world-lod/src/lod_renderer.zig
@@ -50,6 +50,7 @@ const MeshMap = lod_gpu.MeshMap;
 const RegionMap = lod_gpu.RegionMap;
 const ChunkChecker = lod_gpu.ChunkChecker;
 const LODStats = @import("lod_stats.zig").LODStats;
+const LODProfilingCollector = @import("lod_stats.zig").LODProfilingCollector;
 
 const Vec3 = @import("engine-math").Vec3;
 const Mat4 = @import("engine-math").Mat4;
@@ -189,6 +190,7 @@ pub fn LODRenderer(comptime RHI: type) type {
             max_distance_chunks: ?i32,
             layer: LODRenderLayer,
             stats: ?*LODStats,
+            profiling: ?*LODProfilingCollector,
         ) void {
             // Update frame index
             const query = if (@hasDecl(RHI, "query")) self.rhi.query() else self.rhi;
@@ -228,7 +230,7 @@ pub fn LODRenderer(comptime RHI: type) type {
             while (i > 0) {
                 i -= 1;
                 const lod: LODLevel = @enumFromInt(@as(u3, @intCast(i)));
-                self.collectVisibleMeshes(meshes, regions, lod, config, view_proj, camera_pos, frustum, lod_y_offset, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, layer, stats) catch |err| {
+                self.collectVisibleMeshes(meshes, regions, lod, config, view_proj, camera_pos, frustum, lod_y_offset, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, layer, stats, profiling) catch |err| {
                     log.log.errWithTrace("Failed to collect visible meshes for LOD{}: {}", .{ i, err });
                 };
             }
@@ -327,6 +329,7 @@ pub fn LODRenderer(comptime RHI: type) type {
             max_distance_chunks: ?i32,
             layer: LODRenderLayer,
             stats: ?*LODStats,
+            profiling: ?*LODProfilingCollector,
         ) !void {
             const meshes = &all_meshes[@intFromEnum(lod)];
             const regions = &all_regions[@intFromEnum(lod)];
@@ -349,19 +352,23 @@ pub fn LODRenderer(comptime RHI: type) type {
                 const mesh = entry.value_ptr.*;
                 const draw_range = mesh.drawRange(layer) orelse {
                     diag.not_ready += 1;
+                    if (profiling) |profile| profile.addRejected();
                     continue;
                 };
                 if (!mesh.isReady() or draw_range.count == 0) {
                     diag.not_ready += 1;
+                    if (profiling) |profile| profile.addRejected();
                     continue;
                 }
                 if (regions.get(entry.key_ptr.*)) |chunk| {
                     if (!chunk.isRenderable()) {
                         diag.bad_state += 1;
+                        if (profiling) |profile| profile.addRejected();
                         continue;
                     }
                     if (self.isCoveredByFinerLOD(chunk, config)) {
                         diag.covered_finer_lod += 1;
+                        if (profiling) |profile| profile.addRejected();
                         continue;
                     }
 
@@ -371,6 +378,7 @@ pub fn LODRenderer(comptime RHI: type) type {
                     if (max_distance_chunks) |max_dist| {
                         if (!isRegionInRange(chunk_bounds, camera_pos, max_dist)) {
                             diag.out_of_range += 1;
+                            if (profiling) |profile| profile.addRejected();
                             continue;
                         }
                     }
@@ -382,10 +390,16 @@ pub fn LODRenderer(comptime RHI: type) type {
                             const pc_x = camera_chunk.chunk_x;
                             const pc_z = camera_chunk.chunk_z;
                             const chunk_radius = config.getChunkRenderRadius();
+                            const coverage_timer = if (profiling) |profile| profile.begin() else null;
                             const cov = self.isCoveredByChunks(bounds, checker, ctx_ptr, pc_x, pc_z, chunk_radius);
+                            if (profiling) |profile| {
+                                profile.end(.coverage, coverage_timer);
+                                profile.addCoverage();
+                            }
                             if (cov.covered) {
                                 lod_covered += 1;
                                 diag.covered_chunks += 1;
+                                if (profiling) |profile| profile.addRejected();
                                 continue;
                             }
                             if (lod_rendered == 0) {
@@ -408,6 +422,7 @@ pub fn LODRenderer(comptime RHI: type) type {
                     if (use_frustum and !disable_frustum) {
                         if (!isRegionInFrustum(frustum, bounds, camera_pos)) {
                             diag.frustum_culled += 1;
+                            if (profiling) |profile| profile.addRejected();
                             continue;
                         }
                     }
@@ -434,6 +449,7 @@ pub fn LODRenderer(comptime RHI: type) type {
                         });
                     }
                     diag.drawn += 1;
+                    if (profiling) |profile| profile.addVisible();
                     if (stats) |s| {
                         const lod_idx = @intFromEnum(lod);
                         if (layer == .fluid) {
@@ -446,6 +462,7 @@ pub fn LODRenderer(comptime RHI: type) type {
                     }
                 } else {
                     diag.missing_region += 1;
+                    if (profiling) |profile| profile.addRejected();
                 }
             }
 
@@ -621,9 +638,10 @@ pub fn LODRenderer(comptime RHI: type) type {
                     max_distance_chunks: ?i32,
                     layer: LODRenderLayer,
                     stats: ?*LODStats,
+                    profiling: ?*LODProfilingCollector,
                 ) void {
                     const renderer: *Self = @ptrCast(@alignCast(self_ptr));
-                    renderer.render(meshes, regions, config, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, layer, stats);
+                    renderer.render(meshes, regions, config, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, layer, stats, profiling);
                 }
                 fn deinitFn(self_ptr: *anyopaque) void {
                     const renderer: *Self = @ptrCast(@alignCast(self_ptr));
@@ -824,7 +842,7 @@ test "LODRenderer batches pooled meshes into per-LOD indirect draws" {
     try regions[2].put(.{ .rx = 8, .rz = 0, .lod = .lod2 }, &chunk_lod2);
 
     var mock_config = LODConfig{ .radii = .{ 16, 128, 256, 512, 1024 } };
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, null, null);
 
     try std.testing.expectEqual(@as(u32, 2), mock_state.draw_indirect_calls);
     try std.testing.expectEqual(@as(u32, 2), mock_state.last_draw_count);
@@ -945,7 +963,7 @@ test "LODRenderer render draw path" {
     var stats = LODStats{};
 
     // Call render with explicit parameters
-    renderer.render(&meshes, &regions, mock_config.interface(), view_proj, camera_pos, null, null, false, null, .terrain, &stats);
+    renderer.render(&meshes, &regions, mock_config.interface(), view_proj, camera_pos, null, null, false, null, .terrain, &stats, null);
 
     // Verify draw was called with correct parameters
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);
@@ -955,7 +973,7 @@ test "LODRenderer render draw path" {
     try std.testing.expectEqual(@as(u32, 1), stats.drawn[1]);
     try std.testing.expectEqual(@as(u32, 1), stats.instances[1]);
 
-    renderer.render(&meshes, &regions, mock_config.interface(), view_proj, camera_pos, null, null, false, null, .fluid, &stats);
+    renderer.render(&meshes, &regions, mock_config.interface(), view_proj, camera_pos, null, null, false, null, .fluid, &stats, null);
     try std.testing.expectEqual(@as(u32, 2), mock_state.draw_calls);
     try std.testing.expectEqual(@as(u32, 6), mock_state.last_vertex_count);
     try std.testing.expectEqual(@as(u32, 1), stats.drawn[1]);
@@ -1030,7 +1048,7 @@ test "LODRenderer keeps coarse LOD visible while finer bands stream" {
         .radii = .{ 16, 32, 64, 100, 256 },
     };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, null, null);
 
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);
     try std.testing.expectEqual(@as(u32, 1), mock_state.set_matrix_calls);
@@ -1104,7 +1122,7 @@ test "LODRenderer disables mask when chunks are missing inside chunk render radi
         }
     };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.missingInRadius, &checker_ctx, false, null, .terrain, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.missingInRadius, &checker_ctx, false, null, .terrain, null, null);
 
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);
     try std.testing.expectEqual(LOD_UNMASKED_SENTINEL, mock_state.last_mask_radius);
@@ -1184,7 +1202,7 @@ test "LODRenderer chunk mask uses chunk render radius instead of LOD0 radius" {
         }
     };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.missing, &checker_ctx, false, null, .terrain, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.missing, &checker_ctx, false, null, .terrain, null, null);
 
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);
     try std.testing.expectEqual(mock_config.interface().calculateMaskRadius(), mock_state.last_mask_radius);
@@ -1258,7 +1276,7 @@ test "LODRenderer keeps mask when only outside-radius chunks are uncovered" {
         }
     };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.loaded, &checker_ctx, false, null, .terrain, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.loaded, &checker_ctx, false, null, .terrain, null, null);
 
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);
     try std.testing.expectEqual(mock_config.interface().calculateMaskRadius(), mock_state.last_mask_radius);
@@ -1332,7 +1350,7 @@ test "LODRenderer keeps mask for partially covered chunk regions" {
         }
     };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.partiallyLoaded, &checker_ctx, false, null, .terrain, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, Checker.partiallyLoaded, &checker_ctx, false, null, .terrain, null, null);
 
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);
     try std.testing.expectEqual(mock_config.interface().calculateMaskRadius(), mock_state.last_mask_radius);
@@ -1418,7 +1436,7 @@ test "LODRenderer skips coarse LOD when finer coverage is ready" {
         .radii = .{ 16, 32, 64, 100, 256 },
     };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, null, null);
 
     try std.testing.expectEqual(@as(u32, 4), mock_state.draw_calls);
 }
@@ -1483,7 +1501,7 @@ test "LODRenderer always renders ready LOD0 regions" {
 
     var mock_config = LODConfig{ .radii = .{ 16, 32, 64, 100, 256 } };
     var stats = LODStats{};
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, &stats);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, &stats, null);
 
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);
     try std.testing.expectEqual(@as(u32, 1), stats.drawn[0]);
@@ -1568,7 +1586,7 @@ test "LODRenderer keeps coarse LOD when a finer child is missing" {
 
     var mock_config = LODConfig{ .radii = .{ 16, 32, 64, 100, 256 } };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, null, null);
 
     try std.testing.expectEqual(@as(u32, 4), mock_state.draw_calls);
     try std.testing.expectEqual(@as(u32, 106), mock_state.handle_sum);
@@ -1653,7 +1671,7 @@ test "LODRenderer resolves finer coverage across negative region boundaries" {
 
     var mock_config = LODConfig{ .radii = .{ 16, 32, 64, 100, 256 } };
 
-    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, null);
+    renderer.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, null, null);
 
     try std.testing.expectEqual(@as(u32, 4), mock_state.draw_calls);
     try std.testing.expectEqual(@as(u32, 10), mock_state.handle_sum);
@@ -1751,7 +1769,7 @@ test "LODRenderer createGPUBridge and toInterface round-trip" {
     var mock_config = LODConfig{};
 
     // Render through the type-erased interface
-    iface.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, null);
+    iface.render(&meshes, &regions, mock_config.interface(), Mat4.identity, Vec3.zero, null, null, false, null, .terrain, null, null);
 
     // Verify the real renderer's draw was invoked through the interface
     try std.testing.expectEqual(@as(u32, 1), mock_state.draw_calls);

--- a/modules/world-lod/src/lod_stats.zig
+++ b/modules/world-lod/src/lod_stats.zig
@@ -1,11 +1,215 @@
 //! LOD system statistics and aggregation helpers.
 
+const std = @import("std");
+const MonotonicTimer = @import("engine-core").time.MonotonicTimer;
 const lod_types = @import("lod_types.zig");
 const LODLevel = lod_types.LODLevel;
 const LODState = lod_types.LODState;
 
+/// Read-only, cumulative LOD profiling data. CPU durations measure only
+/// instrumented CPU work; they are not GPU timings or GPU-memory accounting.
+pub const LODProfilingSnapshot = struct {
+    enabled: bool = false,
+    update_ms: f64 = 0,
+    scheduling_ms: f64 = 0,
+    cache_ms: f64 = 0,
+    generation_dispatch_ms: f64 = 0,
+    state_transition_ms: f64 = 0,
+    upload_prep_ms: f64 = 0,
+    upload_submission_ms: f64 = 0,
+    visibility_ms: f64 = 0,
+    coverage_ms: f64 = 0,
+    eviction_ms: f64 = 0,
+    worker_generation_ms: f64 = 0,
+    worker_mesh_construction_ms: f64 = 0,
+    upload_bytes: u64 = 0,
+    pending_cpu_upload_bytes: u64 = 0,
+    /// Upload-budget deferrals plus RHI upload-pressure errors.
+    staging_pressure_count: u64 = 0,
+    visible_count: u64 = 0,
+    rejected_count: u64 = 0,
+    coverage_count: u64 = 0,
+    /// Known CPU vertex-capacity bytes retained by meshes awaiting deletion.
+    /// GPU pool allocations are deliberately not reported because they are not
+    /// available through the current RHI/LOD pool interface.
+    deferred_deletion_bytes: u64 = 0,
+    wait_idle_count: u64 = 0,
+    wait_idle_ms: f64 = 0,
+};
+
+/// Thread-safe backing store for an `LODProfilingSnapshot`.
+///
+/// Profiling is enabled once when an LOD manager is initialized. All timing
+/// methods return before touching a clock when disabled, while worker updates
+/// use atomics so they never race snapshot collection on the update thread.
+pub const LODProfilingCollector = struct {
+    const AtomicU64 = std.atomic.Value(u64);
+
+    pub const TimerKind = enum {
+        update,
+        scheduling,
+        cache,
+        generation_dispatch,
+        state_transition,
+        upload_prep,
+        upload_submission,
+        visibility,
+        coverage,
+        eviction,
+        worker_generation,
+        worker_mesh_construction,
+        wait_idle,
+    };
+
+    enabled: bool = false,
+    update_ns: AtomicU64 = AtomicU64.init(0),
+    scheduling_ns: AtomicU64 = AtomicU64.init(0),
+    cache_ns: AtomicU64 = AtomicU64.init(0),
+    generation_dispatch_ns: AtomicU64 = AtomicU64.init(0),
+    state_transition_ns: AtomicU64 = AtomicU64.init(0),
+    upload_prep_ns: AtomicU64 = AtomicU64.init(0),
+    upload_submission_ns: AtomicU64 = AtomicU64.init(0),
+    visibility_ns: AtomicU64 = AtomicU64.init(0),
+    coverage_ns: AtomicU64 = AtomicU64.init(0),
+    eviction_ns: AtomicU64 = AtomicU64.init(0),
+    worker_generation_ns: AtomicU64 = AtomicU64.init(0),
+    worker_mesh_construction_ns: AtomicU64 = AtomicU64.init(0),
+    wait_idle_ns: AtomicU64 = AtomicU64.init(0),
+    upload_bytes: AtomicU64 = AtomicU64.init(0),
+    pending_cpu_upload_bytes: AtomicU64 = AtomicU64.init(0),
+    staging_pressure_count: AtomicU64 = AtomicU64.init(0),
+    visible_count: AtomicU64 = AtomicU64.init(0),
+    rejected_count: AtomicU64 = AtomicU64.init(0),
+    coverage_count: AtomicU64 = AtomicU64.init(0),
+    deferred_deletion_bytes: AtomicU64 = AtomicU64.init(0),
+    wait_idle_count: AtomicU64 = AtomicU64.init(0),
+
+    pub fn init(enabled: bool) LODProfilingCollector {
+        return .{ .enabled = enabled };
+    }
+
+    pub fn begin(self: *const LODProfilingCollector) ?MonotonicTimer {
+        if (!self.enabled) return null;
+        return MonotonicTimer.start();
+    }
+
+    pub fn end(self: *LODProfilingCollector, kind: TimerKind, timer: ?MonotonicTimer) void {
+        const elapsed = timer orelse return;
+        _ = self.counterFor(kind).fetchAdd(elapsed.read(), .monotonic);
+    }
+
+    pub fn add(self: *LODProfilingCollector, counter: *AtomicU64, value: u64) void {
+        if (!self.enabled or value == 0) return;
+        _ = counter.fetchAdd(value, .monotonic);
+    }
+
+    pub fn addUploadBytes(self: *LODProfilingCollector, bytes: usize) void {
+        self.add(&self.upload_bytes, @intCast(bytes));
+    }
+
+    pub fn setPendingCpuUploadBytes(self: *LODProfilingCollector, bytes: usize) void {
+        if (!self.enabled) return;
+        self.pending_cpu_upload_bytes.store(@intCast(bytes), .monotonic);
+    }
+
+    pub fn addStagingPressure(self: *LODProfilingCollector) void {
+        self.add(&self.staging_pressure_count, 1);
+    }
+
+    pub fn addVisible(self: *LODProfilingCollector) void {
+        self.add(&self.visible_count, 1);
+    }
+
+    pub fn addRejected(self: *LODProfilingCollector) void {
+        self.add(&self.rejected_count, 1);
+    }
+
+    pub fn addCoverage(self: *LODProfilingCollector) void {
+        self.add(&self.coverage_count, 1);
+    }
+
+    pub fn addDeferredDeletionBytes(self: *LODProfilingCollector, bytes: usize) void {
+        self.add(&self.deferred_deletion_bytes, @intCast(bytes));
+    }
+
+    pub fn removeDeferredDeletionBytes(self: *LODProfilingCollector, bytes: usize) void {
+        if (!self.enabled or bytes == 0) return;
+        _ = self.deferred_deletion_bytes.fetchSub(@intCast(bytes), .monotonic);
+    }
+
+    pub fn addWaitIdle(self: *LODProfilingCollector) void {
+        self.add(&self.wait_idle_count, 1);
+    }
+
+    /// Resets cumulative profiling counters. Concurrent worker completion may
+    /// land immediately before or after this reset, but snapshots are always
+    /// race-free and never contain torn values.
+    pub fn reset(self: *LODProfilingCollector) void {
+        inline for (.{
+            &self.update_ns,              &self.scheduling_ns,           &self.cache_ns,
+            &self.generation_dispatch_ns, &self.state_transition_ns,     &self.upload_prep_ns,
+            &self.upload_submission_ns,   &self.visibility_ns,           &self.coverage_ns,
+            &self.eviction_ns,            &self.worker_generation_ns,    &self.worker_mesh_construction_ns,
+            &self.wait_idle_ns,           &self.upload_bytes,            &self.pending_cpu_upload_bytes,
+            &self.staging_pressure_count, &self.visible_count,           &self.rejected_count,
+            &self.coverage_count,         &self.deferred_deletion_bytes, &self.wait_idle_count,
+        }) |counter| counter.store(0, .monotonic);
+    }
+
+    pub fn snapshot(self: *const LODProfilingCollector) LODProfilingSnapshot {
+        return .{
+            .enabled = self.enabled,
+            .update_ms = nsToMs(self.update_ns.load(.monotonic)),
+            .scheduling_ms = nsToMs(self.scheduling_ns.load(.monotonic)),
+            .cache_ms = nsToMs(self.cache_ns.load(.monotonic)),
+            .generation_dispatch_ms = nsToMs(self.generation_dispatch_ns.load(.monotonic)),
+            .state_transition_ms = nsToMs(self.state_transition_ns.load(.monotonic)),
+            .upload_prep_ms = nsToMs(self.upload_prep_ns.load(.monotonic)),
+            .upload_submission_ms = nsToMs(self.upload_submission_ns.load(.monotonic)),
+            .visibility_ms = nsToMs(self.visibility_ns.load(.monotonic)),
+            .coverage_ms = nsToMs(self.coverage_ns.load(.monotonic)),
+            .eviction_ms = nsToMs(self.eviction_ns.load(.monotonic)),
+            .worker_generation_ms = nsToMs(self.worker_generation_ns.load(.monotonic)),
+            .worker_mesh_construction_ms = nsToMs(self.worker_mesh_construction_ns.load(.monotonic)),
+            .upload_bytes = self.upload_bytes.load(.monotonic),
+            .pending_cpu_upload_bytes = self.pending_cpu_upload_bytes.load(.monotonic),
+            .staging_pressure_count = self.staging_pressure_count.load(.monotonic),
+            .visible_count = self.visible_count.load(.monotonic),
+            .rejected_count = self.rejected_count.load(.monotonic),
+            .coverage_count = self.coverage_count.load(.monotonic),
+            .deferred_deletion_bytes = self.deferred_deletion_bytes.load(.monotonic),
+            .wait_idle_count = self.wait_idle_count.load(.monotonic),
+            .wait_idle_ms = nsToMs(self.wait_idle_ns.load(.monotonic)),
+        };
+    }
+
+    fn counterFor(self: *LODProfilingCollector, kind: TimerKind) *AtomicU64 {
+        return switch (kind) {
+            .update => &self.update_ns,
+            .scheduling => &self.scheduling_ns,
+            .cache => &self.cache_ns,
+            .generation_dispatch => &self.generation_dispatch_ns,
+            .state_transition => &self.state_transition_ns,
+            .upload_prep => &self.upload_prep_ns,
+            .upload_submission => &self.upload_submission_ns,
+            .visibility => &self.visibility_ns,
+            .coverage => &self.coverage_ns,
+            .eviction => &self.eviction_ns,
+            .worker_generation => &self.worker_generation_ns,
+            .worker_mesh_construction => &self.worker_mesh_construction_ns,
+            .wait_idle => &self.wait_idle_ns,
+        };
+    }
+};
+
+fn nsToMs(ns: u64) f64 {
+    return @as(f64, @floatFromInt(ns)) / @as(f64, std.time.ns_per_ms);
+}
+
 /// Statistics for LOD system monitoring.
 pub const LODStats = struct {
+    /// Cumulative opt-in CPU, upload, and pressure telemetry snapshot.
+    profiling: LODProfilingSnapshot = .{},
     loaded: [LODLevel.count]u32 = [_]u32{0} ** LODLevel.count,
     generating: [LODLevel.count]u32 = [_]u32{0} ** LODLevel.count,
     generated: [LODLevel.count]u32 = [_]u32{0} ** LODLevel.count,
@@ -47,6 +251,7 @@ pub const LODStats = struct {
     }
 
     pub fn reset(self: *LODStats) void {
+        self.profiling = .{};
         self.loaded = [_]u32{0} ** LODLevel.count;
         self.generating = [_]u32{0} ** LODLevel.count;
         self.generated = [_]u32{0} ** LODLevel.count;
@@ -92,8 +297,6 @@ pub const LODStats = struct {
     }
 };
 
-const std = @import("std");
-
 test "LODStats reports cache hit rate" {
     var stats = LODStats{};
     try std.testing.expectEqual(@as(f32, 0.0), stats.cacheHitRate());
@@ -101,4 +304,45 @@ test "LODStats reports cache hit rate" {
     stats.store_hits = 3;
     stats.store_misses = 1;
     try std.testing.expectEqual(@as(f32, 0.75), stats.cacheHitRate());
+}
+
+test "LOD profiling collector snapshots and resets cumulative counters" {
+    var collector = LODProfilingCollector.init(true);
+    collector.addUploadBytes(128);
+    collector.setPendingCpuUploadBytes(64);
+    collector.addVisible();
+    collector.addRejected();
+    collector.addCoverage();
+    collector.addDeferredDeletionBytes(32);
+    collector.addWaitIdle();
+
+    const snapshot = collector.snapshot();
+    try std.testing.expect(snapshot.enabled);
+    try std.testing.expectEqual(@as(u64, 128), snapshot.upload_bytes);
+    try std.testing.expectEqual(@as(u64, 64), snapshot.pending_cpu_upload_bytes);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.visible_count);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.rejected_count);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.coverage_count);
+    try std.testing.expectEqual(@as(u64, 32), snapshot.deferred_deletion_bytes);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.wait_idle_count);
+
+    collector.reset();
+    const reset_snapshot = collector.snapshot();
+    try std.testing.expectEqual(@as(u64, 0), reset_snapshot.upload_bytes);
+    try std.testing.expectEqual(@as(u64, 0), reset_snapshot.visible_count);
+    try std.testing.expectEqual(@as(u64, 0), reset_snapshot.deferred_deletion_bytes);
+}
+
+test "disabled LOD profiling collector does not accumulate samples" {
+    var collector = LODProfilingCollector.init(false);
+    const timer = collector.begin();
+    collector.end(.update, timer);
+    collector.addUploadBytes(256);
+    collector.addVisible();
+
+    const snapshot = collector.snapshot();
+    try std.testing.expect(!snapshot.enabled);
+    try std.testing.expectEqual(@as(f64, 0), snapshot.update_ms);
+    try std.testing.expectEqual(@as(u64, 0), snapshot.upload_bytes);
+    try std.testing.expectEqual(@as(u64, 0), snapshot.visible_count);
 }

--- a/modules/world-lod/src/lod_upload_queue.zig
+++ b/modules/world-lod/src/lod_upload_queue.zig
@@ -12,6 +12,7 @@ const LODRegionKey = lod_chunk.LODRegionKey;
 const LODRegionKeyContext = lod_chunk.LODRegionKeyContext;
 const ILODConfig = lod_chunk.ILODConfig;
 const LODStats = @import("lod_stats.zig").LODStats;
+const LODProfilingCollector = @import("lod_stats.zig").LODProfilingCollector;
 const LODMesh = @import("lod_mesh.zig").LODMesh;
 const Vec3 = @import("engine-math").Vec3;
 const Mat4 = @import("engine-math").Mat4;
@@ -95,6 +96,7 @@ pub const LODRenderInterface = struct {
         max_distance_chunks: ?i32,
         layer: LODRenderLayer,
         stats: ?*LODStats,
+        profiling: ?*LODProfilingCollector,
     ) void,
     /// Destroy renderer resources.
     deinit_fn: *const fn (self_ptr: *anyopaque) void,
@@ -114,8 +116,9 @@ pub const LODRenderInterface = struct {
         max_distance_chunks: ?i32,
         layer: LODRenderLayer,
         stats: ?*LODStats,
+        profiling: ?*LODProfilingCollector,
     ) void {
-        self.render_fn(self.ptr, meshes, regions, config, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, layer, stats);
+        self.render_fn(self.ptr, meshes, regions, config, view_proj, camera_pos, chunk_checker, checker_ctx, use_frustum, max_distance_chunks, layer, stats, profiling);
     }
 
     pub fn deinit(self: LODRenderInterface) void {

--- a/modules/world-lod/src/root.zig
+++ b/modules/world-lod/src/root.zig
@@ -41,5 +41,6 @@ pub const LODRenderLayer = lod_upload_queue.LODRenderLayer;
 pub const LODStreamingCoordinator = lod_streaming_coordinator.LODStreamingCoordinator;
 pub const LODState = lod_types.LODState;
 pub const LODStats = lod_stats.LODStats;
+pub const LODProfilingSnapshot = lod_stats.LODProfilingSnapshot;
 pub const LODVertexPool = lod_vertex_pool.LODVertexPool;
 pub const WorldLOD = world_lod.WorldLOD;

--- a/modules/world-runtime/src/world_renderer.zig
+++ b/modules/world-runtime/src/world_renderer.zig
@@ -13,6 +13,7 @@ const rhi_mod = @import("engine-rhi").rhi;
 const ResourceManager = rhi_mod.ResourceManager;
 const RenderContext = rhi_mod.RenderContext;
 const IDeviceQuery = rhi_mod.IDeviceQuery;
+const IDeviceTiming = rhi_mod.IDeviceTiming;
 const LODManager = @import("world-lod").LODManager;
 const LODRenderLayer = @import("world-lod").LODRenderLayer;
 const math = @import("engine-math");
@@ -103,6 +104,7 @@ pub const WorldRenderer = struct {
     rm: ResourceManager,
     render_ctx: RenderContext,
     query: IDeviceQuery,
+    timing: IDeviceTiming,
     culling_screen_size: rhi_mod.RenderResolution,
 
     vertex_allocator: *GlobalVertexAllocator,
@@ -221,6 +223,7 @@ pub const WorldRenderer = struct {
             .rm = rm,
             .render_ctx = render_ctx,
             .query = query,
+            .timing = rhi.timing(),
             .culling_screen_size = culling_screen_size,
             .vertex_allocator = vertex_allocator,
             .visible_chunks = .empty,
@@ -321,10 +324,14 @@ pub const WorldRenderer = struct {
         if (render_lod) {
             if (lod_manager) |lod_mgr| {
                 if (layer != .fluid) {
+                    self.timing.beginPassTiming("LODTerrainPass");
                     lod_mgr.render(view_proj, camera_pos, ChunkStorage.isChunkRenderable, @ptrCast(self.storage), true, null, LODRenderLayer.terrain);
+                    self.timing.endPassTiming("LODTerrainPass");
                 }
                 if (layer != .terrain and parseEnabledEnv(getenv("ZIGCRAFT_LOD_WATER"), true)) {
+                    self.timing.beginPassTiming("LODWaterPass");
                     lod_mgr.render(view_proj, camera_pos, ChunkStorage.isChunkRenderable, @ptrCast(self.storage), true, null, LODRenderLayer.fluid);
+                    self.timing.endPassTiming("LODWaterPass");
                 }
             }
         }

--- a/src/game/app.zig
+++ b/src/game/app.zig
@@ -15,6 +15,7 @@ const InputMapper = @import("game-core").InputMapper;
 const RenderSystem = @import("engine-graphics").RenderSystem;
 const AudioSystemManager = @import("audio_system_manager.zig").AudioSystemManager;
 const BenchmarkRunner = @import("game-core").BenchmarkRunner;
+const BENCHMARK_WORLD_SEED = @import("game-core").BENCHMARK_WORLD_SEED;
 const json_presets = @import("game-core").settings.json_presets;
 
 const SettingsManager = @import("game-core").SettingsManager;
@@ -200,9 +201,20 @@ pub const App = struct {
 
         var benchmark_runner: ?*BenchmarkRunner = null;
         if (build_options.benchmark) {
+            // Benchmarks include GPU pass breakdowns, including LOD passes.
+            render_system.getRHI().timing().setTimingEnabled(true);
             const runner = try allocator.create(BenchmarkRunner);
             const benchmark_duration_s: f32 = @as(f32, @floatFromInt(build_options.benchmark_duration));
-            runner.* = try BenchmarkRunner.init(allocator, build_options.benchmark_preset, settings_manager.settings.render_distance, benchmark_duration_s, build_options.benchmark_output);
+            runner.* = try BenchmarkRunner.init(
+                allocator,
+                build_options.benchmark_preset,
+                build_options.benchmark_scenario,
+                settings_manager.settings.render_distance,
+                benchmark_duration_s,
+                BENCHMARK_WORLD_SEED,
+                build_options.benchmark_build_mode,
+                build_options.benchmark_output,
+            );
             benchmark_runner = runner;
         }
 
@@ -232,7 +244,7 @@ pub const App = struct {
         };
         errdefer app.screen_manager.deinit();
 
-        if (build_options.smoke_test or build_options.screenshot_path.len > 0 or build_options.benchmark) {
+        if (build_options.smoke_test or build_options.screenshot_path.len > 0) {
             app.render_system.getRHI().timing().setTimingEnabled(true);
         }
 
@@ -253,7 +265,7 @@ pub const App = struct {
             }
         } else if (build_options.benchmark) {
             log.log.info("BENCHMARK MODE: Deferring world launch until swapchain settles", .{});
-            app.pending_world_launch = .{ .seed = 12345, .generator_index = 0 };
+            app.pending_world_launch = .{ .seed = BENCHMARK_WORLD_SEED, .generator_index = 0 };
             if (runtime_env.strictSafeModeAutoEnabled()) app.direct_launch_resize_guard_frames = 240;
         } else if (resolveAutoWorldGenerator()) |generator_index| {
             log.log.info("AUTO WORLD MODE: Deferring '{s}' world launch until swapchain settles", .{build_options.auto_world});


### PR DESCRIPTION
## Summary
- retain the Phase 0 LOD profiling baseline now present on `stage`
- share frame-keyed LOD visibility and coverage between terrain and water, with cheap rejects before coverage scans
- default-enable pooled LOD MDI for terrain and water while preserving mixed/direct fallback paths
- move cache reads, serialization, and writes to a bounded dedicated worker with token/revision validation
- mesh outside the global manager lock and reconcile paused queued jobs safely
- add per-level visibility/rejection telemetry to benchmark artifacts

## Validation
- `nix develop --command zig build test`
- `nix develop --command zig build -Doptimize=ReleaseFast`
- `nix develop --command zig build -Dskip-present`
- bounded ReleaseFast traversal benchmark (artifact produced; local GPU-memory SLO exceeded due environment allocation reporting)
- pre-push formatting and full test hooks

Closes #920