### PR TITLE
perf: remove LOD streaming device stalls

### DIFF
--- a/modules/world-lod/src/lod_manager_cache_ops.zig
+++ b/modules/world-lod/src/lod_manager_cache_ops.zig
@@ -57,10 +57,9 @@ pub fn flushCacheIO(self: *Self) void {
 /// `flushDirtyStores` and never wait for I/O.
 pub fn shutdownCacheIO(self: *Self) void {
     var attempts: usize = 0;
-    while (attempts < 2048) {
+    while (attempts < 2048) : (attempts += 1) {
         const queued = queueDirtyStores(self, cache_io.MAX_PENDING_TASKS);
         if (queued == 0) break;
-        attempts += queued;
         self.cache_io.waitUntilIdle();
         drainCacheCompletions(self);
     }
@@ -94,7 +93,10 @@ pub fn drainCacheCompletions(self: *Self) void {
                                 dispatch_generation = true;
                             } else {
                                 region.data = .{ .simplified = data.* };
-                                data.* = undefined;
+                                // Ownership moved into the region. Retag the
+                                // completion so deferred cleanup does not
+                                // deinitialize the consumed payload.
+                                read.result = .miss;
                                 region.updateHeightBoundsFromData();
                                 region.source_revision +%= 1;
                                 region.setState(.generated);

--- a/modules/world-lod/src/lod_manager_context.zig
+++ b/modules/world-lod/src/lod_manager_context.zig
@@ -109,9 +109,9 @@ pub fn lodUploadBudgetBytes() usize {
     return std.math.mul(usize, mb, 1024 * 1024) catch DEFAULT_LOD_UPLOAD_BUDGET_BYTES;
 }
 
-pub fn wouldExceedUploadBudget(uploaded_bytes: usize, pending_bytes: usize, budget_bytes: usize, uploads: u32) bool {
+pub fn wouldExceedUploadBudget(uploaded_bytes: usize, pending_bytes: usize, budget_bytes: usize) bool {
     if (budget_bytes == 0 or budget_bytes == std.math.maxInt(usize)) return false;
-    if (pending_bytes == 0 or uploads == 0) return false;
+    if (pending_bytes == 0) return false;
     if (uploaded_bytes >= budget_bytes) return true;
     return pending_bytes > budget_bytes - uploaded_bytes;
 }

--- a/modules/world-lod/src/lod_manager_eviction_ops.zig
+++ b/modules/world-lod/src/lod_manager_eviction_ops.zig
@@ -140,13 +140,10 @@ pub fn processMeshDeletions(self: *Self, max_count: usize) void {
     const count = @min(max_count, self.mesh_disposal.queue.items.len);
     if (count == 0) return;
 
-    // LODMesh does not carry a per-frame fence today, so destruction still
-    // requires GPU idle. Bound each sweep so a memory-pressure eviction burst
-    // cannot turn into an unbounded main-thread stall.
-    const wait_idle_timer = self.profiling.begin();
-    self.profiling.addWaitIdle();
-    self.gpu_bridge.waitIdle();
-    self.profiling.end(.wait_idle, wait_idle_timer);
+    // Meshes have already spent a full disposal grace period outside the
+    // render maps. Whole buffers are retired by the RHI's frame-fence deletion
+    // queue; pooled ranges are only returned here, after that grace period.
+    // Do not turn routine streaming eviction into a device-global stall.
     var processed: usize = 0;
     while (processed < count) : (processed += 1) {
         const idx = self.mesh_disposal.queue.items.len - 1;

--- a/modules/world-lod/src/lod_manager_internal_tests.zig
+++ b/modules/world-lod/src/lod_manager_internal_tests.zig
@@ -25,6 +25,7 @@ const manager_mod = @import("lod_manager.zig");
 const LODManager = manager_mod.LODManager;
 const MAX_CACHE_LOADS_PER_UPDATE = @import("lod_manager_context.zig").MAX_CACHE_LOADS_PER_UPDATE;
 const DEFAULT_LOD_UPLOAD_BUDGET_BYTES = @import("lod_manager_context.zig").DEFAULT_LOD_UPLOAD_BUDGET_BYTES;
+const wouldExceedUploadBudget = @import("lod_manager_context.zig").wouldExceedUploadBudget;
 const testing = std.testing;
 
 test "LODManager cache helpers save and reload source data" {
@@ -430,6 +431,34 @@ test "LODManager upload budget defers remaining queued meshes" {
     try testing.expectEqual(LODState.renderable, first.state);
     try testing.expectEqual(LODState.uploading, second.state);
     try testing.expectEqual(@as(usize, 1), manager.upload_queues[1].count());
+}
+
+test "LODManager upload budget defers an oversized first mesh" {
+    var config = LODConfig{ .max_uploads_per_frame = 8 };
+    var manager = try initEvictionTestManager(testing.allocator, &config);
+    defer deinitEvictionTestManager(&manager);
+
+    var mock = UploadMock{ .allocator = testing.allocator };
+    manager.gpu_bridge = mock.bridge();
+
+    const key = LODRegionKey{ .rx = 0, .rz = 0, .lod = .lod1 };
+    const chunk = try putTestRegion(&manager, key, .uploading);
+    _ = try putTestPendingMesh(&manager, key, 1);
+    try manager.upload_queues[1].push(chunk);
+
+    manager.processUploadsWithBudget(@sizeOf(Vertex) - 1);
+
+    try testing.expectEqual(@as(u32, 0), mock.calls);
+    try testing.expectEqual(LODState.uploading, chunk.state);
+    try testing.expectEqual(@as(usize, 1), manager.upload_queues[1].count());
+}
+
+test "LOD upload budget permits zero-pending and unlimited uploads" {
+    const pending_bytes = @sizeOf(Vertex);
+
+    try testing.expect(!wouldExceedUploadBudget(0, 0, 1));
+    try testing.expect(!wouldExceedUploadBudget(0, pending_bytes, 0));
+    try testing.expect(!wouldExceedUploadBudget(0, pending_bytes, std.math.maxInt(usize)));
 }
 
 test "LODManager staging pressure failure stops upload sweep" {

--- a/modules/world-lod/src/lod_manager_upload_ops.zig
+++ b/modules/world-lod/src/lod_manager_upload_ops.zig
@@ -103,7 +103,7 @@ pub fn processUploadsWithBudget(self: *Self, upload_budget_bytes: usize) void {
                 const key = chunk.key();
                 if (self.meshes[i].get(key)) |mesh| {
                     const pending_bytes = mesh.pendingUploadBytes();
-                    if (wouldExceedUploadBudget(uploaded_bytes, pending_bytes, upload_budget_bytes, uploads)) {
+                    if (wouldExceedUploadBudget(uploaded_bytes, pending_bytes, upload_budget_bytes)) {
                         self.profiling.addStagingPressure();
                         self.requeueUpload(i, chunk);
                         stop_processing = true;

--- a/modules/world-lod/src/lod_mesh.zig
+++ b/modules/world-lod/src/lod_mesh.zig
@@ -661,7 +661,6 @@ pub const LODMesh = struct {
 
         if (pending.len == 0) {
             if (self.buffer_handle != 0 and !self.pooled) {
-                resources.waitIdle();
                 resources.destroyBuffer(self.buffer_handle);
             }
             self.buffer_handle = 0;
@@ -685,7 +684,7 @@ pub const LODMesh = struct {
         var new_handle: BufferHandle = 0;
 
         // Create or resize buffer. Keep the old buffer renderable until the
-        // replacement upload succeeds, then destroy it after an idle wait.
+        // replacement upload succeeds, then retire it through the RHI.
         if (self.buffer_handle == 0 or needed_capacity > self.capacity * @sizeOf(Vertex)) {
             new_handle = try resources.createBuffer(needed_capacity, .vertex);
             upload_handle = new_handle;
@@ -701,7 +700,6 @@ pub const LODMesh = struct {
             self.vertex_offset = 0;
             self.pooled = false;
             if (old_handle != 0 and !self.pooled) {
-                resources.waitIdle();
                 resources.destroyBuffer(old_handle);
             }
         }

--- a/modules/world-lod/src/lod_renderer.zig
+++ b/modules/world-lod/src/lod_renderer.zig
@@ -398,22 +398,27 @@ pub fn LODRenderer(comptime RHI: type) type {
                     const mesh = entry.value_ptr.*;
                     if (!mesh.isReady()) {
                         telemetry.rejected_not_ready += 1;
+                        if (profiling) |profile| profile.addRejected();
                         continue;
                     }
                     if ((mesh.drawRange(.terrain) orelse mesh.drawRange(.fluid)) == null) {
                         telemetry.rejected_no_draw += 1;
+                        if (profiling) |profile| profile.addRejected();
                         continue;
                     }
                     const chunk = all_regions[i].get(entry.key_ptr.*) orelse {
                         telemetry.rejected_missing_region += 1;
+                        if (profiling) |profile| profile.addRejected();
                         continue;
                     };
                     if (!chunk.isRenderable()) {
                         telemetry.rejected_not_renderable += 1;
+                        if (profiling) |profile| profile.addRejected();
                         continue;
                     }
                     if (self.isCoveredByFinerLOD(chunk, config)) {
                         telemetry.rejected_finer_coverage += 1;
+                        if (profiling) |profile| profile.addRejected();
                         continue;
                     }
 
@@ -424,11 +429,13 @@ pub fn LODRenderer(comptime RHI: type) type {
                     if (max_distance_chunks) |max_dist| {
                         if (!isRegionInRange(chunk_bounds, camera_pos, max_dist)) {
                             telemetry.rejected_range += 1;
+                            if (profiling) |profile| profile.addRejected();
                             continue;
                         }
                     }
                     if (use_frustum and !disable_frustum and !isRegionInFrustum(frustum, bounds, camera_pos)) {
                         telemetry.rejected_frustum += 1;
+                        if (profiling) |profile| profile.addRejected();
                         continue;
                     }
 
@@ -437,10 +444,14 @@ pub fn LODRenderer(comptime RHI: type) type {
                         if (checker_ctx) |ctx_ptr| {
                             const coverage_timer = if (profiling) |profile| profile.begin() else null;
                             const cov = self.isCoveredByChunks(bounds, checker, ctx_ptr, camera_chunk.chunk_x, camera_chunk.chunk_z, chunk_radius);
-                            if (profiling) |profile| profile.end(.coverage, coverage_timer);
+                            if (profiling) |profile| {
+                                profile.end(.coverage, coverage_timer);
+                                profile.addCoverage();
+                            }
                             telemetry.coverage_checks += 1;
                             if (cov.covered) {
                                 telemetry.rejected_chunk_coverage += 1;
+                                if (profiling) |profile| profile.addRejected();
                                 continue;
                             }
                             if (cov.missing_chunk_in_radius and !cov.has_chunk_coverage_in_radius) mask_radius = LOD_UNMASKED_SENTINEL;

--- a/modules/world-lod/src/lod_vertex_pool.zig
+++ b/modules/world-lod/src/lod_vertex_pool.zig
@@ -250,7 +250,6 @@ pub const LODVertexPool = struct {
         }
 
         if (old_handle != 0) {
-            resources.waitIdle();
             resources.destroyBuffer(old_handle);
         }
         if (old_shadow) |shadow| self.allocator.free(shadow);
@@ -536,7 +535,7 @@ test "LODVertexPool grows and preserves pooled handles" {
     try std.testing.expectEqual(first.buffer_handle, second.buffer_handle);
     try std.testing.expectEqual(@as(u32, 0), resources.uploaded);
     try std.testing.expect(resources.updated >= 1);
-    try std.testing.expectEqual(@as(u32, 1), resources.wait_idle);
+    try std.testing.expectEqual(@as(u32, 0), resources.wait_idle);
     pool.destroyMesh(&first);
     pool.destroyMesh(&second);
 }


### PR DESCRIPTION
## Summary
- retire replaced and evicted LOD buffers through the existing frame-fence-backed RHI deletion queues instead of calling `vkDeviceWaitIdle`
- preserve a grace period before pooled ranges are returned while keeping streaming eviction bounded
- enforce the configured upload byte budget from the first upload, deferring oversized meshes rather than overrunning staging capacity
- add regression coverage for oversized first uploads and no-stall pool growth

## Validation
- `nix develop --command zig build test`
- `nix develop --command zig build -Doptimize=ReleaseFast`
- pre-push formatting and full test hooks

Addresses #919.