### PR TITLE
ci: convert daily scheduled workflows to weekly

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [dev]
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "17 3 * * 3"
   workflow_dispatch:
     inputs:
       duration:

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -2,7 +2,7 @@ name: Profiling
 
 on:
   schedule:
-    - cron: "43 4 * * *"
+    - cron: "43 4 * * 4"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -2,7 +2,7 @@ name: Sanitize
 
 on:
   schedule:
-    - cron: "17 5 * * *"
+    - cron: "17 5 * * 6"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [dev]
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "17 3 * * 1"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Stale Issues and PRs
 
 on:
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "17 3 * * 5"
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/visual-test.yml
+++ b/.github/workflows/visual-test.yml
@@ -2,7 +2,7 @@ name: visual-test
 
 on:
   schedule:
-    - cron: "43 4 * * *"
+    - cron: "43 4 * * 2"
   pull_request:
     branches: [dev]
     types: [labeled]


### PR DESCRIPTION
Reduces CI spend by moving the six daily cron schedules to weekly, spread across weekdays to avoid runner contention. Git (push/PR) triggers are unchanged.

| Workflow | Before | After |
|---|---|---|
| security | daily 03:17 | Mon 03:17 |
| visual-test | daily 04:43 | Tue 04:43 |
| benchmark | daily 03:17 | Wed 03:17 |
| profiling | daily 04:43 | Thu 04:43 |
| stale | daily 03:17 | Fri 03:17 |
| sanitize | daily 05:17 | Sat 05:17 |

The four already-weekly schedules (opencode-audit, opencode-test-writer, model-update-checker, stale-branch-cleanup) are unchanged.