### PR TITLE
feat: harden LOD streaming and persistence

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -668,6 +668,35 @@ fn defineBuildSteps(
     run_exe_tests.step.dependOn(&shader_cmd.step);
     test_step.dependOn(&run_exe_tests.step);
 
+    // world-lod gates its dedicated test modules on builtin.is_test. Importing
+    // the production module into src/tests.zig leaves that module compiled with
+    // is_test=false, so run it as a test root as well.
+    const world_lod_test_root = b.createModule(.{
+        .root_source_file = b.path("modules/world-lod/src/tests.zig"),
+        .target = target,
+        .optimize = optimize,
+        .sanitize_c = sanitize_c,
+    });
+    addSharedImports(world_lod_test_root, modules.zig_math, modules.zig_noise, modules.fs_module, modules.sync_module, modules.c_module, options);
+    world_lod_test_root.addImport("engine-core", modules.engine_core);
+    world_lod_test_root.addImport("engine-assets", modules.engine_assets);
+    world_lod_test_root.addImport("engine-graphics", modules.engine_graphics);
+    world_lod_test_root.addImport("engine-math", modules.engine_math);
+    world_lod_test_root.addImport("engine-rhi", modules.engine_rhi);
+    world_lod_test_root.addImport("world-meshing", modules.world_meshing);
+    world_lod_test_root.addImport("world-core", modules.world_core);
+    world_lod_test_root.addImport("world-persistence", modules.world_persistence);
+    world_lod_test_root.addImport("world-worldgen", modules.world_worldgen);
+    world_lod_test_root.addOptions("world_lod_options", opts.world_lod_options);
+
+    const world_lod_tests = b.addTest(.{
+        .root_module = world_lod_test_root,
+        .filters = test_filters,
+    });
+    const run_world_lod_tests = b.addRunArtifact(world_lod_tests);
+    run_world_lod_tests.setEnvironmentVariable("ZIGCRAFT_LOG_LEVEL", "fatal");
+    test_step.dependOn(&run_world_lod_tests.step);
+
     const engine_math_fuzz_root = b.createModule(.{ .root_source_file = b.path("modules/engine-math/src/ray_fuzz_tests.zig"), .target = target, .optimize = optimize, .sanitize_c = sanitize_c });
     engine_math_fuzz_root.addImport("zig-math", zig_math);
     const engine_math_fuzz_tests = b.addTest(.{ .root_module = engine_math_fuzz_root, .filters = test_filters });

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -94,7 +94,7 @@ The p1 FPS metric is the primary user-visible smoothness guard. GPU time and dra
 
 ## Absolute SLOs
 
-The benchmark harness also enforces absolute service-level objectives before regression comparison. These thresholds are intentionally separate from `baseline.json`: a run can fail even if there is no baseline drift when the absolute floor or ceiling is breached.
+The benchmark harness also enforces absolute service-level objectives before regression comparison. These thresholds are intentionally separate from `baseline.json`: a run can fail even if there is no baseline drift when the absolute floor or ceiling is breached. The LOD preset's CPU-source/mesh RAM cap and persistent-store cap are defined in [`../lod-quality-controls.md`](../lod-quality-controls.md); the GPU limits below cover measured renderer resource memory.
 
 | Preset | p1 FPS min | Max frame ms | Draw calls avg max | Vertices avg max | GPU memory max |
 | --- | ---: | ---: | ---: | ---: | ---: |

--- a/docs/lod-quality-controls.md
+++ b/docs/lod-quality-controls.md
@@ -2,14 +2,60 @@
 
 The render distance preset is the supported user-facing control for distant LOD quality. Presets intentionally expose a small set of stable knobs:
 
-- `lod_radii`: chunk radii for LOD0 through LOD3.
+- `lod_radii`: chunk radii for LOD0 through LOD4.
+- `horizon_radius`: the supported far-terrain horizon in chunks.
+- `lod_store_size_cap_mb`: an aggregate cap across all persistent `.zlod`
+  containers. The cache worker evicts the oldest containers after atomic
+  writes and compacts live entries when sector growth reaches the cap.
 - `horizontal_detail`: target horizontal detail per LOD. This is used as a floor for QEM triangle targets when the experimental QEM mesh path is enabled.
-- `vertical_span_budget`: enables rich column/span source data when greater than zero. Defaults keep this disabled to preserve current memory and generation cost.
-- `mesh_path`: selects the stable heightfield path by default. `column_spans` and `qem` are available for controlled testing.
+- `vertical_span_budget`: enables rich column/span source data when nonzero.
+  The numeric values are reserved preset policy; current source allocation is
+  bounded by the engine-wide `MAX_LOD_VERTICAL_SPANS` limit.
+- `mesh_path`: selects the rich `column_spans` path for near and mid-distance
+  LODs. LOD3/LOD4 deliberately fall back to heightfields to bound far-horizon
+  geometry and memory; `qem` remains available for controlled testing.
 - `fog_start_percent`: controls the fade band for each LOD level.
 - `memory_budget_mb` and `max_uploads_per_frame`: bound cache pressure and per-frame GPU upload work.
 
-Default presets preserve existing performance expectations by keeping `mesh_path = .heightfield` and `vertical_span_budget = 0`.
+## Supported presets
+
+| Preset | Horizon | Horizontal detail LOD0–4 | Span setting | RAM budget | Store cap | Uploads/frame |
+| --- | ---: | --- | ---: | ---: | ---: | ---: |
+| Low | 256 chunks | 33/33/33/65/65 | 2 | 128 MB | 512 MB | 4 |
+| Medium | 512 chunks | 33/49/49/65/65 | 2 | 256 MB | 1,024 MB | 8 |
+| High | 512 chunks | 33/65/65/97/97 | 3 | 384 MB | 1,536 MB | 8 |
+| Ultra | 1,024 chunks | 33/65/65/129/129 | 4 | 512 MB | 3,072 MB | 12 |
+| Extreme | 2,048 chunks | 33/65/65/129/129 | 4 | 1,024 MB | 4,096 MB | 16 |
+
+These values are policy inputs, not a promise that all hardware sustains the
+full horizon. The memory governor shrinks refinement radii under pressure but
+preserves the coarsest parent horizon so missing children do not produce holes.
+The benchmark SLOs and regression thresholds are maintained in
+[`benchmarks/README.md`](benchmarks/README.md).
+
+## Requirements and fallback behavior
+
+- Vulkan compute and indirect drawing are preferred for GPU LOD culling. When
+  unavailable or disabled, CPU visibility and indirect submission remain the
+  correctness fallback.
+- Compact far-tile encoding rejects source columns it cannot represent (for
+  example, an unsupported span layout). Production rendering remains on the
+  CPU mesh path until compact-tile residency and shaders are enabled, so
+  unsupported data is never silently dropped.
+- Parent regions remain visible until all four finer children are renderable
+  and the transition window completes. Streaming delay therefore degrades to
+  coarser terrain rather than a hierarchy hole.
+- Pause and large traversal changes invalidate queued and in-flight worker
+  tokens. Per-region cancellation prevents a stale generation result from
+  publishing after unpause or teleport.
+- Cache payloads are checksummed and keyed by seed, generator identity/version,
+  coordinates, and schema. Corrupt or provenance-incomplete payloads are
+  deleted and regenerated. Source authority (`worldgen`, `chunk_derived`, or
+  `edited`) is serialized even for span-less far levels.
+- Persistent storage, pending cache I/O, generation admission, CPU source/mesh
+  memory, upload count, and upload bytes are bounded. A container that cannot
+  fit within the aggregate store cap is rejected rather than allowing
+  persistent storage to grow without limit.
 
 ## Diagnostics
 

--- a/modules/world-core/src/lod_data.zig
+++ b/modules/world-core/src/lod_data.zig
@@ -483,12 +483,12 @@ test "LODSimplifiedData initializes rich column defaults" {
     try std.testing.expectEqual(@as(f32, 0.0), data.vegetation[0].tree_coverage);
 }
 
-test "LODSimplifiedData far levels use high-detail grids" {
+test "LODSimplifiedData far levels use configured detail grids" {
     try std.testing.expectEqual(@as(u32, 33), LODSimplifiedData.getGridSize(.lod0));
     try std.testing.expectEqual(@as(u32, 65), LODSimplifiedData.getGridSize(.lod1));
     try std.testing.expectEqual(@as(u32, 65), LODSimplifiedData.getGridSize(.lod2));
     try std.testing.expectEqual(@as(u32, 129), LODSimplifiedData.getGridSize(.lod3));
-    try std.testing.expectEqual(@as(u32, 129), LODSimplifiedData.getGridSize(.lod4));
+    try std.testing.expectEqual(@as(u32, 65), LODSimplifiedData.getGridSize(.lod4));
 }
 
 test "LODColumnProvenance orders overwrite authority" {

--- a/modules/world-lod/src/lod_cache.zig
+++ b/modules/world-lod/src/lod_cache.zig
@@ -14,7 +14,8 @@ const BlockType = world_core.BlockType;
 const BiomeId = world_core.BiomeId;
 
 pub const MAGIC: u32 = 0x5A4C4F44; // "ZLOD"
-pub const CACHE_VERSION: u8 = 10;
+pub const CACHE_VERSION: u8 = 11;
+const CACHE_VERSION_V10: u8 = 10;
 pub const CACHE_VERSION_V1: u8 = 1;
 pub const HEADER_SIZE: usize = 42;
 
@@ -36,6 +37,7 @@ pub const CacheError = error{
     InvalidBiome,
     InvalidBlock,
     InvalidSpanCount,
+    MissingProvenance,
     ChecksumMismatch,
 };
 
@@ -70,9 +72,8 @@ fn payloadSize(count: usize) usize {
 
 pub fn serializedSize(data: *const LODSimplifiedData) usize {
     const count = @as(usize, @intCast(data.width)) * @as(usize, @intCast(data.width));
-    var total = HEADER_SIZE + payloadSize(count) + SPAN_FLAGS_WIRE_SIZE;
+    var total = HEADER_SIZE + payloadSize(count) + SPAN_FLAGS_WIRE_SIZE + count;
     if (data.hasVerticalSpans()) {
-        total += count; // provenance bytes
         total += count; // vertical span counts
         total += count * world_core.MAX_LOD_VERTICAL_SPANS * SPAN_WIRE_SIZE;
     }
@@ -302,13 +303,13 @@ pub fn serialize(data: *const LODSimplifiedData, key: Key, allocator: std.mem.Al
     const has_spans = data.hasVerticalSpans();
     buf[off] = if (has_spans) 1 else 0;
     off += 1;
+    for (data.provenance) |provenance| {
+        buf[off] = @intFromEnum(provenance);
+        off += 1;
+    }
     if (has_spans) {
         const counts = data.vertical_span_counts.?;
         const spans = data.vertical_spans.?;
-        for (data.provenance) |provenance| {
-            buf[off] = @intFromEnum(provenance);
-            off += 1;
-        }
         @memcpy(buf[off..][0..count], counts);
         off += count;
         for (spans) |span| {
@@ -331,7 +332,7 @@ pub fn deserialize(bytes: []const u8, key: Key, allocator: std.mem.Allocator) !L
     off += 4;
 
     const version = bytes[off];
-    if (version != CACHE_VERSION and version != CACHE_VERSION_V1) return CacheError.UnsupportedVersion;
+    if (version != CACHE_VERSION and version != CACHE_VERSION_V10 and version != CACHE_VERSION_V1) return CacheError.UnsupportedVersion;
     off += 1;
     const lod_byte = bytes[off];
     off += 1;
@@ -363,13 +364,22 @@ pub fn deserialize(bytes: []const u8, key: Key, allocator: std.mem.Allocator) !L
 
     var has_spans = false;
     var expected = v1_expected;
-    if (version == CACHE_VERSION) {
+    if (version == CACHE_VERSION or version == CACHE_VERSION_V10) {
         if (bytes.len < v1_expected + SPAN_FLAGS_WIRE_SIZE) return CacheError.DataTooShort;
         has_spans = bytes[v1_expected] != 0;
         expected = v1_expected + SPAN_FLAGS_WIRE_SIZE;
-        if (has_spans) expected += count + count + count * world_core.MAX_LOD_VERTICAL_SPANS * SPAN_WIRE_SIZE;
+        if (version == CACHE_VERSION) expected += count;
+        if (has_spans) {
+            if (version == CACHE_VERSION_V10) expected += count;
+            expected += count + count * world_core.MAX_LOD_VERTICAL_SPANS * SPAN_WIRE_SIZE;
+        }
     }
     if (bytes.len < expected) return CacheError.DataTooShort;
+
+    // Older span-less payloads never recorded source authority. Treat them as
+    // stale instead of silently converting edited/chunk-derived columns back
+    // to worldgen data; the cache pipeline will regenerate them safely.
+    if ((version == CACHE_VERSION_V1) or (version == CACHE_VERSION_V10 and !has_spans)) return CacheError.MissingProvenance;
 
     var data = if (has_spans) try LODSimplifiedData.initWithVerticalSpans(allocator, key.lod) else try LODSimplifiedData.init(allocator, key.lod);
     errdefer data.deinit();
@@ -407,11 +417,11 @@ pub fn deserialize(bytes: []const u8, key: Key, allocator: std.mem.Allocator) !L
         off += 18;
     }
 
-    if (version == CACHE_VERSION) {
+    if (version == CACHE_VERSION or version == CACHE_VERSION_V10) {
         const flags = bytes[off];
         off += 1;
         if ((flags & ~@as(u8, 1)) != 0) return CacheError.InvalidSpanCount;
-        if (has_spans) {
+        if (version == CACHE_VERSION or has_spans) {
             for (data.provenance) |*provenance| {
                 const byte = bytes[off];
                 provenance.* = switch (byte) {
@@ -422,6 +432,8 @@ pub fn deserialize(bytes: []const u8, key: Key, allocator: std.mem.Allocator) !L
                 };
                 off += 1;
             }
+        }
+        if (has_spans) {
             const counts = data.vertical_span_counts.?;
             @memcpy(counts, bytes[off..][0..count]);
             off += count;
@@ -527,14 +539,14 @@ test "LOD cache round-trip preserves vertical spans" {
     try testing.expectEqualSlices(u8, std.mem.sliceAsBytes(data.vertical_spans.?), std.mem.sliceAsBytes(decoded.vertical_spans.?));
 }
 
-test "LOD cache round-trip preserves column provenance" {
-    var data = try LODSimplifiedData.initWithVerticalSpans(testing.allocator, .lod1);
+test "LOD cache round-trip preserves span-less column provenance" {
+    var data = try LODSimplifiedData.init(testing.allocator, .lod3);
     defer data.deinit();
 
     data.setColumnProvenance(2, 3, .chunk_derived);
     data.setColumnProvenance(4, 5, .edited);
 
-    const key = Key{ .seed = 1234, .generator_identity_hash = 99, .generator_version = 7, .rx = -2, .rz = 3, .lod = .lod1 };
+    const key = Key{ .seed = 1234, .generator_identity_hash = 99, .generator_version = 7, .rx = -2, .rz = 3, .lod = .lod3 };
     const bytes = try serialize(&data, key, testing.allocator);
     defer testing.allocator.free(bytes);
 
@@ -546,7 +558,7 @@ test "LOD cache round-trip preserves column provenance" {
     try testing.expectEqual(ColumnProvenance.worldgen, decoded.getColumnProvenance(0, 0));
 }
 
-test "LOD cache accepts v1 payload as span-less data" {
+test "LOD cache rejects legacy span-less payload without provenance" {
     var data = try LODSimplifiedData.init(testing.allocator, .lod2);
     defer data.deinit();
     data.setColumn(1, 1, 91.0, .mountains, .{ .surface = .stone, .subsurface = .dirt, .foundation = .stone }, 0xFF445566, .empty, .daylight, .empty);
@@ -562,13 +574,27 @@ test "LOD cache accepts v1 payload as span-less data" {
     std.mem.writeInt(u32, v1_bytes[6..][0..4], 0, .little);
     std.mem.writeInt(u32, v1_bytes[6..][0..4], computeCrc(v1_bytes), .little);
 
-    var decoded = try deserialize(v1_bytes, key, testing.allocator);
-    defer decoded.deinit();
+    try testing.expectError(CacheError.MissingProvenance, deserialize(v1_bytes, key, testing.allocator));
+}
 
-    try testing.expect(!decoded.hasVerticalSpans());
-    const idx = 1 + data.width;
-    try testing.expectEqual(data.heightmap[idx], decoded.heightmap[idx]);
-    try testing.expectEqual(data.biomes[idx], decoded.biomes[idx]);
+test "LOD cache rejects v10 span-less payload without provenance" {
+    var data = try LODSimplifiedData.init(testing.allocator, .lod3);
+    defer data.deinit();
+
+    const key = Key{ .seed = 4, .generator_identity_hash = 5, .generator_version = 6, .rx = 1, .rz = -2, .lod = .lod3 };
+    const current_bytes = try serialize(&data, key, testing.allocator);
+    defer testing.allocator.free(current_bytes);
+    const count = @as(usize, @intCast(data.width)) * @as(usize, @intCast(data.width));
+    const legacy_size = current_bytes.len - count;
+    const legacy_bytes = try testing.allocator.alloc(u8, legacy_size);
+    defer testing.allocator.free(legacy_bytes);
+    const provenance_offset = HEADER_SIZE + payloadSize(count) + SPAN_FLAGS_WIRE_SIZE;
+    @memcpy(legacy_bytes[0..provenance_offset], current_bytes[0..provenance_offset]);
+    legacy_bytes[4] = CACHE_VERSION_V10;
+    std.mem.writeInt(u32, legacy_bytes[6..][0..4], 0, .little);
+    std.mem.writeInt(u32, legacy_bytes[6..][0..4], computeCrc(legacy_bytes), .little);
+
+    try testing.expectError(CacheError.MissingProvenance, deserialize(legacy_bytes, key, testing.allocator));
 }
 
 test "LOD cache rejects checksum mismatch" {
@@ -610,4 +636,9 @@ test "LOD cache checksum covers key header fields" {
 test "LOD cache payload size follows named wire fields" {
     try testing.expectEqual(@as(usize, 50), payloadSize(1));
     try testing.expectEqual(@as(usize, HEADER_SIZE + 50 * 4), HEADER_SIZE + payloadSize(4));
+
+    var data = try LODSimplifiedData.init(testing.allocator, .lod0);
+    defer data.deinit();
+    const count = @as(usize, @intCast(data.width)) * @as(usize, @intCast(data.width));
+    try testing.expectEqual(HEADER_SIZE + payloadSize(count) + SPAN_FLAGS_WIRE_SIZE + count, serializedSize(&data));
 }

--- a/modules/world-lod/src/lod_cache.zig
+++ b/modules/world-lod/src/lod_cache.zig
@@ -37,6 +37,7 @@ pub const CacheError = error{
     InvalidBiome,
     InvalidBlock,
     InvalidSpanCount,
+    InvalidProvenance,
     MissingProvenance,
     ChecksumMismatch,
 };
@@ -428,7 +429,7 @@ pub fn deserialize(bytes: []const u8, key: Key, allocator: std.mem.Allocator) !L
                     0 => .worldgen,
                     1 => .chunk_derived,
                     2 => .edited,
-                    else => return CacheError.InvalidSpanCount,
+                    else => return CacheError.InvalidProvenance,
                 };
                 off += 1;
             }
@@ -535,8 +536,8 @@ test "LOD cache round-trip preserves vertical spans" {
     try testing.expect(decoded.hasVerticalSpans());
     try testing.expectEqual(data.vertical_span_counts.?.len, decoded.vertical_span_counts.?.len);
     try testing.expectEqualSlices(u8, data.vertical_span_counts.?, decoded.vertical_span_counts.?);
-    try testing.expectEqual(data.vertical_spans.?.len, decoded.vertical_spans.?.len);
-    try testing.expectEqualSlices(u8, std.mem.sliceAsBytes(data.vertical_spans.?), std.mem.sliceAsBytes(decoded.vertical_spans.?));
+    try testing.expectEqual(lower, decoded.getVerticalSpan(2, 3, 0).?);
+    try testing.expectEqual(upper, decoded.getVerticalSpan(2, 3, 1).?);
 }
 
 test "LOD cache round-trip preserves span-less column provenance" {
@@ -607,6 +608,22 @@ test "LOD cache rejects checksum mismatch" {
     bytes[bytes.len - 1] ^= 0x01;
 
     try testing.expectError(CacheError.ChecksumMismatch, deserialize(bytes, key, testing.allocator));
+}
+
+test "LOD cache reports invalid provenance" {
+    var data = try LODSimplifiedData.init(testing.allocator, .lod2);
+    defer data.deinit();
+
+    const key = Key{ .seed = 1, .generator_identity_hash = 2, .generator_version = 1, .rx = 0, .rz = 0, .lod = .lod2 };
+    const bytes = try serialize(&data, key, testing.allocator);
+    defer testing.allocator.free(bytes);
+    const count = @as(usize, @intCast(data.width)) * @as(usize, @intCast(data.width));
+    const provenance_offset = HEADER_SIZE + payloadSize(count) + SPAN_FLAGS_WIRE_SIZE;
+    bytes[provenance_offset] = 3;
+    std.mem.writeInt(u32, bytes[6..][0..4], 0, .little);
+    std.mem.writeInt(u32, bytes[6..][0..4], computeCrc(bytes), .little);
+
+    try testing.expectError(CacheError.InvalidProvenance, deserialize(bytes, key, testing.allocator));
 }
 
 test "LOD cache rejects mismatched cache key" {

--- a/modules/world-lod/src/lod_cache_io.zig
+++ b/modules/world-lod/src/lod_cache_io.zig
@@ -33,6 +33,8 @@ pub const Completion = union(enum) {
         key: LODRegionKey,
         revision: u32,
         success: bool,
+        size_limited: bool,
+        store_size_cap_mb: u32,
     },
 };
 
@@ -204,17 +206,19 @@ pub const CacheIoPipeline = struct {
                 defer data.deinit();
                 const bytes = lod_cache.serialize(&data, write.cache_key, self.allocator) catch |err| {
                     log.log.warn("Failed to serialize LOD{} cache ({}, {}): {}", .{ @intFromEnum(write.region_key.lod), write.region_key.rx, write.region_key.rz, err });
-                    break :blk .{ .write = .{ .key = write.region_key, .revision = write.revision, .success = false } };
+                    break :blk .{ .write = .{ .key = write.region_key, .revision = write.revision, .success = false, .size_limited = false, .store_size_cap_mb = write.store_size_cap_mb } };
                 };
                 defer self.allocator.free(bytes);
+                var size_limited = false;
                 const success = blk_success: {
                     lod_store.writePayload(self.allocator, write.path, write.cache_key, bytes, write.store_size_cap_mb) catch |err| {
                         log.log.warn("Failed to write LOD{} store ({}, {}): {}", .{ @intFromEnum(write.region_key.lod), write.region_key.rx, write.region_key.rz, err });
+                        size_limited = err == lod_store.StoreError.StoreSizeLimit;
                         break :blk_success false;
                     };
                     break :blk_success true;
                 };
-                break :blk .{ .write = .{ .key = write.region_key, .revision = write.revision, .success = success } };
+                break :blk .{ .write = .{ .key = write.region_key, .revision = write.revision, .success = success, .size_limited = size_limited, .store_size_cap_mb = write.store_size_cap_mb } };
             },
         };
     }

--- a/modules/world-lod/src/lod_chunk.zig
+++ b/modules/world-lod/src/lod_chunk.zig
@@ -204,6 +204,10 @@ pub const LODChunk = struct {
     /// thread and prevent duplicate requests without pinning region memory.
     cache_read_queued: bool,
     store_write_queued: bool,
+    /// Suppresses retries for a snapshot that cannot fit the current store
+    /// cap. A source revision or cap increase makes it eligible again.
+    store_size_limited: bool,
+    store_size_limit_cap_mb: u32,
 
     /// Creates an empty LOD region record in the missing state.
     /// Source data, mesh handles, readiness counts, and transition state are initialized to safe defaults.
@@ -227,6 +231,8 @@ pub const LODChunk = struct {
             .source_revision = 0,
             .cache_read_queued = false,
             .store_write_queued = false,
+            .store_size_limited = false,
+            .store_size_limit_cap_mb = 0,
         };
     }
 
@@ -370,6 +376,7 @@ pub const LODChunk = struct {
     pub fn markSourceDirty(self: *LODChunk) void {
         self.dirty = true;
         self.store_dirty = true;
+        self.store_size_limited = false;
         self.source_revision +%= 1;
     }
 

--- a/modules/world-lod/src/lod_chunk.zig
+++ b/modules/world-lod/src/lod_chunk.zig
@@ -161,6 +161,11 @@ pub const LODChunk = struct {
     /// Pin count for preventing unload during async work
     pin_count: std.atomic.Value(u32),
 
+    /// Per-region cancellation signal for worker jobs invalidated by pause,
+    /// teleport, or horizon changes. Unlike the manager teardown flag, this
+    /// remains set until a new job is explicitly dispatched for the region.
+    cancel_requested: std.atomic.Value(bool),
+
     /// Chunk data - either full detail or simplified
     data: union(enum) {
         /// LOD0: Full chunk data (pointer to existing Chunk)
@@ -210,6 +215,7 @@ pub const LODChunk = struct {
             .state = .missing,
             .job_token = 0,
             .pin_count = std.atomic.Value(u32).init(0),
+            .cancel_requested = std.atomic.Value(bool).init(false),
             .data = .{ .empty = {} },
             .mesh_handle = 0,
             .min_height = 0.0,
@@ -252,6 +258,18 @@ pub const LODChunk = struct {
     /// This is an atomic read suitable for eviction checks.
     pub fn isPinned(self: *const LODChunk) bool {
         return self.pin_count.load(.monotonic) > 0;
+    }
+
+    pub fn requestCancellation(self: *LODChunk) void {
+        self.cancel_requested.store(true, .release);
+    }
+
+    pub fn resetCancellation(self: *LODChunk) void {
+        self.cancel_requested.store(false, .release);
+    }
+
+    pub fn cancellationRequested(self: *const LODChunk) bool {
+        return self.cancel_requested.load(.acquire);
     }
 
     /// Returns the immutable map key corresponding to this chunk's region coordinates and LOD level.

--- a/modules/world-lod/src/lod_ingest.zig
+++ b/modules/world-lod/src/lod_ingest.zig
@@ -575,23 +575,23 @@ test "writeIngestedColumn respects provenance authority" {
 
     // Worldgen cell can be upgraded by chunk_derived.
     data.setColumn(1, 1, 5.0, .plains, .{ .surface = .grass, .subsurface = .dirt, .foundation = .stone }, 0, LODWaterState.empty, LODLightingHint.daylight, LODVegetationHint.empty);
-    const upgraded = writeIngestedColumn(data, 1, 1, .{ .terrain_height = 40.0, .biome = .forest }, .chunk_derived);
+    const upgraded = writeIngestedColumn(&data, 1, 1, .{ .terrain_height = 40.0, .biome = .forest }, .chunk_derived);
     try testing.expect(upgraded);
     try testing.expectEqual(@as(f32, 40.0), data.getHeight(1, 1));
 
     // chunk_derived refresh can replace previous chunk_derived data.
-    const refreshed = writeIngestedColumn(data, 1, 1, .{ .terrain_height = 45.0, .biome = .forest }, .chunk_derived);
+    const refreshed = writeIngestedColumn(&data, 1, 1, .{ .terrain_height = 45.0, .biome = .forest }, .chunk_derived);
     try testing.expect(refreshed);
     try testing.expectEqual(@as(f32, 45.0), data.getHeight(1, 1));
 
     // chunk_derived must NOT be overwritten by worldgen.
-    const clobbered = writeIngestedColumn(data, 1, 1, .{ .terrain_height = 1.0, .biome = .desert }, .worldgen);
+    const clobbered = writeIngestedColumn(&data, 1, 1, .{ .terrain_height = 1.0, .biome = .desert }, .worldgen);
     try testing.expect(!clobbered);
     try testing.expectEqual(@as(f32, 45.0), data.getHeight(1, 1));
     try testing.expectEqual(BiomeId.forest, data.biomes[1 + data.width]);
 
     // edited beats chunk_derived.
-    const edited = writeIngestedColumn(data, 1, 1, .{ .terrain_height = 70.0, .biome = .mountains }, .edited);
+    const edited = writeIngestedColumn(&data, 1, 1, .{ .terrain_height = 70.0, .biome = .mountains }, .edited);
     try testing.expect(edited);
     try testing.expectEqual(@as(f32, 70.0), data.getHeight(1, 1));
     try testing.expectEqual(LODColumnProvenance.edited, data.getColumnProvenance(1, 1));

--- a/modules/world-lod/src/lod_manager.zig
+++ b/modules/world-lod/src/lod_manager.zig
@@ -172,6 +172,7 @@ pub const LODManager = struct {
     profiling: @import("lod_stats.zig").LODProfilingCollector,
     cache_hits: u32,
     cache_misses: u32,
+    cancelled_jobs: u32,
 
     // Mutex for thread safety
     mutex: sync.RwLock,

--- a/modules/world-lod/src/lod_manager_cache_ops.zig
+++ b/modules/world-lod/src/lod_manager_cache_ops.zig
@@ -108,11 +108,6 @@ pub fn drainCacheCompletions(self: *Self) void {
                             dispatch_generation = true;
                         },
                     }
-                } else if (region.cache_read_queued and region.getState() == .queued_for_generation) {
-                    // The completion belongs to an invalidated token. Do not
-                    // apply it, but release the request gate so the current
-                    // revision can enqueue its own read next update.
-                    region.cache_read_queued = false;
                 }
             }
             self.mutex.unlock();
@@ -332,6 +327,7 @@ pub fn initCacheTestManager(allocator: std.mem.Allocator, cache_dir_path: []cons
         .profiling = .init(false),
         .cache_hits = 0,
         .cache_misses = 0,
+        .cancelled_jobs = 0,
         .mutex = .{},
         .gpu_bridge = undefined,
         .generator = .{ .ptr = undefined, .generate_heightmap_only = undefined, .maybe_recenter_cache = undefined, .seed = 42, .identity_hash = 99, .version = 7 },

--- a/modules/world-lod/src/lod_manager_cache_ops.zig
+++ b/modules/world-lod/src/lod_manager_cache_ops.zig
@@ -115,11 +115,16 @@ pub fn drainCacheCompletions(self: *Self) void {
             if (dispatch_generation) self.dispatchCacheMiss(read.key, read.token);
         },
         .write => |write| {
+            // Explicit saveCachedSourceData requests are not tied to a live
+            // region lifecycle and use revision zero.
+            if (write.revision == 0) continue;
             self.mutex.lock();
             if (self.regions[@intFromEnum(write.key.lod)].get(write.key)) |region| {
                 if (region.store_write_queued and region.source_revision == write.revision) {
                     region.store_write_queued = false;
                     region.store_dirty = !write.success;
+                    region.store_size_limited = write.size_limited;
+                    region.store_size_limit_cap_mb = if (write.size_limited) write.store_size_cap_mb else 0;
                 } else if (region.store_write_queued) {
                     // A newer source snapshot arrived while this write was in
                     // flight. Preserve dirty state and let a later update
@@ -146,6 +151,8 @@ fn queueDirtyStores(self: *Self, max_count: usize) usize {
             if (queued >= max_count) break;
             const region = entry.value_ptr.*;
             if (!region.store_dirty or region.store_write_queued) continue;
+            const store_size_cap_mb = if (self.cache_store.use_config_store_size_cap) self.config.getLODStoreSizeCapMB() else self.cache_store.store_size_cap_mb;
+            if (region.store_size_limited and store_size_cap_mb <= region.store_size_limit_cap_mb) continue;
             const snapshot = switch (region.data) {
                 .simplified => |*data| lod_cache.cloneSourceData(data, entry.key_ptr.*.lod, self.allocator) catch |err| {
                     log.log.warn("Failed to snapshot LOD{} cache ({}, {}): {}", .{ @intFromEnum(entry.key_ptr.*.lod), entry.key_ptr.*.rx, entry.key_ptr.*.rz, err });
@@ -155,7 +162,6 @@ fn queueDirtyStores(self: *Self, max_count: usize) usize {
             };
             const key = entry.key_ptr.*;
             const revision = region.source_revision;
-            const store_size_cap_mb = if (self.cache_store.use_config_store_size_cap) self.config.getLODStoreSizeCapMB() else self.cache_store.store_size_cap_mb;
             region.store_write_queued = true;
             const accepted = self.cache_io.enqueueWrite(path, key, self.cacheKey(key), revision, snapshot, store_size_cap_mb) catch |err| blk: {
                 log.log.warn("Failed to queue LOD{} cache write ({}, {}): {}", .{ @intFromEnum(key.lod), key.rx, key.rz, err });

--- a/modules/world-lod/src/lod_manager_core_ops.zig
+++ b/modules/world-lod/src/lod_manager_core_ops.zig
@@ -66,6 +66,7 @@ const LOD_FRAME_DT_APPROX = manager_ctx.LOD_FRAME_DT_APPROX;
 const lodUploadBudgetBytes = manager_ctx.lodUploadBudgetBytes;
 const wouldExceedUploadBudget = manager_ctx.wouldExceedUploadBudget;
 const isUploadPressureError = manager_ctx.isUploadPressureError;
+const TELEPORT_CANCEL_DISTANCE_CHUNKS: i32 = 32;
 
 pub fn storePlayerChunkPos(self: *Self, cx: i32, cz: i32) void {
     self.player_cx.store(cx, .release);
@@ -136,6 +137,7 @@ pub fn init(allocator: std.mem.Allocator, config: ILODConfig, gpu_bridge: LODGPU
         .profiling = .init(engine_core.envFlag("ZIGCRAFT_LOD_PROFILE", false) or lod_options.benchmark_lod_profile),
         .cache_hits = 0,
         .cache_misses = 0,
+        .cancelled_jobs = 0,
         .mutex = .{},
         .gpu_bridge = gpu_bridge,
         .generator = generator,
@@ -177,6 +179,13 @@ pub fn deinit(self: *Self) void {
     // This is the ONLY place stop_flag is set: normal pause()/unpause() and
     // map-open leave it false so LOD generation runs uninterrupted.
     self.job_dispatcher.stop_flag.store(true, .release);
+
+    self.mutex.lock();
+    for (0..LODLevel.count) |i| {
+        var iter = self.regions[i].iterator();
+        while (iter.next()) |entry| entry.value_ptr.*.requestCancellation();
+    }
+    self.mutex.unlock();
 
     // Stop and cleanup queues
     for (0..LODLevel.count) |i| {
@@ -260,7 +269,13 @@ pub fn update(self: *Self, player_pos: Vec3, player_velocity: Vec3, chunk_checke
     if (!std.math.isFinite(player_pos.x) or !std.math.isFinite(player_pos.z)) return;
 
     const pc = worldToChunkFromFloat(player_pos.x, player_pos.z);
+    const previous_pc = self.loadPlayerChunkPos();
     self.storePlayerChunkPos(pc.chunk_x, pc.chunk_z);
+    const moved_x = @abs(@as(i64, pc.chunk_x) - @as(i64, previous_pc.cx));
+    const moved_z = @abs(@as(i64, pc.chunk_z) - @as(i64, previous_pc.cz));
+    if (moved_x >= TELEPORT_CANCEL_DISTANCE_CHUNKS or moved_z >= TELEPORT_CANCEL_DISTANCE_CHUNKS) {
+        cancelWorkOutsideHorizon(self, pc.chunk_x, pc.chunk_z);
+    }
 
     // Keep LOD job priorities fresh as the player moves. doReprioritize is
     // LOD-aware (scales region coords to chunk space, preserves LOD-bias
@@ -380,33 +395,69 @@ pub fn pause(self: *Self) void {
         self.job_dispatcher.queues[i].setPaused(true);
     }
 
-    // setPaused clears jobs that have not reached a worker. Reconcile their
-    // lifecycle states while holding the manager lock; otherwise they would
-    // remain permanently .generating/.meshing with no queued job. A pinned
-    // chunk belongs to a worker that already accepted its job, so leave both
-    // its state and token intact for that worker to publish safely.
+    // setPaused clears queued jobs. In-flight jobs are cancelled through their
+    // per-region signal and token so they cannot publish stale data after an
+    // unpause, even when unpause happens before a worker checks cancellation.
     self.mutex.lock();
     defer self.mutex.unlock();
     for (0..LODLevel.count) |i| {
         var iter = self.regions[i].iterator();
         while (iter.next()) |entry| {
             const chunk = entry.value_ptr.*;
-            if (chunk.isPinned()) continue;
             switch (chunk.getState()) {
                 .generating => {
+                    chunk.requestCancellation();
                     chunk.job_token +%= 1;
+                    chunk.cache_read_queued = false;
                     if (self.pending_region_count > 0) self.pending_region_count -= 1;
                     chunk.setState(.missing);
+                    self.cancelled_jobs +|= 1;
                 },
                 .meshing => {
+                    chunk.requestCancellation();
                     chunk.job_token +%= 1;
                     // The generated source data remains valid. Requeue the
                     // mesh transition after unpause without discarding its
                     // pending admission slot.
                     chunk.setState(.generated);
+                    self.cancelled_jobs +|= 1;
+                },
+                .queued_for_generation => {
+                    chunk.requestCancellation();
+                    chunk.job_token +%= 1;
+                    chunk.cache_read_queued = false;
+                    if (self.pending_region_count > 0) self.pending_region_count -= 1;
+                    chunk.setState(.missing);
+                    self.cancelled_jobs +|= 1;
                 },
                 else => {},
             }
+        }
+    }
+}
+
+pub fn cancelWorkOutsideHorizon(self: *Self, player_cx: i32, player_cz: i32) void {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+    const radii = self.config.getRadii();
+    const active = lod_chunk.activeLODCount(self.config);
+    for (0..LODLevel.count) |i| {
+        var iter = self.regions[i].iterator();
+        while (iter.next()) |entry| {
+            const chunk = entry.value_ptr.*;
+            switch (chunk.getState()) {
+                .queued_for_generation, .generating, .meshing => {},
+                else => continue,
+            }
+            if (i < active and entry.key_ptr.*.chunkBounds().intersectsRadius(player_cx, player_cz, radii[i])) continue;
+
+            const was_generation = chunk.getState() != .meshing;
+            chunk.requestCancellation();
+            chunk.job_token +%= 1;
+            chunk.cache_read_queued = false;
+            if (was_generation and self.pending_region_count > 0) self.pending_region_count -= 1;
+            chunk.setState(if (was_generation) .missing else .generated);
+            self.cancelled_jobs +|= 1;
         }
     }
 }

--- a/modules/world-lod/src/lod_manager_core_ops.zig
+++ b/modules/world-lod/src/lod_manager_core_ops.zig
@@ -273,7 +273,8 @@ pub fn update(self: *Self, player_pos: Vec3, player_velocity: Vec3, chunk_checke
     self.storePlayerChunkPos(pc.chunk_x, pc.chunk_z);
     const moved_x = @abs(@as(i64, pc.chunk_x) - @as(i64, previous_pc.cx));
     const moved_z = @abs(@as(i64, pc.chunk_z) - @as(i64, previous_pc.cz));
-    if (moved_x >= TELEPORT_CANCEL_DISTANCE_CHUNKS or moved_z >= TELEPORT_CANCEL_DISTANCE_CHUNKS) {
+    const teleport_distance_sq = @as(i64, TELEPORT_CANCEL_DISTANCE_CHUNKS) * TELEPORT_CANCEL_DISTANCE_CHUNKS;
+    if (moved_x * moved_x + moved_z * moved_z >= teleport_distance_sq) {
         cancelWorkOutsideHorizon(self, pc.chunk_x, pc.chunk_z);
     }
 

--- a/modules/world-lod/src/lod_manager_eviction_ops.zig
+++ b/modules/world-lod/src/lod_manager_eviction_ops.zig
@@ -313,6 +313,7 @@ pub fn updateStats(self: *Self) void {
     self.stats.store_misses = self.cache_misses;
     self.stats.cache_hits = self.cache_hits;
     self.stats.cache_misses = self.cache_misses;
+    self.stats.cancelled_jobs = self.cancelled_jobs;
     self.memory_governor.used_bytes = mem_usage;
     self.profiling.setPendingCpuUploadBytes(pending_cpu_upload_bytes);
 

--- a/modules/world-lod/src/lod_manager_generation_ops.zig
+++ b/modules/world-lod/src/lod_manager_generation_ops.zig
@@ -210,6 +210,7 @@ fn dispatchGenerationCandidate(self: *Self, candidate: GenerationCandidate) !voi
         self.mutex.unlock();
         return;
     }
+    candidate.chunk.resetCancellation();
     candidate.chunk.setState(.generating);
     self.mutex.unlock();
 
@@ -261,6 +262,7 @@ pub fn processStateTransitions(self: *Self, velocity: Vec3) !void {
         var iter = self.regions[i].iterator();
         while (iter.next()) |entry| {
             const chunk = entry.value_ptr.*;
+            if (chunk.isPinned()) continue;
             if (chunk.getState() == .generated) {
                 const center_cx = chunk.region_x * scale + @divFloor(scale, 2);
                 const center_cz = chunk.region_z * scale + @divFloor(scale, 2);
@@ -299,6 +301,7 @@ pub fn processStateTransitions(self: *Self, velocity: Vec3) !void {
             continue;
         }
         mc.chunk.setState(.meshing);
+        mc.chunk.resetCancellation();
         self.job_dispatcher.queues[LODLevel.count - 1].push(.{
             .type = .chunk_meshing,
             .dist_sq = mc.encoded_priority,
@@ -446,6 +449,13 @@ pub fn processLODJob(ctx: *anyopaque, job: Job) void {
         return;
     };
 
+    // Reject invalidated work before any state reconciliation. A stale queued
+    // job must never demote a newer job for the same region.
+    if (chunk.job_token != job.data.chunk.job_token) {
+        self.mutex.unlock();
+        return;
+    }
+
     // Stale job check (too far from player)
     const player = self.loadPlayerChunkPos();
     const radius = job.data.chunk.lod_radius;
@@ -461,12 +471,6 @@ pub fn processLODJob(ctx: *anyopaque, job: Job) void {
             if (self.pending_region_count > 0) self.pending_region_count -= 1;
             chunk.setState(.missing);
         }
-        self.mutex.unlock();
-        return;
-    }
-
-    // Skip if token mismatch
-    if (chunk.job_token != job.data.chunk.job_token) {
         self.mutex.unlock();
         return;
     }
@@ -530,14 +534,14 @@ pub fn processLODJob(ctx: *anyopaque, job: Job) void {
                     };
 
                 // Generate heightmap data (expensive, done without lock).
-                // Pass the stop flag so teardown/pause can interrupt the
-                // multi-second coarse-LOD heightmap loop instead of
-                // forcing the worker-join to block until it finishes.
-                self.generator.generateHeightmapOnly(&data, chunk.region_x, chunk.region_z, lod_level, &self.job_dispatcher.stop_flag);
+                // Pass the region cancellation signal so pause and teleport
+                // can interrupt a multi-second coarse-LOD generation loop.
+                // Teardown sets both the manager flag and every region signal.
+                self.generator.generateHeightmapOnly(&data, chunk.region_x, chunk.region_z, lod_level, &chunk.cancel_requested);
 
                 // If generation was aborted, discard the partial data
                 // and leave the chunk in .missing so it re-generates later.
-                if (self.job_dispatcher.stop_flag.load(.acquire)) {
+                if (self.job_dispatcher.stop_flag.load(.acquire) or chunk.cancellationRequested()) {
                     data.deinit();
                     new_state = .missing;
                     self.mutex.lock();

--- a/modules/world-lod/src/lod_manager_ingestion_ops.zig
+++ b/modules/world-lod/src/lod_manager_ingestion_ops.zig
@@ -133,7 +133,8 @@ pub fn applyIngestionToRegions(self: *Self, cx: i32, cz: i32, chunk: *const Chun
                 // Defer if a mesh/generation/upload job is mid-flight for
                 // this region: writing source data concurrently with a
                 // mesh job reading it (under the shared lock) would race.
-                if (lod_chunk_ptr.getState() == .generating or
+                if (lod_chunk_ptr.isPinned() or
+                    lod_chunk_ptr.getState() == .generating or
                     lod_chunk_ptr.getState() == .meshing or
                     lod_chunk_ptr.getState() == .uploading)
                 {

--- a/modules/world-lod/src/lod_manager_internal_tests.zig
+++ b/modules/world-lod/src/lod_manager_internal_tests.zig
@@ -26,6 +26,7 @@ const LODManager = manager_mod.LODManager;
 const MAX_CACHE_LOADS_PER_UPDATE = @import("lod_manager_context.zig").MAX_CACHE_LOADS_PER_UPDATE;
 const DEFAULT_LOD_UPLOAD_BUDGET_BYTES = @import("lod_manager_context.zig").DEFAULT_LOD_UPLOAD_BUDGET_BYTES;
 const wouldExceedUploadBudget = @import("lod_manager_context.zig").wouldExceedUploadBudget;
+const cancelWorkOutsideHorizon = @import("lod_manager_core_ops.zig").cancelWorkOutsideHorizon;
 const testing = std.testing;
 
 test "LODManager cache helpers save and reload source data" {
@@ -487,7 +488,7 @@ test "LODManager staging pressure failure stops upload sweep" {
     try testing.expectEqual(@as(u32, 1), manager.stats.upload_failures);
 }
 
-test "LODManager pause reconciles cleared jobs while preserving pinned work" {
+test "LODManager pause cancels queued and pinned stale work" {
     var config = LODConfig{};
     var manager = try initEvictionTestManager(testing.allocator, &config);
     defer deinitEvictionTestManager(&manager);
@@ -517,11 +518,39 @@ test "LODManager pause reconciles cleared jobs while preserving pinned work" {
     try testing.expectEqual(@as(u32, 12), queued_generation.job_token);
     try testing.expectEqual(LODState.generated, queued_mesh.state);
     try testing.expectEqual(@as(u32, 13), queued_mesh.job_token);
-    try testing.expectEqual(LODState.generating, running_generation.state);
-    try testing.expectEqual(@as(u32, 13), running_generation.job_token);
-    try testing.expectEqual(LODState.meshing, running_mesh.state);
-    try testing.expectEqual(@as(u32, 14), running_mesh.job_token);
-    try testing.expectEqual(@as(usize, 3), manager.pending_region_count);
+    try testing.expectEqual(LODState.missing, running_generation.state);
+    try testing.expectEqual(@as(u32, 14), running_generation.job_token);
+    try testing.expect(running_generation.cancellationRequested());
+    try testing.expectEqual(LODState.generated, running_mesh.state);
+    try testing.expectEqual(@as(u32, 15), running_mesh.job_token);
+    try testing.expect(running_mesh.cancellationRequested());
+    try testing.expectEqual(@as(usize, 2), manager.pending_region_count);
+    try testing.expectEqual(@as(u32, 4), manager.cancelled_jobs);
+}
+
+test "LODManager traversal cancels work outside its level horizon" {
+    var config = LODConfig{ .radii = .{ 8, 16, 32, 64, 128 } };
+    var manager = try initEvictionTestManager(testing.allocator, &config);
+    defer deinitEvictionTestManager(&manager);
+
+    const near = try putTestRegion(&manager, .{ .rx = 0, .rz = 0, .lod = .lod1 }, .generating);
+    near.job_token = 7;
+    const stale = try putTestRegion(&manager, .{ .rx = 100, .rz = 100, .lod = .lod1 }, .generating);
+    stale.job_token = 9;
+    stale.cache_read_queued = true;
+    manager.pending_region_count = 2;
+
+    cancelWorkOutsideHorizon(&manager, 0, 0);
+
+    try testing.expectEqual(LODState.generating, near.state);
+    try testing.expectEqual(@as(u32, 7), near.job_token);
+    try testing.expect(!near.cancellationRequested());
+    try testing.expectEqual(LODState.missing, stale.state);
+    try testing.expectEqual(@as(u32, 10), stale.job_token);
+    try testing.expect(stale.cancellationRequested());
+    try testing.expect(!stale.cache_read_queued);
+    try testing.expectEqual(@as(usize, 1), manager.pending_region_count);
+    try testing.expectEqual(@as(u32, 1), manager.cancelled_jobs);
 }
 
 test "LODManager ready child counters update on renderable transitions and removal" {

--- a/modules/world-lod/src/lod_manager_internal_tests.zig
+++ b/modules/world-lod/src/lod_manager_internal_tests.zig
@@ -209,6 +209,9 @@ test "LODManager queued generation applies source-store completion asynchronousl
             manager.job_dispatcher.queues[i].deinit();
             testing.allocator.destroy(manager.job_dispatcher.queues[i]);
         }
+        manager.generation_candidates_scratch.deinit(testing.allocator);
+        manager.mesh_candidates_scratch.deinit(testing.allocator);
+        manager.upload_candidates_scratch.deinit(testing.allocator);
     }
 
     const chunk = try testing.allocator.create(LODChunk);
@@ -276,6 +279,9 @@ test "LODManager queued generation dispatches beyond cache read budget" {
             manager.job_dispatcher.queues[i].deinit();
             testing.allocator.destroy(manager.job_dispatcher.queues[i]);
         }
+        manager.generation_candidates_scratch.deinit(testing.allocator);
+        manager.mesh_candidates_scratch.deinit(testing.allocator);
+        manager.upload_candidates_scratch.deinit(testing.allocator);
     }
 
     const candidate_count = MAX_CACHE_LOADS_PER_UPDATE + 4;
@@ -350,6 +356,9 @@ fn deinitEvictionTestManager(manager: *LODManager) void {
     }
     manager.mesh_disposal.queue.deinit(manager.allocator);
     manager.ingestion_queue.edit_dirty.deinit();
+    manager.generation_candidates_scratch.deinit(manager.allocator);
+    manager.mesh_candidates_scratch.deinit(manager.allocator);
+    manager.upload_candidates_scratch.deinit(manager.allocator);
 }
 
 fn putTestRegion(manager: *LODManager, key: LODRegionKey, state: LODState) !*LODChunk {
@@ -376,6 +385,36 @@ fn putTestPendingMesh(manager: *LODManager, key: LODRegionKey, vertex_count: usi
     mesh.pending_vertices = try manager.allocator.alloc(Vertex, vertex_count);
     try manager.meshes[@intFromEnum(key.lod)].put(key, mesh);
     return mesh;
+}
+
+test "LODManager backs off size-limited store writes until the cap changes" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const save_dir = try dir.realpath(".", &path_buf);
+
+    var config = LODConfig{ .lod_store_size_cap_mb = 1 };
+    var manager = try initEvictionTestManager(testing.allocator, &config);
+    defer deinitEvictionTestManager(&manager);
+    manager.cache_store.cache_dir_path = try testing.allocator.dupe(u8, save_dir);
+    defer testing.allocator.free(manager.cache_store.cache_dir_path.?);
+    manager.cache_store.use_config_store_size_cap = true;
+
+    const key = LODRegionKey{ .rx = 0, .rz = 0, .lod = .lod1 };
+    const chunk = try putTestRegion(&manager, key, .generated);
+    chunk.data = .{ .simplified = try LODSimplifiedData.init(testing.allocator, .lod1) };
+    chunk.store_dirty = true;
+    chunk.store_size_limited = true;
+    chunk.store_size_limit_cap_mb = 1;
+
+    manager.flushDirtyStores();
+    try testing.expect(!chunk.store_write_queued);
+    try testing.expect(chunk.store_dirty);
+
+    config.lod_store_size_cap_mb = 2;
+    manager.flushDirtyStores();
+    try testing.expect(chunk.store_write_queued);
 }
 
 const UploadMock = struct {

--- a/modules/world-lod/src/lod_manager_tests.zig
+++ b/modules/world-lod/src/lod_manager_tests.zig
@@ -405,6 +405,29 @@ test "ingestChunk upgrades worldgen region data and schedules a remesh" {
     try std.testing.expect(lchunk.store_dirty);
 }
 
+test "ingestChunk defers while a cancelled worker still pins source data" {
+    const allocator = std.testing.allocator;
+    var config = LODConfig{ .radii = .{ 2, 4, 8, 16, 32 } };
+    const mgr = try buildIngestionManager(allocator, &config);
+    defer mgr.deinit();
+
+    const lchunk = try placeSimplifiedRegion(mgr, allocator, 0, 0, .lod1);
+    lchunk.data.simplified.setColumn(0, 0, 10.0, .plains, .{ .surface = .grass, .subsurface = .dirt, .foundation = .stone }, 0x4D8033, .empty, .daylight, .empty);
+    lchunk.state = .generated;
+    lchunk.pin();
+    defer lchunk.unpin();
+
+    var chunk = Chunk.init(0, 0);
+    var y: u32 = 0;
+    while (y <= 64) : (y += 1) chunk.setBlock(0, y, 0, .stone);
+
+    mgr.ingestChunk(0, 0, &chunk, .edited);
+
+    try std.testing.expectEqual(@as(f32, 10.0), lchunk.data.simplified.getHeight(0, 0));
+    try std.testing.expectEqual(LODColumnProvenance.worldgen, lchunk.data.simplified.getColumnProvenance(0, 0));
+    try std.testing.expect(mgr.ingestion_queue.pending_ingestions.items.len > 0);
+}
+
 test "ingestChunk provenance authority: edited beats chunk_derived, worldgen cannot overwrite" {
     const allocator = std.testing.allocator;
     var config = LODConfig{ .radii = .{ 2, 4, 8, 16, 32 } };

--- a/modules/world-lod/src/lod_manager_tests.zig
+++ b/modules/world-lod/src/lod_manager_tests.zig
@@ -6,19 +6,20 @@ const Vec3 = @import("engine-math").Vec3;
 const rhi_types = @import("engine-rhi").rhi_types;
 const Chunk = @import("world-core").Chunk;
 const world_core = @import("world-core");
-const lod_manager = @import("world-lod").lod_manager;
+const lod_manager = @import("lod_manager.zig");
 const LODManager = lod_manager.LODManager;
+const LODGenerator = @import("lod_generator.zig").LODGenerator;
 const LODStats = lod_manager.LODStats;
 const LODProfilingCollector = @import("lod_stats.zig").LODProfilingCollector;
-const MAX_LOD_REGIONS = lod_manager.MAX_LOD_REGIONS;
-const lod_chunk = @import("world-lod").lod_chunk;
+const MAX_LOD_REGIONS = @import("lod_manager_context.zig").MAX_LOD_REGIONS;
+const lod_chunk = @import("lod_chunk.zig");
 const LODLevel = lod_chunk.LODLevel;
 const LODConfig = lod_chunk.LODConfig;
 const ILODConfig = lod_chunk.ILODConfig;
 const LODChunk = lod_chunk.LODChunk;
 const LODSimplifiedData = lod_chunk.LODSimplifiedData;
-const LODMesh = @import("world-lod").LODMesh;
-const lod_gpu = @import("world-lod").lod_upload_queue;
+const LODMesh = @import("lod_mesh.zig").LODMesh;
+const lod_gpu = @import("lod_upload_queue.zig");
 const LODGPUBridge = lod_gpu.LODGPUBridge;
 const LODRenderInterface = lod_gpu.LODRenderInterface;
 const MeshMap = lod_gpu.MeshMap;
@@ -31,6 +32,17 @@ const ColumnInfo = world_worldgen.ColumnInfo;
 const Generator = world_worldgen.Generator;
 const RegionInfo = world_worldgen.region.RegionInfo;
 
+fn lodGeneratorFromGenerator(generator: Generator) LODGenerator {
+    return .{
+        .ptr = generator.ptr,
+        .generate_heightmap_only = generator.vtable.generateHeightmapOnly,
+        .maybe_recenter_cache = generator.vtable.maybeRecenterCache,
+        .seed = generator.getSeed(),
+        .identity_hash = std.hash.Wyhash.hash(0, generator.info.name),
+        .version = generator.info.version,
+    };
+}
+
 test "LODManager initialization" {
     const allocator = std.testing.allocator;
 
@@ -40,7 +52,7 @@ test "LODManager initialization" {
     };
 
     const MockGenerator = struct {
-        fn generate(_: *anyopaque, _: *Chunk, _: ?*const bool) void {}
+        fn generate(_: *anyopaque, _: *Chunk, _: ?*const bool) error{OutOfMemory}!void {}
         fn generateHeightmapOnly(_: *anyopaque, _: *LODSimplifiedData, _: i32, _: i32, _: LODLevel, _: ?*const std.atomic.Value(bool)) void {}
         fn maybeRecenterCache(_: *anyopaque, _: i32, _: i32) bool {
             return false;
@@ -71,7 +83,7 @@ test "LODManager initialization" {
     const mock_gen = Generator{
         .ptr = &mock_gen_impl,
         .vtable = &MockGenerator.vtable,
-        .info = .{ .name = "Mock", .description = "Mock Generator" },
+        .info = .{ .name = "Mock", .description = "Mock Generator", .version = 1 },
     };
 
     var config = LODConfig{
@@ -118,7 +130,7 @@ test "LODManager initialization" {
         .tile_mappings = [_]TextureAtlas.BlockTiles{TextureAtlas.BlockTiles.uniform(0)} ** MAX_BLOCK_TYPES,
     };
 
-    var mgr = try LODManager.init(allocator, config.interface(), mock_bridge, mock_render, mock_gen.toLODGenerator(), &mock_atlas);
+    var mgr = try LODManager.init(allocator, config.interface(), mock_bridge, mock_render, lodGeneratorFromGenerator(mock_gen), &mock_atlas);
     mgr.cleanup_covered_regions = false;
 
     const stats = mgr.getStats();
@@ -137,7 +149,7 @@ test "LODManager end-to-end covered cleanup" {
     const allocator = std.testing.allocator;
 
     const MockGenerator = struct {
-        fn generate(_: *anyopaque, _: *Chunk, _: ?*const bool) void {}
+        fn generate(_: *anyopaque, _: *Chunk, _: ?*const bool) error{OutOfMemory}!void {}
         fn generateHeightmapOnly(_: *anyopaque, _: *LODSimplifiedData, _: i32, _: i32, _: LODLevel, _: ?*const std.atomic.Value(bool)) void {}
         fn maybeRecenterCache(_: *anyopaque, _: i32, _: i32) bool {
             return false;
@@ -168,7 +180,7 @@ test "LODManager end-to-end covered cleanup" {
     const mock_gen = Generator{
         .ptr = &mock_gen_impl,
         .vtable = &MockGenerator.vtable,
-        .info = .{ .name = "Mock", .description = "Mock Generator" },
+        .info = .{ .name = "Mock", .description = "Mock Generator", .version = 1 },
     };
 
     var config = LODConfig{
@@ -212,7 +224,7 @@ test "LODManager end-to-end covered cleanup" {
         .tile_mappings = [_]TextureAtlas.BlockTiles{TextureAtlas.BlockTiles.uniform(0)} ** MAX_BLOCK_TYPES,
     };
 
-    var mgr = try LODManager.init(allocator, config.interface(), mock_bridge, mock_render, mock_gen.toLODGenerator(), &mock_atlas);
+    var mgr = try LODManager.init(allocator, config.interface(), mock_bridge, mock_render, lodGeneratorFromGenerator(mock_gen), &mock_atlas);
     mgr.cleanup_covered_regions = false;
     defer mgr.deinit();
 
@@ -288,7 +300,7 @@ test "LODManager constants" {
 /// `config` (it must outlive the returned manager, since ILODConfig references it).
 fn buildIngestionManager(allocator: std.mem.Allocator, config: *LODConfig) !*LODManager {
     const MockGenerator = struct {
-        fn generate(_: *anyopaque, _: *Chunk, _: ?*const bool) void {}
+        fn generate(_: *anyopaque, _: *Chunk, _: ?*const bool) error{OutOfMemory}!void {}
         fn generateHeightmapOnly(_: *anyopaque, _: *LODSimplifiedData, _: i32, _: i32, _: LODLevel, _: ?*const std.atomic.Value(bool)) void {}
         fn maybeRecenterCache(_: *anyopaque, _: i32, _: i32) bool {
             return false;
@@ -319,7 +331,7 @@ fn buildIngestionManager(allocator: std.mem.Allocator, config: *LODConfig) !*LOD
     const mock_gen = Generator{
         .ptr = &mock_gen_impl,
         .vtable = &MockGenerator.vtable,
-        .info = .{ .name = "Mock", .description = "Mock Generator" },
+        .info = .{ .name = "Mock", .description = "Mock Generator", .version = 1 },
     };
 
     var noop_ctx: u8 = 0;
@@ -359,7 +371,7 @@ fn buildIngestionManager(allocator: std.mem.Allocator, config: *LODConfig) !*LOD
         .tile_mappings = [_]TextureAtlas.BlockTiles{TextureAtlas.BlockTiles.uniform(0)} ** MAX_BLOCK_TYPES,
     };
 
-    const mgr = try LODManager.init(allocator, config.interface(), mock_bridge, mock_render, mock_gen.toLODGenerator(), &mock_atlas);
+    const mgr = try LODManager.init(allocator, config.interface(), mock_bridge, mock_render, lodGeneratorFromGenerator(mock_gen), &mock_atlas);
     mgr.cleanup_covered_regions = false;
     return mgr;
 }
@@ -492,7 +504,7 @@ test "markChunkEdited coalesces and re-ingests via the resolver on update" {
     mgr.markChunkEdited(0, 0);
 
     // update() drains the edit queue on its cooldown (starts expired).
-    try mgr.update(Vec3.zero, Vec3.zero, null, null);
+    for (0..4) |_| try mgr.update(Vec3.zero, Vec3.zero, null, null);
 
     try std.testing.expectEqual(@as(f32, 90.0), lchunk.data.simplified.getHeight(0, 0));
     try std.testing.expectEqual(LODColumnProvenance.edited, lchunk.data.simplified.getColumnProvenance(0, 0));
@@ -510,10 +522,10 @@ test "enforceMemoryBudget shrinks finer radii under sustained pressure and spare
 
     // Force sustained over-budget state with no evictable regions, so the
     // hysteresis grow path must fire.
-    mgr.memory_used_bytes = 50_000_000;
-    try mgr.update(Vec3.zero, Vec3.zero, null, null);
+    mgr.memory_governor.used_bytes = 50_000_000;
+    try mgr.enforceMemoryBudget();
 
     // Finer levels (1..count-2) must have grown; coarsest (horizon) untouched.
-    try std.testing.expect(mgr.radius_shrink_chunks[1] > 0);
-    try std.testing.expectEqual(@as(i32, 0), mgr.radius_shrink_chunks[LODLevel.count - 1]);
+    try std.testing.expect(mgr.memory_governor.radius_shrink_chunks[1] > 0);
+    try std.testing.expectEqual(@as(i32, 0), mgr.memory_governor.radius_shrink_chunks[LODLevel.count - 1]);
 }

--- a/modules/world-lod/src/lod_scheduler.zig
+++ b/modules/world-lod/src/lod_scheduler.zig
@@ -192,7 +192,10 @@ pub fn queueLODRegions(ctx: SchedulerContext, lod: LODLevel, velocity: Vec3, chu
 
         const existing = storage.get(cand.key);
         if (existing != null) diag.existing += 1;
-        const needs_queue = if (existing) |chunk| chunk.getState() == .missing else true;
+        // A cancelled worker keeps the region pinned until it observes its
+        // cancellation signal. Do not reset that signal by dispatching a new
+        // generation for the same region concurrently.
+        const needs_queue = if (existing) |chunk| chunk.getState() == .missing and !chunk.isPinned() else true;
         if (!needs_queue) continue;
 
         const chunk = if (existing) |c| c else blk: {
@@ -208,6 +211,7 @@ pub fn queueLODRegions(ctx: SchedulerContext, lod: LODLevel, velocity: Vec3, chu
         if (ctx.defer_generation_dispatch) {
             chunk.setState(.queued_for_generation);
         } else {
+            chunk.resetCancellation();
             chunk.setState(.generating);
             queue.push(.{
                 .type = .chunk_generation,

--- a/modules/world-lod/src/lod_stats.zig
+++ b/modules/world-lod/src/lod_stats.zig
@@ -309,6 +309,8 @@ pub const LODStats = struct {
     upgrades_pending: u32 = 0,
     downgrades_pending: u32 = 0,
     upload_failures: u32 = 0,
+    /// Worker and queued jobs invalidated before stale results could publish.
+    cancelled_jobs: u32 = 0,
 
     pub fn totalLoaded(self: *const LODStats) u32 {
         var total: u32 = 0;
@@ -347,6 +349,7 @@ pub const LODStats = struct {
         self.downgrades_pending = 0;
         self.upload_failures = 0;
         self.ingestion_backlog = 0;
+        self.cancelled_jobs = 0;
     }
 
     pub fn recordState(self: *LODStats, lod_idx: usize, state: LODState) void {

--- a/modules/world-lod/src/lod_store.zig
+++ b/modules/world-lod/src/lod_store.zig
@@ -264,7 +264,10 @@ fn writeCompactedContainer(allocator: std.mem.Allocator, path: []const u8, tmp_p
         }
     }
 
-    try region.writeChunk(target_x, target_z, bytes);
+    region.writeChunk(target_x, target_z, bytes) catch |err| {
+        if (err == error.FileTooShort) return StoreError.StoreSizeLimit;
+        return err;
+    };
     region.close();
 }
 
@@ -331,6 +334,7 @@ pub fn writePayload(allocator: std.mem.Allocator, save_dir_path: []const u8, key
         region.writeChunk(localCoord(key.rx), localCoord(key.rz), bytes) catch |err| {
             region.close();
             fs.cwd().deleteFile(tmp_path) catch {};
+            if (err == error.FileTooShort) return StoreError.StoreSizeLimit;
             return err;
         };
         region.close();

--- a/modules/world-lod/src/lod_store.zig
+++ b/modules/world-lod/src/lod_store.zig
@@ -18,6 +18,7 @@ pub const StoreHeader = struct {
 
 pub const StoreError = error{
     CorruptContainer,
+    StoreSizeLimit,
 };
 
 pub fn headersMatch(a: StoreHeader, b: StoreHeader) bool {
@@ -129,6 +130,144 @@ fn storeSizeCapBytes(cap_mb: u32) usize {
     return @as(usize, @max(cap_mb, 1)) * 1024 * 1024;
 }
 
+const ContainerCandidate = struct {
+    path: []u8,
+    mtime_ns: i96,
+};
+
+const StoreUsage = struct {
+    total_size: u64 = 0,
+    oldest_candidate: ?ContainerCandidate = null,
+};
+
+fn isActiveLodDirectory(name: []const u8) bool {
+    const lod_index = std.fmt.parseInt(u8, name, 10) catch return false;
+    return lod_index < @import("lod_types.zig").LODLevel.count;
+}
+
+fn isOlderContainer(candidate: ContainerCandidate, path: []const u8, mtime_ns: i96) bool {
+    return mtime_ns < candidate.mtime_ns or
+        (mtime_ns == candidate.mtime_ns and std.mem.order(u8, path, candidate.path) == .lt);
+}
+
+/// Returns the total size of all LOD containers and the oldest removable one.
+///
+/// This only retains one candidate path, so eviction memory use remains bounded
+/// regardless of how many containers are on disk. Files that cannot be opened
+/// or statted are skipped; malformed region contents need not be parsed to
+/// account for their on-disk size.
+fn scanStoreUsage(allocator: std.mem.Allocator, lod_root: []const u8, protected_path: []const u8) !StoreUsage {
+    var usage = StoreUsage{};
+    errdefer if (usage.oldest_candidate) |candidate| allocator.free(candidate.path);
+
+    var root_dir = fs.cwd().openDir(lod_root, .{ .iterate = true }) catch |err| switch (err) {
+        error.FileNotFound => return usage,
+        else => return err,
+    };
+    defer root_dir.close();
+
+    var lod_iter = root_dir.iterate();
+    while (true) {
+        const maybe_lod_entry = try lod_iter.next();
+        const lod_entry = maybe_lod_entry orelse break;
+        if (lod_entry.kind != .directory or !isActiveLodDirectory(lod_entry.name)) continue;
+
+        var lod_dir = root_dir.openDir(lod_entry.name, .{ .iterate = true }) catch continue;
+        defer lod_dir.close();
+
+        var container_iter = lod_dir.iterate();
+        while (true) {
+            const maybe_container_entry = try container_iter.next();
+            const container_entry = maybe_container_entry orelse break;
+            if (container_entry.kind != .file or !std.mem.endsWith(u8, container_entry.name, ".zlod")) continue;
+
+            const file = lod_dir.openFile(container_entry.name, .{}) catch continue;
+            const stat = file.stat() catch {
+                file.close();
+                continue;
+            };
+            file.close();
+
+            usage.total_size +|= stat.size;
+            const path = try fs.path.join(allocator, &.{ lod_root, lod_entry.name, container_entry.name });
+            if (std.mem.eql(u8, path, protected_path)) {
+                allocator.free(path);
+                continue;
+            }
+
+            if (usage.oldest_candidate) |candidate| {
+                if (!isOlderContainer(candidate, path, stat.mtime.nanoseconds)) {
+                    allocator.free(path);
+                    continue;
+                }
+                allocator.free(candidate.path);
+            }
+            usage.oldest_candidate = .{
+                .path = path,
+                .mtime_ns = stat.mtime.nanoseconds,
+            };
+        }
+    }
+
+    return usage;
+}
+
+/// Enforces the aggregate container limit after a successful atomic write.
+/// The just-written container is never selected, even when it alone exceeds
+/// the configured limit.
+fn enforceStoreSizeCap(allocator: std.mem.Allocator, save_dir_path: []const u8, protected_path: []const u8, cap_mb: u32) !void {
+    const lod_root = try fs.path.join(allocator, &.{ save_dir_path, "lod" });
+    defer allocator.free(lod_root);
+    const cap_bytes = storeSizeCapBytes(cap_mb);
+
+    while (true) {
+        const usage = try scanStoreUsage(allocator, lod_root, protected_path);
+        if (usage.total_size <= cap_bytes) return;
+
+        const candidate = usage.oldest_candidate orelse return;
+        defer allocator.free(candidate.path);
+        fs.cwd().deleteFile(candidate.path) catch |err| switch (err) {
+            error.FileNotFound => continue,
+            else => return err,
+        };
+    }
+}
+
+fn writeCompactedContainer(allocator: std.mem.Allocator, path: []const u8, tmp_path: []const u8, key: lod_cache.Key, bytes: []const u8) !void {
+    var region = RegionFile.create(allocator, tmp_path) catch |err| {
+        fs.cwd().deleteFile(tmp_path) catch {};
+        return err;
+    };
+    errdefer {
+        region.close();
+        fs.cwd().deleteFile(tmp_path) catch {};
+    }
+
+    var existing_region = try RegionFile.open(allocator, path);
+    defer existing_region.close();
+    const target_x = localCoord(key.rx);
+    const target_z = localCoord(key.rz);
+    for (0..REGION_GRID) |z| {
+        for (0..REGION_GRID) |x| {
+            const local_x: u5 = @intCast(x);
+            const local_z: u5 = @intCast(z);
+            if (local_x == target_x and local_z == target_z) continue;
+            const existing = existing_region.readChunk(local_x, local_z, allocator) catch |err| switch (err) {
+                error.ChunkNotFound => continue,
+                else => return err,
+            };
+            region.writeChunk(local_x, local_z, existing) catch |err| {
+                allocator.free(existing);
+                return err;
+            };
+            allocator.free(existing);
+        }
+    }
+
+    try region.writeChunk(target_x, target_z, bytes);
+    region.close();
+}
+
 pub fn writePayload(allocator: std.mem.Allocator, save_dir_path: []const u8, key: lod_cache.Key, bytes: []const u8, store_size_cap_mb: u32) !void {
     const dir_path = try lodDirPath(allocator, save_dir_path, key.lod);
     defer allocator.free(dir_path);
@@ -152,37 +291,86 @@ pub fn writePayload(allocator: std.mem.Allocator, save_dir_path: []const u8, key
         break :blk true;
     };
 
+    var force_compaction = false;
+    // Recover boundedly from a store created by an older implementation that
+    // allowed one container to grow beyond the aggregate cap.
     if (use_existing) {
-        const existing = try fs.cwd().readFileAlloc(path, allocator, storeSizeCapBytes(store_size_cap_mb));
-        defer allocator.free(existing);
-        const tmp_file = try fs.cwd().createFile(tmp_path, .{ .truncate = true });
-        tmp_file.writeAll(existing) catch |err| {
+        const existing_file = try fs.cwd().openFile(path, .{});
+        const existing_stat = existing_file.stat() catch |err| {
+            existing_file.close();
+            return err;
+        };
+        existing_file.close();
+        if (existing_stat.size > storeSizeCapBytes(store_size_cap_mb)) {
+            force_compaction = true;
+        }
+    }
+
+    if (force_compaction) {
+        try writeCompactedContainer(allocator, path, tmp_path, key, bytes);
+    } else {
+        if (use_existing) {
+            const existing = try fs.cwd().readFileAlloc(path, allocator, storeSizeCapBytes(store_size_cap_mb));
+            defer allocator.free(existing);
+            const tmp_file = try fs.cwd().createFile(tmp_path, .{ .truncate = true });
+            tmp_file.writeAll(existing) catch |err| {
+                tmp_file.close();
+                fs.cwd().deleteFile(tmp_path) catch {};
+                return err;
+            };
             tmp_file.close();
+        }
+
+        var region = (if (use_existing)
+            RegionFile.open(allocator, tmp_path)
+        else
+            RegionFile.create(allocator, tmp_path)) catch |err| {
             fs.cwd().deleteFile(tmp_path) catch {};
             return err;
         };
-        tmp_file.close();
+        region.writeChunk(localCoord(key.rx), localCoord(key.rz), bytes) catch |err| {
+            region.close();
+            fs.cwd().deleteFile(tmp_path) catch {};
+            return err;
+        };
+        region.close();
     }
 
-    var region = (if (use_existing)
-        RegionFile.open(allocator, tmp_path)
-    else
-        RegionFile.create(allocator, tmp_path)) catch |err| {
+    var completed_tmp = try fs.cwd().openFile(tmp_path, .{});
+    var completed_stat = completed_tmp.stat() catch |err| {
+        completed_tmp.close();
         fs.cwd().deleteFile(tmp_path) catch {};
         return err;
     };
-
-    region.writeChunk(localCoord(key.rx), localCoord(key.rz), bytes) catch |err| {
-        region.close();
+    completed_tmp.close();
+    if (completed_stat.size > storeSizeCapBytes(store_size_cap_mb) and use_existing and !force_compaction) {
+        // Sector growth crossed the cap. Rebuild only live entries on the
+        // cache worker, then re-check before atomically replacing the source.
+        try fs.cwd().deleteFile(tmp_path);
+        try writeCompactedContainer(allocator, path, tmp_path, key, bytes);
+        completed_tmp = try fs.cwd().openFile(tmp_path, .{});
+        completed_stat = completed_tmp.stat() catch |err| {
+            completed_tmp.close();
+            fs.cwd().deleteFile(tmp_path) catch {};
+            return err;
+        };
+        completed_tmp.close();
+    }
+    if (completed_stat.size > storeSizeCapBytes(store_size_cap_mb)) {
         fs.cwd().deleteFile(tmp_path) catch {};
-        return err;
-    };
-    region.close();
+        // Keep an in-budget previous atomic container. Legacy oversized
+        // containers are discarded because they cannot satisfy the new bound.
+        if (force_compaction) fs.cwd().deleteFile(path) catch {};
+        try enforceStoreSizeCap(allocator, save_dir_path, path, store_size_cap_mb);
+        return StoreError.StoreSizeLimit;
+    }
 
     fs.cwd().rename(tmp_path, path) catch |err| {
         fs.cwd().deleteFile(tmp_path) catch {};
         return err;
     };
+
+    try enforceStoreSizeCap(allocator, save_dir_path, path, store_size_cap_mb);
 }
 
 pub fn deletePayload(allocator: std.mem.Allocator, save_dir_path: []const u8, key: lod_cache.Key) void {
@@ -195,6 +383,16 @@ pub fn deletePayload(allocator: std.mem.Allocator, save_dir_path: []const u8, ke
 }
 
 const testing = std.testing;
+
+fn fillPseudoRandom(bytes: []u8, initial_state: u64) void {
+    var state = initial_state;
+    for (bytes) |*byte| {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        byte.* = @truncate(state);
+    }
+}
 
 test "LOD store round-trips payloads through region containers" {
     var tmp_dir = testing.tmpDir(.{});
@@ -274,6 +472,83 @@ test "LOD store write replaces corrupt containers" {
     try testing.expectEqualStrings("replacement", loaded);
 }
 
+test "LOD store evicts old containers to enforce the total size cap" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const save_dir = try dir.realpath(".", &path_buf);
+    const header = StoreHeader{ .seed = 1, .generator_identity_hash = 2, .generator_version = 3 };
+    try writeHeader(testing.allocator, save_dir, header);
+
+    const payload_size = 700 * 1024;
+    const old_payload = try testing.allocator.alloc(u8, payload_size);
+    defer testing.allocator.free(old_payload);
+    const new_payload = try testing.allocator.alloc(u8, payload_size);
+    defer testing.allocator.free(new_payload);
+    fillPseudoRandom(old_payload, 0x123456789abcdef0);
+    fillPseudoRandom(new_payload, 0xfedcba9876543210);
+
+    const old_key = lod_cache.Key{ .seed = 1, .generator_identity_hash = 2, .generator_version = 3, .rx = 0, .rz = 0, .lod = .lod1 };
+    const new_key = lod_cache.Key{ .seed = 1, .generator_identity_hash = 2, .generator_version = 3, .rx = 32, .rz = 0, .lod = .lod1 };
+    try writePayload(testing.allocator, save_dir, old_key, old_payload, 1);
+    try writePayload(testing.allocator, save_dir, new_key, new_payload, 1);
+
+    try testing.expect((try readPayload(testing.allocator, save_dir, old_key)) == null);
+    const retained = (try readPayload(testing.allocator, save_dir, new_key)).?;
+    defer testing.allocator.free(retained);
+    try testing.expectEqualSlices(u8, new_payload, retained);
+    try testing.expect(headersMatch(header, (try readHeader(testing.allocator, save_dir)).?));
+}
+
+test "LOD store compacts live entries when sector growth reaches the cap" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const save_dir = try dir.realpath(".", &path_buf);
+    const old_payload = try testing.allocator.alloc(u8, 200 * 1024);
+    defer testing.allocator.free(old_payload);
+    const sibling_payload = try testing.allocator.alloc(u8, 200 * 1024);
+    defer testing.allocator.free(sibling_payload);
+    const replacement = try testing.allocator.alloc(u8, 600 * 1024);
+    defer testing.allocator.free(replacement);
+    fillPseudoRandom(old_payload, 0x1111111111111111);
+    fillPseudoRandom(sibling_payload, 0x2222222222222222);
+    fillPseudoRandom(replacement, 0x3333333333333333);
+
+    const target_key = lod_cache.Key{ .seed = 1, .generator_identity_hash = 2, .generator_version = 3, .rx = 0, .rz = 0, .lod = .lod1 };
+    const sibling_key = lod_cache.Key{ .seed = 1, .generator_identity_hash = 2, .generator_version = 3, .rx = 1, .rz = 0, .lod = .lod1 };
+    try writePayload(testing.allocator, save_dir, target_key, old_payload, 1);
+    try writePayload(testing.allocator, save_dir, sibling_key, sibling_payload, 1);
+    try writePayload(testing.allocator, save_dir, target_key, replacement, 1);
+
+    const loaded_target = (try readPayload(testing.allocator, save_dir, target_key)).?;
+    defer testing.allocator.free(loaded_target);
+    try testing.expectEqualSlices(u8, replacement, loaded_target);
+    const loaded_sibling = (try readPayload(testing.allocator, save_dir, sibling_key)).?;
+    defer testing.allocator.free(loaded_sibling);
+    try testing.expectEqualSlices(u8, sibling_payload, loaded_sibling);
+}
+
+test "LOD store rejects a container larger than the aggregate cap" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const dir = fs.Dir{ .inner = tmp_dir.dir };
+    var path_buf: [fs.max_path_bytes]u8 = undefined;
+    const save_dir = try dir.realpath(".", &path_buf);
+    const payload = try testing.allocator.alloc(u8, 2 * 1024 * 1024);
+    defer testing.allocator.free(payload);
+    fillPseudoRandom(payload, 0x9e3779b97f4a7c15);
+
+    const key = lod_cache.Key{ .seed = 1, .generator_identity_hash = 2, .generator_version = 3, .rx = 0, .rz = 0, .lod = .lod1 };
+    try testing.expectError(StoreError.StoreSizeLimit, writePayload(testing.allocator, save_dir, key, payload, 1));
+    try testing.expect((try readPayload(testing.allocator, save_dir, key)) == null);
+}
+
 test "LOD store missing and corrupt containers are advisory misses" {
     var tmp_dir = testing.tmpDir(.{});
     defer tmp_dir.cleanup();
@@ -311,7 +586,7 @@ test "LOD store writes metadata header atomically" {
     defer testing.allocator.free(bytes);
 
     try testing.expect(std.mem.indexOf(u8, bytes, "\"seed\": 123") != null);
-    try testing.expect(std.mem.indexOf(u8, bytes, "\"lod_data_version\": 10") != null);
+    try testing.expect(std.mem.indexOf(u8, bytes, "\"lod_data_version\": 11") != null);
 }
 
 test "LOD store reads and deletes metadata store" {

--- a/modules/world-lod/src/tests.zig
+++ b/modules/world-lod/src/tests.zig
@@ -1,0 +1,8 @@
+//! Dedicated world-lod test root.
+
+test {
+    _ = @import("lod_cache.zig");
+    _ = @import("lod_manager_internal_tests.zig");
+    _ = @import("lod_manager_tests.zig");
+    _ = @import("lod_store.zig");
+}

--- a/modules/world-persistence/src/region_file.zig
+++ b/modules/world-persistence/src/region_file.zig
@@ -125,6 +125,7 @@ pub const RegionFile = struct {
 
         const total_len: u32 = @intCast(compressed.len + 1);
         const sectors_needed = (total_len + 4 + SECTOR_SIZE - 1) / SECTOR_SIZE;
+        if (sectors_needed > std.math.maxInt(u8)) return RegionError.FileTooShort;
 
         const idx = @as(u32, local_z) * 32 + @as(u32, local_x);
         const old_entry = self.header[idx];

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -70,11 +70,6 @@ test {
     _ = @import("world-worldgen").terrain_modifier_tests;
     _ = @import("world-worldgen").terrain_shape_generator_tests;
     _ = @import("world-worldgen").terrain_report;
-    _ = @import("world-lod").lod_manager_tests;
-    _ = @import("world-lod").lod_manager_internal_tests;
-    _ = @import("world-lod").lod_seam;
-    _ = @import("world-lod").lod_renderer;
-    _ = @import("world-lod").lod_tile;
     _ = @import("engine-atmosphere").atmosphere_tests;
     _ = @import("game-core").settings_tests;
     _ = @import("game-core").input_settings;


### PR DESCRIPTION
## Summary
- preserve edited/chunk-derived provenance for span-less far LOD cache payloads and safely regenerate provenance-incomplete legacy data
- cancel stale queued and in-flight generation on pause and large traversal changes without allowing old workers or cache completions to publish over newer work
- enforce an aggregate persistent-store cap with oldest-container eviction, pressure-triggered live-entry compaction, oversized-container rejection, and corruption-safe atomic replacement
- document coherent preset budgets, regression SLO links, requirements, and fallback behavior

## Tests
- `nix develop --command zig build test`
- `nix develop --command zig build -Doptimize=ReleaseFast`
- pre-push formatting and full-test hooks

Refs #922